### PR TITLE
feat: vault description as MCP server instruction, config tools

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -31,6 +31,7 @@ const READ_TOOLS = new Set([
   "find-path",
   "list-tags",
   "list-vaults",
+  "get-vault-description",
 ]);
 
 /** Check if a tool call is allowed for a given scope. */

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -35,13 +35,11 @@ describe("config", () => {
     const config: VaultConfig = {
       name: "testvault",
       description: "A test vault for testing",
-      tool_hints: {
-        "create-note": "Always add a #test tag",
-      },
       api_keys: [
         {
           id: "k_abc123",
           label: "default",
+          scope: "write",
           key_hash: "sha256:fakehash",
           created_at: "2026-01-01T00:00:00.000Z",
         },
@@ -57,7 +55,6 @@ describe("config", () => {
     expect(loaded!.description).toBe("A test vault for testing");
     expect(loaded!.api_keys.length).toBe(1);
     expect(loaded!.api_keys[0].id).toBe("k_abc123");
-    expect(loaded!.tool_hints?.["create-note"]).toBe("Always add a #test tag");
 
     rmSync(tmpDir, { recursive: true, force: true });
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,7 +60,6 @@ export interface StoredKey {
 export interface VaultConfig {
   name: string;
   description?: string;
-  tool_hints?: Record<string, string>;
   api_keys: StoredKey[];
   created_at: string;
 }
@@ -85,13 +84,6 @@ function serializeVaultConfig(config: VaultConfig): string {
     }
   }
   lines.push(`created_at: "${config.created_at}"`);
-
-  if (config.tool_hints && Object.keys(config.tool_hints).length > 0) {
-    lines.push("tool_hints:");
-    for (const [key, val] of Object.entries(config.tool_hints)) {
-      lines.push(`  ${key}: "${val}"`);
-    }
-  }
 
   lines.push("api_keys:");
   for (const key of config.api_keys) {
@@ -132,17 +124,6 @@ function parseVaultConfig(yaml: string, name: string): VaultConfig {
   } else {
     const descSimple = yaml.match(/^description:\s*(.+)/m);
     if (descSimple) config.description = descSimple[1].trim().replace(/^"(.*)"$/, "$1");
-  }
-
-  // Parse tool_hints
-  const hintsSection = yaml.match(/^tool_hints:\n((?:\s{2}\S.+\n?)+)/m);
-  if (hintsSection) {
-    config.tool_hints = {};
-    const hintLines = hintsSection[1].split("\n");
-    for (const line of hintLines) {
-      const m = line.match(/^\s{2}(\S+):\s*"?([^"\n]+)"?/);
-      if (m) config.tool_hints[m[1]] = m[2];
-    }
   }
 
   // Parse api_keys

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -3,9 +3,10 @@
  *
  * Two modes:
  *   /mcp              — unified, all vaults via `vault` param + list-vaults
- *   /vaults/{name}/mcp — scoped to one vault, no vault param, clean 17 tools
+ *   /vaults/{name}/mcp — scoped to one vault, no vault param
  *
- * Both enforce read-only scope when the API key has scope: "read".
+ * Vault description is sent as the MCP server instruction on session init.
+ * Read-only keys see fewer tools.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -14,7 +15,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { generateUnifiedMcpTools, generateScopedMcpTools } from "./mcp-tools.ts";
+import { generateUnifiedMcpTools, generateScopedMcpTools, getServerInstruction } from "./mcp-tools.ts";
 import { isToolAllowed } from "./auth.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
 import type { KeyScope } from "./config.ts";
@@ -29,12 +30,14 @@ const sessions = new Map<string, Session>();
 
 /** Handle unified MCP at /mcp (all vaults). */
 export async function handleUnifiedMcp(req: Request, scope: KeyScope): Promise<Response> {
-  return handleMcp(req, () => generateUnifiedMcpTools(), "parachute-vault", scope);
+  const instruction = getServerInstruction();
+  return handleMcp(req, () => generateUnifiedMcpTools(), "parachute-vault", scope, instruction);
 }
 
 /** Handle scoped MCP at /vaults/{name}/mcp (single vault). */
 export async function handleScopedMcp(req: Request, vaultName: string, scope: KeyScope): Promise<Response> {
-  return handleMcp(req, () => generateScopedMcpTools(vaultName), `parachute-vault/${vaultName}`, scope);
+  const instruction = getServerInstruction(vaultName);
+  return handleMcp(req, () => generateScopedMcpTools(vaultName), `parachute-vault/${vaultName}`, scope, instruction);
 }
 
 async function handleMcp(
@@ -42,6 +45,7 @@ async function handleMcp(
   getTools: () => McpToolDef[],
   serverName: string,
   scope: KeyScope,
+  instruction: string,
 ): Promise<Response> {
   const sessionId = req.headers.get("mcp-session-id");
   const existing = sessionId ? sessions.get(sessionId) : undefined;
@@ -50,12 +54,17 @@ async function handleMcp(
     return existing.transport.handleRequest(req);
   }
 
-  const session = createSession(getTools(), serverName, scope);
+  const session = createSession(getTools(), serverName, scope, instruction);
   await session.server.connect(session.transport);
   return session.transport.handleRequest(req);
 }
 
-function createSession(mcpTools: McpToolDef[], serverName: string, scope: KeyScope): Session {
+function createSession(
+  mcpTools: McpToolDef[],
+  serverName: string,
+  scope: KeyScope,
+  instruction: string,
+): Session {
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: () => crypto.randomUUID(),
     onsessioninitialized: (id) => {
@@ -68,7 +77,10 @@ function createSession(mcpTools: McpToolDef[], serverName: string, scope: KeySco
 
   const server = new Server(
     { name: serverName, version: "0.1.0" },
-    { capabilities: { tools: {} } },
+    {
+      capabilities: { tools: {} },
+      instructions: instruction,
+    },
   );
 
   // For read-only keys, only list readable tools
@@ -87,7 +99,6 @@ function createSession(mcpTools: McpToolDef[], serverName: string, scope: KeySco
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
-    // Enforce scope
     if (!isToolAllowed(name, scope)) {
       return {
         content: [{ type: "text" as const, text: `Forbidden: read-only key cannot call ${name}` }],

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -3,15 +3,36 @@
  *
  * Every tool gets an optional `vault` parameter. Defaults to the
  * configured default vault. Single-vault users never notice it.
- * Multi-vault users pass `vault: "work"` to target a specific vault.
  *
- * Also adds a `list-vaults` tool for vault discovery.
+ * Vault description is sent as the MCP server instruction (not
+ * prepended to each tool). Agents get the guidance once at session
+ * start.
  */
 
 import { generateMcpTools } from "../core/src/mcp.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
-import { readVaultConfig, readGlobalConfig, listVaults as getVaultNames } from "./config.ts";
+import { readVaultConfig, writeVaultConfig, readGlobalConfig, listVaults as getVaultNames } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
+
+/**
+ * Get the MCP server instruction for a vault (or the default vault).
+ * This is sent once at session init — not per tool.
+ */
+export function getServerInstruction(vaultName?: string): string {
+  const globalConfig = readGlobalConfig();
+  const name = vaultName ?? globalConfig.default_vault ?? "default";
+  const config = readVaultConfig(name);
+
+  const parts: string[] = [
+    `You are connected to Parachute Vault "${name}".`,
+  ];
+
+  if (config?.description) {
+    parts.push("", config.description);
+  }
+
+  return parts.join("\n");
+}
 
 /**
  * Generate the unified MCP tool set.
@@ -27,25 +48,13 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
   const defaultStore = getVaultStore(defaultVault);
   const coreTools = generateMcpTools(defaultStore.db);
 
-  // Get default vault config for description enrichment
-  const defaultConfig = readVaultConfig(defaultVault);
-  const prefix = defaultConfig?.description
-    ? `[Vault: ${defaultVault}] ${defaultConfig.description}\n\n`
-    : "";
-  const hints = defaultConfig?.tool_hints ?? {};
-
   // Wrap each core tool with vault resolution
   const tools: McpToolDef[] = coreTools.map((coreTool) => {
-    // Build enriched description
     let description = coreTool.description;
-    if (prefix) description = prefix + description;
-    const hint = hints[coreTool.name];
-    if (hint) description = description + "\n\n" + hint;
     if (multiVault) {
       description += `\n\nMulti-vault: pass 'vault' to target a specific vault. Default: "${defaultVault}". Available: ${vaultNames.join(", ")}`;
     }
 
-    // Add vault param to schema
     const inputSchema = {
       ...coreTool.inputSchema,
       properties: {
@@ -63,43 +72,21 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
       inputSchema,
       execute: (params) => {
         const vaultName = (params.vault as string) ?? defaultVault;
-
-        // Validate vault exists
         const config = readVaultConfig(vaultName);
         if (!config) {
           throw new Error(`Vault "${vaultName}" not found. Available: ${getVaultNames().join(", ")}`);
         }
-
-        // Get the store and generate tools for this vault's db
         const store = getVaultStore(vaultName);
         const vaultTools = generateMcpTools(store.db);
         const tool = vaultTools.find((t) => t.name === coreTool.name)!;
-
-        // Strip vault param before passing to core tool
         const { vault: _, ...rest } = params;
         return tool.execute(rest);
       },
     };
   });
 
-  // Add list-vaults tool
-  tools.push({
-    name: "list-vaults",
-    description: "List all available vaults with their descriptions.",
-    inputSchema: { type: "object", properties: {} },
-    execute: () => {
-      const names = getVaultNames();
-      return names.map((name) => {
-        const config = readVaultConfig(name);
-        return {
-          name,
-          description: config?.description,
-          created_at: config?.created_at,
-          is_default: name === defaultVault,
-        };
-      });
-    },
-  });
+  // Vault management tools
+  addVaultManagementTools(tools, defaultVault);
 
   return tools;
 }
@@ -107,23 +94,80 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
 /**
  * Generate MCP tools scoped to a single vault.
  * No vault param — tools operate on that vault only.
- * Descriptions enriched with the vault's hints.
  */
 export function generateScopedMcpTools(vaultName: string): McpToolDef[] {
   const store = getVaultStore(vaultName);
   const tools = generateMcpTools(store.db);
-  const config = readVaultConfig(vaultName);
+  addVaultManagementTools(tools, vaultName, true);
+  return tools;
+}
 
-  const prefix = config?.description
-    ? `[Vault: ${vaultName}] ${config.description}\n\n`
-    : "";
-  const hints = config?.tool_hints ?? {};
+/**
+ * Add vault management tools (list-vaults, get/update description).
+ */
+function addVaultManagementTools(tools: McpToolDef[], defaultVault: string, scoped = false) {
+  if (!scoped) {
+    tools.push({
+      name: "list-vaults",
+      description: "List all available vaults with their descriptions.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => {
+        const names = getVaultNames();
+        return names.map((name) => {
+          const config = readVaultConfig(name);
+          return {
+            name,
+            description: config?.description,
+            created_at: config?.created_at,
+            is_default: name === defaultVault,
+          };
+        });
+      },
+    });
+  }
 
-  return tools.map((tool) => {
-    let description = tool.description;
-    if (prefix) description = prefix + description;
-    const hint = hints[tool.name];
-    if (hint) description = description + "\n\n" + hint;
-    return { ...tool, description };
+  tools.push({
+    name: "get-vault-description",
+    description: "Get the description/instructions for a vault. The description tells agents how to use this vault — what tags to use, what conventions to follow, etc.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...(scoped ? {} : {
+          vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
+        }),
+      },
+    },
+    execute: (params) => {
+      const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
+      const config = readVaultConfig(name);
+      if (!config) throw new Error(`Vault "${name}" not found`);
+      return {
+        name: config.name,
+        description: config.description ?? null,
+      };
+    },
+  });
+
+  tools.push({
+    name: "update-vault-description",
+    description: "Update the description/instructions for a vault. The description guides how AI agents use this vault — tag conventions, writing guidelines, etc. IMPORTANT: Only update when the user explicitly asks you to change the vault's configuration. Never modify unprompted.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...(scoped ? {} : {
+          vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
+        }),
+        description: { type: "string", description: "New vault description/instructions" },
+      },
+      required: ["description"],
+    },
+    execute: (params) => {
+      const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
+      const config = readVaultConfig(name);
+      if (!config) throw new Error(`Vault "${name}" not found`);
+      config.description = params.description as string;
+      writeVaultConfig(config);
+      return { updated: true, name, description: config.description };
+    },
   });
 }


### PR DESCRIPTION
## Summary

Simplifies how agents get guidance from a vault. One description, sent once.

**Before:** `tool_hints` map in vault.yaml, prepended to every tool description. Verbose, repetitive, hard to maintain.

**After:** Single `description` field in vault.yaml, sent as the MCP server instruction on session init. Agents get it once at connection time. New tools let agents read and update it (with user permission).

### Changes

- Dropped `tool_hints` from VaultConfig
- `description` is now the single source of agent guidance
- Sent via MCP `instructions` field on initialize response
- New tools: `get-vault-description`, `update-vault-description`
- `update-vault-description` tool description says "Only update when the user explicitly asks"
- `get-vault-description` is read-safe (allowed for read-only keys)

### How a user configures their vault

Via an agent:
```
"Set up my vault for journaling. I use #daily for journal entries, 
#doc for persistent notes, and #digest for AI summaries."
→ agent calls update-vault-description
```

Or via CLI: edit `~/.parachute/vaults/default/vault.yaml`

## Test plan
- [x] 81 tests pass
- [x] tool_hints removed from config round-trip test
- [x] Server instruction wired in MCP session

🤖 Generated with [Claude Code](https://claude.com/claude-code)