### PR TITLE
fix: MCP tools use store hooks, POST /notes passes created_at

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -394,4 +394,20 @@ describe("MCP tools", () => {
     deleteLink.execute({ source_id: "a", target_id: "b", relationship: "mentions" });
     expect((getLinks.execute({ id: "a" }) as any[]).length).toBe(0);
   });
+
+  it("create-note via store triggers wikilink sync", () => {
+    // When MCP tools are generated with a Store, wikilinks should auto-sync
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+
+    // Create target note first
+    store.createNote("Target", { path: "Target Note" });
+
+    // Create source via MCP tool with a wikilink
+    const source = createNote.execute({ content: "See [[Target Note]]" }) as any;
+
+    // Wikilink should have been resolved into a link
+    const links = store.getLinks(source.id, { direction: "outbound" });
+    expect(links.some((l) => l.relationship === "wikilink")).toBe(true);
+  });
 });

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1,4 +1,5 @@
 import { Database } from "bun:sqlite";
+import type { Store } from "./types.js";
 import * as notes from "./notes.js";
 import * as links from "./links.js";
 
@@ -11,8 +12,15 @@ export interface McpToolDef {
 
 /**
  * Generate MCP tools for a vault.
+ *
+ * Accepts a Store so that create/update/delete operations go through
+ * the store's hooks (wikilink sync, path normalization, etc.).
+ * Read-only operations use the db directly for efficiency.
  */
-export function generateMcpTools(db: Database): McpToolDef[] {
+export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
+  // Support both Store and raw Database for backwards compat (tests)
+  const store: Store | null = 'createNote' in storeOrDb ? storeOrDb as Store : null;
+  const db: Database = store ? (store as any).db : storeOrDb as Database;
   return [
     {
       name: "get-note",
@@ -56,12 +64,15 @@ export function generateMcpTools(db: Database): McpToolDef[] {
         },
         required: ["content"],
       },
-      execute: (params) => notes.createNote(db, params.content as string, {
-        tags: params.tags as string[] | undefined,
-        path: params.path as string | undefined,
-        metadata: params.metadata as Record<string, unknown> | undefined,
-        created_at: params.created_at as string | undefined,
-      }),
+      execute: (params) => {
+        const fn = store ? store.createNote.bind(store) : (c: string, o?: any) => notes.createNote(db, c, o);
+        return fn(params.content as string, {
+          tags: params.tags as string[] | undefined,
+          path: params.path as string | undefined,
+          metadata: params.metadata as Record<string, unknown> | undefined,
+          created_at: params.created_at as string | undefined,
+        });
+      },
     },
     {
       name: "update-note",
@@ -76,11 +87,14 @@ export function generateMcpTools(db: Database): McpToolDef[] {
         },
         required: ["id"],
       },
-      execute: (params) => notes.updateNote(db, params.id as string, {
-        content: params.content as string | undefined,
-        path: params.path as string | undefined,
-        metadata: params.metadata as Record<string, unknown> | undefined,
-      }),
+      execute: (params) => {
+        const fn = store ? store.updateNote.bind(store) : (id: string, u: any) => notes.updateNote(db, id, u);
+        return fn(params.id as string, {
+          content: params.content as string | undefined,
+          path: params.path as string | undefined,
+          metadata: params.metadata as Record<string, unknown> | undefined,
+        });
+      },
     },
     {
       name: "delete-note",
@@ -93,7 +107,11 @@ export function generateMcpTools(db: Database): McpToolDef[] {
         required: ["id"],
       },
       execute: (params) => {
-        notes.deleteNote(db, params.id as string);
+        if (store) {
+          store.deleteNote(params.id as string);
+        } else {
+          notes.deleteNote(db, params.id as string);
+        }
         return { deleted: true };
       },
     },

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -56,7 +56,7 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
 
   // Get tool definitions from core (using default vault for schema)
   const defaultStore = getVaultStore(defaultVault);
-  const coreTools = generateMcpTools(defaultStore.db);
+  const coreTools = generateMcpTools(defaultStore);
 
   // Wrap each core tool with vault resolution
   const tools: McpToolDef[] = coreTools.map((coreTool) => {
@@ -87,7 +87,7 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
           throw new Error(`Vault "${vaultName}" not found. Available: ${getVaultNames().join(", ")}`);
         }
         const store = getVaultStore(vaultName);
-        const vaultTools = generateMcpTools(store.db);
+        const vaultTools = generateMcpTools(store);
         const tool = vaultTools.find((t) => t.name === coreTool.name)!;
         const { vault: _, ...rest } = params;
         return tool.execute(rest);
@@ -110,7 +110,7 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
  */
 export function generateScopedMcpTools(vaultName: string): McpToolDef[] {
   const store = getVaultStore(vaultName);
-  const tools = generateMcpTools(store.db);
+  const tools = generateMcpTools(store);
   addVaultManagementTools(tools, vaultName, true);
   addSemanticSearchTools(tools, vaultName, false);
   return tools;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -61,11 +61,15 @@ export async function handleNotes(
       id?: string;
       path?: string;
       tags?: string[];
+      metadata?: Record<string, unknown>;
+      created_at?: string;
     };
     const note = store.createNote(body.content ?? "", {
       id: body.id,
       path: body.path,
       tags: body.tags,
+      metadata: body.metadata,
+      created_at: body.created_at,
     });
     return json(note, 201);
   }


### PR DESCRIPTION
## Summary
Two bugs fixed:

1. **MCP tools bypassed store hooks**: `create-note`, `update-note`, `delete-note` called `noteOps` directly, so notes created via MCP never got wikilink sync or path normalization. Now `generateMcpTools()` accepts a `Store` and routes mutations through it. Falls back to raw `Database` for backwards compat.

2. **`POST /api/notes` dropped `created_at` and `metadata`**: The Daily app sends `created_at` on typed notes but the route ignored it — notes always got server time. Also added `metadata` pass-through.

## Test plan
- [x] 171 tests pass (1 new test verifying MCP create-note triggers wikilink sync)
- [x] Existing MCP tests still pass (raw db fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)