### PR TITLE
feat: self-hosted deployment — Docker, Railway, Fly.io, systemd

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.git
+*.test.ts
+*.test.js
+.env
+*.log
+*.err
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Parachute Vault — Configuration
+# Copy to .env and fill in your values.
+
+# Server
+PORT=1940
+
+# Domain for HTTPS (required for MCP from Claude Desktop)
+# Leave empty for local-only / development use.
+# VAULT_DOMAIN=vault.yourdomain.com
+
+# Transcription (optional)
+# Providers: groq, openai, parakeet-mlx (local Mac only)
+# TRANSCRIBE_PROVIDER=groq
+# GROQ_API_KEY=gsk_...
+
+# AI cleanup of transcriptions (optional)
+# Providers: claude, ollama, none
+# CLEANUP_PROVIDER=claude
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# Embeddings / semantic search (optional)
+# Providers: openai, ollama, none
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=text-embedding-3-small
+# OPENAI_API_KEY=sk-...
+
+# Ollama (if using ollama for embeddings or cleanup)
+# OLLAMA_BASE_URL=http://localhost:11434

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+{$VAULT_DOMAIN:localhost} {
+	reverse_proxy vault:1940
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM oven/bun:1.2-alpine AS base
+WORKDIR /app
+
+# Install deps
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+# Copy source
+COPY core core
+COPY src src
+COPY bunfig.toml ./
+
+# Data directory — mount a volume here for persistence
+ENV PARACHUTE_HOME=/data
+RUN mkdir -p /data
+
+EXPOSE 1940
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+  CMD wget -qO- http://localhost:1940/health || exit 1
+
+CMD ["bun", "src/server.ts"]

--- a/deploy/parachute-vault.service
+++ b/deploy/parachute-vault.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Parachute Vault
+After=network.target
+
+[Service]
+Type=simple
+User=parachute
+WorkingDirectory=/opt/parachute-vault
+ExecStart=/usr/local/bin/bun src/server.ts
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=/opt/parachute-vault/.env
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/parachute/.parachute
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+# Parachute Vault — self-hosted deployment
+#
+# Quick start:
+#   1. Copy .env.example to .env and fill in your values
+#   2. docker compose up -d
+#
+# For HTTPS (required for MCP from Claude Desktop):
+#   Set VAULT_DOMAIN in .env, ensure DNS points to this server.
+#   Caddy handles Let's Encrypt automatically.
+#
+# Without HTTPS (local/development):
+#   Leave VAULT_DOMAIN empty — Caddy proxies on port 80 only.
+
+services:
+  vault:
+    build: .
+    restart: unless-stopped
+    volumes:
+      - vault-data:/data
+    env_file: .env
+    environment:
+      - PARACHUTE_HOME=/data
+    expose:
+      - "1940"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:1940/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    environment:
+      - VAULT_DOMAIN=${VAULT_DOMAIN:-localhost}
+    depends_on:
+      vault:
+        condition: service_healthy
+
+volumes:
+  vault-data:
+  caddy-data:
+  caddy-config:

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,24 @@
+app = "parachute-vault"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "1940"
+  PARACHUTE_HOME = "/data"
+
+[http_service]
+  internal_port = 1940
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+
+[[mounts]]
+  source = "vault_data"
+  destination = "/data"

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "bun src/server.ts",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 5,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ import crypto from "node:crypto";
 // Paths
 // ---------------------------------------------------------------------------
 
-export const CONFIG_DIR = join(homedir(), ".parachute");
+export const CONFIG_DIR = process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
 export const VAULTS_DIR = join(CONFIG_DIR, "vaults");
 export const GLOBAL_CONFIG_PATH = join(CONFIG_DIR, "config.yaml");
 export const ENV_PATH = join(CONFIG_DIR, ".env");

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,9 +14,10 @@
 
 // If embeddings are configured, swap to Homebrew SQLite on macOS (must happen before any DB opens)
 import { existsSync, readFileSync } from "fs";
-import { resolve } from "path";
+import { resolve, join } from "path";
 import { homedir } from "os";
-const _envPath = resolve(homedir(), ".parachute", ".env");
+const _configDir = process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
+const _envPath = resolve(_configDir, ".env");
 if (existsSync(_envPath)) {
   const _envContent = readFileSync(_envPath, "utf-8");
   if (/EMBEDDING_PROVIDER\s*=/.test(_envContent) && !/EMBEDDING_PROVIDER\s*=\s*none/i.test(_envContent)) {
@@ -25,7 +26,7 @@ if (existsSync(_envPath)) {
   }
 }
 
-import { readVaultConfig, readGlobalConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile } from "./config.ts";
+import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile, generateApiKey, hashKey } from "./config.ts";
 import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed } from "./auth.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
@@ -33,6 +34,37 @@ import { handleNotes, handleTags, handleLinks, handleSearch, handleStorage, hand
 
 ensureConfigDirSync();
 loadEnvFile();
+
+// Auto-init: create a default vault if none exist (first run in Docker)
+if (listVaults().length === 0) {
+  const globalConfig = readGlobalConfig();
+  if (!globalConfig.default_vault) {
+    const { fullKey, keyId } = generateApiKey();
+    writeVaultConfig({
+      name: "default",
+      api_keys: [{
+        id: keyId,
+        label: "default",
+        scope: "write",
+        key_hash: hashKey(fullKey),
+        created_at: new Date().toISOString(),
+      }],
+      created_at: new Date().toISOString(),
+    });
+    globalConfig.default_vault = "default";
+    if (!globalConfig.api_keys?.length) {
+      globalConfig.api_keys = [{
+        id: keyId,
+        label: "default",
+        scope: "write",
+        key_hash: hashKey(fullKey),
+        created_at: new Date().toISOString(),
+      }];
+    }
+    writeGlobalConfig(globalConfig);
+    console.log(`Auto-created default vault (API key: ${fullKey})`);
+  }
+}
 
 const globalConfig = readGlobalConfig();
 const port = parseInt(process.env.PORT ?? "") || globalConfig.port || DEFAULT_PORT;


### PR DESCRIPTION
## Summary
Everything needed for self-hosted deployment:

### Docker
- **Dockerfile**: Bun Alpine, healthcheck, `/data` volume for persistence
- **docker-compose.yml**: Vault + Caddy for automatic HTTPS via Let's Encrypt
- **Caddyfile**: Reverse proxy config, auto-configures from `VAULT_DOMAIN` env var

### Cloud platforms
- **railway.json**: One-click deploy on Railway ($5/mo)
- **fly.toml**: Fly.io deploy with persistent volume mount ($3-5/mo)

### Linux VPS
- **systemd unit**: `deploy/parachute-vault.service` for Hetzner/DigitalOcean etc.

### Infrastructure changes
- **`PARACHUTE_HOME` env var**: Override `~/.parachute` data directory (essential for Docker volumes)
- **Auto-init**: Server auto-creates a default vault on first run if none exist. Prints the API key to stdout.
- **`.env.example`**: Documents all config vars (port, transcription, embeddings, etc.)

### Quick start
```bash
# Docker (local)
cp .env.example .env
docker compose up -d

# Docker (with HTTPS)
echo "VAULT_DOMAIN=vault.yourdomain.com" >> .env
docker compose up -d

# Railway
# Click Deploy button (forthcoming README update)

# Fly.io
fly launch --copy-config
fly volumes create vault_data --size 1
fly deploy
```

## Test plan
- [x] Docker build succeeds
- [x] Container starts, auto-creates vault, health check passes
- [x] 171 existing tests pass
- [x] `PARACHUTE_HOME` override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)