### PR TITLE
fix: MCP endpoint 500 — pass process.env to embedding provider

### DIFF
--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -197,8 +197,8 @@ const _vecInitialized = new Set<string>();
 
 function getEmbedProvider(): EmbeddingProvider | null {
   if (_embedProvider !== undefined) return _embedProvider;
-  const env = loadEnvFile();
-  _embedProvider = createEmbeddingProvider(env);
+  loadEnvFile();
+  _embedProvider = createEmbeddingProvider(process.env);
   return _embedProvider;
 }
 


### PR DESCRIPTION
## Summary
- \`loadEnvFile()\` returns void (it mutates \`process.env\`), but \`getEmbedProvider\` was passing the void return value into \`createEmbeddingProvider\`, which then crashed on \`env.EMBEDDING_PROVIDER\`.
- Every request to \`/mcp\` blew up with a 500 before the handler could respond.
- Fix: call \`loadEnvFile()\`, then pass \`process.env\` to the factory.

## Test plan
- [x] \`POST /mcp\` initialize returns a valid MCP response
- [x] Daemon restart picks up the change cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)