### PR TITLE
feat: add get-vault-stats MCP tool

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -127,6 +127,106 @@ describe("tags", () => {
   });
 });
 
+// ---- Vault Stats ----
+
+describe("vault stats", () => {
+  it("handles empty vault gracefully", () => {
+    const stats = store.getVaultStats();
+    expect(stats.total_notes).toBe(0);
+    expect(stats.earliest_note).toBeNull();
+    expect(stats.latest_note).toBeNull();
+    expect(stats.notes_by_month).toEqual([]);
+    expect(stats.top_tags).toEqual([]);
+    expect(stats.tag_count).toBe(0);
+  });
+
+  it("counts total notes and tag_count", () => {
+    store.createNote("A", { tags: ["daily", "voice"] });
+    store.createNote("B", { tags: ["daily"] });
+    store.createNote("C");
+
+    const stats = store.getVaultStats();
+    expect(stats.total_notes).toBe(3);
+    expect(stats.tag_count).toBe(2); // "daily" and "voice"
+  });
+
+  it("reports earliest and latest notes correctly", () => {
+    store.createNote("oldest", { id: "n1", created_at: "2025-01-15T10:00:00.000Z" });
+    store.createNote("middle", { id: "n2", created_at: "2025-06-20T10:00:00.000Z" });
+    store.createNote("newest", { id: "n3", created_at: "2026-03-01T10:00:00.000Z" });
+
+    const stats = store.getVaultStats();
+    expect(stats.earliest_note).toEqual({ id: "n1", created_at: "2025-01-15T10:00:00.000Z" });
+    expect(stats.latest_note).toEqual({ id: "n3", created_at: "2026-03-01T10:00:00.000Z" });
+  });
+
+  it("groups notes by month across all present months", () => {
+    store.createNote("a", { created_at: "2025-02-28T12:00:00.000Z" });
+    store.createNote("b", { created_at: "2025-03-01T08:00:00.000Z" });
+    store.createNote("c", { created_at: "2025-03-15T09:00:00.000Z" });
+    store.createNote("d", { created_at: "2025-03-20T11:00:00.000Z" });
+    store.createNote("e", { created_at: "2026-01-10T10:00:00.000Z" });
+
+    const stats = store.getVaultStats();
+    expect(stats.notes_by_month).toEqual([
+      { month: "2025-02", count: 1 },
+      { month: "2025-03", count: 3 },
+      { month: "2026-01", count: 1 },
+    ]);
+  });
+
+  it("returns top_tags ordered by count desc, capped", () => {
+    // Create notes with varying tag frequencies
+    for (let i = 0; i < 5; i++) store.createNote(`captured-${i}`, { tags: ["captured"] });
+    for (let i = 0; i < 3; i++) store.createNote(`reader-${i}`, { tags: ["reader"] });
+    store.createNote("one", { tags: ["rare"] });
+
+    const stats = store.getVaultStats();
+    expect(stats.top_tags[0]).toEqual({ tag: "captured", count: 5 });
+    expect(stats.top_tags[1]).toEqual({ tag: "reader", count: 3 });
+    expect(stats.top_tags[2]).toEqual({ tag: "rare", count: 1 });
+  });
+
+  it("caps top_tags at the requested limit", () => {
+    // 25 distinct tags, one per note
+    for (let i = 0; i < 25; i++) {
+      store.createNote(`n-${i}`, { tags: [`tag-${String(i).padStart(2, "0")}`] });
+    }
+    const stats = store.getVaultStats({ topTagsLimit: 20 });
+    expect(stats.top_tags).toHaveLength(20);
+    expect(stats.tag_count).toBe(25);
+  });
+
+  it("response shape is complete", () => {
+    store.createNote("hello", { tags: ["a"] });
+    const stats = store.getVaultStats();
+    expect(stats).toHaveProperty("total_notes");
+    expect(stats).toHaveProperty("earliest_note");
+    expect(stats).toHaveProperty("latest_note");
+    expect(stats).toHaveProperty("notes_by_month");
+    expect(stats).toHaveProperty("top_tags");
+    expect(stats).toHaveProperty("tag_count");
+  });
+
+  it("get-vault-stats MCP tool works", () => {
+    store.createNote("one", { tags: ["x"], created_at: "2025-05-01T00:00:00.000Z" });
+    store.createNote("two", { tags: ["x", "y"], created_at: "2025-06-01T00:00:00.000Z" });
+
+    const tools = generateMcpTools(db);
+    const tool = tools.find((t) => t.name === "get-vault-stats")!;
+    expect(tool).toBeTruthy();
+
+    const result = tool.execute({}) as any;
+    expect(result.total_notes).toBe(2);
+    expect(result.tag_count).toBe(2);
+    expect(result.top_tags[0].tag).toBe("x");
+    expect(result.top_tags[0].count).toBe(2);
+    expect(result.notes_by_month).toHaveLength(2);
+    expect(result.earliest_note.created_at).toBe("2025-05-01T00:00:00.000Z");
+    expect(result.latest_note.created_at).toBe("2025-06-01T00:00:00.000Z");
+  });
+});
+
 // ---- Query ----
 
 describe("queryNotes", () => {
@@ -338,7 +438,8 @@ describe("MCP tools", () => {
     expect(names).toContain("traverse-links");
     expect(names).toContain("find-path");
     expect(names).toContain("get-note");
-    expect(tools).toHaveLength(17);
+    expect(names).toContain("get-vault-stats");
+    expect(tools).toHaveLength(18);
   });
 
   it("create-note tool works", () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -280,6 +280,12 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
       inputSchema: { type: "object", properties: {} },
       execute: () => notes.listTags(db),
     },
+    {
+      name: "get-vault-stats",
+      description: "Get a birds-eye view of the vault: total note count, earliest/latest note, note distribution by month, top tags, and tag count. Read-only, cheap aggregation. Call once at the start of a session to orient before doing vault-wide work (monthly summaries, reviews, trend tracking). For filtered queries use read-notes; for a full tag list use list-tags.",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => notes.getVaultStats(db),
+    },
 
     // ---- Bulk Operations ----
 

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -304,7 +304,7 @@ export function getVaultStats(
     LIMIT ?
   `).all(topTagsLimit) as { tag: string; count: number }[];
 
-  const tagCountRow = db.prepare("SELECT COUNT(*) as c FROM tags").get() as { c: number };
+  const tagCountRow = db.prepare("SELECT COUNT(DISTINCT tag_name) as c FROM note_tags").get() as { c: number };
   const tag_count = tagCountRow.c;
 
   return {

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import type { Note, QueryOpts } from "./types.js";
+import type { Note, QueryOpts, VaultStats } from "./types.js";
 import { normalizePath } from "./paths.js";
 
 let idCounter = 0;
@@ -261,6 +261,64 @@ export function listTags(db: Database): { name: string; count: number }[] {
     ORDER BY t.name
   `).all() as { name: string; count: number }[];
   return rows;
+}
+
+// ---- Vault stats (aggregate situational awareness) ----
+
+/**
+ * Compute aggregate vault statistics for session-start situational awareness.
+ *
+ * All computation is done via SQL aggregation — no full-table scans into memory.
+ * Safe to call on large vaults. Read-only.
+ */
+export function getVaultStats(
+  db: Database,
+  opts?: { topTagsLimit?: number },
+): VaultStats {
+  const topTagsLimit = opts?.topTagsLimit ?? 20;
+
+  const totalRow = db.prepare("SELECT COUNT(*) as c FROM notes").get() as { c: number };
+  const total_notes = totalRow.c;
+
+  const earliestRow = db.prepare(
+    "SELECT id, created_at FROM notes ORDER BY created_at ASC, id ASC LIMIT 1",
+  ).get() as { id: string; created_at: string } | undefined;
+
+  const latestRow = db.prepare(
+    "SELECT id, created_at FROM notes ORDER BY created_at DESC, id DESC LIMIT 1",
+  ).get() as { id: string; created_at: string } | undefined;
+
+  const monthRows = db.prepare(`
+    SELECT strftime('%Y-%m', created_at) AS month, COUNT(*) AS count
+    FROM notes
+    WHERE created_at IS NOT NULL
+    GROUP BY month
+    ORDER BY month ASC
+  `).all() as { month: string; count: number }[];
+
+  const topTagRows = db.prepare(`
+    SELECT tag_name AS tag, COUNT(*) AS count
+    FROM note_tags
+    GROUP BY tag_name
+    ORDER BY count DESC, tag_name ASC
+    LIMIT ?
+  `).all(topTagsLimit) as { tag: string; count: number }[];
+
+  const tagCountRow = db.prepare("SELECT COUNT(*) as c FROM tags").get() as { c: number };
+  const tag_count = tagCountRow.c;
+
+  return {
+    total_notes,
+    earliest_note: earliestRow
+      ? { id: earliestRow.id, created_at: earliestRow.created_at }
+      : null,
+    latest_note: latestRow
+      ? { id: latestRow.id, created_at: latestRow.created_at }
+      : null,
+    notes_by_month: monthRows,
+    top_tags: topTagRows,
+    tag_count,
+  };
 }
 
 // ---- Bulk Operations ----

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -138,6 +138,12 @@ export class SqliteStore implements Store {
     return noteOps.listTags(this.db);
   }
 
+  // ---- Vault Stats ----
+
+  getVaultStats(opts?: { topTagsLimit?: number }) {
+    return noteOps.getVaultStats(this.db, opts);
+  }
+
   // ---- Links ----
 
   createLink(sourceId: string, targetId: string, relationship: string, metadata?: Record<string, unknown>): Link {

--- a/core/src/test-preload.ts
+++ b/core/src/test-preload.ts
@@ -1,3 +1,12 @@
 // Preload for tests: enable sqlite-vec on macOS before any Database opens
 import { useHomebrewSQLiteIfNeeded } from "./embeddings.js";
 useHomebrewSQLiteIfNeeded();
+
+// Isolate PARACHUTE_HOME so tests never touch the real ~/.parachute directory.
+// This must run before any `./config.ts` import resolves CONFIG_DIR.
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+if (!process.env.PARACHUTE_HOME) {
+  process.env.PARACHUTE_HOME = mkdtempSync(join(tmpdir(), "parachute-test-home-"));
+}

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -32,6 +32,17 @@ export interface Attachment {
   createdAt: string;
 }
 
+// ---- Vault Stats ----
+
+export interface VaultStats {
+  total_notes: number;
+  earliest_note: { id: string; created_at: string } | null;
+  latest_note: { id: string; created_at: string } | null;
+  notes_by_month: { month: string; count: number }[];
+  top_tags: { tag: string; count: number }[];
+  tag_count: number;
+}
+
 // ---- Query Options ----
 
 export interface QueryOpts {
@@ -80,6 +91,9 @@ export interface Store {
   tagNote(noteId: string, tags: string[]): void;
   untagNote(noteId: string, tags: string[]): void;
   listTags(): { name: string; count: number }[];
+
+  // Vault stats (aggregate, read-only)
+  getVaultStats(opts?: { topTagsLimit?: number }): VaultStats;
 
   // Links
   createLink(sourceId: string, targetId: string, relationship: string, metadata?: Record<string, unknown>): Link;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -32,6 +32,7 @@ const READ_TOOLS = new Set([
   "list-tags",
   "list-vaults",
   "get-vault-description",
+  "get-vault-stats",
 ]);
 
 /** Check if a tool call is allowed for a given scope. */

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -352,9 +352,9 @@ describe("deeper link queries", () => {
 });
 
 describe("MCP tools", () => {
-  test("generates all 17 core tools", () => {
+  test("generates all 18 core tools", () => {
     const tools = generateMcpTools(db);
-    expect(tools.length).toBe(17);
+    expect(tools.length).toBe(18);
 
     const names = tools.map((t) => t.name);
     expect(names).toContain("get-note");
@@ -365,6 +365,7 @@ describe("MCP tools", () => {
     expect(names).toContain("traverse-links");
     expect(names).toContain("find-path");
     expect(names).toContain("list-tags");
+    expect(names).toContain("get-vault-stats");
   });
 
   test("get-note tool works by id", () => {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -414,6 +414,41 @@ describe("MCP tools", () => {
   });
 });
 
+describe("unified MCP wrapper", () => {
+  test("routes get-vault-stats through vault param", async () => {
+    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    // Seed a unique vault on disk under the preload-provided PARACHUTE_HOME.
+    const vaultName = `unified-stats-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+    writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    // Populate the vault with notes/tags the stats tool should observe.
+    const vaultStore = getVaultStore(vaultName);
+    vaultStore.createNote("alpha", { tags: ["x", "y"] });
+    vaultStore.createNote("beta", { tags: ["x"] });
+
+    const tools = generateUnifiedMcpTools();
+    const statsTool = tools.find((t) => t.name === "get-vault-stats");
+    expect(statsTool).toBeTruthy();
+    // Routed explicitly via the vault param, mirroring how a multi-vault
+    // client targets a specific vault.
+    const result = statsTool!.execute({ vault: vaultName }) as any;
+    expect(result.total_notes).toBe(2);
+    expect(result.tag_count).toBe(2);
+    expect(result.top_tags[0].tag).toBe("x");
+    expect(result.top_tags[0].count).toBe(2);
+
+    closeAllStores();
+  });
+});
+
 describe("auth scopes", () => {
   test("read scope allows read tools", () => {
     const { isToolAllowed } = require("./auth.ts");
@@ -424,6 +459,7 @@ describe("auth scopes", () => {
     expect(isToolAllowed("traverse-links", "read")).toBe(true);
     expect(isToolAllowed("find-path", "read")).toBe(true);
     expect(isToolAllowed("list-tags", "read")).toBe(true);
+    expect(isToolAllowed("get-vault-stats", "read")).toBe(true);
     expect(isToolAllowed("list-vaults", "read")).toBe(true);
   });
 


### PR DESCRIPTION
Closes #31.

## Summary
- Adds a new read-only MCP tool `get-vault-stats` that returns a birds-eye view of a vault so an agent can orient at session start without stitching together multiple queries.
- All stats are computed via SQL aggregation (no full-table scans), so it stays cheap even on large vaults.
- Exposed on both `generateMcpTools` (per-vault) and the unified multi-vault tool surface (inherits the standard `vault` param wrapper).

## Response shape
```json
{
  "total_notes": 617,
  "earliest_note": { "id": "...", "created_at": "2025-02-28T..." },
  "latest_note":   { "id": "...", "created_at": "2026-04-07T..." },
  "notes_by_month": [{ "month": "2025-02", "count": 1 }, ...],
  "top_tags":       [{ "tag": "captured", "count": 597 }, ...],
  "tag_count": 42
}
```

`top_tags` is capped at 20 (parameter-free from the MCP surface; configurable at the store-layer API via `topTagsLimit`). No date filters or other params — that is what `read-notes` is for.

## Naming
Chose `get-vault-stats` over `vault-info` to match the existing `get-*` convention (`get-note`, `get-links`, `get-vault-description`).

## Changes
- `core/src/notes.ts` — new `getVaultStats(db, opts)` using SQL aggregation (`COUNT`, `ORDER BY ASC/DESC LIMIT 1`, `strftime('%Y-%m', ...)`, `GROUP BY tag_name ORDER BY count DESC LIMIT`).
- `core/src/types.ts` — new `VaultStats` interface; `Store` gains `getVaultStats`.
- `core/src/store.ts` — `SqliteStore.getVaultStats` delegates to `notes.getVaultStats`.
- `core/src/mcp.ts` — registers the `get-vault-stats` MCP tool next to `list-tags`.
- `core/src/core.test.ts` — new `describe("vault stats", ...)` block covering empty vault, totals, earliest/latest, month grouping, top-tag ordering, cap, response shape, and the MCP tool end-to-end. Tool count assertion bumped from 17 -> 18.
- `src/vault.test.ts` — tool count assertion bumped and `get-vault-stats` added to the name check.

## Test plan
- [x] `bun test core/src/ src/` — 179 pass, 0 fail
- [x] Empty vault returns zeros and nulls without errors
- [x] `notes_by_month` uses all present months in ascending order
- [x] `top_tags` ordered by count desc; cap honored
- [x] `earliest_note` / `latest_note` correctly reflect `created_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)