### PR TITLE
refactor: use narrate's typed error classes in handleTtsSpeech

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -590,14 +590,23 @@ export async function handleTtsSpeech(req: Request, deps: TtsSpeechDeps = {}): P
   } catch (err) {
     // Narrate exposes typed error classes on the module surface; we
     // `instanceof`-check against the resolved module to map them to HTTP
-    // statuses without substring-matching error messages.
-    if (err instanceof narrate.NarrateEmptyInputError) {
+    // statuses without substring-matching error messages. The fields are
+    // optional on `NarrateModule` so an older narrate without them doesn't
+    // crash the catch block with `instanceof undefined` — we null-check
+    // before each check.
+    if (
+      narrate.NarrateEmptyInputError &&
+      err instanceof narrate.NarrateEmptyInputError
+    ) {
       return json(
         { error: "input has no speakable content after markdown preprocessing" },
         400,
       );
     }
-    if (err instanceof narrate.NarrateNoProviderError) {
+    if (
+      narrate.NarrateNoProviderError &&
+      err instanceof narrate.NarrateNoProviderError
+    ) {
       return json({ error: "TTS provider not configured" }, 503);
     }
     const message = err instanceof Error ? err.message : "TTS synthesis failed";

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -529,8 +529,6 @@ export interface TtsSpeechDeps {
   getNarrate?: () => Promise<NarrateModule | null>;
 }
 
-const EMPTY_INPUT_MARKER = "empty after markdown preprocessing";
-const NO_PROVIDER_MARKER = "no TTS provider configured";
 
 /**
  * POST /v1/audio/speech — OpenAI-compatible text-to-speech.
@@ -590,19 +588,19 @@ export async function handleTtsSpeech(req: Request, deps: TtsSpeechDeps = {}): P
       },
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "TTS synthesis failed";
-    // Narrate throws plain `Error`s with prefixed messages; we match on
-    // substring to map them to the right HTTP status. See
-    // parachute-narrate/src/synthesize.ts for the canonical messages.
-    if (message.includes(EMPTY_INPUT_MARKER)) {
+    // Narrate exposes typed error classes on the module surface; we
+    // `instanceof`-check against the resolved module to map them to HTTP
+    // statuses without substring-matching error messages.
+    if (err instanceof narrate.NarrateEmptyInputError) {
       return json(
         { error: "input has no speakable content after markdown preprocessing" },
         400,
       );
     }
-    if (message.includes(NO_PROVIDER_MARKER)) {
+    if (err instanceof narrate.NarrateNoProviderError) {
       return json({ error: "TTS provider not configured" }, 503);
     }
+    const message = err instanceof Error ? err.message : "TTS synthesis failed";
     console.error("TTS synthesis error:", message);
     return json({ error: message }, 500);
   }

--- a/src/speech-route.test.ts
+++ b/src/speech-route.test.ts
@@ -10,6 +10,22 @@ import { describe, test, expect } from "bun:test";
 import { handleTtsSpeech } from "./routes.ts";
 import type { NarrateModule } from "./tts-hook.ts";
 
+// Local stand-ins for narrate's typed error classes. Tests don't import
+// from parachute-narrate directly — they stub the whole module — so we
+// mint local subclasses that `instanceof` correctly against themselves.
+class StubNarrateEmptyInputError extends Error {
+  constructor(message = "narrate.synthesize: text is empty after markdown preprocessing") {
+    super(message);
+  }
+}
+class StubNarrateNoProviderError extends Error {
+  constructor(
+    message = "narrate.synthesize: no TTS provider configured (set TTS_PROVIDER=kokoro|elevenlabs)",
+  ) {
+    super(message);
+  }
+}
+
 function stubNarrate(
   calls: Array<{ text: string; voice?: string }>,
 ): NarrateModule {
@@ -24,15 +40,19 @@ function stubNarrate(
       };
     },
     markdownToSpeech: (t) => t,
+    NarrateEmptyInputError: StubNarrateEmptyInputError,
+    NarrateNoProviderError: StubNarrateNoProviderError,
   };
 }
 
-function throwingNarrate(message: string): NarrateModule {
+function throwingNarrate(err: Error): NarrateModule {
   return {
     async synthesize() {
-      throw new Error(message);
+      throw err;
     },
     markdownToSpeech: (t) => t,
+    NarrateEmptyInputError: StubNarrateEmptyInputError,
+    NarrateNoProviderError: StubNarrateNoProviderError,
   };
 }
 
@@ -133,16 +153,11 @@ describe("handleTtsSpeech", () => {
     expect(res.status).toBe(400);
   });
 
-  test("narrate reporting empty-after-preprocess returns 400 with the specific error", async () => {
-    // Mirrors the message narrate actually throws from synthesize.ts:
-    //   "narrate.synthesize: text is empty after markdown preprocessing"
+  test("NarrateEmptyInputError returns 400 with the specific error", async () => {
     const res = await handleTtsSpeech(
       makeRequest({ input: "```\ncode\n```" }),
       {
-        getNarrate: async () =>
-          throwingNarrate(
-            "narrate.synthesize: text is empty after markdown preprocessing",
-          ),
+        getNarrate: async () => throwingNarrate(new StubNarrateEmptyInputError()),
       },
     );
     expect(res.status).toBe(400);
@@ -152,14 +167,11 @@ describe("handleTtsSpeech", () => {
     );
   });
 
-  test("narrate reporting no-provider returns 503 with the specific error", async () => {
+  test("NarrateNoProviderError returns 503 with the specific error", async () => {
     const res = await handleTtsSpeech(
       makeRequest({ input: "hi" }),
       {
-        getNarrate: async () =>
-          throwingNarrate(
-            "narrate.synthesize: no TTS provider configured (set TTS_PROVIDER=kokoro|elevenlabs)",
-          ),
+        getNarrate: async () => throwingNarrate(new StubNarrateNoProviderError()),
       },
     );
     expect(res.status).toBe(503);
@@ -204,7 +216,7 @@ describe("handleTtsSpeech", () => {
   test("narrate throwing a generic error returns 500 with the error message", async () => {
     const res = await handleTtsSpeech(
       makeRequest({ input: "hi" }),
-      { getNarrate: async () => throwingNarrate("provider exploded") },
+      { getNarrate: async () => throwingNarrate(new Error("provider exploded")) },
     );
     expect(res.status).toBe(500);
     const body = (await res.json()) as { error: string };

--- a/src/speech-route.test.ts
+++ b/src/speech-route.test.ts
@@ -14,15 +14,13 @@ import type { NarrateModule } from "./tts-hook.ts";
 // from parachute-narrate directly — they stub the whole module — so we
 // mint local subclasses that `instanceof` correctly against themselves.
 class StubNarrateEmptyInputError extends Error {
-  constructor(message = "narrate.synthesize: text is empty after markdown preprocessing") {
-    super(message);
+  constructor(...args: unknown[]) {
+    super((args[0] as string | undefined) ?? "empty after markdown preprocessing");
   }
 }
 class StubNarrateNoProviderError extends Error {
-  constructor(
-    message = "narrate.synthesize: no TTS provider configured (set TTS_PROVIDER=kokoro|elevenlabs)",
-  ) {
-    super(message);
+  constructor(...args: unknown[]) {
+    super((args[0] as string | undefined) ?? "no TTS provider configured");
   }
 }
 

--- a/src/tts-hook.ts
+++ b/src/tts-hook.ts
@@ -55,11 +55,14 @@ export interface NarrateModule {
     provider: string;
   }>;
   markdownToSpeech(text: string): string;
-  // Error classes — referenced via `instanceof err instanceof narrate.NarrateEmptyInputError`
-  // so we can distinguish "empty input" from "no provider" without substring
-  // matching on error messages.
-  NarrateEmptyInputError: new (...args: never[]) => Error;
-  NarrateNoProviderError: new (...args: never[]) => Error;
+  // Error classes — referenced by consumers via
+  // `err instanceof narrate.NarrateEmptyInputError` so we can distinguish
+  // "empty input" from "no provider" without substring-matching error
+  // messages. Optional so vault still loads against older narrate builds
+  // that predate parachute-narrate#2 — call sites must null-check before
+  // using them.
+  NarrateEmptyInputError?: new (...args: unknown[]) => Error;
+  NarrateNoProviderError?: new (...args: unknown[]) => Error;
 }
 
 export interface RegisterTtsHookOptions {

--- a/src/tts-hook.ts
+++ b/src/tts-hook.ts
@@ -55,6 +55,11 @@ export interface NarrateModule {
     provider: string;
   }>;
   markdownToSpeech(text: string): string;
+  // Error classes — referenced via `instanceof err instanceof narrate.NarrateEmptyInputError`
+  // so we can distinguish "empty input" from "no provider" without substring
+  // matching on error messages.
+  NarrateEmptyInputError: new (...args: never[]) => Error;
+  NarrateNoProviderError: new (...args: never[]) => Error;
 }
 
 export interface RegisterTtsHookOptions {

--- a/src/tts.test.ts
+++ b/src/tts.test.ts
@@ -31,6 +31,21 @@ async function settle(hooks: HookRegistry): Promise<void> {
   await hooks.drain();
 }
 
+// No-op narrate error classes — the hook never catches typed errors from
+// narrate (it only uses markdownToSpeech + synthesize), but the interface
+// now requires these constructors. Define local shims so the TypeScript
+// shape matches without pulling in parachute-narrate directly.
+class StubNarrateEmptyInputError extends Error {
+  constructor(...args: unknown[]) {
+    super((args[0] as string | undefined) ?? "empty");
+  }
+}
+class StubNarrateNoProviderError extends Error {
+  constructor(...args: unknown[]) {
+    super((args[0] as string | undefined) ?? "no provider");
+  }
+}
+
 /**
  * Stub narrate module. `synthesize` returns deterministic OggS-prefixed
  * bytes and captures the call args for assertion. `markdownToSpeech` is a
@@ -62,6 +77,8 @@ function stubNarrate(
         .trim();
       return stripped;
     },
+    NarrateEmptyInputError: StubNarrateEmptyInputError,
+    NarrateNoProviderError: StubNarrateNoProviderError,
     ...overrides,
   };
 }
@@ -277,6 +294,8 @@ describe("registerTtsHook — #reader → audio", () => {
         throw new Error("boom");
       },
       markdownToSpeech: (t) => t,
+      NarrateEmptyInputError: StubNarrateEmptyInputError,
+      NarrateNoProviderError: StubNarrateNoProviderError,
     };
     registerTtsHook(hooks, {
       narrate: failingNarrate,
@@ -356,6 +375,8 @@ describe("registerTtsHook — #reader → audio", () => {
         };
       },
       markdownToSpeech: (t) => t,
+      NarrateEmptyInputError: StubNarrateEmptyInputError,
+      NarrateNoProviderError: StubNarrateNoProviderError,
     };
     registerTtsHook(hooks, {
       narrate: slowNarrate,


### PR DESCRIPTION
## Summary
- Follow-up to parachute-narrate#2 (which added `NarrateEmptyInputError` / `NarrateNoProviderError`).
- `handleTtsSpeech` swaps substring matching on error messages for `instanceof` checks against the resolved narrate module.
- Widens `NarrateModule` interface in `tts-hook.ts` to expose the error classes so tests can stub them with local subclasses.

## Test plan
- [x] `bun test src/speech-route.test.ts` — 13/13 green
- [x] `bun test` full suite — 233/233 green
- [x] Typed errors work via `instanceof` against the module reference
- [x] Generic errors still fall through to 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)