### PR TITLE
feat: allow updating metadata and created_at via update-note

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -62,6 +62,31 @@ describe("notes", () => {
     expect(updated.path).toBe("Notes/Test");
   });
 
+  it("updates created_at", () => {
+    const note = store.createNote("Test");
+    const newDate = "2025-01-15T12:00:00.000Z";
+    const updated = store.updateNote(note.id, { created_at: newDate });
+    expect(updated.createdAt).toBe(newDate);
+    expect(updated.content).toBe("Test"); // content unchanged
+    expect(updated.updatedAt).not.toBe(note.updatedAt); // updated_at bumped
+  });
+
+  it("updates metadata and created_at together", () => {
+    const note = store.createNote("Test");
+    const newDate = "2025-06-30T23:59:59.000Z";
+    const meta = { source: "import", version: 2 };
+    const updated = store.updateNote(note.id, { metadata: meta, created_at: newDate });
+    expect(updated.createdAt).toBe(newDate);
+    expect(updated.metadata).toEqual(meta);
+    expect(updated.content).toBe("Test");
+  });
+
+  it("leaves created_at unchanged when not provided", () => {
+    const note = store.createNote("Test");
+    const updated = store.updateNote(note.id, { content: "Updated" });
+    expect(updated.createdAt).toBe(note.createdAt);
+  });
+
   it("deletes a note", () => {
     const note = store.createNote("Delete me");
     store.deleteNote(note.id);
@@ -448,6 +473,25 @@ describe("MCP tools", () => {
     const result = createNote.execute({ content: "Hello", tags: ["daily"] }) as any;
     expect(result.content).toBe("Hello");
     expect(result.tags).toContain("daily");
+  });
+
+  it("update-note tool updates created_at", () => {
+    const note = store.createNote("Test");
+    const tools = generateMcpTools(db);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const newDate = "2025-03-01T00:00:00.000Z";
+    const result = updateNote.execute({ id: note.id, created_at: newDate }) as any;
+    expect(result.createdAt).toBe(newDate);
+    expect(result.content).toBe("Test");
+  });
+
+  it("update-note tool updates metadata", () => {
+    const note = store.createNote("Test");
+    const tools = generateMcpTools(db);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const meta = { importance: "high" };
+    const result = updateNote.execute({ id: note.id, metadata: meta }) as any;
+    expect(result.metadata).toEqual(meta);
   });
 
   it("read-notes tool works", () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -76,7 +76,7 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
     },
     {
       name: "update-note",
-      description: "Update a note's content, path, or metadata.",
+      description: "Update a note's content, path, metadata, or created_at.",
       inputSchema: {
         type: "object",
         properties: {
@@ -84,6 +84,7 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
           content: { type: "string", description: "New content" },
           path: { type: "string", description: "New path/name" },
           metadata: { type: "object", description: "New metadata (replaces existing)" },
+          created_at: { type: "string", description: "New created_at timestamp (ISO 8601)" },
         },
         required: ["id"],
       },
@@ -93,6 +94,7 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
           content: params.content as string | undefined,
           path: params.path as string | undefined,
           metadata: params.metadata as Record<string, unknown> | undefined,
+          created_at: params.created_at as string | undefined,
         });
       },
     },

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -75,7 +75,7 @@ export function getNotes(db: Database, ids: string[]): Note[] {
 export function updateNote(
   db: Database,
   id: string,
-  updates: { content?: string; path?: string; metadata?: Record<string, unknown>; skipUpdatedAt?: boolean },
+  updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean },
 ): Note {
   const sets: string[] = [];
   const values: unknown[] = [];
@@ -98,6 +98,10 @@ export function updateNote(
   if (updates.metadata !== undefined) {
     sets.push("metadata = ?");
     values.push(JSON.stringify(updates.metadata));
+  }
+  if (updates.created_at !== undefined) {
+    sets.push("created_at = ?");
+    values.push(updates.created_at);
   }
 
   // No-op: skipUpdatedAt with no other fields. Avoid generating invalid SQL.

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -51,7 +51,7 @@ export class SqliteStore implements Store {
     return noteOps.getNotes(this.db, ids);
   }
 
-  updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; skipUpdatedAt?: boolean }): Note {
+  updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean }): Note {
     // Capture old path before update for rename cascading
     let oldPath: string | undefined;
     if (updates.path !== undefined) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -93,8 +93,8 @@ export async function handleNotes(
   if (method === "PATCH" && subpath === "") {
     const existing = store.getNote(noteId);
     if (!existing) return json({ error: "Not found" }, 404);
-    const body = await req.json() as { content?: string; path?: string };
-    const updated = store.updateNote(noteId, { content: body.content, path: body.path });
+    const body = await req.json() as { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string };
+    const updated = store.updateNote(noteId, { content: body.content, path: body.path, metadata: body.metadata, created_at: body.created_at });
     return json(updated);
   }
 


### PR DESCRIPTION
## Summary
- Extends `updateNote` store function to accept `created_at` field
- Adds `created_at` to the MCP `update-note` tool schema
- Adds `metadata` and `created_at` to the REST `PATCH /notes/:id` handler (previously only accepted `content` and `path`)
- Adds 5 new tests covering: created_at update, metadata+created_at together, backwards compat, and MCP tool-level tests

Closes #36

## Test plan
- [x] `bun test` — 238 tests pass, 0 failures
- [x] Store-level: `created_at` only, `metadata` + `created_at` together, omitting `created_at` preserves existing value
- [x] MCP tool-level: `update-note` with `created_at`, `update-note` with `metadata`

🤖 Generated with [Claude Code](https://claude.com/claude-code)