### PR TITLE
feat: add #capture → transcription hook via parachute-scribe

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
 import { handleNotes, handleTags, handleLinks, handleSearch, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech } from "./routes.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTtsHook, type NarrateModule } from "./tts-hook.ts";
+import { registerTranscriptionHook, type ScribeModule } from "./transcription-hook.ts";
 import { getVaultNameForStore } from "./vault-store.ts";
 import { assetsDir } from "./routes.ts";
 import type { SqliteStore } from "../core/src/store.ts";
@@ -76,7 +77,38 @@ async function registerHooks(): Promise<void> {
   });
   console.log(`[hooks] tts-reader hook registered (provider=${probedProvider.name}, via parachute-narrate)`);
 }
+
+async function registerTranscriptionHooks(): Promise<void> {
+  if (process.env.AUTO_TRANSCRIBE === "false") {
+    console.log("[hooks] AUTO_TRANSCRIBE=false; skipping transcribe-capture hook");
+    return;
+  }
+
+  let scribe: ScribeModule | null = null;
+  try {
+    scribe = (await import("parachute-scribe")) as unknown as ScribeModule;
+  } catch {
+    console.log("[hooks] parachute-scribe not installed; skipping transcribe-capture hook");
+    return;
+  }
+
+  registerTranscriptionHook(defaultHookRegistry, {
+    scribe,
+    transcribeProvider: process.env.TRANSCRIBE_PROVIDER,
+    cleanupProvider: process.env.CLEANUP_PROVIDER,
+    resolveAssetsDir: (store) => {
+      const name = getVaultNameForStore(store as SqliteStore);
+      if (!name) {
+        throw new Error("transcription-hook: store is not registered with a vault");
+      }
+      return assetsDir(name);
+    },
+  });
+  console.log("[hooks] transcribe-capture hook registered (via parachute-scribe)");
+}
+
 await registerHooks();
+await registerTranscriptionHooks();
 
 ensureConfigDirSync();
 loadEnvFile();

--- a/src/transcription-hook.ts
+++ b/src/transcription-hook.ts
@@ -1,0 +1,188 @@
+/**
+ * The `#capture` → transcription hook.
+ *
+ * Mirrors the shape of `tts-hook.ts`. When a note tagged `#capture` arrives
+ * with an audio attachment and empty content, we transcribe the audio via
+ * `parachute-scribe` and write the transcript into `note.content`.
+ *
+ * ## Two-phase marker
+ *
+ *   1. On entry: write `metadata.transcript_pending_at = <now>` synchronously.
+ *      The predicate excludes notes with EITHER `transcript_rendered_at` OR
+ *      `transcript_pending_at` set, preventing re-entry.
+ *   2. On success: replace `transcript_pending_at` with `transcript_rendered_at`.
+ *   3. On failure: leave `transcript_pending_at` set. The note is "stuck"
+ *      and will not retry automatically. Clear the field manually to re-run.
+ *
+ * ## Cascade behavior
+ *
+ * Writing `note.content` is a note mutation that re-dispatches hooks. If the
+ * note is also tagged `#reader`, the TTS hook will fire (the note now has
+ * content + reader tag + no `audio_rendered_at`). This is intentional —
+ * voice memo → auto-transcribe → auto-narrate is the dream pipeline.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { Note, Store } from "../core/src/types.ts";
+import type { HookRegistry } from "../core/src/hooks.ts";
+
+/**
+ * The subset of the `parachute-scribe` module surface the hook uses.
+ * Declared here so tests can stub it with a plain object.
+ */
+export interface ScribeModule {
+  transcribe(audio: File, opts?: { provider?: string; cleanup?: string }): Promise<string>;
+}
+
+export interface RegisterTranscriptionHookOptions {
+  /** Injected scribe module (pass the result of `await import("parachute-scribe")`). */
+  scribe: ScribeModule;
+  /**
+   * Resolve the vault assets directory for a given store. Called once per
+   * handler invocation so the hook can work with multiple vaults.
+   */
+  resolveAssetsDir: (store: Store) => string;
+  /** Optional logger override. */
+  logger?: { error: (...args: unknown[]) => void; info?: (...args: unknown[]) => void };
+  /** Transcription provider override (from env TRANSCRIBE_PROVIDER). */
+  transcribeProvider?: string;
+  /** Cleanup provider override (from env CLEANUP_PROVIDER). */
+  cleanupProvider?: string;
+}
+
+/**
+ * Register the `#capture` → transcription hook on a HookRegistry.
+ * Returns the unregister function from `HookRegistry.onNote`.
+ */
+export function registerTranscriptionHook(
+  hooks: HookRegistry,
+  opts: RegisterTranscriptionHookOptions,
+): () => void {
+  const logger = opts.logger ?? console;
+  const scribe = opts.scribe;
+
+  return hooks.onNote({
+    name: "transcribe-capture",
+    event: ["created", "updated"],
+    when: (note: Note) => {
+      if (!note.tags?.includes("capture")) return false;
+      const meta = note.metadata as Record<string, unknown> | undefined;
+      if (meta?.transcript_rendered_at) return false;
+      if (meta?.transcript_pending_at) return false;
+      // Only fire when content is empty/whitespace — the audio IS the content
+      if (note.content && note.content.trim().length > 0) return false;
+      return true;
+    },
+    handler: async (note: Note, store: Store) => {
+      const existingMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
+
+      // Handler-side re-check (same race-window protection as tts-hook).
+      if (existingMeta.transcript_pending_at || existingMeta.transcript_rendered_at) {
+        return;
+      }
+
+      // Check for audio attachments
+      const attachments = store.getAttachments(note.id);
+      const audioAttachment = attachments.find((a) => a.mimeType.startsWith("audio/"));
+      if (!audioAttachment) {
+        return;
+      }
+
+      const pendingAt = new Date().toISOString();
+
+      // Phase 1: claim the note
+      try {
+        store.updateNote(note.id, {
+          metadata: { ...existingMeta, transcript_pending_at: pendingAt },
+          skipUpdatedAt: true,
+        });
+      } catch (err) {
+        logger.error(
+          `[transcription-hook] failed to claim note ${note.id} (could not write transcript_pending_at):`,
+          err,
+        );
+        throw err;
+      }
+
+      // Read the audio file from the assets directory
+      let audioBuffer: Buffer;
+      try {
+        const assetsPath = opts.resolveAssetsDir(store);
+        const filePath = join(assetsPath, audioAttachment.path);
+        audioBuffer = readFileSync(filePath) as Buffer;
+      } catch (err) {
+        logger.error(
+          `[transcription-hook] failed to read audio file for note ${note.id}; note left in transcript_pending_at state:`,
+          err,
+        );
+        throw err;
+      }
+
+      // Construct a File object (scribe's transcribe expects File)
+      const audioFile = new File([audioBuffer], audioAttachment.path.split("/").pop() ?? "recording.ogg", {
+        type: audioAttachment.mimeType,
+      });
+
+      // Transcribe
+      let transcript: string;
+      try {
+        transcript = await scribe.transcribe(audioFile, {
+          provider: opts.transcribeProvider,
+          cleanup: opts.cleanupProvider,
+        });
+      } catch (err) {
+        logger.error(
+          `[transcription-hook] scribe.transcribe failed for note ${note.id}; note left in transcript_pending_at state (manual recovery required):`,
+          err,
+        );
+        throw err;
+      }
+
+      // Handle empty transcription
+      if (!transcript || !transcript.trim()) {
+        try {
+          const freshSkip = store.getNote(note.id);
+          const freshSkipMeta = (freshSkip?.metadata as Record<string, unknown> | undefined) ?? existingMeta;
+          const { transcript_pending_at: _dropSkip, ...restSkipMeta } = freshSkipMeta;
+          store.updateNote(note.id, {
+            metadata: {
+              ...restSkipMeta,
+              transcript_rendered_at: new Date().toISOString(),
+              transcript_skipped_reason: "empty transcription result",
+            },
+            skipUpdatedAt: true,
+          });
+        } catch (err) {
+          logger.error(
+            `[transcription-hook] failed to mark note ${note.id} as transcript-skipped:`,
+            err,
+          );
+        }
+        return;
+      }
+
+      // Phase 2: write transcript to content and update markers
+      try {
+        const fresh = store.getNote(note.id);
+        const freshMeta = (fresh?.metadata as Record<string, unknown> | undefined) ?? existingMeta;
+        const { transcript_pending_at: _drop, ...restMeta } = freshMeta;
+        store.updateNote(note.id, {
+          content: transcript,
+          metadata: {
+            ...restMeta,
+            transcript_rendered_at: new Date().toISOString(),
+            transcript_provider: opts.transcribeProvider,
+          },
+          skipUpdatedAt: true,
+        });
+      } catch (err) {
+        logger.error(
+          `[transcription-hook] failed to write transcript for note ${note.id}:`,
+          err,
+        );
+        throw err;
+      }
+    },
+  });
+}

--- a/src/transcription.test.ts
+++ b/src/transcription.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for the `#capture` → transcription hook (vault-side integration).
+ *
+ * The transcription pipeline itself lives in `parachute-scribe`. These tests
+ * stub the scribe module so they cover only what vault owns: the tag
+ * predicate, two-phase marker discipline, content writeback, skip-on-empty
+ * behavior, and the failure path that leaves notes in `transcript_pending_at`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { SqliteStore } from "../core/src/store.ts";
+import { HookRegistry } from "../core/src/hooks.ts";
+import { registerTranscriptionHook, type ScribeModule } from "./transcription-hook.ts";
+
+const silentLogger = { error: () => {}, info: () => {} };
+
+/** Wait for queued dispatches + in-flight handlers to settle. */
+async function settle(hooks: HookRegistry): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await hooks.drain();
+  await Promise.resolve();
+  await Promise.resolve();
+  await hooks.drain();
+}
+
+/**
+ * Stub scribe module. `transcribe` returns deterministic text and captures
+ * the call args for assertion.
+ */
+function stubScribe(
+  calls: Array<{ fileName: string; provider?: string; cleanup?: string }>,
+  overrides: { transcript?: string; fail?: boolean } = {},
+): ScribeModule {
+  return {
+    async transcribe(audio, opts) {
+      calls.push({
+        fileName: audio.name,
+        provider: opts?.provider,
+        cleanup: opts?.cleanup,
+      });
+      if (overrides.fail) {
+        throw new Error("transcription failed");
+      }
+      return overrides.transcript ?? "This is the transcribed text.";
+    },
+  };
+}
+
+/** Write a fake audio file into the assets dir and add an attachment for it. */
+function addAudioAttachment(
+  store: SqliteStore,
+  noteId: string,
+  assetsBase: string,
+  filename = "recording.ogg",
+  mimeType = "audio/ogg",
+): void {
+  const dir = join(assetsBase, "audio");
+  mkdirSync(dir, { recursive: true });
+  const relativePath = `audio/${filename}`;
+  writeFileSync(join(assetsBase, relativePath), Buffer.from("OggS-fake-audio-data"));
+  store.addAttachment(noteId, relativePath, mimeType);
+}
+
+let db: Database;
+let hooks: HookRegistry;
+let store: SqliteStore;
+let tmpDir: string;
+let assetsBase: string;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `transcription-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tmpDir, { recursive: true });
+  assetsBase = join(tmpDir, "assets");
+  mkdirSync(assetsBase, { recursive: true });
+
+  db = new Database(join(tmpDir, "test.db"));
+  hooks = new HookRegistry({ concurrency: 4, logger: silentLogger });
+  store = new SqliteStore(db, { hooks });
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("registerTranscriptionHook — #capture → transcription", () => {
+  test("fires for a #capture note with audio attachment and empty content", async () => {
+    const calls: Array<{ fileName: string; provider?: string; cleanup?: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+      transcribeProvider: "groq",
+      cleanupProvider: "claude",
+    });
+
+    const note = store.createNote("", { tags: ["capture"] });
+    addAudioAttachment(store, note.id, assetsBase);
+
+    // Trigger an update so the hook sees the attachment
+    store.updateNote(note.id, { content: "" });
+    await settle(hooks);
+
+    expect(calls.length).toBe(1);
+    expect(calls[0].provider).toBe("groq");
+    expect(calls[0].cleanup).toBe("claude");
+
+    const fresh = store.getNote(note.id);
+    expect(fresh).not.toBeNull();
+    expect(fresh!.content).toBe("This is the transcribed text.");
+    const meta = fresh!.metadata as Record<string, unknown>;
+    expect(meta.transcript_rendered_at).toBeTruthy();
+    expect(meta.transcript_provider).toBe("groq");
+    expect(meta.transcript_pending_at).toBeUndefined();
+  });
+
+  test("hook writes do not bump updatedAt (issue #44)", async () => {
+    const calls: Array<{ fileName: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("", { tags: ["capture"] });
+    addAudioAttachment(store, note.id, assetsBase);
+    store.updateNote(note.id, { content: "", skipUpdatedAt: true });
+    await settle(hooks);
+
+    const fresh = store.getNote(note.id);
+    expect(fresh!.updatedAt).toBeUndefined();
+    const meta = fresh!.metadata as Record<string, unknown>;
+    expect(meta.transcript_rendered_at).toBeTruthy();
+  });
+
+  test("does not fire for notes without the #capture tag", async () => {
+    const calls: Array<{ fileName: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("", { tags: ["other"] });
+    addAudioAttachment(store, note.id, assetsBase);
+    store.updateNote(note.id, { content: "" });
+    await settle(hooks);
+
+    expect(calls.length).toBe(0);
+  });
+
+  test("does not fire when note has non-empty content", async () => {
+    const calls: Array<{ fileName: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("Already has content", { tags: ["capture"] });
+    addAudioAttachment(store, note.id, assetsBase);
+    store.updateNote(note.id, { content: "Already has content" });
+    await settle(hooks);
+
+    expect(calls.length).toBe(0);
+  });
+
+  test("does not fire when note has no audio attachment", async () => {
+    const calls: Array<{ fileName: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("", { tags: ["capture"] });
+    // No audio attachment added
+    store.updateNote(note.id, { content: "" });
+    await settle(hooks);
+
+    expect(calls.length).toBe(0);
+  });
+
+  test("does not re-fire when transcript_rendered_at is already set", async () => {
+    const calls: Array<{ fileName: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("", {
+      tags: ["capture"],
+      metadata: { transcript_rendered_at: "2025-01-01T00:00:00Z" },
+    });
+    addAudioAttachment(store, note.id, assetsBase);
+    store.updateNote(note.id, { content: "" });
+    await settle(hooks);
+
+    expect(calls.length).toBe(0);
+  });
+
+  test("scribe failure leaves note stuck in transcript_pending_at (no retry loop)", async () => {
+    let callCount = 0;
+    const failingScribe: ScribeModule = {
+      async transcribe() {
+        callCount++;
+        throw new Error("provider exploded");
+      },
+    };
+    registerTranscriptionHook(hooks, {
+      scribe: failingScribe,
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("", { tags: ["capture"] });
+    addAudioAttachment(store, note.id, assetsBase);
+    store.updateNote(note.id, { content: "" });
+    await settle(hooks);
+
+    expect(callCount).toBe(1);
+
+    const fresh = store.getNote(note.id)!;
+    const meta = fresh.metadata as Record<string, unknown>;
+    expect(meta.transcript_rendered_at).toBeUndefined();
+    expect(meta.transcript_pending_at).toBeTruthy();
+
+    // A subsequent mutation should NOT re-fire (pending still set).
+    store.updateNote(note.id, { content: "", skipUpdatedAt: true });
+    await settle(hooks);
+    expect(callCount).toBe(1);
+  });
+
+  test("empty transcription result marks note as skipped, not stuck", async () => {
+    const calls: Array<{ fileName: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls, { transcript: "" }),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("", { tags: ["capture"] });
+    addAudioAttachment(store, note.id, assetsBase);
+    store.updateNote(note.id, { content: "" });
+    await settle(hooks);
+
+    expect(calls.length).toBe(1);
+
+    const fresh = store.getNote(note.id)!;
+    const meta = fresh.metadata as Record<string, unknown>;
+    expect(meta.transcript_pending_at).toBeUndefined();
+    expect(meta.transcript_rendered_at).toBeTruthy();
+    expect(meta.transcript_skipped_reason).toBe("empty transcription result");
+    expect(fresh.content).toBe("");
+  });
+
+  test("clearing transcript_rendered_at re-runs transcription on next update", async () => {
+    const calls: Array<{ fileName: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("", { tags: ["capture"] });
+    addAudioAttachment(store, note.id, assetsBase);
+    store.updateNote(note.id, { content: "" });
+    await settle(hooks);
+    expect(calls.length).toBe(1);
+
+    // Clear markers and content to re-trigger
+    const meta = store.getNote(note.id)!.metadata as Record<string, unknown>;
+    const { transcript_rendered_at: _r, transcript_provider: _p, ...rest } = meta;
+    store.updateNote(note.id, { metadata: rest, content: "" });
+    await settle(hooks);
+
+    expect(calls.length).toBe(2);
+    const freshMeta = store.getNote(note.id)!.metadata as Record<string, unknown>;
+    expect(freshMeta.transcript_rendered_at).toBeTruthy();
+    expect(freshMeta.transcript_pending_at).toBeUndefined();
+  });
+
+  test("two synchronous mutations in the same tick do not double-transcribe", async () => {
+    const calls: Array<{ fileName: string }> = [];
+    registerTranscriptionHook(hooks, {
+      scribe: stubScribe(calls),
+      resolveAssetsDir: () => assetsBase,
+      logger: silentLogger,
+    });
+
+    const note = store.createNote("", { tags: ["capture"] });
+    addAudioAttachment(store, note.id, assetsBase);
+    // Two mutations, same tick
+    store.updateNote(note.id, { content: "" });
+    store.updateNote(note.id, { content: "  " }); // whitespace-only still counts as empty
+    await settle(hooks);
+
+    expect(calls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/transcription-hook.ts`: when a note tagged `#capture` has an audio attachment and empty content, auto-transcribes via `parachute-scribe` and writes the result to `note.content`
- Two-phase marker discipline (`transcript_pending_at` / `transcript_rendered_at`) prevents re-entry, same pattern as the TTS hook
- Empty transcription results are marked as skipped (not stuck)
- Cascades into TTS hook when note also has `#reader` tag — enabling voice memo → transcript → narration pipeline
- Registered in `server.ts` with `AUTO_TRANSCRIBE` env var gate (default true when scribe is installed)
- 10 new tests covering: happy path, updatedAt preservation, tag predicate, content predicate, attachment predicate, re-entry prevention, failure stuck state, empty result handling, re-run after marker clear, double-mutation dedup

Closes #39

## Test plan
- [x] `bun test` — 248 tests pass, 0 failures
- [x] Hook fires only for `#capture` + audio attachment + empty content
- [x] Two-phase markers prevent re-entry and infinite loops
- [x] `skipUpdatedAt: true` on all hook writes (issue #44)
- [x] Empty transcription → skipped, not stuck
- [x] Scribe failure → stuck in `transcript_pending_at`, no retry loop
- [x] Clearing `transcript_rendered_at` + emptying content re-triggers transcription
- [x] Self-review via nested reviewer — fixed metadata merge bug in skip path

🤖 Generated with [Claude Code](https://claude.com/claude-code)