### PR TITLE
feat: tag-as-type system with schemas in vault.yaml

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -58,4 +58,81 @@ describe("config", () => {
 
     rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  test("round-trips tag_schemas in vault config", () => {
+    const config: VaultConfig = {
+      name: "testvault",
+      api_keys: [
+        {
+          id: "k_abc123",
+          label: "default",
+          scope: "write",
+          key_hash: "sha256:fakehash",
+          created_at: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      created_at: "2026-01-01T00:00:00.000Z",
+      tag_schemas: {
+        person: {
+          description: "A person in Aaron's life",
+          fields: {
+            first_appeared: {
+              type: "string",
+              description: "When this person first appeared",
+            },
+            relationship: {
+              type: "string",
+              description: "How they relate to Aaron",
+            },
+          },
+        },
+        project: {
+          description: "A project",
+          fields: {
+            status: {
+              type: "string",
+              enum: ["active", "completed", "abandoned"],
+              description: "Current project status",
+            },
+          },
+        },
+        "summary/monthly": {
+          description: "Monthly summary note",
+        },
+      },
+    };
+
+    writeVaultConfig(config);
+
+    const loaded = readVaultConfig("testvault");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.tag_schemas).toBeDefined();
+
+    const person = loaded!.tag_schemas!.person;
+    expect(person.description).toBe("A person in Aaron's life");
+    expect(person.fields!.first_appeared.type).toBe("string");
+    expect(person.fields!.first_appeared.description).toBe("When this person first appeared");
+    expect(person.fields!.relationship.type).toBe("string");
+
+    const project = loaded!.tag_schemas!.project;
+    expect(project.fields!.status.enum).toEqual(["active", "completed", "abandoned"]);
+
+    const monthly = loaded!.tag_schemas!["summary/monthly"];
+    expect(monthly.description).toBe("Monthly summary note");
+    expect(monthly.fields).toBeUndefined();
+  });
+
+  test("vault config without tag_schemas loads cleanly", () => {
+    const config: VaultConfig = {
+      name: "testvault",
+      api_keys: [],
+      created_at: "2026-01-01T00:00:00.000Z",
+    };
+
+    writeVaultConfig(config);
+
+    const loaded = readVaultConfig("testvault");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.tag_schemas).toBeUndefined();
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,11 +57,23 @@ export interface StoredKey {
   last_used_at?: string;
 }
 
+export interface TagFieldSchema {
+  type: string;
+  description?: string;
+  enum?: string[];
+}
+
+export interface TagSchema {
+  description?: string;
+  fields?: Record<string, TagFieldSchema>;
+}
+
 export interface VaultConfig {
   name: string;
   description?: string;
   api_keys: StoredKey[];
   created_at: string;
+  tag_schemas?: Record<string, TagSchema>;
 }
 
 export interface GlobalConfig {
@@ -94,6 +106,29 @@ function serializeVaultConfig(config: VaultConfig): string {
     lines.push(`    created_at: "${key.created_at}"`);
     if (key.last_used_at) {
       lines.push(`    last_used_at: "${key.last_used_at}"`);
+    }
+  }
+
+  if (config.tag_schemas && Object.keys(config.tag_schemas).length > 0) {
+    lines.push("tag_schemas:");
+    for (const [tag, schema] of Object.entries(config.tag_schemas)) {
+      lines.push(`  ${tag}:`);
+      if (schema.description) {
+        lines.push(`    description: "${schema.description}"`);
+      }
+      if (schema.fields && Object.keys(schema.fields).length > 0) {
+        lines.push("    fields:");
+        for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+          lines.push(`      ${field}:`);
+          lines.push(`        type: ${fieldSchema.type}`);
+          if (fieldSchema.description) {
+            lines.push(`        description: "${fieldSchema.description}"`);
+          }
+          if (fieldSchema.enum) {
+            lines.push(`        enum: [${fieldSchema.enum.join(", ")}]`);
+          }
+        }
+      }
     }
   }
 
@@ -148,7 +183,81 @@ function parseVaultConfig(yaml: string, name: string): VaultConfig {
     }
   }
 
+  // Parse tag_schemas
+  config.tag_schemas = parseTagSchemas(yaml);
+
   return config;
+}
+
+/**
+ * Parse the tag_schemas section from vault.yaml.
+ * Uses line-by-line indent tracking since the main parser is hand-rolled.
+ */
+function parseTagSchemas(yaml: string): Record<string, TagSchema> | undefined {
+  const startMatch = yaml.match(/^tag_schemas:\s*$/m);
+  if (!startMatch) return undefined;
+
+  const startIdx = (startMatch.index ?? 0) + startMatch[0].length;
+  const lines = yaml.slice(startIdx).split("\n");
+
+  const schemas: Record<string, TagSchema> = {};
+  let currentTag: string | null = null;
+  let currentField: string | null = null;
+
+  for (const line of lines) {
+    // Stop at next top-level key (no indent)
+    if (line.match(/^\S/) && line.trim().length > 0) break;
+    if (line.trim().length === 0) continue;
+
+    const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+
+    if (indent === 2) {
+      // Tag name (e.g., "  person:")
+      const tagMatch = line.match(/^\s{2}(\S+):\s*$/);
+      if (tagMatch) {
+        currentTag = tagMatch[1];
+        currentField = null;
+        schemas[currentTag] = {};
+      }
+    } else if (indent === 4 && currentTag) {
+      // Tag-level property (description, fields:)
+      const descMatch = line.match(/^\s{4}description:\s*"?([^"]*)"?\s*$/);
+      if (descMatch) {
+        schemas[currentTag].description = descMatch[1];
+        continue;
+      }
+      const fieldsMatch = line.match(/^\s{4}fields:\s*$/);
+      if (fieldsMatch) {
+        schemas[currentTag].fields = schemas[currentTag].fields ?? {};
+        currentField = null;
+      }
+    } else if (indent === 6 && currentTag && schemas[currentTag].fields !== undefined) {
+      // Field name (e.g., "      first_appeared:")
+      const fieldMatch = line.match(/^\s{6}(\S+):\s*$/);
+      if (fieldMatch) {
+        currentField = fieldMatch[1];
+        schemas[currentTag].fields![currentField] = { type: "string" };
+      }
+    } else if (indent === 8 && currentTag && currentField && schemas[currentTag].fields) {
+      // Field property (type, description, enum)
+      const typeMatch = line.match(/^\s{8}type:\s*(\S+)/);
+      if (typeMatch) {
+        schemas[currentTag].fields![currentField].type = typeMatch[1];
+        continue;
+      }
+      const fdescMatch = line.match(/^\s{8}description:\s*"?([^"]*)"?\s*$/);
+      if (fdescMatch) {
+        schemas[currentTag].fields![currentField].description = fdescMatch[1];
+        continue;
+      }
+      const enumMatch = line.match(/^\s{8}enum:\s*\[([^\]]*)\]/);
+      if (enumMatch) {
+        schemas[currentTag].fields![currentField].enum = enumMatch[1].split(",").map((s) => s.trim());
+      }
+    }
+  }
+
+  return Object.keys(schemas).length > 0 ? schemas : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -90,13 +90,26 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
         const vaultTools = generateMcpTools(store);
         const tool = vaultTools.find((t) => t.name === coreTool.name)!;
         const { vault: _, ...rest } = params;
-        return tool.execute(rest);
+        const result = tool.execute(rest);
+
+        // Soft validation: warn about missing schema fields on note-producing tools
+        if (config.tag_schemas && result && typeof result === "object" && "tags" in result) {
+          const warnings = checkTagSchemaWarnings(result as any, config.tag_schemas);
+          if (warnings.length > 0) {
+            (result as any)._schema_warnings = warnings;
+          }
+        }
+
+        return result;
       },
     };
   });
 
   // Vault management tools
   addVaultManagementTools(tools, defaultVault);
+
+  // Tag schema tools
+  addTagSchemaTools(tools, defaultVault, multiVault);
 
   // Semantic search tools (if embeddings configured)
   addSemanticSearchTools(tools, defaultVault, multiVault);
@@ -112,6 +125,7 @@ export function generateScopedMcpTools(vaultName: string): McpToolDef[] {
   const store = getVaultStore(vaultName);
   const tools = generateMcpTools(store);
   addVaultManagementTools(tools, vaultName, true);
+  addTagSchemaTools(tools, vaultName, false, true);
   addSemanticSearchTools(tools, vaultName, false);
   return tools;
 }
@@ -182,6 +196,84 @@ function addVaultManagementTools(tools: McpToolDef[], defaultVault: string, scop
       config.description = params.description as string;
       writeVaultConfig(config);
       return { updated: true, name, description: config.description };
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tag schema validation (soft)
+// ---------------------------------------------------------------------------
+
+import type { TagSchema } from "./config.ts";
+
+/**
+ * Check a note's tags against tag schemas and return warnings for missing
+ * metadata fields. Purely advisory — never rejects a write.
+ */
+function checkTagSchemaWarnings(
+  note: { tags?: string[]; metadata?: Record<string, unknown> },
+  schemas: Record<string, TagSchema>,
+): string[] {
+  const warnings: string[] = [];
+  if (!note.tags) return warnings;
+
+  for (const tag of note.tags) {
+    const schema = schemas[tag];
+    if (!schema?.fields) continue;
+    const meta = note.metadata ?? {};
+    const missing = Object.keys(schema.fields).filter((f) => !(f in meta));
+    if (missing.length > 0) {
+      warnings.push(`Tag "${tag}" expects metadata fields: ${missing.join(", ")}`);
+    }
+  }
+
+  return warnings;
+}
+
+// ---------------------------------------------------------------------------
+// Tag schema tools
+// ---------------------------------------------------------------------------
+
+function addTagSchemaTools(tools: McpToolDef[], defaultVault: string, multiVault = false, scoped = false) {
+  tools.push({
+    name: "list-tag-schemas",
+    description: "List all tag schemas defined for this vault. Tag schemas describe the expected metadata fields for notes with specific tags.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...(scoped ? {} : {
+          vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
+        }),
+      },
+    },
+    execute: (params) => {
+      const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
+      const config = readVaultConfig(name);
+      if (!config) throw new Error(`Vault "${name}" not found`);
+      return config.tag_schemas ?? {};
+    },
+  });
+
+  tools.push({
+    name: "describe-tag",
+    description: "Get the schema for a specific tag — its description and expected metadata fields. Returns null if no schema is defined for the tag.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...(scoped ? {} : {
+          vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
+        }),
+        tag: { type: "string", description: "Tag name to describe" },
+      },
+      required: ["tag"],
+    },
+    execute: (params) => {
+      const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
+      const config = readVaultConfig(name);
+      if (!config) throw new Error(`Vault "${name}" not found`);
+      const tag = params.tag as string;
+      const schema = config.tag_schemas?.[tag];
+      return schema ?? null;
     },
   });
 }

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -563,6 +563,100 @@ describe("unified MCP wrapper", () => {
 
     closeAllStores();
   });
+
+  test("list-tag-schemas and describe-tag tools work", async () => {
+    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `tag-schema-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+      tag_schemas: {
+        person: {
+          description: "A person",
+          fields: {
+            name: { type: "string", description: "Full name" },
+          },
+        },
+        project: {
+          description: "A project",
+        },
+      },
+    });
+    writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const tools = generateUnifiedMcpTools();
+
+    const listTool = tools.find((t) => t.name === "list-tag-schemas");
+    expect(listTool).toBeTruthy();
+    const schemas = listTool!.execute({ vault: vaultName }) as any;
+    expect(schemas.person).toBeDefined();
+    expect(schemas.person.description).toBe("A person");
+    expect(schemas.project).toBeDefined();
+
+    const describeTool = tools.find((t) => t.name === "describe-tag");
+    expect(describeTool).toBeTruthy();
+    const personSchema = describeTool!.execute({ vault: vaultName, tag: "person" }) as any;
+    expect(personSchema.description).toBe("A person");
+    expect(personSchema.fields.name.type).toBe("string");
+
+    const unknown = describeTool!.execute({ vault: vaultName, tag: "nonexistent" }) as any;
+    expect(unknown).toBeNull();
+
+    closeAllStores();
+  });
+
+  test("soft schema validation warns about missing metadata fields", async () => {
+    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `schema-warn-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+      tag_schemas: {
+        person: {
+          description: "A person",
+          fields: {
+            first_appeared: { type: "string", description: "When" },
+            relationship: { type: "string", description: "How" },
+          },
+        },
+      },
+    });
+    writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const tools = generateUnifiedMcpTools();
+    const createNote = tools.find((t) => t.name === "create-note")!;
+
+    // Create a note tagged person with no metadata — should get warnings
+    const result = createNote.execute({
+      vault: vaultName,
+      content: "Alice",
+      tags: ["person"],
+    }) as any;
+    expect(result.content).toBe("Alice");
+    expect(result._schema_warnings).toBeDefined();
+    expect(result._schema_warnings.length).toBe(1);
+    expect(result._schema_warnings[0]).toContain("first_appeared");
+    expect(result._schema_warnings[0]).toContain("relationship");
+
+    // Create with metadata — no warnings
+    const result2 = createNote.execute({
+      vault: vaultName,
+      content: "Bob",
+      tags: ["person"],
+      metadata: { first_appeared: "2024-01", relationship: "friend" },
+    }) as any;
+    expect(result2._schema_warnings).toBeUndefined();
+
+    closeAllStores();
+  });
 });
 
 describe("auth scopes", () => {


### PR DESCRIPTION
## Summary
- Adds `tag_schemas` to `VaultConfig` — tags can define expected metadata fields, turning them into lightweight type markers
- New MCP tools: `list-tag-schemas` (returns all schemas), `describe-tag` (returns schema for a specific tag)
- Soft validation: note-producing tools (create-note, update-note, tag-note) append `_schema_warnings` when expected metadata fields are missing — advisory only, never rejects writes
- YAML parser/serializer extended to handle nested tag_schemas section
- 4 new tests: config round-trip with schemas, config without schemas, MCP tool functionality, soft validation warnings

## Notes
- `conductor/state` → `uni-state` rename: no references to `conductor/state` exist in the vault codebase. The reference is in `~/UnforcedAGI/CLAUDE.md` — outside this PR's scope. Flagged for separate handling.
- Schemas are static config in vault.yaml, not a dynamic registry. Intentionally simple.

## Test plan
- [x] `bun test` — 252 tests pass, 0 failures
- [x] Tag schemas round-trip through YAML serializer/parser (including tags with slashes, schemas without fields)
- [x] `list-tag-schemas` returns all defined schemas
- [x] `describe-tag` returns schema for known tag, null for unknown
- [x] Soft validation: create-note with schema tag + missing metadata → `_schema_warnings` present
- [x] Soft validation: create-note with schema tag + all metadata → no warnings
- [x] Self-review via nested reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)