### PR TITLE
feat: auto-populate metadata defaults from tag schemas

### DIFF
--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -92,6 +92,17 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
         const { vault: _, ...rest } = params;
         const result = tool.execute(rest);
 
+        // Auto-populate metadata defaults when a tag with a schema is applied
+        if (config.tag_schemas && (coreTool.name === "tag-note" || coreTool.name === "batch-tag")) {
+          const tags = rest.tags as string[] | undefined;
+          if (tags) {
+            const noteIds = coreTool.name === "tag-note"
+              ? [rest.id as string]
+              : (rest.note_ids as string[]) ?? [];
+            populateSchemaDefaults(store, noteIds, tags, config.tag_schemas);
+          }
+        }
+
         // Soft validation: warn about missing schema fields on note-producing tools
         if (config.tag_schemas && result && typeof result === "object" && "tags" in result) {
           const warnings = checkTagSchemaWarnings(result as any, config.tag_schemas);
@@ -124,6 +135,28 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
 export function generateScopedMcpTools(vaultName: string): McpToolDef[] {
   const store = getVaultStore(vaultName);
   const tools = generateMcpTools(store);
+
+  // Wrap tag tools with schema default population for scoped mode
+  const config = readVaultConfig(vaultName);
+  if (config?.tag_schemas) {
+    for (const tool of tools) {
+      if (tool.name === "tag-note" || tool.name === "batch-tag") {
+        const originalExecute = tool.execute;
+        tool.execute = (params) => {
+          const result = originalExecute(params);
+          const tags = params.tags as string[] | undefined;
+          if (tags) {
+            const noteIds = tool.name === "tag-note"
+              ? [params.id as string]
+              : (params.note_ids as string[]) ?? [];
+            populateSchemaDefaults(store, noteIds, tags, config.tag_schemas!);
+          }
+          return result;
+        };
+      }
+    }
+  }
+
   addVaultManagementTools(tools, vaultName, true);
   addTagSchemaTools(tools, vaultName, false, true);
   addSemanticSearchTools(tools, vaultName, false);
@@ -204,7 +237,59 @@ function addVaultManagementTools(tools: McpToolDef[], defaultVault: string, scop
 // Tag schema validation (soft)
 // ---------------------------------------------------------------------------
 
-import type { TagSchema } from "./config.ts";
+import type { TagSchema, TagFieldSchema } from "./config.ts";
+import type { Store } from "../core/src/types.ts";
+
+/**
+ * Auto-populate metadata defaults for notes when tags with schemas are applied.
+ * Only adds fields that are missing — never overwrites existing values.
+ * Uses skipUpdatedAt since this is system enrichment, not a user edit.
+ */
+function populateSchemaDefaults(
+  store: Store,
+  noteIds: string[],
+  tags: string[],
+  schemas: Record<string, TagSchema>,
+): void {
+  // Collect all default fields from the applied tags' schemas
+  const defaults: Record<string, unknown> = {};
+  for (const tag of tags) {
+    const schema = schemas[tag];
+    if (!schema?.fields) continue;
+    for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+      if (!(field in defaults)) {
+        defaults[field] = defaultForField(fieldSchema);
+      }
+    }
+  }
+  if (Object.keys(defaults).length === 0) return;
+
+  for (const noteId of noteIds) {
+    const note = store.getNote(noteId);
+    if (!note) continue;
+    const existing = (note.metadata as Record<string, unknown> | undefined) ?? {};
+    const missing: Record<string, unknown> = {};
+    for (const [field, value] of Object.entries(defaults)) {
+      if (!(field in existing)) {
+        missing[field] = value;
+      }
+    }
+    if (Object.keys(missing).length === 0) continue;
+    store.updateNote(noteId, {
+      metadata: { ...existing, ...missing },
+      skipUpdatedAt: true,
+    });
+  }
+}
+
+function defaultForField(field: TagFieldSchema): unknown {
+  if (field.enum && field.enum.length > 0) return field.enum[0];
+  switch (field.type) {
+    case "boolean": return false;
+    case "integer": return 0;
+    default: return "";
+  }
+}
 
 /**
  * Check a note's tags against tag schemas and return warnings for missing

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -657,6 +657,120 @@ describe("unified MCP wrapper", () => {
 
     closeAllStores();
   });
+
+  test("tag-note auto-populates metadata defaults from tag schema", async () => {
+    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores: close } = await import("./vault-store.ts");
+
+    const vaultName = `schema-defaults-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+      tag_schemas: {
+        person: {
+          description: "A person",
+          fields: {
+            first_appeared: { type: "string", description: "When" },
+            relationship: { type: "string", description: "How" },
+          },
+        },
+        project: {
+          description: "A project",
+          fields: {
+            status: { type: "string", enum: ["active", "completed", "abandoned"], description: "Status" },
+            active: { type: "boolean", description: "Is active" },
+            priority: { type: "integer", description: "Priority level" },
+          },
+        },
+      },
+    });
+    writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const vaultStore = getVaultStore(vaultName);
+    const tools = generateUnifiedMcpTools();
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    const tagNote = tools.find((t) => t.name === "tag-note")!;
+    const getNote = tools.find((t) => t.name === "get-note")!;
+
+    // Create a note, then tag it with #person
+    const note = createNote.execute({ vault: vaultName, content: "Alice" }) as any;
+    tagNote.execute({ vault: vaultName, id: note.id, tags: ["person"] });
+    const after = getNote.execute({ vault: vaultName, id: note.id }) as any;
+    expect(after.metadata.first_appeared).toBe("");
+    expect(after.metadata.relationship).toBe("");
+
+    // Tag note that already has partial metadata — only missing fields populated
+    const note2 = createNote.execute({
+      vault: vaultName,
+      content: "Bob",
+      metadata: { first_appeared: "2023-11" },
+    }) as any;
+    tagNote.execute({ vault: vaultName, id: note2.id, tags: ["person"] });
+    const after2 = getNote.execute({ vault: vaultName, id: note2.id }) as any;
+    expect(after2.metadata.first_appeared).toBe("2023-11"); // preserved
+    expect(after2.metadata.relationship).toBe(""); // added
+
+    // Tag with no schema — no metadata changes
+    const note3 = createNote.execute({ vault: vaultName, content: "No schema" }) as any;
+    tagNote.execute({ vault: vaultName, id: note3.id, tags: ["random"] });
+    const after3 = getNote.execute({ vault: vaultName, id: note3.id }) as any;
+    expect(after3.metadata).toBeUndefined();
+
+    // Tag with #project — enum defaults to first value, boolean to false, integer to 0
+    const note4 = createNote.execute({ vault: vaultName, content: "My Project" }) as any;
+    tagNote.execute({ vault: vaultName, id: note4.id, tags: ["project"] });
+    const after4 = getNote.execute({ vault: vaultName, id: note4.id }) as any;
+    expect(after4.metadata.status).toBe("active");
+    expect(after4.metadata.active).toBe(false);
+    expect(after4.metadata.priority).toBe(0);
+
+    // Multiple schema tags at once — all defaults merged
+    const note5 = createNote.execute({ vault: vaultName, content: "Multi" }) as any;
+    tagNote.execute({ vault: vaultName, id: note5.id, tags: ["person", "project"] });
+    const after5 = getNote.execute({ vault: vaultName, id: note5.id }) as any;
+    expect(after5.metadata.first_appeared).toBe("");
+    expect(after5.metadata.relationship).toBe("");
+    expect(after5.metadata.status).toBe("active");
+    expect(after5.metadata.active).toBe(false);
+
+    close();
+  });
+
+  test("tag-note auto-populate does not bump updatedAt", async () => {
+    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores: close } = await import("./vault-store.ts");
+
+    const vaultName = `schema-noupdate-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+      tag_schemas: {
+        person: {
+          description: "A person",
+          fields: { name: { type: "string" } },
+        },
+      },
+    });
+    writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const tools = generateUnifiedMcpTools();
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    const tagNote = tools.find((t) => t.name === "tag-note")!;
+    const getNote = tools.find((t) => t.name === "get-note")!;
+
+    const note = createNote.execute({ vault: vaultName, content: "Test" }) as any;
+    const originalUpdatedAt = note.updatedAt;
+    tagNote.execute({ vault: vaultName, id: note.id, tags: ["person"] });
+    const after = getNote.execute({ vault: vaultName, id: note.id }) as any;
+    expect(after.updatedAt).toBe(originalUpdatedAt);
+    expect(after.metadata.name).toBe("");
+
+    close();
+  });
 });
 
 describe("auth scopes", () => {


### PR DESCRIPTION
## Summary
- When `tag-note` or `batch-tag` applies a tag that has a schema (defined in `vault.yaml` `tag_schemas`), auto-populate missing metadata fields with type-appropriate defaults
- Defaults: `string` → `""`, `boolean` → `false`, `integer` → `0`, `enum` → first enum value
- Existing metadata fields are never overwritten
- Uses `skipUpdatedAt: true` (system enrichment, not user edit)
- Works in both unified and scoped MCP tool modes

## Test plan
- [x] `bun test` — 254 tests pass, 0 failures
- [x] Tag with `#person` → metadata gains default string fields
- [x] Tag note with existing partial metadata → only missing fields added, existing preserved
- [x] Tag with no schema → no metadata changes
- [x] Tag with `#project` → enum defaults to first value, boolean to false, integer to 0
- [x] Multiple schema tags at once → all defaults merged
- [x] Auto-populate does not bump `updatedAt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)