### PR TITLE
feat: stateless MCP transport — no initialize handshake required

### DIFF
--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -1,11 +1,20 @@
 /**
- * Streamable HTTP MCP transport.
+ * Streamable HTTP MCP transport — stateless mode.
+ *
+ * Each request gets a fresh transport+server pair with no session ID
+ * generator. The SDK skips session validation when sessionIdGenerator
+ * is undefined, so clients can send `tools/call` or `tools/list`
+ * directly without a prior `initialize` handshake.
+ *
+ * This means server restarts never break existing MCP clients — the
+ * root cause of vault#56. The `initialize` method still works if a
+ * client sends it (the Server class handles it natively).
  *
  * Two modes:
  *   /mcp              — unified, all vaults via `vault` param + list-vaults
  *   /vaults/{name}/mcp — scoped to one vault, no vault param
  *
- * Vault description is sent as the MCP server instruction on session init.
+ * Vault description is sent as the MCP server instruction.
  * Read-only keys see fewer tools.
  */
 
@@ -19,14 +28,6 @@ import { generateUnifiedMcpTools, generateScopedMcpTools, getServerInstruction }
 import { isToolAllowed } from "./auth.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
 import type { KeyScope } from "./config.ts";
-import crypto from "node:crypto";
-
-interface Session {
-  transport: WebStandardStreamableHTTPServerTransport;
-  server: Server;
-}
-
-const sessions = new Map<string, Session>();
 
 /** Handle unified MCP at /mcp (all vaults). */
 export async function handleUnifiedMcp(req: Request, scope: KeyScope): Promise<Response> {
@@ -47,32 +48,9 @@ async function handleMcp(
   scope: KeyScope,
   instruction: string,
 ): Promise<Response> {
-  const sessionId = req.headers.get("mcp-session-id");
-  const existing = sessionId ? sessions.get(sessionId) : undefined;
-
-  if (existing) {
-    return existing.transport.handleRequest(req);
-  }
-
-  const session = createSession(getTools(), serverName, scope, instruction);
-  await session.server.connect(session.transport);
-  return session.transport.handleRequest(req);
-}
-
-function createSession(
-  mcpTools: McpToolDef[],
-  serverName: string,
-  scope: KeyScope,
-  instruction: string,
-): Session {
   const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: () => crypto.randomUUID(),
-    onsessioninitialized: (id) => {
-      sessions.set(id, session);
-    },
-    onsessionclosed: (id) => {
-      sessions.delete(id);
-    },
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
   });
 
   const server = new Server(
@@ -82,6 +60,8 @@ function createSession(
       instructions: instruction,
     },
   );
+
+  const mcpTools = getTools();
 
   // For read-only keys, only list readable tools
   const visibleTools = scope === "read"
@@ -127,6 +107,6 @@ function createSession(
     }
   });
 
-  const session: Session = { transport, server };
-  return session;
+  await server.connect(transport);
+  return transport.handleRequest(req);
 }

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -852,3 +852,129 @@ describe("auth scopes", () => {
     expect(isMethodAllowed("DELETE", "read")).toBe(false);
   });
 });
+
+describe("stateless MCP transport", () => {
+  test("tools/call works without prior initialize handshake", async () => {
+    const { handleUnifiedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `stateless-mcp-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+    writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const vaultStore = getVaultStore(vaultName);
+    vaultStore.createNote("test note", { tags: ["daily"] });
+
+    // Direct tools/call — no initialize, no session header
+    const req = new Request("http://localhost:1940/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "get-vault-stats", arguments: { vault: vaultName } },
+      }),
+    });
+
+    const res = await handleUnifiedMcp(req, "write");
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as any;
+    expect(body.result).toBeDefined();
+    const content = JSON.parse(body.result.content[0].text);
+    expect(content.total_notes).toBe(1);
+
+    closeAllStores();
+  });
+
+  test("tools/list works without prior initialize handshake", async () => {
+    const { handleUnifiedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `stateless-list-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+    writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const req = new Request("http://localhost:1940/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    const res = await handleUnifiedMcp(req, "write");
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as any;
+    expect(body.result.tools).toBeDefined();
+    expect(body.result.tools.length).toBeGreaterThan(0);
+    const toolNames = body.result.tools.map((t: any) => t.name);
+    expect(toolNames).toContain("create-note");
+    expect(toolNames).toContain("get-vault-stats");
+
+    closeAllStores();
+  });
+
+  test("initialize still works for clients that send it", async () => {
+    const { handleUnifiedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `stateless-init-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+    writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const req = new Request("http://localhost:1940/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0" },
+        },
+      }),
+    });
+
+    const res = await handleUnifiedMcp(req, "write");
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as any;
+    expect(body.result.protocolVersion).toBe("2024-11-05");
+    expect(body.result.serverInfo.name).toBe("parachute-vault");
+    expect(body.result.capabilities.tools).toBeDefined();
+
+    closeAllStores();
+  });
+});


### PR DESCRIPTION
## Summary
- Switches MCP HTTP transport from session-stateful to stateless mode
- Each request gets a fresh `transport+server` pair with `sessionIdGenerator: undefined`
- The MCP SDK skips all session validation in this mode — clients can send `tools/call` or `tools/list` directly without prior `initialize`
- `initialize` still works for clients that send it (Server class handles it natively)
- Removes all session tracking code (the `sessions` Map, `Session` interface, `createSession` function)
- Adds `enableJsonResponse: true` for cleaner JSON responses instead of SSE

Fixes #56

## Why this works
The MCP SDK's `WebStandardStreamableHTTPServerTransport` has a built-in stateless mode: when `sessionIdGenerator` is `undefined`, `validateSession()` returns immediately without checking `_initialized` or session headers. The `Server` class itself has no initialization gate — the `_initialized` check only exists in the transport layer.

## Tradeoffs
- **Gain**: Server restarts never break MCP clients. Any HTTP client can call tools directly.
- **Gain**: Simpler code — net -37 lines deleted, no session tracking
- **Cost**: Fresh Server+transport per request (negligible — these are lightweight objects)
- **Cost**: No SSE streaming or server-initiated notifications (not used today)

## Test plan
- [x] `bun test` — 257 tests pass, 0 failures
- [x] `tools/call` works without prior `initialize` (new test)
- [x] `tools/list` works without prior `initialize` (new test)
- [x] `initialize` still works for clients that send it (new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)