### PR TITLE
feat: add delete-tag API endpoint and MCP tool

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -464,7 +464,8 @@ describe("MCP tools", () => {
     expect(names).toContain("find-path");
     expect(names).toContain("get-note");
     expect(names).toContain("get-vault-stats");
-    expect(tools).toHaveLength(18);
+    expect(names).toContain("delete-tag");
+    expect(tools).toHaveLength(19);
   });
 
   it("create-note tool works", () => {
@@ -667,6 +668,61 @@ describe("MCP tools", () => {
     const deleteLink = tools.find((t) => t.name === "delete-link")!;
     deleteLink.execute({ source_id: "a", target_id: "b", relationship: "mentions" });
     expect((getLinks.execute({ id: "a" }) as any[]).length).toBe(0);
+  });
+
+  it("delete-tag with zero notes removes tag from list", () => {
+    store.createNote("Test", { tags: ["ephemeral"] });
+    store.untagNote(store.queryNotes({}).find((n) => n.tags?.includes("ephemeral"))!.id, ["ephemeral"]);
+    // Tag exists in tags table but has 0 notes
+    const before = store.listTags();
+    expect(before.some((t) => t.name === "ephemeral")).toBe(true);
+
+    const result = store.deleteTag("ephemeral");
+    expect(result).toEqual({ deleted: true, notes_untagged: 0 });
+
+    const after = store.listTags();
+    expect(after.some((t) => t.name === "ephemeral")).toBe(false);
+  });
+
+  it("delete-tag with N notes untags all but preserves notes", () => {
+    const n1 = store.createNote("A", { tags: ["doomed"] });
+    const n2 = store.createNote("B", { tags: ["doomed", "keeper"] });
+
+    const result = store.deleteTag("doomed");
+    expect(result).toEqual({ deleted: true, notes_untagged: 2 });
+
+    // Notes still exist
+    expect(store.getNote(n1.id)).not.toBeNull();
+    expect(store.getNote(n2.id)).not.toBeNull();
+
+    // Tags removed from notes
+    expect(store.getNote(n1.id)!.tags).not.toContain("doomed");
+    expect(store.getNote(n2.id)!.tags).not.toContain("doomed");
+    // Other tags preserved
+    expect(store.getNote(n2.id)!.tags).toContain("keeper");
+
+    // Tag no longer in list
+    expect(store.listTags().some((t) => t.name === "doomed")).toBe(false);
+  });
+
+  it("delete-tag nonexistent returns deleted: false", () => {
+    const result = store.deleteTag("never-existed");
+    expect(result).toEqual({ deleted: false, notes_untagged: 0 });
+  });
+
+  it("delete-tag MCP tool works", () => {
+    const tools = generateMcpTools(db);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    createNote.execute({ content: "Test", tags: ["mcp-tag"] });
+
+    const deleteTool = tools.find((t) => t.name === "delete-tag")!;
+    const result = deleteTool.execute({ tag: "mcp-tag" }) as any;
+    expect(result.deleted).toBe(true);
+    expect(result.notes_untagged).toBe(1);
+
+    const listTool = tools.find((t) => t.name === "list-tags")!;
+    const tags = listTool.execute({}) as any[];
+    expect(tags.some((t: any) => t.name === "mcp-tag")).toBe(false);
   });
 
   it("create-note via store triggers wikilink sync", () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -312,6 +312,21 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
       execute: () => notes.listTags(db),
     },
     {
+      name: "delete-tag",
+      description: "Delete a tag and remove it from all notes. Notes themselves are NOT deleted — just untagged. Use this to clean up unused or obsolete tags.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          tag: { type: "string", description: "Tag name to delete" },
+        },
+        required: ["tag"],
+      },
+      execute: (params) => {
+        const fn = store ? store.deleteTag.bind(store) : (name: string) => notes.deleteTag(db, name);
+        return fn(params.tag as string);
+      },
+    },
+    {
       name: "get-vault-stats",
       description: "Get a birds-eye view of the vault: total note count, earliest/latest note, note distribution by month, top tags, and tag count. Read-only, cheap aggregation. Call once at the start of a session to orient before doing vault-wide work (monthly summaries, reviews, trend tracking). For filtered queries use read-notes; for a full tag list use list-tags.",
       inputSchema: { type: "object", properties: {} },

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -278,6 +278,19 @@ export function listTags(db: Database): { name: string; count: number }[] {
   return rows;
 }
 
+export function deleteTag(db: Database, name: string): { deleted: boolean; notes_untagged: number } {
+  const exists = db.prepare("SELECT 1 FROM tags WHERE name = ?").get(name);
+  if (!exists) return { deleted: false, notes_untagged: 0 };
+
+  const countRow = db.prepare("SELECT COUNT(*) as c FROM note_tags WHERE tag_name = ?").get(name) as { c: number };
+  const notesUntagged = countRow.c;
+
+  db.prepare("DELETE FROM note_tags WHERE tag_name = ?").run(name);
+  db.prepare("DELETE FROM tags WHERE name = ?").run(name);
+
+  return { deleted: true, notes_untagged: notesUntagged };
+}
+
 // ---- Vault stats (aggregate situational awareness) ----
 
 /**

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -148,6 +148,10 @@ export class SqliteStore implements Store {
     return noteOps.listTags(this.db);
   }
 
+  deleteTag(name: string): { deleted: boolean; notes_untagged: number } {
+    return noteOps.deleteTag(this.db, name);
+  }
+
   // ---- Vault Stats ----
 
   getVaultStats(opts?: { topTagsLimit?: number }) {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -91,6 +91,7 @@ export interface Store {
   tagNote(noteId: string, tags: string[]): void;
   untagNote(noteId: string, tags: string[]): void;
   listTags(): { name: string; count: number }[];
+  deleteTag(name: string): { deleted: boolean; notes_untagged: number };
 
   // Vault stats (aggregate, read-only)
   getVaultStats(opts?: { topTagsLimit?: number }): VaultStats;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -156,10 +156,19 @@ export async function handleNotes(
 // Tags
 // ---------------------------------------------------------------------------
 
-export function handleTags(req: Request, store: Store): Response {
-  if (req.method === "GET") {
+export function handleTags(req: Request, store: Store, subpath = ""): Response {
+  if (req.method === "GET" && subpath === "") {
     return json(store.listTags());
   }
+
+  // DELETE /tags/:name
+  const nameMatch = subpath.match(/^\/(.+)$/);
+  if (req.method === "DELETE" && nameMatch) {
+    const tagName = decodeURIComponent(nameMatch[1]);
+    const result = store.deleteTag(tagName);
+    return json(result);
+  }
+
   return json({ error: "Method not allowed" }, 405);
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -255,7 +255,7 @@ async function route(req: Request, path: string): Promise<Response> {
     const store = getVaultStore(defaultVault);
     const apiPath = path.slice(4); // strip "/api"
     if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6));
-    if (apiPath === "/tags") return handleTags(req, store);
+    if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
     if (apiPath === "/links") return handleLinks(req, store);
     if (apiPath === "/search") return handleSearch(req, store);
     if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), defaultVault);
@@ -308,8 +308,8 @@ async function route(req: Request, path: string): Promise<Response> {
   if (apiPath.startsWith("/notes")) {
     return handleNotes(req, store, apiPath.slice(6));
   }
-  if (apiPath === "/tags") {
-    return handleTags(req, store);
+  if (apiPath.startsWith("/tags")) {
+    return handleTags(req, store, apiPath.slice(5));
   }
   if (apiPath === "/links") {
     return handleLinks(req, store);

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -468,9 +468,9 @@ describe("deeper link queries", () => {
 });
 
 describe("MCP tools", () => {
-  test("generates all 18 core tools", () => {
+  test("generates all 19 core tools", () => {
     const tools = generateMcpTools(db);
-    expect(tools.length).toBe(18);
+    expect(tools.length).toBe(19);
 
     const names = tools.map((t) => t.name);
     expect(names).toContain("get-note");


### PR DESCRIPTION
## Summary
- Adds `store.deleteTag(name)` in core — deletes the tag row and all note_tags associations, preserves notes
- REST API: `DELETE /api/tags/:name` returns `{ deleted, notes_untagged }`
- MCP tool: `delete-tag { tag }` — same behavior
- Nonexistent tags return `{ deleted: false, notes_untagged: 0 }` (no error)

## Test plan
- [x] Delete tag with 0 notes — tag removed from list
- [x] Delete tag with N notes — notes survive, tag removed, other tags preserved
- [x] Delete nonexistent tag — returns `{ deleted: false, notes_untagged: 0 }`
- [x] MCP tool works end-to-end
- [x] Full test suite passes (262 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)