### PR TITLE
feat: add resolve-wikilink and list-unresolved-wikilinks tools

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -465,7 +465,9 @@ describe("MCP tools", () => {
     expect(names).toContain("get-note");
     expect(names).toContain("get-vault-stats");
     expect(names).toContain("delete-tag");
-    expect(tools).toHaveLength(19);
+    expect(names).toContain("resolve-wikilink");
+    expect(names).toContain("list-unresolved-wikilinks");
+    expect(tools).toHaveLength(21);
   });
 
   it("create-note tool works", () => {
@@ -723,6 +725,68 @@ describe("MCP tools", () => {
     const listTool = tools.find((t) => t.name === "list-tags")!;
     const tags = listTool.execute({}) as any[];
     expect(tags.some((t: any) => t.name === "mcp-tag")).toBe(false);
+  });
+
+  it("resolve-wikilink: exact match", () => {
+    store.createNote("Mickey doc", { path: "People/Mickey Myers" });
+    const tools = generateMcpTools(store);
+    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
+    const result = resolve.execute({ target: "People/Mickey Myers" }) as any;
+    expect(result.resolved).toBe(true);
+    expect(result.path).toBe("People/Mickey Myers");
+    expect(result.note_id).toBeTruthy();
+    expect(result.candidates).toEqual([]);
+  });
+
+  it("resolve-wikilink: basename match", () => {
+    store.createNote("Mickey doc", { path: "People/Mickey" });
+    const tools = generateMcpTools(store);
+    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
+    const result = resolve.execute({ target: "Mickey" }) as any;
+    expect(result.resolved).toBe(true);
+    expect(result.path).toBe("People/Mickey");
+  });
+
+  it("resolve-wikilink: ambiguous — multiple basename matches", () => {
+    store.createNote("Atlas person", { path: "People/Atlas" });
+    store.createNote("Atlas project", { path: "Projects/Atlas" });
+    const tools = generateMcpTools(store);
+    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
+    const result = resolve.execute({ target: "Atlas" }) as any;
+    expect(result.resolved).toBe(false);
+    expect(result.ambiguous).toBe(true);
+    expect(result.candidates).toHaveLength(2);
+    expect(result.candidates.map((c: any) => c.path).sort()).toEqual(["People/Atlas", "Projects/Atlas"]);
+  });
+
+  it("resolve-wikilink: no match", () => {
+    const tools = generateMcpTools(store);
+    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
+    const result = resolve.execute({ target: "Nonexistent" }) as any;
+    expect(result.resolved).toBe(false);
+    expect(result.ambiguous).toBe(false);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it("list-unresolved-wikilinks: returns unresolved entries", () => {
+    // Create a note with a wikilink to a nonexistent target
+    store.createNote("See [[Ghost Note]]", { path: "Source" });
+    const tools = generateMcpTools(store);
+    const listUnresolved = tools.find((t) => t.name === "list-unresolved-wikilinks")!;
+    const result = listUnresolved.execute({}) as any;
+    expect(result.count).toBeGreaterThanOrEqual(1);
+    const ghost = result.unresolved.find((u: any) => u.target_path === "Ghost Note");
+    expect(ghost).toBeTruthy();
+    expect(ghost.source_path).toBe("Source");
+  });
+
+  it("list-unresolved-wikilinks: empty when all resolved", () => {
+    const tools = generateMcpTools(store);
+    const listUnresolved = tools.find((t) => t.name === "list-unresolved-wikilinks")!;
+    // Fresh store with no wikilinks
+    const result = listUnresolved.execute({}) as any;
+    expect(result.count).toBe(0);
+    expect(result.unresolved).toEqual([]);
   });
 
   it("create-note via store triggers wikilink sync", () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import type { Store } from "./types.js";
 import * as notes from "./notes.js";
 import * as links from "./links.js";
+import { resolveWikilinkDetailed, listUnresolvedWikilinks } from "./wikilinks.js";
 
 export interface McpToolDef {
   name: string;
@@ -431,6 +432,32 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
         params.target_id as string,
         { max_depth: Math.min((params.max_depth as number) ?? 5, 10) },
       ),
+    },
+
+    // ---- Wikilink Tools ----
+
+    {
+      name: "resolve-wikilink",
+      description: "Resolve a [[wikilink]] target to a note. Returns the matched note (resolved), multiple candidates (ambiguous), or empty (unresolved). Uses the same resolution logic as vault's write-time wikilink sync.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          target: { type: "string", description: "Wikilink target (e.g., 'Mickey', 'Projects/Atlas')" },
+        },
+        required: ["target"],
+      },
+      execute: (params) => resolveWikilinkDetailed(db, params.target as string),
+    },
+    {
+      name: "list-unresolved-wikilinks",
+      description: "List wikilinks that couldn't be resolved to any note. Useful for graph health audits and finding broken links.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          limit: { type: "number", description: "Max results (default 50)" },
+        },
+      },
+      execute: (params) => listUnresolvedWikilinks(db, (params.limit as number) ?? 50),
     },
 
   ];

--- a/core/src/wikilinks.ts
+++ b/core/src/wikilinks.ts
@@ -139,6 +139,94 @@ export function resolveWikilink(db: Database, target: string): string | null {
   return null;
 }
 
+/** Result of a detailed wikilink resolution. */
+export interface WikilinkResolution {
+  resolved: boolean;
+  note_id?: string;
+  path?: string;
+  ambiguous?: boolean;
+  candidates: { note_id: string; path: string }[];
+}
+
+/**
+ * Resolve a wikilink target with full detail — single match, ambiguous, or unresolved.
+ */
+export function resolveWikilinkDetailed(db: Database, target: string): WikilinkResolution {
+  // 1. Exact match (case-insensitive)
+  const exact = db.prepare(
+    "SELECT id, path FROM notes WHERE path = ? COLLATE NOCASE",
+  ).get(target) as { id: string; path: string } | undefined;
+  if (exact) {
+    return { resolved: true, note_id: exact.id, path: exact.path, candidates: [] };
+  }
+
+  // 2. Basename match
+  const basename = db.prepare(`
+    SELECT id, path FROM notes
+    WHERE path IS NOT NULL
+      AND (
+        path = ? COLLATE NOCASE
+        OR path LIKE ? COLLATE NOCASE
+      )
+  `).all(target, `%/${target}`) as { id: string; path: string }[];
+
+  if (basename.length === 1) {
+    return { resolved: true, note_id: basename[0].id, path: basename[0].path, candidates: [] };
+  }
+
+  if (basename.length > 1) {
+    return {
+      resolved: false,
+      ambiguous: true,
+      candidates: basename.map((r) => ({ note_id: r.id, path: r.path })),
+    };
+  }
+
+  return { resolved: false, ambiguous: false, candidates: [] };
+}
+
+/** Entry from the unresolved_wikilinks table. */
+export interface UnresolvedWikilink {
+  source_id: string;
+  source_path?: string;
+  target_path: string;
+}
+
+/**
+ * List unresolved wikilinks across the vault.
+ */
+export function listUnresolvedWikilinks(db: Database, limit = 50): { unresolved: UnresolvedWikilink[]; count: number } {
+  let total: number;
+  let rows: { source_id: string; target_path: string }[];
+  try {
+    total = (db.prepare("SELECT COUNT(*) as c FROM unresolved_wikilinks").get() as { c: number }).c;
+    rows = db.prepare(
+      "SELECT source_id, target_path FROM unresolved_wikilinks ORDER BY source_id LIMIT ?",
+    ).all(limit) as { source_id: string; target_path: string }[];
+  } catch {
+    // Table doesn't exist yet
+    return { unresolved: [], count: 0 };
+  }
+
+  // Hydrate source paths
+  if (rows.length === 0) return { unresolved: [], count: total };
+
+  const sourceIds = [...new Set(rows.map((r) => r.source_id))];
+  const placeholders = sourceIds.map(() => "?").join(", ");
+  const pathRows = db.prepare(
+    `SELECT id, path FROM notes WHERE id IN (${placeholders})`,
+  ).all(...sourceIds) as { id: string; path: string | null }[];
+  const pathMap = new Map(pathRows.map((r) => [r.id, r.path]));
+
+  const unresolved: UnresolvedWikilink[] = rows.map((r) => ({
+    source_id: r.source_id,
+    source_path: pathMap.get(r.source_id) ?? undefined,
+    target_path: r.target_path,
+  }));
+
+  return { unresolved, count: total };
+}
+
 // ---------------------------------------------------------------------------
 // Sync — maintain wikilink-based links for a note
 // ---------------------------------------------------------------------------

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,6 +33,8 @@ const READ_TOOLS = new Set([
   "list-vaults",
   "get-vault-description",
   "get-vault-stats",
+  "resolve-wikilink",
+  "list-unresolved-wikilinks",
 ]);
 
 /** Check if a tool call is allowed for a given scope. */

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Store } from "../core/src/types.ts";
+import { resolveWikilinkDetailed, listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
 import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { vaultDir } from "./config.ts";
@@ -221,6 +222,26 @@ export function handleSearch(req: Request, store: Store): Response {
 
   const results = store.searchNotes(query, { tags, limit });
   return json(results);
+}
+
+// ---------------------------------------------------------------------------
+// Wikilinks
+// ---------------------------------------------------------------------------
+
+export function handleResolveWikilink(req: Request, store: Store): Response {
+  const url = new URL(req.url);
+  const target = url.searchParams.get("target");
+  if (!target) return json({ error: "target parameter is required" }, 400);
+  const db = (store as any).db;
+  return json(resolveWikilinkDetailed(db, target));
+}
+
+export function handleUnresolvedWikilinks(req: Request, store: Store): Response {
+  const url = new URL(req.url);
+  const limitStr = url.searchParams.get("limit");
+  const limit = limitStr ? parseInt(limitStr, 10) : 50;
+  const db = (store as any).db;
+  return json(listUnresolvedWikilinks(db, limit));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,7 @@ import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig,
 import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed } from "./auth.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
-import { handleNotes, handleTags, handleLinks, handleSearch, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech } from "./routes.ts";
+import { handleNotes, handleTags, handleLinks, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech } from "./routes.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTtsHook, type NarrateModule } from "./tts-hook.ts";
 import { registerTranscriptionHook, type ScribeModule } from "./transcription-hook.ts";
@@ -258,6 +258,8 @@ async function route(req: Request, path: string): Promise<Response> {
     if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
     if (apiPath === "/links") return handleLinks(req, store);
     if (apiPath === "/search") return handleSearch(req, store);
+    if (apiPath === "/resolve-wikilink") return handleResolveWikilink(req, store);
+    if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store);
     if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), defaultVault);
     if (apiPath === "/ingest") return handleIngest(req, store, defaultVault);
     if (apiPath === "/health") return Response.json({ status: "ok", vault: defaultVault });
@@ -316,6 +318,12 @@ async function route(req: Request, path: string): Promise<Response> {
   }
   if (apiPath === "/search") {
     return handleSearch(req, store);
+  }
+  if (apiPath === "/resolve-wikilink") {
+    return handleResolveWikilink(req, store);
+  }
+  if (apiPath === "/unresolved-wikilinks") {
+    return handleUnresolvedWikilinks(req, store);
   }
   if (apiPath.startsWith("/storage")) {
     return handleStorage(req, apiPath.slice(8), vaultName);

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -468,9 +468,9 @@ describe("deeper link queries", () => {
 });
 
 describe("MCP tools", () => {
-  test("generates all 19 core tools", () => {
+  test("generates all 21 core tools", () => {
     const tools = generateMcpTools(db);
-    expect(tools.length).toBe(19);
+    expect(tools.length).toBe(21);
 
     const names = tools.map((t) => t.name);
     expect(names).toContain("get-note");


### PR DESCRIPTION
## Summary
- `resolve-wikilink { target }` — resolve a [[wikilink]] target to a note. Returns single match (resolved), multiple candidates (ambiguous), or empty (unresolved). Uses the same resolution logic as vault's write-time sync.
- `list-unresolved-wikilinks { limit? }` — list broken wikilinks for graph health audits
- REST: `GET /api/resolve-wikilink?target=X` and `GET /api/unresolved-wikilinks?limit=N`
- Both added to read-only tool allowlist

## Test plan
- [x] resolve-wikilink: exact path match
- [x] resolve-wikilink: basename match
- [x] resolve-wikilink: ambiguous (multiple basename matches) returns candidates
- [x] resolve-wikilink: no match returns unresolved
- [x] list-unresolved-wikilinks: returns entries with hydrated source paths
- [x] list-unresolved-wikilinks: empty when no unresolved
- [x] Full test suite passes (268 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)