### PR TITLE
refactor: remove resolve-wikilink tool (scope narrowed)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -465,9 +465,8 @@ describe("MCP tools", () => {
     expect(names).toContain("get-note");
     expect(names).toContain("get-vault-stats");
     expect(names).toContain("delete-tag");
-    expect(names).toContain("resolve-wikilink");
     expect(names).toContain("list-unresolved-wikilinks");
-    expect(tools).toHaveLength(21);
+    expect(tools).toHaveLength(20);
   });
 
   it("create-note tool works", () => {
@@ -725,47 +724,6 @@ describe("MCP tools", () => {
     const listTool = tools.find((t) => t.name === "list-tags")!;
     const tags = listTool.execute({}) as any[];
     expect(tags.some((t: any) => t.name === "mcp-tag")).toBe(false);
-  });
-
-  it("resolve-wikilink: exact match", () => {
-    store.createNote("Mickey doc", { path: "People/Mickey Myers" });
-    const tools = generateMcpTools(store);
-    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
-    const result = resolve.execute({ target: "People/Mickey Myers" }) as any;
-    expect(result.resolved).toBe(true);
-    expect(result.path).toBe("People/Mickey Myers");
-    expect(result.note_id).toBeTruthy();
-    expect(result.candidates).toEqual([]);
-  });
-
-  it("resolve-wikilink: basename match", () => {
-    store.createNote("Mickey doc", { path: "People/Mickey" });
-    const tools = generateMcpTools(store);
-    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
-    const result = resolve.execute({ target: "Mickey" }) as any;
-    expect(result.resolved).toBe(true);
-    expect(result.path).toBe("People/Mickey");
-  });
-
-  it("resolve-wikilink: ambiguous — multiple basename matches", () => {
-    store.createNote("Atlas person", { path: "People/Atlas" });
-    store.createNote("Atlas project", { path: "Projects/Atlas" });
-    const tools = generateMcpTools(store);
-    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
-    const result = resolve.execute({ target: "Atlas" }) as any;
-    expect(result.resolved).toBe(false);
-    expect(result.ambiguous).toBe(true);
-    expect(result.candidates).toHaveLength(2);
-    expect(result.candidates.map((c: any) => c.path).sort()).toEqual(["People/Atlas", "Projects/Atlas"]);
-  });
-
-  it("resolve-wikilink: no match", () => {
-    const tools = generateMcpTools(store);
-    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
-    const result = resolve.execute({ target: "Nonexistent" }) as any;
-    expect(result.resolved).toBe(false);
-    expect(result.ambiguous).toBe(false);
-    expect(result.candidates).toEqual([]);
   });
 
   it("list-unresolved-wikilinks: returns unresolved entries", () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import type { Store } from "./types.js";
 import * as notes from "./notes.js";
 import * as links from "./links.js";
-import { resolveWikilinkDetailed, listUnresolvedWikilinks } from "./wikilinks.js";
+import { listUnresolvedWikilinks } from "./wikilinks.js";
 
 export interface McpToolDef {
   name: string;
@@ -436,18 +436,6 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
 
     // ---- Wikilink Tools ----
 
-    {
-      name: "resolve-wikilink",
-      description: "Resolve a [[wikilink]] target to a note. Returns the matched note (resolved), multiple candidates (ambiguous), or empty (unresolved). Uses the same resolution logic as vault's write-time wikilink sync.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          target: { type: "string", description: "Wikilink target (e.g., 'Mickey', 'Projects/Atlas')" },
-        },
-        required: ["target"],
-      },
-      execute: (params) => resolveWikilinkDetailed(db, params.target as string),
-    },
     {
       name: "list-unresolved-wikilinks",
       description: "List wikilinks that couldn't be resolved to any note. Useful for graph health audits and finding broken links.",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,7 +33,6 @@ const READ_TOOLS = new Set([
   "list-vaults",
   "get-vault-description",
   "get-vault-stats",
-  "resolve-wikilink",
   "list-unresolved-wikilinks",
 ]);
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Store } from "../core/src/types.ts";
-import { resolveWikilinkDetailed, listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
+import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
 import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { vaultDir } from "./config.ts";
@@ -227,14 +227,6 @@ export function handleSearch(req: Request, store: Store): Response {
 // ---------------------------------------------------------------------------
 // Wikilinks
 // ---------------------------------------------------------------------------
-
-export function handleResolveWikilink(req: Request, store: Store): Response {
-  const url = new URL(req.url);
-  const target = url.searchParams.get("target");
-  if (!target) return json({ error: "target parameter is required" }, 400);
-  const db = (store as any).db;
-  return json(resolveWikilinkDetailed(db, target));
-}
 
 export function handleUnresolvedWikilinks(req: Request, store: Store): Response {
   const url = new URL(req.url);

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,7 @@ import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig,
 import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed } from "./auth.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
-import { handleNotes, handleTags, handleLinks, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech } from "./routes.ts";
+import { handleNotes, handleTags, handleLinks, handleSearch, handleUnresolvedWikilinks, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech } from "./routes.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTtsHook, type NarrateModule } from "./tts-hook.ts";
 import { registerTranscriptionHook, type ScribeModule } from "./transcription-hook.ts";
@@ -258,7 +258,6 @@ async function route(req: Request, path: string): Promise<Response> {
     if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
     if (apiPath === "/links") return handleLinks(req, store);
     if (apiPath === "/search") return handleSearch(req, store);
-    if (apiPath === "/resolve-wikilink") return handleResolveWikilink(req, store);
     if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store);
     if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), defaultVault);
     if (apiPath === "/ingest") return handleIngest(req, store, defaultVault);
@@ -318,9 +317,6 @@ async function route(req: Request, path: string): Promise<Response> {
   }
   if (apiPath === "/search") {
     return handleSearch(req, store);
-  }
-  if (apiPath === "/resolve-wikilink") {
-    return handleResolveWikilink(req, store);
   }
   if (apiPath === "/unresolved-wikilinks") {
     return handleUnresolvedWikilinks(req, store);

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -468,9 +468,9 @@ describe("deeper link queries", () => {
 });
 
 describe("MCP tools", () => {
-  test("generates all 21 core tools", () => {
+  test("generates all 20 core tools", () => {
     const tools = generateMcpTools(db);
-    expect(tools.length).toBe(21);
+    expect(tools.length).toBe(20);
 
     const names = tools.map((t) => t.name);
     expect(names).toContain("get-note");


### PR DESCRIPTION
## Summary
- Removes `resolve-wikilink` MCP tool and REST endpoint added in #60
- Scope narrowed: not needed at current scale
- Keeps `list-unresolved-wikilinks` (the useful part)
- `resolveWikilinkDetailed()` remains in `wikilinks.ts` as internal API (unused but harmless)

## Test plan
- [x] Full test suite passes (264 tests)
- [x] resolve-wikilink tests removed, tool count decremented

🤖 Generated with [Claude Code](https://claude.com/claude-code)