### PR TITLE
feat: HTTP graph API, lean notes, polymorphic /links

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -157,22 +157,22 @@ describe("tags", () => {
 describe("vault stats", () => {
   it("handles empty vault gracefully", () => {
     const stats = store.getVaultStats();
-    expect(stats.total_notes).toBe(0);
-    expect(stats.earliest_note).toBeNull();
-    expect(stats.latest_note).toBeNull();
-    expect(stats.notes_by_month).toEqual([]);
-    expect(stats.top_tags).toEqual([]);
-    expect(stats.tag_count).toBe(0);
+    expect(stats.totalNotes).toBe(0);
+    expect(stats.earliestNote).toBeNull();
+    expect(stats.latestNote).toBeNull();
+    expect(stats.notesByMonth).toEqual([]);
+    expect(stats.topTags).toEqual([]);
+    expect(stats.tagCount).toBe(0);
   });
 
-  it("counts total notes and tag_count", () => {
+  it("counts total notes and tagCount", () => {
     store.createNote("A", { tags: ["daily", "voice"] });
     store.createNote("B", { tags: ["daily"] });
     store.createNote("C");
 
     const stats = store.getVaultStats();
-    expect(stats.total_notes).toBe(3);
-    expect(stats.tag_count).toBe(2); // "daily" and "voice"
+    expect(stats.totalNotes).toBe(3);
+    expect(stats.tagCount).toBe(2); // "daily" and "voice"
   });
 
   it("reports earliest and latest notes correctly", () => {
@@ -181,8 +181,8 @@ describe("vault stats", () => {
     store.createNote("newest", { id: "n3", created_at: "2026-03-01T10:00:00.000Z" });
 
     const stats = store.getVaultStats();
-    expect(stats.earliest_note).toEqual({ id: "n1", created_at: "2025-01-15T10:00:00.000Z" });
-    expect(stats.latest_note).toEqual({ id: "n3", created_at: "2026-03-01T10:00:00.000Z" });
+    expect(stats.earliestNote).toEqual({ id: "n1", createdAt: "2025-01-15T10:00:00.000Z" });
+    expect(stats.latestNote).toEqual({ id: "n3", createdAt: "2026-03-01T10:00:00.000Z" });
   });
 
   it("groups notes by month across all present months", () => {
@@ -193,44 +193,44 @@ describe("vault stats", () => {
     store.createNote("e", { created_at: "2026-01-10T10:00:00.000Z" });
 
     const stats = store.getVaultStats();
-    expect(stats.notes_by_month).toEqual([
+    expect(stats.notesByMonth).toEqual([
       { month: "2025-02", count: 1 },
       { month: "2025-03", count: 3 },
       { month: "2026-01", count: 1 },
     ]);
   });
 
-  it("returns top_tags ordered by count desc, capped", () => {
+  it("returns topTags ordered by count desc, capped", () => {
     // Create notes with varying tag frequencies
     for (let i = 0; i < 5; i++) store.createNote(`captured-${i}`, { tags: ["captured"] });
     for (let i = 0; i < 3; i++) store.createNote(`reader-${i}`, { tags: ["reader"] });
     store.createNote("one", { tags: ["rare"] });
 
     const stats = store.getVaultStats();
-    expect(stats.top_tags[0]).toEqual({ tag: "captured", count: 5 });
-    expect(stats.top_tags[1]).toEqual({ tag: "reader", count: 3 });
-    expect(stats.top_tags[2]).toEqual({ tag: "rare", count: 1 });
+    expect(stats.topTags[0]).toEqual({ tag: "captured", count: 5 });
+    expect(stats.topTags[1]).toEqual({ tag: "reader", count: 3 });
+    expect(stats.topTags[2]).toEqual({ tag: "rare", count: 1 });
   });
 
-  it("caps top_tags at the requested limit", () => {
+  it("caps topTags at the requested limit", () => {
     // 25 distinct tags, one per note
     for (let i = 0; i < 25; i++) {
       store.createNote(`n-${i}`, { tags: [`tag-${String(i).padStart(2, "0")}`] });
     }
     const stats = store.getVaultStats({ topTagsLimit: 20 });
-    expect(stats.top_tags).toHaveLength(20);
-    expect(stats.tag_count).toBe(25);
+    expect(stats.topTags).toHaveLength(20);
+    expect(stats.tagCount).toBe(25);
   });
 
   it("response shape is complete", () => {
     store.createNote("hello", { tags: ["a"] });
     const stats = store.getVaultStats();
-    expect(stats).toHaveProperty("total_notes");
-    expect(stats).toHaveProperty("earliest_note");
-    expect(stats).toHaveProperty("latest_note");
-    expect(stats).toHaveProperty("notes_by_month");
-    expect(stats).toHaveProperty("top_tags");
-    expect(stats).toHaveProperty("tag_count");
+    expect(stats).toHaveProperty("totalNotes");
+    expect(stats).toHaveProperty("earliestNote");
+    expect(stats).toHaveProperty("latestNote");
+    expect(stats).toHaveProperty("notesByMonth");
+    expect(stats).toHaveProperty("topTags");
+    expect(stats).toHaveProperty("tagCount");
   });
 
   it("get-vault-stats MCP tool works", () => {
@@ -242,13 +242,13 @@ describe("vault stats", () => {
     expect(tool).toBeTruthy();
 
     const result = tool.execute({}) as any;
-    expect(result.total_notes).toBe(2);
-    expect(result.tag_count).toBe(2);
-    expect(result.top_tags[0].tag).toBe("x");
-    expect(result.top_tags[0].count).toBe(2);
-    expect(result.notes_by_month).toHaveLength(2);
-    expect(result.earliest_note.created_at).toBe("2025-05-01T00:00:00.000Z");
-    expect(result.latest_note.created_at).toBe("2025-06-01T00:00:00.000Z");
+    expect(result.totalNotes).toBe(2);
+    expect(result.tagCount).toBe(2);
+    expect(result.topTags[0].tag).toBe("x");
+    expect(result.topTags[0].count).toBe(2);
+    expect(result.notesByMonth).toHaveLength(2);
+    expect(result.earliestNote.createdAt).toBe("2025-05-01T00:00:00.000Z");
+    expect(result.latestNote.createdAt).toBe("2025-06-01T00:00:00.000Z");
   });
 });
 
@@ -467,7 +467,8 @@ describe("MCP tools", () => {
     expect(names).toContain("delete-tag");
     expect(names).toContain("resolve-wikilink");
     expect(names).toContain("list-unresolved-wikilinks");
-    expect(tools).toHaveLength(21);
+    expect(names).toContain("get-graph");
+    expect(tools).toHaveLength(22);
   });
 
   it("create-note tool works", () => {
@@ -675,7 +676,6 @@ describe("MCP tools", () => {
   it("delete-tag with zero notes removes tag from list", () => {
     store.createNote("Test", { tags: ["ephemeral"] });
     store.untagNote(store.queryNotes({}).find((n) => n.tags?.includes("ephemeral"))!.id, ["ephemeral"]);
-    // Tag exists in tags table but has 0 notes
     const before = store.listTags();
     expect(before.some((t) => t.name === "ephemeral")).toBe(true);
 
@@ -693,17 +693,11 @@ describe("MCP tools", () => {
     const result = store.deleteTag("doomed");
     expect(result).toEqual({ deleted: true, notes_untagged: 2 });
 
-    // Notes still exist
     expect(store.getNote(n1.id)).not.toBeNull();
     expect(store.getNote(n2.id)).not.toBeNull();
-
-    // Tags removed from notes
     expect(store.getNote(n1.id)!.tags).not.toContain("doomed");
     expect(store.getNote(n2.id)!.tags).not.toContain("doomed");
-    // Other tags preserved
     expect(store.getNote(n2.id)!.tags).toContain("keeper");
-
-    // Tag no longer in list
     expect(store.listTags().some((t) => t.name === "doomed")).toBe(false);
   });
 
@@ -769,7 +763,6 @@ describe("MCP tools", () => {
   });
 
   it("list-unresolved-wikilinks: returns unresolved entries", () => {
-    // Create a note with a wikilink to a nonexistent target
     store.createNote("See [[Ghost Note]]", { path: "Source" });
     const tools = generateMcpTools(store);
     const listUnresolved = tools.find((t) => t.name === "list-unresolved-wikilinks")!;
@@ -783,10 +776,88 @@ describe("MCP tools", () => {
   it("list-unresolved-wikilinks: empty when all resolved", () => {
     const tools = generateMcpTools(store);
     const listUnresolved = tools.find((t) => t.name === "list-unresolved-wikilinks")!;
-    // Fresh store with no wikilinks
     const result = listUnresolved.execute({}) as any;
     expect(result.count).toBe(0);
     expect(result.unresolved).toEqual([]);
+  });
+
+  it("get-links returns all links when id is omitted", () => {
+    store.createNote("A", { id: "a" });
+    store.createNote("B", { id: "b" });
+    store.createNote("C", { id: "c" });
+    store.createLink("a", "b", "mentions");
+    store.createLink("b", "c", "cites");
+    const tools = generateMcpTools(db);
+    const getLinks = tools.find((t) => t.name === "get-links")!;
+
+    const all = getLinks.execute({}) as any[];
+    expect(all).toHaveLength(2);
+
+    const cites = getLinks.execute({ relationship: "cites" }) as any[];
+    expect(cites).toHaveLength(1);
+    expect(cites[0].relationship).toBe("cites");
+  });
+
+  it("get-links returns bare Link[] (no hydration)", () => {
+    store.createNote("A", { id: "a", path: "alpha" });
+    store.createNote("B", { id: "b", path: "beta" });
+    store.createLink("a", "b", "mentions");
+    const tools = generateMcpTools(db);
+    const getLinks = tools.find((t) => t.name === "get-links")!;
+    const result = getLinks.execute({ id: "a" }) as any[];
+    expect(result[0]).not.toHaveProperty("sourceNote");
+    expect(result[0]).not.toHaveProperty("targetNote");
+    expect(result[0].sourceId).toBe("a");
+    expect(result[0].targetId).toBe("b");
+  });
+
+  it("get-graph returns notes, links, tags, meta with lean notes by default", () => {
+    store.createNote("first", { id: "a", tags: ["proj"] });
+    store.createNote("second", { id: "b", tags: ["proj"] });
+    store.createNote("third", { id: "c", tags: ["other"] });
+    store.createLink("a", "b", "mentions");
+
+    const tools = generateMcpTools(db);
+    const getGraph = tools.find((t) => t.name === "get-graph")!;
+    const graph = getGraph.execute({}) as any;
+
+    expect(graph.notes).toHaveLength(3);
+    expect(graph.links).toHaveLength(1);
+    expect(graph.meta.totalNotes).toBe(3);
+    expect(graph.meta.totalLinks).toBe(1);
+    expect(graph.meta.includeContent).toBe(false);
+    expect(graph.notes[0]).not.toHaveProperty("content");
+    expect(graph.notes[0]).toHaveProperty("byteSize");
+    expect(graph.notes[0]).toHaveProperty("preview");
+  });
+
+  it("get-graph include_content=true returns full notes", () => {
+    store.createNote("body text", { id: "a" });
+    const tools = generateMcpTools(db);
+    const getGraph = tools.find((t) => t.name === "get-graph")!;
+    const graph = getGraph.execute({ include_content: true }) as any;
+    expect(graph.notes[0].content).toBe("body text");
+    expect(graph.meta.includeContent).toBe(true);
+  });
+
+  it("get-graph tag filter restricts notes and links to subgraph", () => {
+    store.createNote("a", { id: "a", tags: ["proj"] });
+    store.createNote("b", { id: "b", tags: ["proj"] });
+    store.createNote("c", { id: "c", tags: ["other"] });
+    store.createLink("a", "b", "mentions");
+    store.createLink("a", "c", "mentions");
+
+    const tools = generateMcpTools(db);
+    const getGraph = tools.find((t) => t.name === "get-graph")!;
+    const graph = getGraph.execute({ tags: ["proj"] }) as any;
+
+    expect(graph.notes).toHaveLength(2);
+    expect(graph.links).toHaveLength(1);
+    expect(graph.links[0].targetId).toBe("b");
+    expect(graph.meta.totalNotes).toBe(3);
+    expect(graph.meta.totalLinks).toBe(2);
+    expect(graph.meta.filteredNotes).toBe(2);
+    expect(graph.meta.filteredLinks).toBe(1);
   });
 
   it("create-note via store triggers wikilink sync", () => {

--- a/core/src/links.ts
+++ b/core/src/links.ts
@@ -39,20 +39,51 @@ export function getLinks(
   noteId: string,
   opts?: { direction?: "outbound" | "inbound" | "both" },
 ): Link[] {
-  const direction = opts?.direction ?? "both";
+  return listLinks(db, { noteId, direction: opts?.direction });
+}
+
+/**
+ * List links with optional filters.
+ * - If `noteId` is provided: restricts to links touching that note
+ *   (respects `direction`: outbound, inbound, or both).
+ * - If `relationship` is provided: restricts to links of that type.
+ * - Without filters: returns every link in the vault.
+ *
+ * Returns bare `Link[]` (no hydration). Callers that need note details
+ * should pair the result with `getNote` / `getNotes`.
+ */
+export function listLinks(
+  db: Database,
+  opts?: {
+    noteId?: string;
+    direction?: "outbound" | "inbound" | "both";
+    relationship?: string;
+  },
+): Link[] {
   const conditions: string[] = [];
   const params: unknown[] = [];
 
-  if (direction === "outbound" || direction === "both") {
-    conditions.push("source_id = ?");
-    params.push(noteId);
-  }
-  if (direction === "inbound" || direction === "both") {
-    conditions.push("target_id = ?");
-    params.push(noteId);
+  if (opts?.noteId) {
+    const direction = opts.direction ?? "both";
+    if (direction === "outbound") {
+      conditions.push("source_id = ?");
+      params.push(opts.noteId);
+    } else if (direction === "inbound") {
+      conditions.push("target_id = ?");
+      params.push(opts.noteId);
+    } else {
+      conditions.push("(source_id = ? OR target_id = ?)");
+      params.push(opts.noteId, opts.noteId);
+    }
   }
 
-  const sql = `SELECT * FROM links WHERE (${conditions.join(" OR ")}) ORDER BY created_at DESC`;
+  if (opts?.relationship) {
+    conditions.push("relationship = ?");
+    params.push(opts.relationship);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `SELECT * FROM links ${where} ORDER BY created_at DESC`;
   const rows = db.prepare(sql).all(...params) as LinkRow[];
   return rows.map(rowToLink);
 }

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -151,29 +151,7 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
           offset: params.offset as number | undefined,
         });
         if (params.include_content === false) {
-          const PREVIEW_LEN = 120;
-          return results.map((note) => {
-            const content = note.content ?? "";
-            const byteSize = Buffer.byteLength(content, "utf8");
-            // Collapse whitespace for a readable single-line preview
-            const collapsed = content.replace(/\s+/g, " ").trim();
-            // Iterate by Unicode code points so we don't split surrogate pairs
-            // (e.g. astral-plane emoji) mid-character.
-            const codePoints = Array.from(collapsed);
-            const preview = codePoints.length > PREVIEW_LEN
-              ? codePoints.slice(0, PREVIEW_LEN).join("")
-              : collapsed;
-            return {
-              id: note.id,
-              path: note.path,
-              createdAt: note.createdAt,
-              updatedAt: note.updatedAt,
-              tags: note.tags,
-              metadata: note.metadata,
-              byteSize,
-              preview,
-            };
-          });
+          return results.map(notes.toNoteIndex);
         }
         return results;
       },
@@ -272,39 +250,20 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
     },
     {
       name: "get-links",
-      description: "Get links for a note. Returns connected notes with their path, tags, and metadata. Use include_content to also get note content.",
+      description: "List links in the vault. Returns bare link edges ({sourceId, targetId, relationship, metadata, createdAt}) — no hydration. Omit `id` to list every link (optionally filtered by `relationship`). Pass `id` to get links touching that note (with `direction`: outbound, inbound, both). Pair with get-note when you need the connected notes' content.",
       inputSchema: {
         type: "object",
         properties: {
-          id: { type: "string", description: "Note ID" },
-          direction: { type: "string", enum: ["outbound", "inbound", "both"], default: "both" },
-          include_content: { type: "boolean", description: "Include full note content in results (default false)" },
+          id: { type: "string", description: "Note ID. If omitted, returns all links in the vault." },
+          direction: { type: "string", enum: ["outbound", "inbound", "both"], default: "both", description: "Only meaningful when `id` is provided." },
+          relationship: { type: "string", description: "Filter to links with this relationship type." },
         },
-        required: ["id"],
       },
-      execute: (params) => {
-        const hydrated = links.getLinksHydrated(db, params.id as string, {
-          direction: params.direction as "outbound" | "inbound" | "both" | undefined,
-        });
-        if (params.include_content) {
-          // Fetch full notes for content
-          const noteIds = new Set<string>();
-          for (const link of hydrated) {
-            noteIds.add(link.sourceId);
-            noteIds.add(link.targetId);
-          }
-          const fullNotes = new Map<string, any>();
-          for (const note of notes.getNotes(db, [...noteIds])) {
-            fullNotes.set(note.id, note);
-          }
-          return hydrated.map((link) => ({
-            ...link,
-            sourceNote: fullNotes.get(link.sourceId) ?? link.sourceNote,
-            targetNote: fullNotes.get(link.targetId) ?? link.targetNote,
-          }));
-        }
-        return hydrated;
-      },
+      execute: (params) => links.listLinks(db, {
+        noteId: params.id as string | undefined,
+        direction: params.direction as "outbound" | "inbound" | "both" | undefined,
+        relationship: params.relationship as string | undefined,
+      }),
     },
     {
       name: "list-tags",
@@ -325,6 +284,55 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
       execute: (params) => {
         const fn = store ? store.deleteTag.bind(store) : (name: string) => notes.deleteTag(db, name);
         return fn(params.tag as string);
+      },
+    },
+    {
+      name: "get-graph",
+      description: "Get the whole vault as a graph in one call: {notes, links, tags, meta}. Default returns lean note indexes (id, path, tags, createdAt, updatedAt, metadata, byteSize, preview) — no content. Pass include_content: true to include full content on each note. Optional tag filter (tags + tag_match + exclude_tags) restricts notes to a subgraph; links are filtered to edges between notes in the subgraph. Useful for rendering visualizations, exports, or bird's-eye analysis.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          tags: { type: "array", items: { type: "string" }, description: "Optional: only include notes with these tags" },
+          tag_match: { type: "string", enum: ["all", "any"], description: "How to match tags (default: all)" },
+          exclude_tags: { type: "array", items: { type: "string" }, description: "Exclude notes with these tags" },
+          include_content: { type: "boolean", description: "Include full note content instead of the lean index shape (default false)" },
+        },
+      },
+      execute: (params) => {
+        const hasTagFilter = (params.tags as string[] | undefined)?.length
+          || (params.exclude_tags as string[] | undefined)?.length;
+        const filteredNotes = notes.queryNotes(db, {
+          tags: params.tags as string[] | undefined,
+          tagMatch: params.tag_match as "all" | "any" | undefined,
+          excludeTags: params.exclude_tags as string[] | undefined,
+          limit: 1_000_000,
+        });
+        const includeContent = params.include_content === true;
+        const outNotes = includeContent ? filteredNotes : filteredNotes.map(notes.toNoteIndex);
+
+        // Links: if no tag filter, return all links in the vault.
+        // Otherwise, only edges between notes in the filtered set.
+        let outLinks = links.listLinks(db);
+        if (hasTagFilter) {
+          const ids = new Set(filteredNotes.map((n) => n.id));
+          outLinks = outLinks.filter((l) => ids.has(l.sourceId) && ids.has(l.targetId));
+        }
+
+        const totalRow = db.prepare("SELECT COUNT(*) as c FROM notes").get() as { c: number };
+        const linkRow = db.prepare("SELECT COUNT(*) as c FROM links").get() as { c: number };
+
+        return {
+          notes: outNotes,
+          links: outLinks,
+          tags: notes.listTags(db),
+          meta: {
+            totalNotes: totalRow.c,
+            totalLinks: linkRow.c,
+            filteredNotes: outNotes.length,
+            filteredLinks: outLinks.length,
+            includeContent,
+          },
+        };
       },
     },
     {

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import type { Note, QueryOpts, VaultStats } from "./types.js";
+import type { Note, NoteIndex, QueryOpts, VaultStats } from "./types.js";
 import { normalizePath } from "./paths.js";
 
 let idCounter = 0;
@@ -291,6 +291,39 @@ export function deleteTag(db: Database, name: string): { deleted: boolean; notes
   return { deleted: true, notes_untagged: notesUntagged };
 }
 
+// ---- Lean note index shape ----
+
+/** Max code points in a NoteIndex preview. */
+export const NOTE_INDEX_PREVIEW_LEN = 120;
+
+/**
+ * Convert a full Note into its lean index shape:
+ * drops `content`, adds `byteSize` and a whitespace-collapsed `preview`.
+ * Shared between the `read-notes` MCP tool, HTTP /notes endpoints, and /graph.
+ */
+export function toNoteIndex(note: Note): NoteIndex {
+  const content = note.content ?? "";
+  const byteSize = Buffer.byteLength(content, "utf8");
+  // Collapse whitespace for a readable single-line preview
+  const collapsed = content.replace(/\s+/g, " ").trim();
+  // Iterate by Unicode code points so we don't split surrogate pairs
+  // (e.g. astral-plane emoji) mid-character.
+  const codePoints = Array.from(collapsed);
+  const preview = codePoints.length > NOTE_INDEX_PREVIEW_LEN
+    ? codePoints.slice(0, NOTE_INDEX_PREVIEW_LEN).join("")
+    : collapsed;
+  return {
+    id: note.id,
+    path: note.path,
+    createdAt: note.createdAt,
+    updatedAt: note.updatedAt,
+    tags: note.tags,
+    metadata: note.metadata,
+    byteSize,
+    preview,
+  };
+}
+
 // ---- Vault stats (aggregate situational awareness) ----
 
 /**
@@ -306,7 +339,7 @@ export function getVaultStats(
   const topTagsLimit = opts?.topTagsLimit ?? 20;
 
   const totalRow = db.prepare("SELECT COUNT(*) as c FROM notes").get() as { c: number };
-  const total_notes = totalRow.c;
+  const totalNotes = totalRow.c;
 
   const earliestRow = db.prepare(
     "SELECT id, created_at FROM notes ORDER BY created_at ASC, id ASC LIMIT 1",
@@ -333,19 +366,19 @@ export function getVaultStats(
   `).all(topTagsLimit) as { tag: string; count: number }[];
 
   const tagCountRow = db.prepare("SELECT COUNT(DISTINCT tag_name) as c FROM note_tags").get() as { c: number };
-  const tag_count = tagCountRow.c;
+  const tagCount = tagCountRow.c;
 
   return {
-    total_notes,
-    earliest_note: earliestRow
-      ? { id: earliestRow.id, created_at: earliestRow.created_at }
+    totalNotes,
+    earliestNote: earliestRow
+      ? { id: earliestRow.id, createdAt: earliestRow.created_at }
       : null,
-    latest_note: latestRow
-      ? { id: latestRow.id, created_at: latestRow.created_at }
+    latestNote: latestRow
+      ? { id: latestRow.id, createdAt: latestRow.created_at }
       : null,
-    notes_by_month: monthRows,
-    top_tags: topTagRows,
-    tag_count,
+    notesByMonth: monthRows,
+    topTags: topTagRows,
+    tagCount,
   };
 }
 

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -172,6 +172,10 @@ export class SqliteStore implements Store {
     return linkOps.getLinks(this.db, noteId, opts);
   }
 
+  listLinks(opts?: { noteId?: string; direction?: "outbound" | "inbound" | "both"; relationship?: string }): Link[] {
+    return linkOps.listLinks(this.db, opts);
+  }
+
   // ---- Bulk Operations ----
 
   createNotes(inputs: noteOps.BulkNoteInput[]): Note[] {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -35,12 +35,12 @@ export interface Attachment {
 // ---- Vault Stats ----
 
 export interface VaultStats {
-  total_notes: number;
-  earliest_note: { id: string; created_at: string } | null;
-  latest_note: { id: string; created_at: string } | null;
-  notes_by_month: { month: string; count: number }[];
-  top_tags: { tag: string; count: number }[];
-  tag_count: number;
+  totalNotes: number;
+  earliestNote: { id: string; createdAt: string } | null;
+  latestNote: { id: string; createdAt: string } | null;
+  notesByMonth: { month: string; count: number }[];
+  topTags: { tag: string; count: number }[];
+  tagCount: number;
 }
 
 // ---- Query Options ----
@@ -66,6 +66,21 @@ export interface NoteSummary {
   createdAt: string;
   updatedAt?: string;
   tags?: string[];
+}
+
+/**
+ * Lean note index entry — summary + byteSize + single-line preview.
+ * Used by read-notes (index mode), GET /notes (list default), and /graph.
+ */
+export interface NoteIndex {
+  id: string;
+  path?: string;
+  createdAt: string;
+  updatedAt?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  byteSize: number;
+  preview: string;
 }
 
 /** Link with hydrated note summaries. */
@@ -100,6 +115,7 @@ export interface Store {
   createLink(sourceId: string, targetId: string, relationship: string, metadata?: Record<string, unknown>): Link;
   deleteLink(sourceId: string, targetId: string, relationship: string): void;
   getLinks(noteId: string, opts?: { direction?: "outbound" | "inbound" | "both" }): Link[];
+  listLinks(opts?: { noteId?: string; direction?: "outbound" | "inbound" | "both"; relationship?: string }): Link[];
 
   // Bulk operations
   createNotes(inputs: { content: string; id?: string; path?: string; tags?: string[] }[]): Note[];

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1,0 +1,344 @@
+# Parachute Vault HTTP API
+
+A flat reference for the Parachute Vault HTTP surface. Intended for humans *and*
+agents building tools that read or write a vault over HTTP.
+
+All endpoints serve JSON. The same vault is reachable at two roots:
+
+- `/api/...` — the server's default vault
+- `/vaults/{name}/api/...` — any named vault on this server
+
+Use whichever is convenient. Examples below use the default `/api` root.
+
+## Quick start — render a graph in 5 lines
+
+```js
+const res = await fetch("http://localhost:1940/api/graph", {
+  headers: { Authorization: `Bearer ${apiKey}` },
+});
+const { notes, links, tags, meta } = await res.json();
+// notes: lightweight NoteIndex[] — id, path, tags, createdAt, byteSize, preview
+// links: Link[]                 — sourceId, targetId, relationship, metadata
+// Hand this to d3-force, cytoscape, sigma.js, etc.
+```
+
+That's the whole happy path. Everything else in this doc is detail.
+
+## Conventions
+
+- **Response payloads are camelCase**: `createdAt`, `sourceId`, `mimeType`,
+  `totalNotes`.
+- **Request payloads are camelCase**: you `POST {sourceId, targetId, ...}` and
+  get the same shape back.
+- **Query params are snake_case**: `?include_content=true`, `?tag_match=any`,
+  `?date_from=2025-01-01`. This matches the MCP tool-arg convention, so one
+  concept ports cleanly between HTTP and MCP.
+- **Timestamps are ISO-8601** UTC strings (e.g. `2026-04-07T15:30:00.000Z`).
+- **No envelope**. Responses are the data itself (`{...}` or `[...]`), not
+  wrapped in `{data: ...}`. Error responses are `{error: "...", message?: "..."}`.
+
+## Authentication
+
+Pass your API key as either:
+
+```
+Authorization: Bearer <key>
+X-API-Key: <key>
+```
+
+Requests from localhost bypass auth (you can hit the server directly without a
+key for local dev).
+
+Keys have a **scope**:
+
+- `write` — full access
+- `read`  — `GET`/`HEAD`/`OPTIONS` only; writes return `403 Forbidden`
+
+A read-only key is the right thing to hand to a visualizer or static-site
+generator.
+
+## The shapes
+
+### `Note`
+
+```ts
+{
+  id: string;
+  content: string;
+  path?: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt?: string;
+  tags?: string[];
+}
+```
+
+### `NoteIndex` (lean shape)
+
+Returned by list endpoints by default. Same as `Note` minus `content`, plus
+`byteSize` and a one-line `preview` (120 code points, whitespace collapsed).
+
+```ts
+{
+  id: string;
+  path?: string;
+  createdAt: string;
+  updatedAt?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  byteSize: number;  // UTF-8 bytes of the full content
+  preview: string;   // first ~120 chars, single line
+}
+```
+
+### `Link`
+
+```ts
+{
+  sourceId: string;
+  targetId: string;
+  relationship: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+}
+```
+
+### `VaultStats`
+
+```ts
+{
+  totalNotes: number;
+  earliestNote: { id: string; createdAt: string } | null;
+  latestNote:   { id: string; createdAt: string } | null;
+  notesByMonth: { month: string; count: number }[];  // e.g. "2026-04"
+  topTags:      { tag: string; count: number }[];
+  tagCount:     number;
+}
+```
+
+## Defaults: lean lists, fat point reads
+
+- **List endpoints** (`GET /notes`, `GET /graph`) default to `NoteIndex`. The
+  common case is viz/listing, which doesn't need the full body of every note.
+- **Point reads** (`GET /notes/:id`) default to the full `Note`. If you asked
+  for one specific thing by ID, you probably want its content.
+
+Both shapes can be forced either way with `?include_content=true|false`.
+
+## Endpoints
+
+### Server-level
+
+#### `GET /health`
+Returns `{status: "ok", vaults: string[]}`. No auth required.
+
+#### `GET /vaults`
+List all vaults on the server.
+```json
+{
+  "vaults": [
+    { "name": "default", "description": "...", "created_at": "..." }
+  ]
+}
+```
+
+#### `GET /vaults/{name}`
+Single-vault landing payload — name, description, createdAt, and stats in one
+round trip. Useful for a viz site's home page.
+```json
+{
+  "name": "default",
+  "description": "My knowledge graph",
+  "createdAt": "2026-01-01T00:00:00.000Z",
+  "stats": { "totalNotes": 617, "topTags": [...], "notesByMonth": [...], ... }
+}
+```
+
+### Notes
+
+#### `GET /notes`
+Query notes. Returns `NoteIndex[]` by default.
+
+Query params:
+- `include_content=true` — return full `Note[]` instead.
+- `ids=a,b,c` — fetch specific notes by ID. Practical limit ~50 IDs due to
+  URL length; for larger batches call multiple times.
+- `tag=foo&tag=bar` — filter by tags (repeat param to pass multiple).
+- `tag_match=all|any` — default `all`.
+- `exclude_tag=foo` — exclude notes with this tag.
+- `date_from=ISO` — inclusive lower bound on `createdAt`.
+- `date_to=ISO` — exclusive upper bound.
+- `sort=asc|desc` — by `createdAt`. Default `asc`.
+- `limit=N` — default 100.
+- `offset=N` — default 0.
+
+#### `POST /notes`
+Create a note. Body:
+```json
+{
+  "content": "...",            // required
+  "id": "optional-client-id",
+  "path": "Projects/Foo",
+  "tags": ["a", "b"],
+  "metadata": { "status": "draft" },
+  "createdAt": "2026-04-07T..."
+}
+```
+Returns the created `Note`, `201 Created`.
+
+#### `GET /notes/{id}`
+Returns the full `Note`. `?include_content=false` returns a `NoteIndex`.
+
+#### `PATCH /notes/{id}`
+Update content, path, or metadata. Body:
+```json
+{ "content": "new body", "path": "new/path", "metadata": {...} }
+```
+
+#### `DELETE /notes/{id}`
+Returns `{deleted: true}`.
+
+#### `POST /notes/{id}/tags`, `DELETE /notes/{id}/tags`
+Body: `{"tags": ["a", "b"]}`.
+
+#### `POST /notes/{id}/attachments`
+Body: `{"path": "files/a.png", "mimeType": "image/png"}`.
+
+#### `GET /notes/{id}/attachments`
+Returns `Attachment[]`.
+
+### Links
+
+#### `GET /links`
+List edges. Polymorphic — filters compose freely.
+
+Query params:
+- `note_id=abc` — only edges touching this note.
+- `direction=outbound|inbound|both` — only meaningful with `note_id`.
+  Default `both`.
+- `relationship=cites` — only edges of this type.
+
+Returns bare `Link[]` — no hydration. If you need the connected notes'
+details, pair the result with `GET /notes?ids=...`.
+
+Examples:
+```
+GET /links                              # everything
+GET /links?note_id=abc                  # all edges touching note abc
+GET /links?note_id=abc&direction=outbound
+GET /links?relationship=cites           # vault-wide, by type
+```
+
+#### `POST /links`
+Body:
+```json
+{ "sourceId": "a", "targetId": "b", "relationship": "cites", "metadata": {...} }
+```
+
+#### `DELETE /links`
+Body:
+```json
+{ "sourceId": "a", "targetId": "b", "relationship": "cites" }
+```
+
+### Graph
+
+#### `GET /graph`
+One-shot knowledge graph payload for visualization.
+
+```json
+{
+  "notes": [ /* NoteIndex[] by default, Note[] if include_content=true */ ],
+  "links": [ /* Link[] */ ],
+  "tags":  [ { "name": "...", "count": 12 } ],
+  "meta": {
+    "totalNotes": 617,
+    "totalLinks": 1234,
+    "filteredNotes": 617,
+    "filteredLinks": 1234,
+    "includeContent": false
+  }
+}
+```
+
+Query params:
+- `include_content=true` — fatten each note to include full content.
+- `tag=foo&tag=bar` — filter to a subgraph (only notes with these tags, and
+  only links where **both** endpoints are in the subset).
+- `tag_match=all|any` — default `all`.
+- `exclude_tag=foo`.
+
+`meta.totalNotes` / `meta.totalLinks` always reflect the full vault;
+`filteredNotes` / `filteredLinks` reflect the response.
+
+### Search
+
+#### `GET /search?q=query`
+Full-text search. Returns `Note[]` (full shape).
+
+Query params:
+- `q=...` — required.
+- `tag=foo` — optional tag filter (repeatable).
+- `limit=N` — default 50.
+
+### Tags
+
+#### `GET /tags`
+Returns `[{name, count}]`.
+
+### Vault stats
+
+You usually want `GET /vaults/{name}` which bundles stats with vault metadata.
+If you only need the stats, call `GET /vaults/{name}` and read `.stats`.
+
+### Storage
+
+#### `POST /storage/upload`
+Multipart form:
+- `file` — required, audio/image, ≤100MB
+- `transcribe=true` — optional, transcribe audio server-side
+
+Returns `{path, size, mimeType, transcription?}`.
+
+#### `GET /storage/{date}/{filename}`
+Serves the uploaded file.
+
+### Ingest (voice note one-shot)
+
+#### `POST /ingest`
+Multipart form that uploads audio, optionally transcribes, and creates a note
+with the audio attached — all in one request.
+
+- `file` — required
+- `content` — optional note body (e.g. client-side transcription)
+- `createdAt` — ISO-8601, optional (defaults to now)
+- `tags` — comma-separated
+- `path`, `id`, `metadata` (JSON string) — optional
+- `sync=true` or `transcribe=true` — transcribe server-side before responding
+
+Returns `{note, attachment, transcription}`.
+
+## CORS
+
+The server sends permissive CORS headers (`Access-Control-Allow-Origin: *`)
+so a static site on any origin can fetch the API. Writes still require a
+valid API key.
+
+## Pairing with MCP
+
+Every read endpoint here has a matching MCP tool over `/mcp`
+(unified) or `/vaults/{name}/mcp` (scoped):
+
+| HTTP                      | MCP tool            |
+|---------------------------|---------------------|
+| `GET /notes`              | `read-notes`        |
+| `GET /notes?ids=...`      | `get-note` (ids)    |
+| `GET /notes/{id}`         | `get-note`          |
+| `GET /links`              | `get-links`         |
+| `GET /graph`              | `get-graph`         |
+| `GET /vaults/{name}`      | `get-vault-stats` + `get-vault-description` |
+| `GET /tags`               | `list-tags`         |
+| `GET /search?q=`          | `search-notes`      |
+
+The MCP tools use the same lean-vs-fat convention (`include_content: true|false`)
+and the same snake_case arg names as the HTTP query params.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -27,6 +27,7 @@ const READ_TOOLS = new Set([
   "read-notes",
   "search-notes",
   "get-links",
+  "get-graph",
   "traverse-links",
   "find-path",
   "list-tags",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,10 +7,16 @@
 
 import type { Store } from "../core/src/types.ts";
 import { resolveWikilinkDetailed, listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
+import { toNoteIndex } from "../core/src/notes.ts";
 import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { vaultDir } from "./config.ts";
 import type { NarrateModule } from "./tts-hook.ts";
+
+function parseBool(val: string | null, defaultVal: boolean): boolean {
+  if (val === null) return defaultVal;
+  return val === "true" || val === "1";
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,19 +47,26 @@ export async function handleNotes(
   const url = new URL(req.url);
   const method = req.method;
 
-  // GET /notes — Query notes
+  // GET /notes — Query notes.
+  // Default response is the lean index shape (no content). Pass
+  // ?include_content=true to get full notes. Pass ?ids=a,b,c to fetch
+  // specific notes by ID (still honors include_content).
   if (method === "GET" && path === "") {
-    const results = store.queryNotes({
-      tags: parseQueryList(url, "tag"),
-      tagMatch: (parseQuery(url, "tag_match") as "all" | "any") ?? undefined,
-      excludeTags: parseQueryList(url, "exclude_tag"),
-      dateFrom: parseQuery(url, "date_from") ?? undefined,
-      dateTo: parseQuery(url, "date_to") ?? undefined,
-      sort: (parseQuery(url, "sort") as "asc" | "desc") ?? undefined,
-      limit: parseQuery(url, "limit") ? parseInt(parseQuery(url, "limit")!, 10) : undefined,
-      offset: parseQuery(url, "offset") ? parseInt(parseQuery(url, "offset")!, 10) : undefined,
-    });
-    return json(results);
+    const includeContent = parseBool(parseQuery(url, "include_content"), false);
+    const ids = parseQueryList(url, "ids");
+    const fetched = ids
+      ? store.getNotes(ids)
+      : store.queryNotes({
+          tags: parseQueryList(url, "tag"),
+          tagMatch: (parseQuery(url, "tag_match") as "all" | "any") ?? undefined,
+          excludeTags: parseQueryList(url, "exclude_tag"),
+          dateFrom: parseQuery(url, "date_from") ?? undefined,
+          dateTo: parseQuery(url, "date_to") ?? undefined,
+          sort: (parseQuery(url, "sort") as "asc" | "desc") ?? undefined,
+          limit: parseQuery(url, "limit") ? parseInt(parseQuery(url, "limit")!, 10) : undefined,
+          offset: parseQuery(url, "offset") ? parseInt(parseQuery(url, "offset")!, 10) : undefined,
+        });
+    return json(includeContent ? fetched : fetched.map(toNoteIndex));
   }
 
   // POST /notes — Create note
@@ -64,14 +77,14 @@ export async function handleNotes(
       path?: string;
       tags?: string[];
       metadata?: Record<string, unknown>;
-      created_at?: string;
+      createdAt?: string;
     };
     const note = store.createNote(body.content ?? "", {
       id: body.id,
       path: body.path,
       tags: body.tags,
       metadata: body.metadata,
-      created_at: body.created_at,
+      created_at: body.createdAt,
     });
     return json(note, 201);
   }
@@ -84,10 +97,13 @@ export async function handleNotes(
   const subpath = idMatch[2] ?? "";
 
   // GET /notes/:id
+  // Defaults to full content (the point-read case). Pass
+  // ?include_content=false to get the lean index shape.
   if (method === "GET" && subpath === "") {
     const note = store.getNote(noteId);
     if (!note) return json({ error: "Not found" }, 404);
-    return json(note);
+    const includeContent = parseBool(parseQuery(url, "include_content"), true);
+    return json(includeContent ? note : toNoteIndex(note));
   }
 
   // PATCH /notes/:id
@@ -125,22 +141,15 @@ export async function handleNotes(
     return json(store.getNote(noteId));
   }
 
-  // GET /notes/:id/links
-  if (method === "GET" && subpath === "/links") {
-    const direction = parseQuery(url, "direction") as "outbound" | "inbound" | "both" | null;
-    const links = store.getLinks(noteId, { direction: direction ?? "both" });
-    return json(links);
-  }
-
   // POST /notes/:id/attachments
   if (method === "POST" && subpath === "/attachments") {
     const existing = store.getNote(noteId);
     if (!existing) return json({ error: "Not found" }, 404);
-    const body = await req.json() as { path: string; mime_type: string };
-    if (!body.path || !body.mime_type) {
-      return json({ error: "path and mime_type are required" }, 400);
+    const body = await req.json() as { path: string; mimeType: string };
+    if (!body.path || !body.mimeType) {
+      return json({ error: "path and mimeType are required" }, 400);
     }
-    const attachment = store.addAttachment(noteId, body.path, body.mime_type);
+    const attachment = store.addAttachment(noteId, body.path, body.mimeType);
     return json(attachment, 201);
   }
 
@@ -181,30 +190,99 @@ export async function handleLinks(
   req: Request,
   store: Store,
 ): Promise<Response> {
+  // GET /links — list edges.
+  // Filters: ?note_id (only links touching this note), ?direction
+  // (outbound|inbound|both, only meaningful with note_id), ?relationship.
+  // Returns bare Link[], no hydration. Pair with GET /notes?ids=... if you
+  // need the connected notes' details.
+  if (req.method === "GET") {
+    const url = new URL(req.url);
+    const noteId = parseQuery(url, "note_id") ?? undefined;
+    const direction = (parseQuery(url, "direction") as "outbound" | "inbound" | "both" | null) ?? undefined;
+    const relationship = parseQuery(url, "relationship") ?? undefined;
+    return json(store.listLinks({ noteId, direction: direction ?? undefined, relationship }));
+  }
+
   if (req.method === "POST") {
     const body = await req.json() as {
-      source_id: string;
-      target_id: string;
+      sourceId: string;
+      targetId: string;
       relationship: string;
+      metadata?: Record<string, unknown>;
     };
-    if (!body.source_id || !body.target_id || !body.relationship) {
-      return json({ error: "source_id, target_id, and relationship are required" }, 400);
+    if (!body.sourceId || !body.targetId || !body.relationship) {
+      return json({ error: "sourceId, targetId, and relationship are required" }, 400);
     }
-    const link = store.createLink(body.source_id, body.target_id, body.relationship);
+    const link = store.createLink(body.sourceId, body.targetId, body.relationship, body.metadata);
     return json(link, 201);
   }
 
   if (req.method === "DELETE") {
     const body = await req.json() as {
-      source_id: string;
-      target_id: string;
+      sourceId: string;
+      targetId: string;
       relationship: string;
     };
-    store.deleteLink(body.source_id, body.target_id, body.relationship);
+    store.deleteLink(body.sourceId, body.targetId, body.relationship);
     return json({ deleted: true });
   }
 
+  // GET handled in the new polymorphic path below
   return json({ error: "Method not allowed" }, 405);
+}
+
+// ---------------------------------------------------------------------------
+// Graph
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /graph — one-shot knowledge graph payload.
+ *
+ * Returns { notes, links, tags, meta }. Lean notes by default (NoteIndex),
+ * include_content=true fattens them. Optional tag filter restricts notes
+ * to a subgraph; links are filtered to edges between notes in the subset.
+ */
+export function handleGraph(req: Request, store: Store): Response {
+  if (req.method !== "GET") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+  const url = new URL(req.url);
+  const tags = parseQueryList(url, "tag");
+  const tagMatch = (parseQuery(url, "tag_match") as "all" | "any") ?? undefined;
+  const excludeTags = parseQueryList(url, "exclude_tag");
+  const includeContent = parseBool(parseQuery(url, "include_content"), false);
+
+  const hasTagFilter = !!(tags?.length || excludeTags?.length);
+  const filteredNotes = store.queryNotes({
+    tags,
+    tagMatch,
+    excludeTags,
+    limit: 1_000_000,
+  });
+  const outNotes = includeContent ? filteredNotes : filteredNotes.map(toNoteIndex);
+
+  const allLinks = store.listLinks();
+  const outLinks = hasTagFilter
+    ? (() => {
+        const ids = new Set(filteredNotes.map((n) => n.id));
+        return allLinks.filter((l) => ids.has(l.sourceId) && ids.has(l.targetId));
+      })()
+    : allLinks;
+
+  const stats = store.getVaultStats({ topTagsLimit: 1_000_000 });
+
+  return json({
+    notes: outNotes,
+    links: outLinks,
+    tags: store.listTags(),
+    meta: {
+      totalNotes: stats.totalNotes,
+      totalLinks: allLinks.length,
+      filteredNotes: outNotes.length,
+      filteredLinks: outLinks.length,
+      includeContent,
+    },
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -306,7 +384,7 @@ export async function handleStorage(req: Request, path: string, vault: string): 
     const result: Record<string, unknown> = {
       path: relativePath,
       size: buffer.length,
-      mime_type: mimeType,
+      mimeType,
     };
 
     // Optional: transcribe audio in the same request
@@ -365,7 +443,7 @@ export async function handleStorage(req: Request, path: string, vault: string): 
  * Multipart form:
  *   file          — audio file (required)
  *   content       — note text (optional, e.g., client transcription or user notes)
- *   created_at    — when the note was taken, ISO-8601 (optional, defaults to now)
+ *   createdAt     — when the note was taken, ISO-8601 (optional, defaults to now)
  *   tags          — comma-separated tags (optional)
  *   path          — note path (optional)
  *   metadata      — JSON string of note metadata (optional)
@@ -434,7 +512,7 @@ export async function handleIngest(
   }
 
   // 4. Parse options
-  const createdAt = (form.get("created_at") as string) ?? undefined;
+  const createdAt = (form.get("createdAt") as string) ?? undefined;
   const tagsStr = form.get("tags") as string | null;
   const tags = tagsStr ? tagsStr.split(",").map((t) => t.trim()).filter(Boolean) : undefined;
   const path = (form.get("path") as string) ?? undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,7 @@ import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig,
 import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed } from "./auth.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
-import { handleNotes, handleTags, handleLinks, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech } from "./routes.ts";
+import { handleNotes, handleTags, handleLinks, handleGraph, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech } from "./routes.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTtsHook, type NarrateModule } from "./tts-hook.ts";
 import { registerTranscriptionHook, type ScribeModule } from "./transcription-hook.ts";
@@ -257,6 +257,7 @@ async function route(req: Request, path: string): Promise<Response> {
     if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6));
     if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
     if (apiPath === "/links") return handleLinks(req, store);
+    if (apiPath === "/graph") return handleGraph(req, store);
     if (apiPath === "/search") return handleSearch(req, store);
     if (apiPath === "/resolve-wikilink") return handleResolveWikilink(req, store);
     if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store);
@@ -291,6 +292,22 @@ async function route(req: Request, path: string): Promise<Response> {
     return handleScopedMcp(req, vaultName, auth.scope);
   }
 
+  // Bare /vaults/{name} — single-vault root. Returns name, description,
+  // createdAt, and stats. One round trip for a viz landing page.
+  if (subpath === "" || subpath === "/") {
+    if (req.method !== "GET") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    const store = getVaultStore(vaultName);
+    const stats = store.getVaultStats();
+    return Response.json({
+      name: vaultName,
+      description: vaultConfig.description,
+      createdAt: vaultConfig.created_at,
+      stats,
+    });
+  }
+
   // REST API — enforce read-only scope
   if (!isMethodAllowed(req.method, auth.scope)) {
     return Response.json(
@@ -315,6 +332,9 @@ async function route(req: Request, path: string): Promise<Response> {
   }
   if (apiPath === "/links") {
     return handleLinks(req, store);
+  }
+  if (apiPath === "/graph") {
+    return handleGraph(req, store);
   }
   if (apiPath === "/search") {
     return handleSearch(req, store);

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "os";
 import { BunStore } from "./vault-store.ts";
 import { generateMcpTools } from "../core/src/mcp.ts";
 import { getLinksHydrated } from "../core/src/links.ts";
+import { handleNotes, handleLinks, handleGraph } from "./routes.ts";
 
 let db: Database;
 let store: BunStore;
@@ -468,9 +469,9 @@ describe("deeper link queries", () => {
 });
 
 describe("MCP tools", () => {
-  test("generates all 21 core tools", () => {
+  test("generates all 22 core tools", () => {
     const tools = generateMcpTools(db);
-    expect(tools.length).toBe(21);
+    expect(tools.length).toBe(22);
 
     const names = tools.map((t) => t.name);
     expect(names).toContain("get-note");
@@ -482,6 +483,7 @@ describe("MCP tools", () => {
     expect(names).toContain("find-path");
     expect(names).toContain("list-tags");
     expect(names).toContain("get-vault-stats");
+    expect(names).toContain("get-graph");
   });
 
   test("get-note tool works by id", () => {
@@ -556,10 +558,10 @@ describe("unified MCP wrapper", () => {
     // Routed explicitly via the vault param, mirroring how a multi-vault
     // client targets a specific vault.
     const result = statsTool!.execute({ vault: vaultName }) as any;
-    expect(result.total_notes).toBe(2);
-    expect(result.tag_count).toBe(2);
-    expect(result.top_tags[0].tag).toBe("x");
-    expect(result.top_tags[0].count).toBe(2);
+    expect(result.totalNotes).toBe(2);
+    expect(result.tagCount).toBe(2);
+    expect(result.topTags[0].tag).toBe("x");
+    expect(result.topTags[0].count).toBe(2);
 
     closeAllStores();
   });
@@ -851,6 +853,198 @@ describe("auth scopes", () => {
     expect(isMethodAllowed("PATCH", "read")).toBe(false);
     expect(isMethodAllowed("DELETE", "read")).toBe(false);
   });
+
+  test("get-graph is a read tool", () => {
+    const { isToolAllowed } = require("./auth.ts");
+    expect(isToolAllowed("get-graph", "read")).toBe(true);
+  });
+});
+
+// ---- HTTP route handlers ----
+
+const BASE = "http://localhost/api";
+
+function mkReq(method: string, path: string, body?: unknown): Request {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { "Content-Type": "application/json" };
+  }
+  return new Request(`${BASE}${path}`, init);
+}
+
+describe("HTTP /notes", () => {
+  test("GET /notes defaults to lean index (no content field)", async () => {
+    store.createNote("one content", { path: "a", tags: ["t"] });
+    store.createNote("two content", { path: "b", tags: ["t"] });
+    const res = await handleNotes(mkReq("GET", "/notes"), store, "");
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(2);
+    expect(body[0]).not.toHaveProperty("content");
+    expect(body[0]).toHaveProperty("byteSize");
+    expect(body[0]).toHaveProperty("preview");
+  });
+
+  test("GET /notes?include_content=true returns full notes", async () => {
+    store.createNote("full body", { path: "a" });
+    const res = await handleNotes(mkReq("GET", "/notes?include_content=true"), store, "");
+    const body = await res.json() as any[];
+    expect(body[0].content).toBe("full body");
+  });
+
+  test("GET /notes?ids=a,b bulk fetch", async () => {
+    const n1 = store.createNote("one", { id: "id-1" });
+    const n2 = store.createNote("two", { id: "id-2" });
+    store.createNote("three", { id: "id-3" });
+    const res = await handleNotes(mkReq("GET", "/notes?ids=id-1,id-2"), store, "");
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(2);
+    const ids = body.map((n) => n.id).sort();
+    expect(ids).toEqual(["id-1", "id-2"]);
+  });
+
+  test("GET /notes/:id defaults to full content", async () => {
+    const n = store.createNote("hello", { id: "x" });
+    const res = await handleNotes(mkReq("GET", "/notes/x"), store, "/x");
+    const body = await res.json() as any;
+    expect(body.content).toBe("hello");
+  });
+
+  test("GET /notes/:id?include_content=false returns lean shape", async () => {
+    store.createNote("hello", { id: "x" });
+    const res = await handleNotes(mkReq("GET", "/notes/x?include_content=false"), store, "/x");
+    const body = await res.json() as any;
+    expect(body).not.toHaveProperty("content");
+    expect(body.byteSize).toBe(5);
+    expect(body.preview).toBe("hello");
+  });
+
+  test("POST /notes accepts createdAt (camelCase) in body", async () => {
+    const res = await handleNotes(
+      mkReq("POST", "/notes", { content: "hi", createdAt: "2025-01-01T00:00:00.000Z" }),
+      store,
+      "",
+    );
+    const body = await res.json() as any;
+    expect(body.createdAt).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  test("POST /notes/:id/attachments accepts mimeType (camelCase) in body", async () => {
+    const n = store.createNote("x", { id: "x" });
+    const res = await handleNotes(
+      mkReq("POST", "/notes/x/attachments", { path: "files/a.png", mimeType: "image/png" }),
+      store,
+      "/x/attachments",
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.mimeType).toBe("image/png");
+  });
+});
+
+describe("HTTP /links (polymorphic)", () => {
+  test("GET /links returns all edges", async () => {
+    store.createNote("a", { id: "a" });
+    store.createNote("b", { id: "b" });
+    store.createNote("c", { id: "c" });
+    store.createLink("a", "b", "mentions");
+    store.createLink("b", "c", "cites");
+    const res = await handleLinks(mkReq("GET", "/links"), store);
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(2);
+  });
+
+  test("GET /links?note_id=a restricts to links touching a", async () => {
+    store.createNote("a", { id: "a" });
+    store.createNote("b", { id: "b" });
+    store.createNote("c", { id: "c" });
+    store.createLink("a", "b", "mentions");
+    store.createLink("b", "c", "cites");
+    const res = await handleLinks(mkReq("GET", "/links?note_id=a"), store);
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(1);
+    expect(body[0].sourceId).toBe("a");
+  });
+
+  test("GET /links?relationship=cites filters by type", async () => {
+    store.createNote("a", { id: "a" });
+    store.createNote("b", { id: "b" });
+    store.createLink("a", "b", "mentions");
+    store.createLink("a", "b", "cites");
+    const res = await handleLinks(mkReq("GET", "/links?relationship=cites"), store);
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(1);
+    expect(body[0].relationship).toBe("cites");
+  });
+
+  test("POST /links accepts sourceId/targetId (camelCase) in body", async () => {
+    store.createNote("a", { id: "a" });
+    store.createNote("b", { id: "b" });
+    const res = await handleLinks(
+      mkReq("POST", "/links", { sourceId: "a", targetId: "b", relationship: "cites" }),
+      store,
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.sourceId).toBe("a");
+    expect(body.targetId).toBe("b");
+  });
+
+  test("POST /links rejects snake_case body fields", async () => {
+    store.createNote("a", { id: "a" });
+    store.createNote("b", { id: "b" });
+    const res = await handleLinks(
+      mkReq("POST", "/links", { source_id: "a", target_id: "b", relationship: "cites" }),
+      store,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("HTTP /graph", () => {
+  test("returns notes, links, tags, meta", async () => {
+    store.createNote("a", { id: "a", tags: ["proj"] });
+    store.createNote("b", { id: "b", tags: ["proj"] });
+    store.createNote("c", { id: "c", tags: ["other"] });
+    store.createLink("a", "b", "mentions");
+    const res = await handleGraph(mkReq("GET", "/graph"), store);
+    const body = await res.json() as any;
+    expect(body.notes).toHaveLength(3);
+    expect(body.links).toHaveLength(1);
+    expect(body.tags.length).toBeGreaterThan(0);
+    expect(body.meta.totalNotes).toBe(3);
+    expect(body.meta.totalLinks).toBe(1);
+    expect(body.meta.includeContent).toBe(false);
+    // Lean by default
+    expect(body.notes[0]).not.toHaveProperty("content");
+    expect(body.notes[0]).toHaveProperty("byteSize");
+  });
+
+  test("?include_content=true returns full note content", async () => {
+    store.createNote("has body", { id: "a" });
+    const res = await handleGraph(mkReq("GET", "/graph?include_content=true"), store);
+    const body = await res.json() as any;
+    expect(body.notes[0].content).toBe("has body");
+    expect(body.meta.includeContent).toBe(true);
+  });
+
+  test("?tag=proj filters notes and links to the subgraph", async () => {
+    store.createNote("a", { id: "a", tags: ["proj"] });
+    store.createNote("b", { id: "b", tags: ["proj"] });
+    store.createNote("c", { id: "c", tags: ["other"] });
+    store.createLink("a", "b", "mentions"); // inside subgraph
+    store.createLink("a", "c", "mentions"); // crosses subgraph boundary
+    const res = await handleGraph(mkReq("GET", "/graph?tag=proj"), store);
+    const body = await res.json() as any;
+    expect(body.notes).toHaveLength(2);
+    expect(body.links).toHaveLength(1);
+    expect(body.links[0].sourceId).toBe("a");
+    expect(body.links[0].targetId).toBe("b");
+    expect(body.meta.totalNotes).toBe(3);
+    expect(body.meta.totalLinks).toBe(2);
+    expect(body.meta.filteredNotes).toBe(2);
+    expect(body.meta.filteredLinks).toBe(1);
+  });
 });
 
 describe("stateless MCP transport", () => {
@@ -891,7 +1085,7 @@ describe("stateless MCP transport", () => {
     const body = await res.json() as any;
     expect(body.result).toBeDefined();
     const content = JSON.parse(body.result.content[0].text);
-    expect(content.total_notes).toBe(1);
+    expect(content.totalNotes).toBe(1);
 
     closeAllStores();
   });


### PR DESCRIPTION
## Summary
- **`GET /graph`** — one-shot knowledge graph payload (`{notes, links, tags, meta}`) for viz sites. Lean by default, `?include_content=true` to fatten. Tag subgraph filtering via `?tag=&tag_match=`.
- **`GET /links`** — polymorphic edge listing. No params → all edges. `?note_id=`, `?direction=`, `?relationship=` compose freely. Replaces the old `GET /notes/:id/links`.
- **`GET /notes`** — now defaults to lean `NoteIndex[]` (id, path, tags, byteSize, preview — no content). `?include_content=true` for full notes. `?ids=a,b,c` for bulk fetch.
- **`GET /vaults/:name`** — single-vault root returning `{name, description, createdAt, stats}` in one call.
- **New `get-graph` MCP tool** — mirrors the HTTP endpoint. Added to read-only tools.
- **`get-links` MCP tool** now polymorphic — `id` is optional, `relationship` filter added, returns bare `Link[]` (no hydration).
- **VaultStats fields renamed to camelCase** (`totalNotes`, `topTags`, `tagCount`, `notesByMonth`, `earliestNote`, `latestNote`).
- **HTTP POST/PATCH bodies renamed to camelCase** (`sourceId`, `targetId`, `mimeType`, `createdAt`). Query params stay snake_case.
- **Shared `toNoteIndex()` helper** extracted from inline MCP code into `core/src/notes.ts`. Used by `read-notes`, HTTP `/notes`, and `/graph`.
- **`docs/HTTP_API.md`** — full endpoint reference with a "5 lines to render a graph" example up top.

## Breaking changes
- `GET /notes` default response is now lean (no `content`). Add `?include_content=true` for the old behavior.
- `GET /notes/:id/links` removed. Use `GET /links?note_id=...` instead.
- `get-links` MCP tool no longer hydrates (no `sourceNote`/`targetNote`). Use `get-note` for connected note details.
- HTTP POST bodies use camelCase (`sourceId` not `source_id`, `mimeType` not `mime_type`).
- `VaultStats` response fields are camelCase (`totalNotes` not `total_notes`).

## Test plan
- [x] `bun test core/src/ src/` — 286 pass, 0 fail
- [x] New tests for: HTTP `/notes` lean/fat/bulk, `/links` polymorphic, `/graph` with tag filter, `get-graph` MCP tool, `get-links` polymorphic MCP, camelCase body migration, snake_case rejection
- [x] Rebased on latest main (0cac19b) — resolved 6 conflicts across notes.ts, mcp.ts, routes.ts, server.ts, and both test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)