### PR TITLE
chore: rename to @openparachute scope, update all imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Use Bun for everything. No Node.js.
 - **Semantic search**: Optional sqlite-vec integration. Embedding providers are configurable (OpenAI, Ollama). Tag/date filters pushed into SQL for efficient filtered search.
 - **Obsidian interop**: Import/export preserves frontmatter, tags, wikilinks, and file paths.
 - **Unified config**: All env vars in `~/.parachute/.env` (or `$PARACHUTE_HOME/.env` in Docker).
-- **Optional transcription**: parachute-scribe is an optional dependency. If installed, vault exposes Whisper-compatible endpoints.
+- **Optional transcription**: `@openparachute/scribe` is an optional dependency. If installed, vault exposes Whisper-compatible endpoints.
 - **Docker-friendly**: `PARACHUTE_HOME` env var overrides data directory. Server auto-creates default vault on first run.
 
 ## Config
@@ -99,7 +99,7 @@ ANTHROPIC_API_KEY=...
 
 - Domain: `parachute.computer`
 - Package ID: `computer.parachute.vault`
-- npm scope: `@parachute/`
+- npm scope: `@openparachute/`
 - Launchd label: `computer.parachute.vault`
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A server on port 1940 with:
 - **Wikilink auto-linking** — `[[wikilinks]]` in note content automatically create links in the graph
 - **Semantic search** — Vector embeddings via sqlite-vec (configure an embedding provider)
 - **Obsidian import/export** — Bidirectional interop with Obsidian vaults
-- **Transcription** — Whisper-compatible endpoint (with [parachute-scribe](https://github.com/ParachuteComputer/parachute-scribe))
+- **Transcription** — Whisper-compatible endpoint (with [@openparachute/scribe](https://github.com/ParachuteComputer/@openparachute/scribe))
 
 Each vault is its own SQLite database. Run multiple vaults on one server.
 
@@ -68,7 +68,7 @@ parachute vault restart
 
 ### Providers
 
-**Transcription** (requires [parachute-scribe](https://github.com/ParachuteComputer/parachute-scribe)):
+**Transcription** (requires [@openparachute/scribe](https://github.com/ParachuteComputer/@openparachute/scribe)):
 
 | Provider | Type | Notes |
 |----------|------|-------|

--- a/core/package.json
+++ b/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@parachute/core",
+  "name": "@openparachute/core",
   "version": "0.1.0",
   "description": "Parachute Vault core — schema, store, graph operations, MCP tools",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@parachute/vault",
+  "name": "@openparachute/vault",
   "version": "0.1.0",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
@@ -23,6 +23,12 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
+    "@openparachute/scribe": "^0.1.0",
+    "@openparachute/narrate": "^0.1.0",
     "typescript": "^5"
+  },
+  "peerDependenciesMeta": {
+    "@openparachute/scribe": { "optional": true },
+    "@openparachute/narrate": { "optional": true }
   }
 }

--- a/scripts/migrate-audio-to-opus.ts
+++ b/scripts/migrate-audio-to-opus.ts
@@ -47,7 +47,7 @@ import { Database } from "bun:sqlite";
 import { existsSync, statSync, unlinkSync, readdirSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
-import { encodeOggOpus } from "parachute-narrate";
+import { encodeOggOpus } from "@openparachute/narrate";
 import { readFileSync, writeFileSync } from "fs";
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -623,7 +623,7 @@ async function cmdStatus() {
     console.log(`  Providers:      ${scribe.transcription.join(", ")}`);
   } else {
     console.log(`  Transcription:  not available`);
-    console.log(`                  bun add parachute-scribe to enable`);
+    console.log(`                  bun add @openparachute/scribe to enable`);
   }
 
   // Embeddings

--- a/src/config.ts
+++ b/src/config.ts
@@ -474,7 +474,7 @@ export async function getScribeStatus(): Promise<{
   activeCleaner: string;
 }> {
   try {
-    const scribe = await import("parachute-scribe");
+    const scribe = await import("@openparachute/scribe");
     const providers = scribe.availableProviders();
     return {
       available: true,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -555,7 +555,7 @@ export async function handleIngest(
 }
 
 // ---------------------------------------------------------------------------
-// Transcription (via parachute-scribe)
+// Transcription (via @openparachute/scribe)
 // ---------------------------------------------------------------------------
 
 let scribeAvailable: boolean | null = null;
@@ -563,7 +563,7 @@ let scribeAvailable: boolean | null = null;
 async function getScribe() {
   if (scribeAvailable === false) return null;
   try {
-    const scribe = await import("parachute-scribe");
+    const scribe = await import("@openparachute/scribe");
     scribeAvailable = true;
     return scribe;
   } catch {
@@ -575,7 +575,7 @@ async function getScribe() {
 export async function handleTranscription(req: Request): Promise<Response> {
   const scribe = await getScribe();
   if (!scribe) {
-    return json({ error: "Transcription not available — parachute-scribe is not installed" }, 501);
+    return json({ error: "Transcription not available — @openparachute/scribe is not installed" }, 501);
   }
 
   const form = await req.formData();
@@ -617,7 +617,7 @@ async function getNarrate(): Promise<NarrateModule | null> {
   if (narrateAvailable === false) return null;
   if (narrateCached) return narrateCached;
   try {
-    const mod = (await import("parachute-narrate")) as unknown as NarrateModule;
+    const mod = (await import("@openparachute/narrate")) as unknown as NarrateModule;
     narrateCached = mod;
     narrateAvailable = true;
     return mod;
@@ -629,7 +629,7 @@ async function getNarrate(): Promise<NarrateModule | null> {
 
 /**
  * Dependencies for `handleTtsSpeech`. Production defaults dynamically
- * import `parachute-narrate`; tests inject a stub module to avoid the
+ * import `@openparachute/narrate`; tests inject a stub module to avoid the
  * real provider, subprocess, and ffmpeg.
  */
 export interface TtsSpeechDeps {
@@ -643,13 +643,13 @@ export interface TtsSpeechDeps {
  *
  * Accepts the OpenAI request shape (`model`, `voice`, `input`,
  * `response_format`). `model` is ignored (the active provider is whatever
- * `parachute-narrate` resolves from env at call time). `response_format`
+ * `@openparachute/narrate` resolves from env at call time). `response_format`
  * accepts `"opus"` / `"mp3"` as aliases and always returns OGG Opus,
  * because the vault unified on that format in #43. Unknown values are
  * rejected with 400 so callers don't silently get the "wrong" format.
  *
  * All heavy lifting (markdown preprocessing, provider resolution, ffmpeg
- * encoding) lives in `parachute-narrate`. This handler's job is just
+ * encoding) lives in `@openparachute/narrate`. This handler's job is just
  * request parsing, validation, narrate invocation, and error-to-status
  * mapping.
  */
@@ -683,7 +683,7 @@ export async function handleTtsSpeech(req: Request, deps: TtsSpeechDeps = {}): P
   const resolveNarrate = deps.getNarrate ?? getNarrate;
   const narrate = await resolveNarrate();
   if (!narrate) {
-    return json({ error: "TTS not available — parachute-narrate is not installed" }, 501);
+    return json({ error: "TTS not available — @openparachute/narrate is not installed" }, 501);
   }
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,15 +40,15 @@ import { assetsDir } from "./routes.ts";
 import type { SqliteStore } from "../core/src/store.ts";
 
 // Features register their note-mutation hooks here. The TTS (#reader →
-// audio) hook is registered if BOTH `parachute-narrate` is installed AND
+// audio) hook is registered if BOTH `@openparachute/narrate` is installed AND
 // a TTS provider is configured in env. Either missing → hook is silently
 // skipped, same shape as how transcription handles optional scribe.
 async function registerHooks(): Promise<void> {
   let narrate: NarrateModule | null = null;
   try {
-    narrate = (await import("parachute-narrate")) as unknown as NarrateModule;
+    narrate = (await import("@openparachute/narrate")) as unknown as NarrateModule;
   } catch {
-    console.log("[hooks] parachute-narrate not installed; skipping tts-reader hook");
+    console.log("[hooks] @openparachute/narrate not installed; skipping tts-reader hook");
     return;
   }
 
@@ -75,7 +75,7 @@ async function registerHooks(): Promise<void> {
       return assetsDir(name);
     },
   });
-  console.log(`[hooks] tts-reader hook registered (provider=${probedProvider.name}, via parachute-narrate)`);
+  console.log(`[hooks] tts-reader hook registered (provider=${probedProvider.name}, via @openparachute/narrate)`);
 }
 
 async function registerTranscriptionHooks(): Promise<void> {
@@ -86,9 +86,9 @@ async function registerTranscriptionHooks(): Promise<void> {
 
   let scribe: ScribeModule | null = null;
   try {
-    scribe = (await import("parachute-scribe")) as unknown as ScribeModule;
+    scribe = (await import("@openparachute/scribe")) as unknown as ScribeModule;
   } catch {
-    console.log("[hooks] parachute-scribe not installed; skipping transcribe-capture hook");
+    console.log("[hooks] @openparachute/scribe not installed; skipping transcribe-capture hook");
     return;
   }
 
@@ -104,7 +104,7 @@ async function registerTranscriptionHooks(): Promise<void> {
       return assetsDir(name);
     },
   });
-  console.log("[hooks] transcribe-capture hook registered (via parachute-scribe)");
+  console.log("[hooks] transcribe-capture hook registered (via @openparachute/scribe)");
 }
 
 await registerHooks();

--- a/src/speech-route.test.ts
+++ b/src/speech-route.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for POST /v1/audio/speech — the OpenAI-compatible TTS endpoint.
  *
- * Injects a stub `parachute-narrate` module so the real provider /
+ * Injects a stub `@openparachute/narrate` module so the real provider /
  * subprocess / ffmpeg never run. Production resolves narrate via dynamic
  * import (mirroring `getScribe`); tests pass a stub via `deps.getNarrate`.
  */
@@ -11,7 +11,7 @@ import { handleTtsSpeech } from "./routes.ts";
 import type { NarrateModule } from "./tts-hook.ts";
 
 // Local stand-ins for narrate's typed error classes. Tests don't import
-// from parachute-narrate directly — they stub the whole module — so we
+// from @openparachute/narrate directly — they stub the whole module — so we
 // mint local subclasses that `instanceof` correctly against themselves.
 class StubNarrateEmptyInputError extends Error {
   constructor(...args: unknown[]) {
@@ -207,7 +207,7 @@ describe("handleTtsSpeech", () => {
     expect(res.status).toBe(501);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe(
-      "TTS not available — parachute-narrate is not installed",
+      "TTS not available — @openparachute/narrate is not installed",
     );
   });
 

--- a/src/transcription-hook.ts
+++ b/src/transcription-hook.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors the shape of `tts-hook.ts`. When a note tagged `#capture` arrives
  * with an audio attachment and empty content, we transcribe the audio via
- * `parachute-scribe` and write the transcript into `note.content`.
+ * `@openparachute/scribe` and write the transcript into `note.content`.
  *
  * ## Two-phase marker
  *
@@ -28,7 +28,7 @@ import type { Note, Store } from "../core/src/types.ts";
 import type { HookRegistry } from "../core/src/hooks.ts";
 
 /**
- * The subset of the `parachute-scribe` module surface the hook uses.
+ * The subset of the `@openparachute/scribe` module surface the hook uses.
  * Declared here so tests can stub it with a plain object.
  */
 export interface ScribeModule {
@@ -36,7 +36,7 @@ export interface ScribeModule {
 }
 
 export interface RegisterTranscriptionHookOptions {
-  /** Injected scribe module (pass the result of `await import("parachute-scribe")`). */
+  /** Injected scribe module (pass the result of `await import("@openparachute/scribe")`). */
   scribe: ScribeModule;
   /**
    * Resolve the vault assets directory for a given store. Called once per

--- a/src/transcription.test.ts
+++ b/src/transcription.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the `#capture` → transcription hook (vault-side integration).
  *
- * The transcription pipeline itself lives in `parachute-scribe`. These tests
+ * The transcription pipeline itself lives in `@openparachute/scribe`. These tests
  * stub the scribe module so they cover only what vault owns: the tag
  * predicate, two-phase marker discipline, content writeback, skip-on-empty
  * behavior, and the failure path that leaves notes in `transcript_pending_at`.

--- a/src/tts-hook.ts
+++ b/src/tts-hook.ts
@@ -4,9 +4,9 @@
  * Vault-specific concerns only: attachment storage, the two-phase marker
  * discipline, and the manual-recovery retry semantics. The actual TTS
  * pipeline (provider resolution, markdown preprocessing, encoding) lives in
- * `parachute-narrate` and is injected into this hook at registration time.
+ * `@openparachute/narrate` and is injected into this hook at registration time.
  *
- * See `parachute-narrate`'s CLAUDE.md for the pipeline; this file documents
+ * See `@openparachute/narrate`'s CLAUDE.md for the pipeline; this file documents
  * the vault-side integration contract.
  *
  * ## Two-phase marker (unchanged from the pre-narrate shape)
@@ -40,7 +40,7 @@ import type { Note, Store } from "../core/src/types.ts";
 import type { HookRegistry } from "../core/src/hooks.ts";
 
 /**
- * The subset of the `parachute-narrate` module surface the hook actually
+ * The subset of the `@openparachute/narrate` module surface the hook actually
  * uses. Declared here so tests can stub it with a plain object and so this
  * file doesn't need a hard type import on the optional dependency.
  */
@@ -59,14 +59,14 @@ export interface NarrateModule {
   // `err instanceof narrate.NarrateEmptyInputError` so we can distinguish
   // "empty input" from "no provider" without substring-matching error
   // messages. Optional so vault still loads against older narrate builds
-  // that predate parachute-narrate#2 — call sites must null-check before
+  // that predate @openparachute/narrate#2 — call sites must null-check before
   // using them.
   NarrateEmptyInputError?: new (...args: unknown[]) => Error;
   NarrateNoProviderError?: new (...args: unknown[]) => Error;
 }
 
 export interface RegisterTtsHookOptions {
-  /** Injected narrate module (pass the result of `await import("parachute-narrate")`). */
+  /** Injected narrate module (pass the result of `await import("@openparachute/narrate")`). */
   narrate: NarrateModule;
   /** Voice id to pass to the provider (usually env.TTS_VOICE or equivalent). */
   voice?: string;

--- a/src/tts.test.ts
+++ b/src/tts.test.ts
@@ -2,7 +2,7 @@
  * Tests for the `#reader` → audio hook (vault-side integration).
  *
  * The TTS pipeline itself (providers, markdown preprocessing, encoding)
- * lives in `parachute-narrate` and has its own tests there. These tests
+ * lives in `@openparachute/narrate` and has its own tests there. These tests
  * stub the narrate module so they cover only what vault owns: the tag
  * predicate, two-phase marker discipline, attachment write, skip-on-empty
  * behavior, and the failure path that leaves notes in `audio_pending_at`.
@@ -34,7 +34,7 @@ async function settle(hooks: HookRegistry): Promise<void> {
 // No-op narrate error classes — the hook never catches typed errors from
 // narrate (it only uses markdownToSpeech + synthesize), but the interface
 // now requires these constructors. Define local shims so the TypeScript
-// shape matches without pulling in parachute-narrate directly.
+// shape matches without pulling in @openparachute/narrate directly.
 class StubNarrateEmptyInputError extends Error {
   constructor(...args: unknown[]) {
     super((args[0] as string | undefined) ?? "empty");


### PR DESCRIPTION
## Summary
- Rename `@parachute/vault` → `@openparachute/vault`, `@parachute/core` → `@openparachute/core`
- Update all dynamic imports: `parachute-scribe` → `@openparachute/scribe`, `parachute-narrate` → `@openparachute/narrate`
- Add optional peerDependencies for `@openparachute/scribe` and `@openparachute/narrate`
- Update CLAUDE.md, README.md, comments, error messages, and CLI output

286 tests pass.

Part of the coordinated move to `@openparachute` npm scope across all repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)