### PR TITLE
feat: serve published notes as public HTML

### DIFF
--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -86,6 +86,37 @@ describe("handlePublicNote", () => {
     expect(html).toContain("&lt;script&gt;");
   });
 
+  it("strips javascript: URI links to prevent XSS", async () => {
+    const store = makeStore({
+      "n6": { content: "[click me](javascript:alert(1))", tags: ["published"] },
+    });
+    const resp = handlePublicNote(store, "n6");
+    const html = await resp.text();
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("click me");
+    expect(html).not.toContain("<a ");
+  });
+
+  it("strips data: URI links to prevent XSS", async () => {
+    const store = makeStore({
+      "n7": { content: "[click](data:text/html;base64,PHNjcmlwdD4=)", tags: ["published"] },
+    });
+    const resp = handlePublicNote(store, "n7");
+    const html = await resp.text();
+    expect(html).not.toContain("data:");
+    expect(html).toContain("click");
+  });
+
+  it("allows safe http/https/mailto links", async () => {
+    const store = makeStore({
+      "n8": { content: "[site](https://example.com) and [mail](mailto:a@b.com)", tags: ["published"] },
+    });
+    const resp = handlePublicNote(store, "n8");
+    const html = await resp.text();
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('href="mailto:a@b.com"');
+  });
+
   it("supports dark mode via media query", async () => {
     const store = makeStore({
       "n5": { content: "test", tags: ["published"] },

--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "bun:test";
+import { handlePublicNote } from "./routes.ts";
+
+// Minimal Store stub — only getNote is needed
+function makeStore(notes: Record<string, { content: string; tags?: string[]; metadata?: Record<string, unknown>; path?: string }>) {
+  return {
+    getNote(id: string) {
+      const n = notes[id];
+      if (!n) return null;
+      return {
+        id,
+        content: n.content,
+        tags: n.tags ?? [],
+        metadata: n.metadata ?? {},
+        path: n.path,
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      };
+    },
+  } as any;
+}
+
+describe("handlePublicNote", () => {
+  it("returns 404 for non-existent note", () => {
+    const store = makeStore({});
+    const resp = handlePublicNote(store, "missing");
+    expect(resp.status).toBe(404);
+  });
+
+  it("returns 404 for note without published tag", () => {
+    const store = makeStore({
+      "n1": { content: "hello", tags: ["other"] },
+    });
+    const resp = handlePublicNote(store, "n1");
+    expect(resp.status).toBe(404);
+  });
+
+  it("serves note with published tag as HTML", async () => {
+    const store = makeStore({
+      "n1": { content: "# Hello\n\nWorld", tags: ["published"], path: "Blog/My Post.md" },
+    });
+    const resp = handlePublicNote(store, "n1");
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+
+    const html = await resp.text();
+    expect(html).toContain("<title>My Post</title>");
+    expect(html).toContain("<h1>Hello</h1>");
+    expect(html).toContain("<p>World</p>");
+  });
+
+  it("serves note with metadata.published=true", async () => {
+    const store = makeStore({
+      "n2": { content: "Content here", metadata: { published: true } },
+    });
+    const resp = handlePublicNote(store, "n2");
+    expect(resp.status).toBe(200);
+    const html = await resp.text();
+    expect(html).toContain("<p>Content here</p>");
+  });
+
+  it("renders markdown features correctly", async () => {
+    const store = makeStore({
+      "n3": {
+        content: "**bold** and *italic* and `code`\n\n- item 1\n- item 2\n\n```\ncode block\n```\n\n[link](https://example.com)",
+        tags: ["published"],
+      },
+    });
+    const resp = handlePublicNote(store, "n3");
+    const html = await resp.text();
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).toContain("<li>item 1</li>");
+    expect(html).toContain("<li>item 2</li>");
+    expect(html).toContain("<pre><code>");
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  it("escapes HTML in note content", async () => {
+    const store = makeStore({
+      "n4": { content: "<script>alert('xss')</script>", tags: ["published"] },
+    });
+    const resp = handlePublicNote(store, "n4");
+    const html = await resp.text();
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("supports dark mode via media query", async () => {
+    const store = makeStore({
+      "n5": { content: "test", tags: ["published"] },
+    });
+    const resp = handlePublicNote(store, "n5");
+    const html = await resp.text();
+    expect(html).toContain("prefers-color-scheme: dark");
+  });
+});

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -651,8 +651,14 @@ function inlineMarkdown(html: string): string {
   html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
   // Inline code
   html = html.replace(/`(.+?)`/g, "<code>$1</code>");
-  // Links [text](url) — url is already escaped
-  html = html.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>');
+  // Links [text](url) — sanitize href to prevent javascript:/data: XSS
+  html = html.replace(/\[(.+?)\]\((.+?)\)/g, (_match, text, url) => {
+    const decoded = url.replace(/&amp;/g, "&");
+    if (/^(https?:|mailto:|#|\/)/i.test(decoded)) {
+      return `<a href="${url}">${text}</a>`;
+    }
+    return text; // strip unsafe links, keep text
+  });
   return html;
 }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -555,6 +555,178 @@ export async function handleIngest(
 }
 
 // ---------------------------------------------------------------------------
+// Published notes — public, no-auth HTML rendering
+// ---------------------------------------------------------------------------
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Minimal markdown-to-HTML for published notes. Handles:
+ * - Paragraphs (blank-line separated)
+ * - Headers (# through ######)
+ * - Bold (**text**), italic (*text*), inline code (`code`)
+ * - Unordered lists (- item)
+ * - Fenced code blocks (```...```)
+ * - Links [text](url)
+ *
+ * This is intentionally simple — we don't pull in a markdown library.
+ */
+function renderMarkdown(md: string): string {
+  const lines = md.split("\n");
+  const out: string[] = [];
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Fenced code blocks
+    if (line.trimStart().startsWith("```")) {
+      if (inCodeBlock) {
+        out.push("</code></pre>");
+        inCodeBlock = false;
+      } else {
+        out.push("<pre><code>");
+        inCodeBlock = true;
+      }
+      continue;
+    }
+    if (inCodeBlock) {
+      out.push(escapeHtml(line));
+      continue;
+    }
+
+    const trimmed = line.trim();
+
+    // Empty line
+    if (!trimmed) {
+      out.push("");
+      continue;
+    }
+
+    // Headers
+    const headerMatch = trimmed.match(/^(#{1,6})\s+(.+)/);
+    if (headerMatch) {
+      const level = headerMatch[1].length;
+      out.push(`<h${level}>${inlineMarkdown(escapeHtml(headerMatch[2]))}</h${level}>`);
+      continue;
+    }
+
+    // Unordered list items
+    if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
+      // Collect consecutive list items
+      const items: string[] = [trimmed.slice(2)];
+      while (i + 1 < lines.length) {
+        const next = lines[i + 1].trim();
+        if (next.startsWith("- ") || next.startsWith("* ")) {
+          items.push(next.slice(2));
+          i++;
+        } else break;
+      }
+      out.push("<ul>");
+      for (const item of items) {
+        out.push(`<li>${inlineMarkdown(escapeHtml(item))}</li>`);
+      }
+      out.push("</ul>");
+      continue;
+    }
+
+    // Paragraph
+    out.push(`<p>${inlineMarkdown(escapeHtml(trimmed))}</p>`);
+  }
+
+  if (inCodeBlock) out.push("</code></pre>");
+  return out.join("\n");
+}
+
+function inlineMarkdown(html: string): string {
+  // Bold
+  html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  // Italic
+  html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
+  // Inline code
+  html = html.replace(/`(.+?)`/g, "<code>$1</code>");
+  // Links [text](url) — url is already escaped
+  html = html.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>');
+  return html;
+}
+
+function isNotePublished(note: { tags?: string[]; metadata?: unknown }): boolean {
+  if (note.tags?.includes("published")) return true;
+  const meta = note.metadata as Record<string, unknown> | undefined;
+  if (meta?.published === true) return true;
+  return false;
+}
+
+/**
+ * GET /public/:noteId — serve a published note as clean HTML, no auth.
+ */
+export function handlePublicNote(store: Store, noteId: string): Response {
+  const note = store.getNote(noteId);
+  if (!note || !isNotePublished(note)) {
+    return new Response("Not Found", { status: 404, headers: { "Content-Type": "text/plain" } });
+  }
+
+  const title = note.path?.split("/").pop()?.replace(/\.[^.]+$/, "") ?? note.id;
+  const rendered = renderMarkdown(note.content);
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+  body {
+    max-width: 42rem;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    line-height: 1.6;
+    color: #1a1a1a;
+  }
+  pre {
+    background: #f5f5f5;
+    padding: 1rem;
+    border-radius: 4px;
+    overflow-x: auto;
+  }
+  code {
+    font-size: 0.9em;
+    background: #f5f5f5;
+    padding: 0.15em 0.3em;
+    border-radius: 3px;
+  }
+  pre code {
+    background: none;
+    padding: 0;
+  }
+  a { color: #0066cc; }
+  h1, h2, h3, h4, h5, h6 { margin-top: 1.5em; margin-bottom: 0.5em; }
+  ul { padding-left: 1.5em; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1a1a; color: #e0e0e0; }
+    pre, code { background: #2a2a2a; }
+    a { color: #66b3ff; }
+  }
+</style>
+</head>
+<body>
+${rendered}
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Transcription (via @openparachute/scribe)
 // ---------------------------------------------------------------------------
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,7 @@ import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig,
 import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed } from "./auth.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
-import { handleNotes, handleTags, handleLinks, handleGraph, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech } from "./routes.ts";
+import { handleNotes, handleTags, handleLinks, handleGraph, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleIngest, handleTranscription, handleModels, handleTtsSpeech, handlePublicNote } from "./routes.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTtsHook, type NarrateModule } from "./tts-hook.ts";
 import { registerTranscriptionHook, type ScribeModule } from "./transcription-hook.ts";
@@ -226,6 +226,14 @@ async function route(req: Request, path: string): Promise<Response> {
     return handleModels();
   }
 
+  // Published notes — public, no auth
+  const publicMatch = path.match(/^\/public\/([^/]+)$/);
+  if (publicMatch && req.method === "GET") {
+    const defaultVault = readGlobalConfig().default_vault ?? "default";
+    const store = getVaultStore(defaultVault);
+    return handlePublicNote(store, publicMatch[1]);
+  }
+
   // List vaults
   if (path === "/vaults" && req.method === "GET") {
     const names = listVaults();
@@ -281,6 +289,13 @@ async function route(req: Request, path: string): Promise<Response> {
       { error: "Vault not found", vault: vaultName },
       { status: 404 },
     );
+  }
+
+  // Published notes — public, no auth (vault-scoped)
+  const vaultPublicMatch = subpath.match(/^\/public\/([^/]+)$/);
+  if (vaultPublicMatch && req.method === "GET") {
+    const store = getVaultStore(vaultName);
+    return handlePublicNote(store, vaultPublicMatch[1]);
   }
 
   // Auth: per-vault key OR global key


### PR DESCRIPTION
## Summary

- Add `GET /public/:noteId` — serves notes tagged `published` (or with `metadata.published: true`) as styled HTML pages, no auth required
- Also available vault-scoped at `GET /vaults/:name/public/:noteId`
- Minimal built-in markdown renderer (headers, bold/italic, code, lists, links) with XSS-safe HTML escaping
- Clean, responsive styling with automatic dark mode support

## Routes

| Route | Auth | Description |
|---|---|---|
| `GET /public/:noteId` | None | Serves from default vault |
| `GET /vaults/:name/public/:noteId` | None | Serves from named vault |

## Test plan

- [x] 7 new tests covering: 404 for missing/unpublished notes, tag-based and metadata-based publishing, markdown rendering, XSS prevention, dark mode CSS
- [x] All 293 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)