### PR TITLE
feat: auth-aware /view endpoint + docs audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ bun install
 bun src/cli.ts vault init
 ```
 
-`vault init` creates a vault, starts a background daemon (launchd on Mac, systemd on Linux), and configures Claude Code's MCP. It walks you through transcription and semantic search setup interactively.
+`vault init` creates a vault, starts a background daemon (launchd on Mac, systemd on Linux), and configures Claude Code's MCP. It walks you through semantic search setup interactively.
 
 For remote access from Claude Desktop or mobile apps, see [Deployment](#deployment) below.
 
@@ -26,7 +26,8 @@ A server on port 1940 with:
 - **Wikilink auto-linking** — `[[wikilinks]]` in note content automatically create links in the graph
 - **Semantic search** — Vector embeddings via sqlite-vec (configure an embedding provider)
 - **Obsidian import/export** — Bidirectional interop with Obsidian vaults
-- **Transcription** — Whisper-compatible endpoint (with [@openparachute/scribe](https://github.com/ParachuteComputer/@openparachute/scribe))
+- **Webhook triggers** — Config-driven webhooks that fire on note mutations matching tag/metadata predicates
+- **View endpoint** — Serve notes as clean HTML pages (public or authenticated)
 
 Each vault is its own SQLite database. Run multiple vaults on one server.
 
@@ -59,23 +60,12 @@ parachute vault restart                    # apply changes
 All config lives in `~/.parachute/.env`. `vault init` walks you through setup. To change later:
 
 ```bash
-parachute vault config set TRANSCRIBE_PROVIDER groq
-parachute vault config set GROQ_API_KEY gsk_...
 parachute vault config set EMBEDDING_PROVIDER openai
 parachute vault config set OPENAI_API_KEY sk-...
 parachute vault restart
 ```
 
 ### Providers
-
-**Transcription** (requires [@openparachute/scribe](https://github.com/ParachuteComputer/@openparachute/scribe)):
-
-| Provider | Type | Notes |
-|----------|------|-------|
-| `groq` | Cloud | Fast, cheap (~$0.06/hr of audio) |
-| `whisper` | Local | Any platform. `pip install whisper-ctranslate2` |
-| `parakeet-mlx` | Local | Mac only. Fastest. |
-| `openai` | Cloud | Reference Whisper API |
 
 **Embeddings** (semantic search):
 
@@ -91,7 +81,7 @@ parachute vault restart
 **Links**: `create-link`, `delete-link`, `get-links`
 **Bulk**: `create-notes`, `batch-tag`, `batch-untag`
 **Graph**: `traverse-links`, `find-path`
-**Vault**: `list-vaults`, `get-vault-description`, `update-vault-description`
+**Vault**: `list-vaults`, `get-vault-description`, `update-vault-description`, `get-vault-stats`
 **Semantic** (when configured): `semantic-search`, `embed-notes`
 
 ### Vault descriptions
@@ -132,6 +122,42 @@ Imports: frontmatter → metadata, `#tags` → tags table, `[[wikilinks]]` → l
 
 Note paths work like Obsidian file paths (`Projects/Parachute/README`). Normalized, unique, case-insensitive resolution. Renaming a note's path updates `[[wikilinks]]` in other notes.
 
+### Webhook triggers
+
+Declarative config-driven webhooks that fire when a note mutation matches a predicate. Configured in `~/.parachute/config.yaml`:
+
+```yaml
+triggers:
+  - name: tts_reader
+    events: [created, updated]
+    when:
+      tags: [reader]
+      has_content: true
+      missing_metadata: [audio_rendered_at]
+    action:
+      webhook: http://localhost:8090/tts
+      timeout: 120000
+```
+
+**Predicate fields**: `tags` (all must match), `has_content` (true/false), `missing_metadata` (keys that must be absent), `has_metadata` (keys that must be present).
+
+**Two-phase markers**: On match, the trigger sets `<name>_pending_at` metadata before calling the webhook, then replaces it with `<name>_rendered_at` on success. This prevents re-entry and concurrent runs.
+
+**Webhook contract**: POST `{ trigger, event, note: { id, content, path, tags, metadata, attachments } }`. Response: `{ content?, metadata?, attachments?, skipped_reason? }`.
+
+### View endpoint
+
+Serve notes as clean HTML pages at `/view/:noteId`:
+
+- **Without auth**: only serves notes tagged `published` (or with `metadata.published: true`). Returns 404 for unpublished notes.
+- **With auth**: serves any note. Pass API key via `Authorization: Bearer pvk_...` header or `?key=pvk_...` query param.
+- **Custom tag**: set `published_tag` in vault.yaml to use a different tag name (default: `published`).
+
+```yaml
+# ~/.parachute/vaults/default/vault.yaml
+published_tag: public
+```
+
 ## REST API
 
 ```
@@ -139,14 +165,19 @@ GET/POST       /api/notes              query or create notes
 GET/PATCH/DEL  /api/notes/:id          read, update, delete
 POST/DEL       /api/notes/:id/tags     tag/untag
 GET            /api/tags               list tags
+DELETE         /api/tags/:name         delete a tag from all notes
 POST/DEL       /api/links              create/delete links
 GET            /api/search?q=...       full-text search
-POST           /api/ingest             upload audio + create note
+GET            /api/resolve-wikilink?title=...  resolve a wikilink title to note
+GET            /api/unresolved-wikilinks        list unresolved wikilinks
+POST           /api/ingest             upload file + create note
+GET            /api/graph              full knowledge graph
 POST           /mcp                    MCP endpoint
+GET            /view/:noteId           render note as HTML (public or auth)
 GET            /health                 health check
 ```
 
-Per-vault routes at `/vaults/{name}/api/...` and `/vaults/{name}/mcp`.
+Per-vault routes at `/vaults/{name}/api/...`, `/vaults/{name}/mcp`, and `/vaults/{name}/view/:noteId`.
 
 ## Data model
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -64,7 +64,15 @@ export function extractApiKey(req: Request): string | null {
   return req.headers.get("x-api-key");
 }
 
-/** Check if a request originates from localhost. */
+/**
+ * Check if a request originates from localhost.
+ *
+ * Trust model: this assumes a trusted network (no untrusted reverse proxy).
+ * The X-Forwarded-For header is spoofable — any external caller behind a proxy
+ * that doesn't strip/overwrite it can fake localhost. This is acceptable for
+ * local dev and trusted-network deployments. For public-facing deployments behind
+ * a reverse proxy, a proper trusted-proxy configuration is needed (see #67).
+ */
 export function isLocalhost(req: Request): boolean {
   const forwarded = req.headers.get("x-forwarded-for");
   if (forwarded) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,8 @@ export interface VaultConfig {
   api_keys: StoredKey[];
   created_at: string;
   tag_schemas?: Record<string, TagSchema>;
+  /** Tag name that marks a note as publicly viewable. Default: "published". */
+  published_tag?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +132,9 @@ function serializeVaultConfig(config: VaultConfig): string {
     }
   }
   lines.push(`created_at: "${config.created_at}"`);
+  if (config.published_tag) {
+    lines.push(`published_tag: ${config.published_tag}`);
+  }
 
   lines.push("api_keys:");
   for (const key of config.api_keys) {
@@ -181,6 +186,9 @@ function parseVaultConfig(yaml: string, name: string): VaultConfig {
 
   const createdMatch = yaml.match(/^created_at:\s*"?([^"\n]+)"?/m);
   if (createdMatch) config.created_at = createdMatch[1];
+
+  const pubTagMatch = yaml.match(/^published_tag:\s*(\S+)/m);
+  if (pubTagMatch) config.published_tag = pubTagMatch[1];
 
   // Parse description (block scalar)
   const descMatch = yaml.match(/^description:\s*\|\s*\n((?:\s{2}.+\n?)+)/m);

--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -1,6 +1,35 @@
 import { describe, it, expect } from "bun:test";
 import { handleViewNote } from "./routes.ts";
 
+// Redirect URL builder — mirrors the logic in server.ts
+function buildRedirectUrl(reqUrl: string, noteId: string, prefix = ""): string {
+  const dest = new URL(`${prefix}/view/${noteId}`, reqUrl);
+  dest.search = new URL(reqUrl).search;
+  return dest.toString();
+}
+
+describe("/public → /view redirect", () => {
+  it("preserves query params including ?key=", () => {
+    const url = buildRedirectUrl("http://localhost:1940/public/abc?key=pvk_secret", "abc");
+    expect(url).toBe("http://localhost:1940/view/abc?key=pvk_secret");
+  });
+
+  it("works without query params", () => {
+    const url = buildRedirectUrl("http://localhost:1940/public/abc", "abc");
+    expect(url).toBe("http://localhost:1940/view/abc");
+  });
+
+  it("preserves multiple query params", () => {
+    const url = buildRedirectUrl("http://localhost:1940/public/abc?key=pvk_x&format=html", "abc");
+    expect(url).toBe("http://localhost:1940/view/abc?key=pvk_x&format=html");
+  });
+
+  it("works for vault-scoped paths", () => {
+    const url = buildRedirectUrl("http://localhost:1940/vaults/work/public/abc?key=pvk_x", "abc", "/vaults/work");
+    expect(url).toBe("http://localhost:1940/vaults/work/view/abc?key=pvk_x");
+  });
+});
+
 // Minimal Store stub — only getNote is needed
 function makeStore(notes: Record<string, { content: string; tags?: string[]; metadata?: Record<string, unknown>; path?: string }>) {
   return {

--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { handlePublicNote } from "./routes.ts";
+import { handleViewNote } from "./routes.ts";
 
 // Minimal Store stub — only getNote is needed
 function makeStore(notes: Record<string, { content: string; tags?: string[]; metadata?: Record<string, unknown>; path?: string }>) {
@@ -20,18 +20,18 @@ function makeStore(notes: Record<string, { content: string; tags?: string[]; met
   } as any;
 }
 
-describe("handlePublicNote", () => {
+describe("handleViewNote", () => {
   it("returns 404 for non-existent note", () => {
     const store = makeStore({});
-    const resp = handlePublicNote(store, "missing");
+    const resp = handleViewNote(store, "missing");
     expect(resp.status).toBe(404);
   });
 
-  it("returns 404 for note without published tag", () => {
+  it("returns 404 for note without published tag (unauthenticated)", () => {
     const store = makeStore({
       "n1": { content: "hello", tags: ["other"] },
     });
-    const resp = handlePublicNote(store, "n1");
+    const resp = handleViewNote(store, "n1");
     expect(resp.status).toBe(404);
   });
 
@@ -39,7 +39,7 @@ describe("handlePublicNote", () => {
     const store = makeStore({
       "n1": { content: "# Hello\n\nWorld", tags: ["published"], path: "Blog/My Post.md" },
     });
-    const resp = handlePublicNote(store, "n1");
+    const resp = handleViewNote(store, "n1");
     expect(resp.status).toBe(200);
     expect(resp.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
 
@@ -53,7 +53,7 @@ describe("handlePublicNote", () => {
     const store = makeStore({
       "n2": { content: "Content here", metadata: { published: true } },
     });
-    const resp = handlePublicNote(store, "n2");
+    const resp = handleViewNote(store, "n2");
     expect(resp.status).toBe(200);
     const html = await resp.text();
     expect(html).toContain("<p>Content here</p>");
@@ -66,7 +66,7 @@ describe("handlePublicNote", () => {
         tags: ["published"],
       },
     });
-    const resp = handlePublicNote(store, "n3");
+    const resp = handleViewNote(store, "n3");
     const html = await resp.text();
     expect(html).toContain("<strong>bold</strong>");
     expect(html).toContain("<em>italic</em>");
@@ -80,7 +80,7 @@ describe("handlePublicNote", () => {
     const store = makeStore({
       "n4": { content: "<script>alert('xss')</script>", tags: ["published"] },
     });
-    const resp = handlePublicNote(store, "n4");
+    const resp = handleViewNote(store, "n4");
     const html = await resp.text();
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
@@ -90,7 +90,7 @@ describe("handlePublicNote", () => {
     const store = makeStore({
       "n6": { content: "[click me](javascript:alert(1))", tags: ["published"] },
     });
-    const resp = handlePublicNote(store, "n6");
+    const resp = handleViewNote(store, "n6");
     const html = await resp.text();
     expect(html).not.toContain("javascript:");
     expect(html).toContain("click me");
@@ -101,7 +101,7 @@ describe("handlePublicNote", () => {
     const store = makeStore({
       "n7": { content: "[click](data:text/html;base64,PHNjcmlwdD4=)", tags: ["published"] },
     });
-    const resp = handlePublicNote(store, "n7");
+    const resp = handleViewNote(store, "n7");
     const html = await resp.text();
     expect(html).not.toContain("data:");
     expect(html).toContain("click");
@@ -111,7 +111,7 @@ describe("handlePublicNote", () => {
     const store = makeStore({
       "n8": { content: "[site](https://example.com) and [mail](mailto:a@b.com)", tags: ["published"] },
     });
-    const resp = handlePublicNote(store, "n8");
+    const resp = handleViewNote(store, "n8");
     const html = await resp.text();
     expect(html).toContain('href="https://example.com"');
     expect(html).toContain('href="mailto:a@b.com"');
@@ -121,8 +121,46 @@ describe("handlePublicNote", () => {
     const store = makeStore({
       "n5": { content: "test", tags: ["published"] },
     });
-    const resp = handlePublicNote(store, "n5");
+    const resp = handleViewNote(store, "n5");
     const html = await resp.text();
     expect(html).toContain("prefers-color-scheme: dark");
+  });
+
+  // Auth-aware behavior
+  it("serves any note when authenticated", async () => {
+    const store = makeStore({
+      "private": { content: "secret stuff", tags: ["internal"] },
+    });
+    const resp = handleViewNote(store, "private", { authenticated: true });
+    expect(resp.status).toBe(200);
+    const html = await resp.text();
+    expect(html).toContain("<p>secret stuff</p>");
+  });
+
+  it("returns 404 for unpublished note when not authenticated", () => {
+    const store = makeStore({
+      "private": { content: "secret stuff", tags: ["internal"] },
+    });
+    const resp = handleViewNote(store, "private");
+    expect(resp.status).toBe(404);
+  });
+
+  // Custom published tag
+  it("uses custom published_tag from config", async () => {
+    const store = makeStore({
+      "n1": { content: "public content", tags: ["public"] },
+    });
+    const resp = handleViewNote(store, "n1", { publishedTag: "public" });
+    expect(resp.status).toBe(200);
+    const html = await resp.text();
+    expect(html).toContain("<p>public content</p>");
+  });
+
+  it("rejects note with default tag when custom tag is configured", () => {
+    const store = makeStore({
+      "n1": { content: "content", tags: ["published"] },
+    });
+    const resp = handleViewNote(store, "n1", { publishedTag: "public" });
+    expect(resp.status).toBe(404);
   });
 });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -612,19 +612,30 @@ function inlineMarkdown(html: string): string {
   return html;
 }
 
-function isNotePublished(note: { tags?: string[]; metadata?: unknown }): boolean {
-  if (note.tags?.includes("published")) return true;
+function isNotePublished(note: { tags?: string[]; metadata?: unknown }, publishedTag: string = "published"): boolean {
+  if (note.tags?.includes(publishedTag)) return true;
   const meta = note.metadata as Record<string, unknown> | undefined;
   if (meta?.published === true) return true;
   return false;
 }
 
 /**
- * GET /public/:noteId — serve a published note as clean HTML, no auth.
+ * GET /view/:noteId — serve a note as clean HTML.
+ *
+ * Without auth: only serves notes marked as published (via tag or metadata).
+ * With auth: serves any note in the vault.
  */
-export function handlePublicNote(store: Store, noteId: string): Response {
+export function handleViewNote(
+  store: Store,
+  noteId: string,
+  options: { authenticated?: boolean; publishedTag?: string } = {},
+): Response {
+  const { authenticated = false, publishedTag = "published" } = options;
   const note = store.getNote(noteId);
-  if (!note || !isNotePublished(note)) {
+  if (!note) {
+    return new Response("Not Found", { status: 404, headers: { "Content-Type": "text/plain" } });
+  }
+  if (!authenticated && !isNotePublished(note, publishedTag)) {
     return new Response("Not Found", { status: 404, headers: { "Content-Type": "text/plain" } });
   }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -612,6 +612,11 @@ function inlineMarkdown(html: string): string {
   return html;
 }
 
+/**
+ * Check if a note is published. A note is published if:
+ * 1. It has the configured published tag (default: "published"), OR
+ * 2. It has metadata.published === true (always honored regardless of custom tag)
+ */
 function isNotePublished(note: { tags?: string[]; metadata?: unknown }, publishedTag: string = "published"): boolean {
   if (note.tags?.includes(publishedTag)) return true;
   const meta = note.metadata as Record<string, unknown> | undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -192,10 +192,12 @@ async function route(req: Request, path: string): Promise<Response> {
     });
   }
 
-  // Backward compat: /public/:noteId → /view/:noteId
+  // Backward compat: /public/:noteId → /view/:noteId (preserving query params)
   const publicMatch = path.match(/^\/public\/([^/]+)$/);
   if (publicMatch && req.method === "GET") {
-    return Response.redirect(new URL(`/view/${publicMatch[1]}`, req.url).toString(), 301);
+    const dest = new URL(`/view/${publicMatch[1]}`, req.url);
+    dest.search = new URL(req.url).search;
+    return Response.redirect(dest.toString(), 301);
   }
 
 
@@ -259,7 +261,9 @@ async function route(req: Request, path: string): Promise<Response> {
   // Backward compat: /vaults/{name}/public/:noteId → /view/:noteId
   const vaultPublicMatch = subpath.match(/^\/public\/([^/]+)$/);
   if (vaultPublicMatch && req.method === "GET") {
-    return Response.redirect(new URL(`/vaults/${vaultName}/view/${vaultPublicMatch[1]}`, req.url).toString(), 301);
+    const dest = new URL(`/vaults/${vaultName}/view/${vaultPublicMatch[1]}`, req.url);
+    dest.search = new URL(req.url).search;
+    return Response.redirect(dest.toString(), 301);
   }
 
   // View endpoint — serves notes as HTML (auth-aware, vault-scoped)

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,10 +25,11 @@ if (existsSync(_envPath)) {
 }
 
 import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile, generateApiKey, hashKey } from "./config.ts";
-import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed } from "./auth.ts";
+import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed, extractApiKey, isLocalhost } from "./auth.ts";
+import type { VaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
-import { handleNotes, handleTags, handleLinks, handleGraph, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleIngest, handlePublicNote } from "./routes.ts";
+import { handleNotes, handleTags, handleLinks, handleGraph, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleIngest, handleViewNote } from "./routes.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTriggers } from "./triggers.ts";
 
@@ -138,6 +139,30 @@ async function shutdown(signal: string): Promise<void> {
 process.on("SIGINT", () => void shutdown("SIGINT"));
 process.on("SIGTERM", () => void shutdown("SIGTERM"));
 
+/**
+ * Check if a /view request has a valid API key (header or ?key= query param).
+ * Returns true if authenticated, false if not. Never rejects — unauthenticated
+ * requests still get public notes.
+ */
+function isViewAuthenticated(req: Request, vaultConfig: VaultConfig | null): boolean {
+  if (isLocalhost(req)) return true;
+
+  // Check query param first (convenient for browsers)
+  const url = new URL(req.url);
+  const queryKey = url.searchParams.get("key");
+  const headerKey = extractApiKey(req);
+  const key = queryKey ?? headerKey;
+  if (!key || !vaultConfig) return false;
+
+  const auth = authenticateVaultRequest(
+    queryKey && !headerKey
+      ? new Request(req.url, { headers: { ...Object.fromEntries(req.headers), "x-api-key": key } })
+      : req,
+    vaultConfig,
+  );
+  return !("error" in auth);
+}
+
 async function route(req: Request, path: string): Promise<Response> {
   // Health check
   if (path === "/health") {
@@ -151,12 +176,17 @@ async function route(req: Request, path: string): Promise<Response> {
     return handleUnifiedMcp(req, auth.scope);
   }
 
-  // Published notes — public, no auth
-  const publicMatch = path.match(/^\/public\/([^/]+)$/);
-  if (publicMatch && req.method === "GET") {
+  // View endpoint — serves notes as HTML (auth-aware)
+  const viewMatch = path.match(/^\/view\/([^/]+)$/);
+  if (viewMatch && req.method === "GET") {
     const defaultVault = readGlobalConfig().default_vault ?? "default";
+    const vaultConfig = readVaultConfig(defaultVault);
     const store = getVaultStore(defaultVault);
-    return handlePublicNote(store, publicMatch[1]);
+    const authenticated = isViewAuthenticated(req, vaultConfig);
+    return handleViewNote(store, viewMatch[1], {
+      authenticated,
+      publishedTag: vaultConfig?.published_tag,
+    });
   }
 
 
@@ -217,11 +247,15 @@ async function route(req: Request, path: string): Promise<Response> {
     );
   }
 
-  // Published notes — public, no auth (vault-scoped)
-  const vaultPublicMatch = subpath.match(/^\/public\/([^/]+)$/);
-  if (vaultPublicMatch && req.method === "GET") {
+  // View endpoint — serves notes as HTML (auth-aware, vault-scoped)
+  const vaultViewMatch = subpath.match(/^\/view\/([^/]+)$/);
+  if (vaultViewMatch && req.method === "GET") {
     const store = getVaultStore(vaultName);
-    return handlePublicNote(store, vaultPublicMatch[1]);
+    const authenticated = isViewAuthenticated(req, vaultConfig);
+    return handleViewNote(store, vaultViewMatch[1], {
+      authenticated,
+      publishedTag: vaultConfig.published_tag,
+    });
   }
 
   // Auth: per-vault key OR global key

--- a/src/server.ts
+++ b/src/server.ts
@@ -181,12 +181,21 @@ async function route(req: Request, path: string): Promise<Response> {
   if (viewMatch && req.method === "GET") {
     const defaultVault = readGlobalConfig().default_vault ?? "default";
     const vaultConfig = readVaultConfig(defaultVault);
+    if (!vaultConfig) {
+      return Response.json({ error: "Default vault not found" }, { status: 404 });
+    }
     const store = getVaultStore(defaultVault);
     const authenticated = isViewAuthenticated(req, vaultConfig);
     return handleViewNote(store, viewMatch[1], {
       authenticated,
-      publishedTag: vaultConfig?.published_tag,
+      publishedTag: vaultConfig.published_tag,
     });
+  }
+
+  // Backward compat: /public/:noteId → /view/:noteId
+  const publicMatch = path.match(/^\/public\/([^/]+)$/);
+  if (publicMatch && req.method === "GET") {
+    return Response.redirect(new URL(`/view/${publicMatch[1]}`, req.url).toString(), 301);
   }
 
 
@@ -245,6 +254,12 @@ async function route(req: Request, path: string): Promise<Response> {
       { error: "Vault not found", vault: vaultName },
       { status: 404 },
     );
+  }
+
+  // Backward compat: /vaults/{name}/public/:noteId → /view/:noteId
+  const vaultPublicMatch = subpath.match(/^\/public\/([^/]+)$/);
+  if (vaultPublicMatch && req.method === "GET") {
+    return Response.redirect(new URL(`/vaults/${vaultName}/view/${vaultPublicMatch[1]}`, req.url).toString(), 301);
   }
 
   // View endpoint — serves notes as HTML (auth-aware, vault-scoped)


### PR DESCRIPTION
## Summary

- **Refactor `/public/:noteId` → `/view/:noteId`**: Auth-aware note rendering. Without API key, only serves notes tagged `published` (or `metadata.published: true`). With API key (header or `?key=` query param), serves any note in the vault.
- **Configurable published tag**: New `published_tag` field in vault.yaml (default: `published`). Parsed, serialized, and passed through to the view handler.
- **README audit**: Removed all scribe/narrate/transcription references. Added webhook triggers section with config example and contract docs. Added view endpoint section. Updated REST API table with new endpoints (`/view`, `/api/resolve-wikilink`, `/api/unresolved-wikilinks`, `DELETE /api/tags/:name`, `/api/graph`). Updated MCP tools list.

## Changes

| File | What |
|---|---|
| `src/config.ts` | Add `published_tag?: string` to `VaultConfig`, parser + serializer |
| `src/routes.ts` | Refactor `handlePublicNote` → `handleViewNote` with auth + tag options |
| `src/server.ts` | Replace `/public` routes with `/view`, add `isViewAuthenticated` helper |
| `src/published.test.ts` | Rename + add 4 new tests (auth, custom tag, 404 behavior) — 14 total |
| `README.md` | Full docs audit — remove stale, add new sections |

## Test plan

- [x] 281 tests pass (1 pre-existing failure: `migrate-audio-to-opus` missing narrate dep)
- [x] 14 view endpoint tests pass (up from 10)
- [ ] Manual: `curl localhost:1940/view/<noteId>` returns 404 for unpublished, 200 for published
- [ ] Manual: `curl localhost:1940/view/<noteId>?key=pvk_...` returns 200 for any note
- [ ] Independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)