### PR TITLE
fix: security hardening for public deployment

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -65,21 +65,25 @@ export function extractApiKey(req: Request): string | null {
 }
 
 /**
- * Check if a request originates from localhost.
- *
- * Trust model: this assumes a trusted network (no untrusted reverse proxy).
- * The X-Forwarded-For header is spoofable — any external caller behind a proxy
- * that doesn't strip/overwrite it can fake localhost. This is acceptable for
- * local dev and trusted-network deployments. For public-facing deployments behind
- * a reverse proxy, a proper trusted-proxy configuration is needed (see #67).
+ * Per-request socket address set by the server before routing.
+ * Bun's server.requestIP() returns the actual TCP peer address,
+ * which cannot be spoofed (unlike X-Forwarded-For).
  */
-export function isLocalhost(req: Request): boolean {
-  const forwarded = req.headers.get("x-forwarded-for");
-  if (forwarded) {
-    const first = forwarded.split(",")[0].trim();
-    return first === "127.0.0.1" || first === "::1" || first === "::ffff:127.0.0.1";
+let _currentSocketAddress: string | null = null;
+
+export function setSocketAddress(addr: string): void {
+  _currentSocketAddress = addr;
+}
+
+const LOCALHOST_ADDRS = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
+
+/** Check if a request originates from localhost using the actual socket address. */
+export function isLocalhost(_req: Request): boolean {
+  if (_currentSocketAddress) {
+    return LOCALHOST_ADDRS.has(_currentSocketAddress);
   }
-  return true;
+  // Fallback: no socket address available (e.g. tests). Conservative: deny.
+  return false;
 }
 
 /**

--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -56,7 +56,7 @@ describe("handleViewNote", () => {
     expect(resp.status).toBe(404);
   });
 
-  it("returns 404 for note without published tag (unauthenticated)", () => {
+  it("returns 404 for note without publish tag (unauthenticated)", () => {
     const store = makeStore({
       "n1": { content: "hello", tags: ["other"] },
     });
@@ -64,9 +64,9 @@ describe("handleViewNote", () => {
     expect(resp.status).toBe(404);
   });
 
-  it("serves note with published tag as HTML", async () => {
+  it("serves note with publish tag as HTML", async () => {
     const store = makeStore({
-      "n1": { content: "# Hello\n\nWorld", tags: ["published"], path: "Blog/My Post.md" },
+      "n1": { content: "# Hello\n\nWorld", tags: ["publish"], path: "Blog/My Post.md" },
     });
     const resp = handleViewNote(store, "n1");
     expect(resp.status).toBe(200);
@@ -92,7 +92,7 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n3": {
         content: "**bold** and *italic* and `code`\n\n- item 1\n- item 2\n\n```\ncode block\n```\n\n[link](https://example.com)",
-        tags: ["published"],
+        tags: ["publish"],
       },
     });
     const resp = handleViewNote(store, "n3");
@@ -107,7 +107,7 @@ describe("handleViewNote", () => {
 
   it("escapes HTML in note content", async () => {
     const store = makeStore({
-      "n4": { content: "<script>alert('xss')</script>", tags: ["published"] },
+      "n4": { content: "<script>alert('xss')</script>", tags: ["publish"] },
     });
     const resp = handleViewNote(store, "n4");
     const html = await resp.text();
@@ -117,7 +117,7 @@ describe("handleViewNote", () => {
 
   it("strips javascript: URI links to prevent XSS", async () => {
     const store = makeStore({
-      "n6": { content: "[click me](javascript:alert(1))", tags: ["published"] },
+      "n6": { content: "[click me](javascript:alert(1))", tags: ["publish"] },
     });
     const resp = handleViewNote(store, "n6");
     const html = await resp.text();
@@ -128,7 +128,7 @@ describe("handleViewNote", () => {
 
   it("strips data: URI links to prevent XSS", async () => {
     const store = makeStore({
-      "n7": { content: "[click](data:text/html;base64,PHNjcmlwdD4=)", tags: ["published"] },
+      "n7": { content: "[click](data:text/html;base64,PHNjcmlwdD4=)", tags: ["publish"] },
     });
     const resp = handleViewNote(store, "n7");
     const html = await resp.text();
@@ -138,7 +138,7 @@ describe("handleViewNote", () => {
 
   it("allows safe http/https/mailto links", async () => {
     const store = makeStore({
-      "n8": { content: "[site](https://example.com) and [mail](mailto:a@b.com)", tags: ["published"] },
+      "n8": { content: "[site](https://example.com) and [mail](mailto:a@b.com)", tags: ["publish"] },
     });
     const resp = handleViewNote(store, "n8");
     const html = await resp.text();
@@ -148,11 +148,22 @@ describe("handleViewNote", () => {
 
   it("supports dark mode via media query", async () => {
     const store = makeStore({
-      "n5": { content: "test", tags: ["published"] },
+      "n5": { content: "test", tags: ["publish"] },
     });
     const resp = handleViewNote(store, "n5");
     const html = await resp.text();
     expect(html).toContain("prefers-color-scheme: dark");
+  });
+
+  // CSP header
+  it("includes Content-Security-Policy header", () => {
+    const store = makeStore({
+      "n1": { content: "test", tags: ["publish"] },
+    });
+    const resp = handleViewNote(store, "n1");
+    const csp = resp.headers.get("Content-Security-Policy");
+    expect(csp).toContain("script-src 'none'");
+    expect(csp).toContain("default-src 'self'");
   });
 
   // Auth-aware behavior
@@ -187,7 +198,7 @@ describe("handleViewNote", () => {
 
   it("rejects note with default tag when custom tag is configured", () => {
     const store = makeStore({
-      "n1": { content: "content", tags: ["published"] },
+      "n1": { content: "content", tags: ["publish"] },
     });
     const resp = handleViewNote(store, "n1", { publishedTag: "public" });
     expect(resp.status).toBe(404);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -370,7 +370,7 @@ export async function handleStorage(req: Request, path: string, vault: string): 
     const dir = join(assets, date);
     mkdirSync(dir, { recursive: true });
 
-    const filename = `${Date.now()}-${file.name}`;
+    const filename = `${Date.now()}-${crypto.randomUUID()}${ext}`;
     const filePath = join(dir, filename);
     const buffer = Buffer.from(await file.arrayBuffer());
     writeFileSync(filePath, buffer);
@@ -604,7 +604,10 @@ ${rendered}
 
   return new Response(html, {
     status: 200,
-    headers: { "Content-Type": "text/html; charset=utf-8" },
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Content-Security-Policy": "default-src 'self'; script-src 'none'; style-src 'unsafe-inline'",
+    },
   });
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@
  */
 
 import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile, generateApiKey, hashKey } from "./config.ts";
-import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed, extractApiKey, isLocalhost } from "./auth.ts";
+import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed, extractApiKey, isLocalhost, setSocketAddress } from "./auth.ts";
 import type { VaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
@@ -89,6 +89,12 @@ const server = Bun.serve({
     }
 
     try {
+      // Inject actual remote IP so auth can verify localhost claims
+      const socketAddr = server.requestIP(req);
+      if (socketAddr) {
+        setSocketAddress(socketAddr.address);
+      }
+
       const start = Date.now();
       const response = await route(req, path);
       const ms = Date.now() - start;
@@ -150,8 +156,12 @@ function isViewAuthenticated(req: Request, vaultConfig: VaultConfig | null): boo
 }
 
 async function route(req: Request, path: string): Promise<Response> {
-  // Health check
+  // Health check — vault names only for authenticated requests
   if (path === "/health") {
+    const auth = authenticateGlobalRequest(req);
+    if ("error" in auth) {
+      return Response.json({ status: "ok" });
+    }
     return Response.json({ status: "ok", vaults: listVaults() });
   }
 
@@ -187,8 +197,10 @@ async function route(req: Request, path: string): Promise<Response> {
   }
 
 
-  // List vaults
+  // List vaults — requires auth
   if (path === "/vaults" && req.method === "GET") {
+    const auth = authenticateGlobalRequest(req);
+    if ("error" in auth) return auth.error;
     const names = listVaults();
     const vaults = names.map((name) => {
       const config = readVaultConfig(name);


### PR DESCRIPTION
## Summary

Five security fixes for vault exposed on public internet:

1. **CRITICAL: /health leaks vault names** — Now returns only `{ status: "ok" }` for unauthenticated requests. Vault names require a valid global API key.
2. **CRITICAL: /vaults unauthenticated** — `GET /vaults` now requires global API key auth. Returns 401 without it.
3. **HIGH: isLocalhost spoofable** — Replaced `X-Forwarded-For` header trust with `server.requestIP()` (Bun's actual TCP socket address). Cannot be spoofed. Falls back to deny when socket address unavailable.
4. **HIGH: CSP on /view** — Added `Content-Security-Policy: default-src 'self'; script-src 'none'; style-src 'unsafe-inline'` to prevent XSS even if markdown escaping has gaps.
5. **MEDIUM: Upload filename sanitization** — User-provided filenames replaced with `{timestamp}-{uuid}.{ext}` to prevent path traversal and injection.

## Changes

| File | Fix |
|---|---|
| `src/server.ts` | Health auth check, vaults auth, inject socket IP |
| `src/auth.ts` | `isLocalhost` uses socket address, `setSocketAddress` export |
| `src/routes.ts` | CSP header on /view, UUID filenames on upload |
| `src/published.test.ts` | Update for `publish` tag default, add CSP test |

## Test plan

- [x] 276 tests pass
- [x] CSP header test added
- [ ] Manual: `curl /health` returns no vault names
- [ ] Manual: `curl /vaults` returns 401
- [ ] Manual: verify upload creates UUID-based filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)