### PR TITLE
feat: move tag schemas from vault.yaml to database

### DIFF
--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { normalizePath } from "./paths.js";
 
-export const SCHEMA_VERSION = 5;
+export const SCHEMA_VERSION = 6;
 
 export const SCHEMA_SQL = `
 -- Notes: the universal record
@@ -44,6 +44,13 @@ CREATE TABLE IF NOT EXISTS links (
   metadata TEXT DEFAULT '{}',
   created_at TEXT NOT NULL,
   UNIQUE(source_id, target_id, relationship)
+);
+
+-- Tag schemas: optional metadata schema per tag
+CREATE TABLE IF NOT EXISTS tag_schemas (
+  tag_name TEXT PRIMARY KEY REFERENCES tags(name) ON DELETE CASCADE,
+  description TEXT,
+  fields TEXT -- JSON: { "field_name": { "type": "string", "description": "..." }, ... }
 );
 
 -- Schema version tracking
@@ -103,6 +110,10 @@ export function initSchema(db: Database): void {
 
   // Migrate v4 → v5: unique path constraint
   migrateToV5(db);
+
+  // Migrate v5 → v6: tag_schemas table (created by SCHEMA_SQL above,
+  // this just ensures the table exists for databases created before v6)
+  migrateToV6(db);
 
   // Record schema version
   db.prepare("INSERT OR REPLACE INTO schema_version (version, applied_at) VALUES (?, ?)").run(
@@ -171,6 +182,19 @@ function migrateToV5(db: Database): void {
   // Drop the old non-unique partial index and create a unique one
   db.exec("DROP INDEX IF EXISTS idx_notes_path");
   db.exec("CREATE UNIQUE INDEX idx_notes_path_unique ON notes(path) WHERE path IS NOT NULL");
+}
+
+/**
+ * Migrate v5 → v6: create tag_schemas table.
+ * The table is already in SCHEMA_SQL so it's created for new vaults.
+ * This migration handles existing vaults that were created before v6.
+ */
+function migrateToV6(db: Database): void {
+  // SCHEMA_SQL already creates the table via CREATE TABLE IF NOT EXISTS,
+  // so this is a no-op for new vaults. For existing vaults where SCHEMA_SQL
+  // ran above, the table now exists. Nothing extra needed here — the
+  // vault.yaml → DB migration happens at the server level (see server.ts),
+  // not at the core schema level, because core doesn't know about config files.
 }
 
 function hasTable(db: Database, name: string): boolean {

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -3,6 +3,7 @@ import type { Store, Note, Link, Attachment, QueryOpts } from "./types.js";
 import { initSchema } from "./schema.js";
 import * as noteOps from "./notes.js";
 import * as linkOps from "./links.js";
+import * as tagSchemaOps from "./tag-schemas.js";
 import { syncWikilinks, resolveUnresolvedWikilinks } from "./wikilinks.js";
 import { normalizePath, pathTitle } from "./paths.js";
 import { HookRegistry } from "./hooks.js";
@@ -205,6 +206,28 @@ export class SqliteStore implements Store {
 
   findPath(sourceId: string, targetId: string, opts?: { max_depth?: number }) {
     return linkOps.findPath(this.db, sourceId, targetId, opts);
+  }
+
+  // ---- Tag Schemas ----
+
+  listTagSchemas() {
+    return tagSchemaOps.listTagSchemas(this.db);
+  }
+
+  getTagSchema(tag: string) {
+    return tagSchemaOps.getTagSchema(this.db, tag);
+  }
+
+  upsertTagSchema(tag: string, schema: { description?: string; fields?: Record<string, tagSchemaOps.TagFieldSchema> }) {
+    return tagSchemaOps.upsertTagSchema(this.db, tag, schema);
+  }
+
+  deleteTagSchema(tag: string) {
+    return tagSchemaOps.deleteTagSchema(this.db, tag);
+  }
+
+  getTagSchemaMap() {
+    return tagSchemaOps.getTagSchemaMap(this.db);
   }
 
   // ---- Batch Wikilink Sync ----

--- a/core/src/tag-schemas.ts
+++ b/core/src/tag-schemas.ts
@@ -1,0 +1,104 @@
+/**
+ * Tag schema CRUD — DB-backed storage for tag metadata schemas.
+ *
+ * Each tag can optionally have a schema that describes expected metadata
+ * fields for notes with that tag. Schemas drive auto-population of defaults
+ * and soft warnings on create/tag operations.
+ */
+
+import { Database } from "bun:sqlite";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TagFieldSchema {
+  type: string;
+  description?: string;
+  enum?: string[];
+}
+
+export interface TagSchema {
+  tag: string;
+  description?: string;
+  fields?: Record<string, TagFieldSchema>;
+}
+
+// DB row shape
+interface TagSchemaRow {
+  tag_name: string;
+  description: string | null;
+  fields: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+/** List all tag schemas. */
+export function listTagSchemas(db: Database): TagSchema[] {
+  const rows = db.prepare("SELECT * FROM tag_schemas ORDER BY tag_name").all() as TagSchemaRow[];
+  return rows.map(rowToSchema);
+}
+
+/** Get a single tag's schema, or null if none defined. */
+export function getTagSchema(db: Database, tag: string): TagSchema | null {
+  const row = db.prepare("SELECT * FROM tag_schemas WHERE tag_name = ?").get(tag) as TagSchemaRow | undefined;
+  return row ? rowToSchema(row) : null;
+}
+
+/** Get all schemas as a lookup map (tag → schema). Used by schema effects. */
+export function getTagSchemaMap(db: Database): Record<string, { description?: string; fields?: Record<string, TagFieldSchema> }> {
+  const schemas = listTagSchemas(db);
+  const map: Record<string, { description?: string; fields?: Record<string, TagFieldSchema> }> = {};
+  for (const s of schemas) {
+    map[s.tag] = { description: s.description, fields: s.fields };
+  }
+  return map;
+}
+
+/**
+ * Create or replace a tag schema (upsert).
+ * Ensures the tag exists in the tags table first.
+ */
+export function upsertTagSchema(
+  db: Database,
+  tag: string,
+  schema: { description?: string; fields?: Record<string, TagFieldSchema> },
+): TagSchema {
+  // Ensure tag exists
+  db.prepare("INSERT OR IGNORE INTO tags (name) VALUES (?)").run(tag);
+
+  const fieldsJson = schema.fields ? JSON.stringify(schema.fields) : null;
+  db.prepare(`
+    INSERT INTO tag_schemas (tag_name, description, fields)
+    VALUES (?, ?, ?)
+    ON CONFLICT(tag_name) DO UPDATE SET
+      description = excluded.description,
+      fields = excluded.fields
+  `).run(tag, schema.description ?? null, fieldsJson);
+
+  return getTagSchema(db, tag)!;
+}
+
+/** Delete a tag's schema. Returns true if a schema was deleted. */
+export function deleteTagSchema(db: Database, tag: string): boolean {
+  const result = db.prepare("DELETE FROM tag_schemas WHERE tag_name = ?").run(tag);
+  return result.changes > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToSchema(row: TagSchemaRow): TagSchema {
+  let fields: Record<string, TagFieldSchema> | undefined;
+  if (row.fields) {
+    try { fields = JSON.parse(row.fields); } catch {}
+  }
+  return {
+    tag: row.tag_name,
+    description: row.description ?? undefined,
+    fields,
+  };
+}

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -127,6 +127,13 @@ export interface Store {
   traverseLinks(noteId: string, opts?: { max_depth?: number; relationship?: string }): { noteId: string; depth: number; relationship: string; direction: "outbound" | "inbound" }[];
   findPath(sourceId: string, targetId: string, opts?: { max_depth?: number }): { path: string[]; relationships: string[] } | null;
 
+  // Tag schemas
+  listTagSchemas(): { tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }[];
+  getTagSchema(tag: string): { tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> } | null;
+  upsertTagSchema(tag: string, schema: { description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }): { tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> };
+  deleteTagSchema(tag: string): boolean;
+  getTagSchemaMap(): Record<string, { description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }>;
+
   // Attachments
   addAttachment(noteId: string, path: string, mimeType: string, metadata?: Record<string, unknown>): Attachment;
   getAttachments(noteId: string): Attachment[];

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -36,6 +36,8 @@ const READ_TOOLS = new Set([
   "get-vault-stats",
   "resolve-wikilink",
   "list-unresolved-wikilinks",
+  "list-tag-schemas",
+  "describe-tag",
 ]);
 
 /** Check if a tool call is allowed for a given scope. */

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -439,9 +439,10 @@ function addTagSchemaTools(tools: McpToolDef[], defaultVault: string, multiVault
       const store = resolveStore(params);
       const tag = params.tag as string;
       const existing = store.getTagSchema(tag);
-      const mergedFields = { ...existing?.fields, ...(params.fields as any) };
+      if (!existing) throw new Error(`No schema defined for tag "${tag}". Use create-tag-schema to create one.`);
+      const mergedFields = { ...existing.fields, ...(params.fields as any) };
       return store.upsertTagSchema(tag, {
-        description: (params.description as string | undefined) ?? existing?.description,
+        description: (params.description as string | undefined) ?? existing.description,
         fields: Object.keys(mergedFields).length > 0 ? mergedFields : undefined,
       });
     },

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -82,8 +82,9 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
         const { vault: _, ...rest } = params;
         const result = tool.execute(rest);
 
-        if (config.tag_schemas) {
-          applyTagSchemaEffects(coreTool.name, result, rest, store, config.tag_schemas);
+        const schemas = store.getTagSchemaMap();
+        if (Object.keys(schemas).length > 0) {
+          applyTagSchemaEffects(coreTool.name, result, rest, store, schemas);
         }
 
         return result;
@@ -109,19 +110,18 @@ export function generateScopedMcpTools(vaultName: string): McpToolDef[] {
   const tools = generateMcpTools(store);
 
   // Wrap tools with schema effects (defaults + warnings) for scoped mode
-  const config = readVaultConfig(vaultName);
-  if (config?.tag_schemas) {
-    const schemas = config.tag_schemas;
-    for (const tool of tools) {
-      if (SCHEMA_EFFECT_TOOLS.has(tool.name)) {
-        const originalExecute = tool.execute;
-        const toolName = tool.name;
-        tool.execute = (params) => {
-          const result = originalExecute(params);
+  for (const tool of tools) {
+    if (SCHEMA_EFFECT_TOOLS.has(tool.name)) {
+      const originalExecute = tool.execute;
+      const toolName = tool.name;
+      tool.execute = (params) => {
+        const result = originalExecute(params);
+        const schemas = store.getTagSchemaMap();
+        if (Object.keys(schemas).length > 0) {
           applyTagSchemaEffects(toolName, result, params, store, schemas);
-          return result;
-        };
-      }
+        }
+        return result;
+      };
     }
   }
 
@@ -204,8 +204,10 @@ function addVaultManagementTools(tools: McpToolDef[], defaultVault: string, scop
 // Tag schema validation (soft)
 // ---------------------------------------------------------------------------
 
-import type { TagSchema, TagFieldSchema } from "./config.ts";
+import type { TagFieldSchema } from "../core/src/tag-schemas.ts";
 import type { Store } from "../core/src/types.ts";
+
+type TagSchema = { description?: string; fields?: Record<string, TagFieldSchema> };
 
 /** Tools that can trigger schema effects (defaults + warnings). */
 const SCHEMA_EFFECT_TOOLS = new Set([
@@ -350,23 +352,20 @@ function checkTagSchemaWarnings(
 // ---------------------------------------------------------------------------
 
 function addTagSchemaTools(tools: McpToolDef[], defaultVault: string, multiVault = false, scoped = false) {
+  const vaultProp = scoped ? {} : {
+    vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
+  };
+
+  function resolveStore(params: Record<string, unknown>) {
+    const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
+    return getVaultStore(name);
+  }
+
   tools.push({
     name: "list-tag-schemas",
     description: "List all tag schemas defined for this vault. Tag schemas describe the expected metadata fields for notes with specific tags.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...(scoped ? {} : {
-          vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
-        }),
-      },
-    },
-    execute: (params) => {
-      const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
-      const config = readVaultConfig(name);
-      if (!config) throw new Error(`Vault "${name}" not found`);
-      return config.tag_schemas ?? {};
-    },
+    inputSchema: { type: "object", properties: { ...vaultProp } },
+    execute: (params) => resolveStore(params).listTagSchemas(),
   });
 
   tools.push({
@@ -374,21 +373,91 @@ function addTagSchemaTools(tools: McpToolDef[], defaultVault: string, multiVault
     description: "Get the schema for a specific tag — its description and expected metadata fields. Returns null if no schema is defined for the tag.",
     inputSchema: {
       type: "object",
+      properties: { ...vaultProp, tag: { type: "string", description: "Tag name to describe" } },
+      required: ["tag"],
+    },
+    execute: (params) => resolveStore(params).getTagSchema(params.tag as string),
+  });
+
+  tools.push({
+    name: "create-tag-schema",
+    description: "Create or replace a tag's schema. Defines what metadata fields notes with this tag should have. Fields get auto-populated with defaults when the tag is applied to a note.",
+    inputSchema: {
+      type: "object",
       properties: {
-        ...(scoped ? {} : {
-          vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
-        }),
-        tag: { type: "string", description: "Tag name to describe" },
+        ...vaultProp,
+        tag: { type: "string", description: "Tag name" },
+        description: { type: "string", description: "Human-readable description of what this tag means" },
+        fields: {
+          type: "object",
+          description: 'Metadata fields. Each key maps to { type, description?, enum? }. Example: { "status": { "type": "string", "enum": ["active", "archived"] } }',
+          additionalProperties: {
+            type: "object",
+            properties: {
+              type: { type: "string", description: "Field type: string, boolean, integer" },
+              description: { type: "string", description: "What this field means" },
+              enum: { type: "array", items: { type: "string" }, description: "Allowed values (first is the default)" },
+            },
+            required: ["type"],
+          },
+        },
+      },
+      required: ["tag"],
+    },
+    execute: (params) => resolveStore(params).upsertTagSchema(
+      params.tag as string,
+      { description: params.description as string | undefined, fields: params.fields as any },
+    ),
+  });
+
+  tools.push({
+    name: "update-tag-schema",
+    description: "Update an existing tag schema. Merges provided fields with existing ones. Pass description to update it, fields to add/replace field definitions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...vaultProp,
+        tag: { type: "string", description: "Tag name" },
+        description: { type: "string", description: "Updated description" },
+        fields: {
+          type: "object",
+          description: "Fields to add or update (merged with existing)",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              type: { type: "string" },
+              description: { type: "string" },
+              enum: { type: "array", items: { type: "string" } },
+            },
+            required: ["type"],
+          },
+        },
       },
       required: ["tag"],
     },
     execute: (params) => {
-      const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
-      const config = readVaultConfig(name);
-      if (!config) throw new Error(`Vault "${name}" not found`);
+      const store = resolveStore(params);
       const tag = params.tag as string;
-      const schema = config.tag_schemas?.[tag];
-      return schema ?? null;
+      const existing = store.getTagSchema(tag);
+      const mergedFields = { ...existing?.fields, ...(params.fields as any) };
+      return store.upsertTagSchema(tag, {
+        description: (params.description as string | undefined) ?? existing?.description,
+        fields: Object.keys(mergedFields).length > 0 ? mergedFields : undefined,
+      });
+    },
+  });
+
+  tools.push({
+    name: "delete-tag-schema",
+    description: "Remove a tag's schema. Does not delete the tag itself or remove it from notes — only removes the metadata schema definition.",
+    inputSchema: {
+      type: "object",
+      properties: { ...vaultProp, tag: { type: "string", description: "Tag name" } },
+      required: ["tag"],
+    },
+    execute: (params) => {
+      const deleted = resolveStore(params).deleteTagSchema(params.tag as string);
+      return { deleted };
     },
   });
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -192,7 +192,7 @@ export async function handleTagSchemas(req: Request, store: Store, subpath = "")
     return json(store.listTagSchemas());
   }
 
-  const tagMatch = subpath.match(/^\/(.+)$/);
+  const tagMatch = subpath.match(/^\/([^/]+)$/);
   if (!tagMatch) return json({ error: "Not found" }, 404);
   const tagName = decodeURIComponent(tagMatch[1]);
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -183,6 +183,43 @@ export function handleTags(req: Request, store: Store, subpath = ""): Response {
 }
 
 // ---------------------------------------------------------------------------
+// Tag Schemas
+// ---------------------------------------------------------------------------
+
+export async function handleTagSchemas(req: Request, store: Store, subpath = ""): Promise<Response> {
+  // GET /tag-schemas — list all
+  if (req.method === "GET" && subpath === "") {
+    return json(store.listTagSchemas());
+  }
+
+  const tagMatch = subpath.match(/^\/(.+)$/);
+  if (!tagMatch) return json({ error: "Not found" }, 404);
+  const tagName = decodeURIComponent(tagMatch[1]);
+
+  // GET /tag-schemas/:tag
+  if (req.method === "GET") {
+    const schema = store.getTagSchema(tagName);
+    if (!schema) return json({ error: "No schema for tag" }, 404);
+    return json(schema);
+  }
+
+  // PUT /tag-schemas/:tag — create or update
+  if (req.method === "PUT") {
+    const body = await req.json() as { description?: string; fields?: Record<string, unknown> };
+    const schema = store.upsertTagSchema(tagName, body as any);
+    return json(schema);
+  }
+
+  // DELETE /tag-schemas/:tag
+  if (req.method === "DELETE") {
+    const deleted = store.deleteTagSchema(tagName);
+    return json({ deleted });
+  }
+
+  return json({ error: "Method not allowed" }, 405);
+}
+
+// ---------------------------------------------------------------------------
 // Links
 // ---------------------------------------------------------------------------
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed, e
 import type { VaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
-import { handleNotes, handleTags, handleLinks, handleGraph, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleViewNote } from "./routes.ts";
+import { handleNotes, handleTags, handleTagSchemas, handleLinks, handleGraph, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleViewNote } from "./routes.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTriggers } from "./triggers.ts";
 
@@ -64,6 +64,24 @@ if (listVaults().length === 0) {
     }
     writeGlobalConfig(globalConfig);
     console.log(`Auto-created default vault (API key: ${fullKey})`);
+  }
+}
+
+// Migrate tag schemas from vault.yaml → DB for each vault.
+// Runs once per vault on first startup after the v6 schema upgrade.
+for (const vaultName of listVaults()) {
+  const vaultConfig = readVaultConfig(vaultName);
+  if (vaultConfig?.tag_schemas && Object.keys(vaultConfig.tag_schemas).length > 0) {
+    const store = getVaultStore(vaultName);
+    const existingSchemas = store.listTagSchemas();
+    if (existingSchemas.length === 0) {
+      let migrated = 0;
+      for (const [tag, schema] of Object.entries(vaultConfig.tag_schemas)) {
+        store.upsertTagSchema(tag, schema);
+        migrated++;
+      }
+      console.log(`[migration] migrated ${migrated} tag schema(s) from vault.yaml to DB for vault "${vaultName}"`);
+    }
   }
 }
 
@@ -220,6 +238,7 @@ async function route(req: Request, path: string): Promise<Response> {
     const store = getVaultStore(defaultVault);
     const apiPath = path.slice(4); // strip "/api"
     if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6));
+    if (apiPath.startsWith("/tag-schemas")) return handleTagSchemas(req, store, apiPath.slice(12));
     if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
     if (apiPath === "/links") return handleLinks(req, store);
     if (apiPath === "/graph") return handleGraph(req, store);
@@ -309,6 +328,9 @@ async function route(req: Request, path: string): Promise<Response> {
 
   if (apiPath.startsWith("/notes")) {
     return handleNotes(req, store, apiPath.slice(6));
+  }
+  if (apiPath.startsWith("/tag-schemas")) {
+    return handleTagSchemas(req, store, apiPath.slice(12));
   }
   if (apiPath.startsWith("/tags")) {
     return handleTags(req, store, apiPath.slice(5));

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,19 +68,23 @@ if (listVaults().length === 0) {
 }
 
 // Migrate tag schemas from vault.yaml → DB for each vault.
-// Runs once per vault on first startup after the v6 schema upgrade.
+// Only inserts schemas that don't already exist in the DB (safe across restarts).
 for (const vaultName of listVaults()) {
   const vaultConfig = readVaultConfig(vaultName);
   if (vaultConfig?.tag_schemas && Object.keys(vaultConfig.tag_schemas).length > 0) {
     const store = getVaultStore(vaultName);
-    const existingSchemas = store.listTagSchemas();
-    if (existingSchemas.length === 0) {
-      let migrated = 0;
-      for (const [tag, schema] of Object.entries(vaultConfig.tag_schemas)) {
+    const existingTags = new Set(store.listTagSchemas().map((s) => s.tag));
+    let migrated = 0;
+    for (const [tag, schema] of Object.entries(vaultConfig.tag_schemas)) {
+      if (!existingTags.has(tag)) {
         store.upsertTagSchema(tag, schema);
         migrated++;
       }
+    }
+    if (migrated > 0) {
       console.log(`[migration] migrated ${migrated} tag schema(s) from vault.yaml to DB for vault "${vaultName}"`);
+    } else {
+      console.log(`[migration] vault "${vaultName}" has tag_schemas in vault.yaml (already in DB — vault.yaml section can be removed)`);
     }
   }
 }

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -569,41 +569,41 @@ describe("unified MCP wrapper", () => {
   test("list-tag-schemas and describe-tag tools work", async () => {
     const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
     const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
-    const { closeAllStores } = await import("./vault-store.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
 
     const vaultName = `tag-schema-${Date.now()}`;
     writeVaultConfig({
       name: vaultName,
       api_keys: [],
       created_at: new Date().toISOString(),
-      tag_schemas: {
-        person: {
-          description: "A person",
-          fields: {
-            name: { type: "string", description: "Full name" },
-          },
-        },
-        project: {
-          description: "A project",
-        },
-      },
     });
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    // Insert schemas into DB
+    const store = getVaultStore(vaultName);
+    store.upsertTagSchema("person", {
+      description: "A person",
+      fields: { name: { type: "string", description: "Full name" } },
+    });
+    store.upsertTagSchema("project", { description: "A project" });
 
     const tools = generateUnifiedMcpTools();
 
     const listTool = tools.find((t) => t.name === "list-tag-schemas");
     expect(listTool).toBeTruthy();
-    const schemas = listTool!.execute({ vault: vaultName }) as any;
-    expect(schemas.person).toBeDefined();
-    expect(schemas.person.description).toBe("A person");
-    expect(schemas.project).toBeDefined();
+    const schemas = listTool!.execute({ vault: vaultName }) as any[];
+    expect(schemas.length).toBe(2);
+    const personSchema = schemas.find((s: any) => s.tag === "person");
+    expect(personSchema).toBeDefined();
+    expect(personSchema.description).toBe("A person");
+    const projectSchema = schemas.find((s: any) => s.tag === "project");
+    expect(projectSchema).toBeDefined();
 
     const describeTool = tools.find((t) => t.name === "describe-tag");
     expect(describeTool).toBeTruthy();
-    const personSchema = describeTool!.execute({ vault: vaultName, tag: "person" }) as any;
-    expect(personSchema.description).toBe("A person");
-    expect(personSchema.fields.name.type).toBe("string");
+    const described = describeTool!.execute({ vault: vaultName, tag: "person" }) as any;
+    expect(described.description).toBe("A person");
+    expect(described.fields.name.type).toBe("string");
 
     const unknown = describeTool!.execute({ vault: vaultName, tag: "nonexistent" }) as any;
     expect(unknown).toBeNull();
@@ -621,17 +621,17 @@ describe("unified MCP wrapper", () => {
       name: vaultName,
       api_keys: [],
       created_at: new Date().toISOString(),
-      tag_schemas: {
-        person: {
-          description: "A person",
-          fields: {
-            first_appeared: { type: "string", description: "When" },
-            relationship: { type: "string", description: "How" },
-          },
-        },
-      },
     });
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const store = getVaultStore(vaultName);
+    store.upsertTagSchema("person", {
+      description: "A person",
+      fields: {
+        first_appeared: { type: "string", description: "When" },
+        relationship: { type: "string", description: "How" },
+      },
+    });
 
     const tools = generateUnifiedMcpTools();
     const createNote = tools.find((t) => t.name === "create-note")!;
@@ -676,12 +676,12 @@ describe("unified MCP wrapper", () => {
       name: vaultName,
       api_keys: [],
       created_at: new Date().toISOString(),
-      tag_schemas: {
-        // Schema with no fields — warnings check but defaults don't help
-        empty: { description: "No fields" },
-      },
     });
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const { getVaultStore } = await import("./vault-store.ts");
+    const store = getVaultStore(vaultName);
+    store.upsertTagSchema("empty", { description: "No fields" });
 
     const tools = generateUnifiedMcpTools();
     const createNote = tools.find((t) => t.name === "create-note")!;
@@ -705,27 +705,25 @@ describe("unified MCP wrapper", () => {
       name: vaultName,
       api_keys: [],
       created_at: new Date().toISOString(),
-      tag_schemas: {
-        person: {
-          description: "A person",
-          fields: {
-            first_appeared: { type: "string", description: "When" },
-            relationship: { type: "string", description: "How" },
-          },
-        },
-        project: {
-          description: "A project",
-          fields: {
-            status: { type: "string", enum: ["active", "completed", "abandoned"], description: "Status" },
-            active: { type: "boolean", description: "Is active" },
-            priority: { type: "integer", description: "Priority level" },
-          },
-        },
-      },
     });
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
+    vaultStore.upsertTagSchema("person", {
+      description: "A person",
+      fields: {
+        first_appeared: { type: "string", description: "When" },
+        relationship: { type: "string", description: "How" },
+      },
+    });
+    vaultStore.upsertTagSchema("project", {
+      description: "A project",
+      fields: {
+        status: { type: "string", enum: ["active", "completed", "abandoned"], description: "Status" },
+        active: { type: "boolean", description: "Is active" },
+        priority: { type: "integer", description: "Priority level" },
+      },
+    });
     const tools = generateUnifiedMcpTools();
     const createNote = tools.find((t) => t.name === "create-note")!;
     const tagNote = tools.find((t) => t.name === "tag-note")!;
@@ -785,14 +783,14 @@ describe("unified MCP wrapper", () => {
       name: vaultName,
       api_keys: [],
       created_at: new Date().toISOString(),
-      tag_schemas: {
-        person: {
-          description: "A person",
-          fields: { name: { type: "string" } },
-        },
-      },
     });
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
+
+    const vaultStore = getVaultStore(vaultName);
+    vaultStore.upsertTagSchema("person", {
+      description: "A person",
+      fields: { name: { type: "string" } },
+    });
 
     const tools = generateUnifiedMcpTools();
     const createNote = tools.find((t) => t.name === "create-note")!;
@@ -822,11 +820,16 @@ describe("auth scopes", () => {
     expect(isToolAllowed("list-tags", "read")).toBe(true);
     expect(isToolAllowed("get-vault-stats", "read")).toBe(true);
     expect(isToolAllowed("list-vaults", "read")).toBe(true);
+    expect(isToolAllowed("list-tag-schemas", "read")).toBe(true);
+    expect(isToolAllowed("describe-tag", "read")).toBe(true);
   });
 
   test("read scope blocks write tools", () => {
     const { isToolAllowed } = require("./auth.ts");
     expect(isToolAllowed("create-note", "read")).toBe(false);
+    expect(isToolAllowed("create-tag-schema", "read")).toBe(false);
+    expect(isToolAllowed("update-tag-schema", "read")).toBe(false);
+    expect(isToolAllowed("delete-tag-schema", "read")).toBe(false);
     expect(isToolAllowed("update-note", "read")).toBe(false);
     expect(isToolAllowed("delete-note", "read")).toBe(false);
     expect(isToolAllowed("tag-note", "read")).toBe(false);


### PR DESCRIPTION
## Summary

- Tag schemas now stored in `tag_schemas` SQLite table (schema v6) instead of vault.yaml config
- Auto-migration on startup: copies vault.yaml schemas to DB per-key (non-destructive, idempotent)
- New MCP tools: `create-tag-schema`, `update-tag-schema`, `delete-tag-schema`
- REST API: `GET/PUT/DELETE /api/tag-schemas[/:tag]`
- Existing `list-tag-schemas` and `describe-tag` tools now read from DB
- Schema effects (auto-populate defaults, warnings) read from DB instead of config

## Why

AI agents can now manage tag schemas via MCP tools without editing config files. This is the first step toward making vault fully self-describing.

## Migration safety

- Benjamin's vault: vault.yaml `tag_schemas` are copied to DB on first startup after update
- Per-key migration: only inserts tags not already in DB (safe across restarts)
- vault.yaml schemas are preserved (not deleted) — a deprecation notice is logged if they remain
- `update-tag-schema` errors if schema doesn't exist (not silent upsert)

## Files changed (9)

- `core/src/tag-schemas.ts` — new CRUD module
- `core/src/schema.ts` — v6 table DDL
- `core/src/types.ts` — Store interface extended
- `core/src/store.ts` — SqliteStore implementation
- `src/mcp-tools.ts` — read from DB, new CRUD tools
- `src/routes.ts` — REST handler
- `src/server.ts` — migration + route wiring
- `src/auth.ts` — read scope for new tools
- `src/vault.test.ts` — updated tests

## Test plan

- [x] 282 server tests pass (including updated schema effect tests)
- [x] 168 core tests pass
- [x] Self-review: migration idempotency, auth coverage, update-tag-schema guard
- [ ] Independent review
- [ ] Test with vault that has existing tag_schemas in vault.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)