### PR TITLE
feat: consolidate 30 MCP tools down to 9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ attachments (id, note_id, path, mime_type, metadata, created_at)
 links       (source_id, target_id, relationship, metadata, created_at)
 ```
 
-Additional tables (created on demand):
+Additional tables:
+- `tag_schemas` — tag description + metadata field definitions (JSON)
 - `unresolved_wikilinks` — pending wikilink resolution
 - `schema_version` — migration tracking
 
@@ -44,15 +45,15 @@ Metadata is a JSON column on notes, links, and attachments. Queryable via `json_
 
 Path is unique (when set), normalized (no .md, no trailing slashes), and used for wikilink resolution.
 
-### MCP Tools (20+)
+### MCP Tools (9)
 
-Core: `get-note`, `create-note`, `update-note`, `delete-note`, `read-notes`, `search-notes`, `tag-note`, `untag-note`, `create-link`, `delete-link`, `get-links`, `list-tags`
+Notes: `query-notes` (single by ID/path, filter, search, graph neighborhood), `create-note` (single or batch), `update-note` (single or batch — content, tags, links, metadata merge), `delete-note`
 
-Bulk: `create-notes`, `batch-tag`, `batch-untag`
+Tags: `list-tags` (with optional schema detail), `update-tag` (upsert schema), `delete-tag`
 
-Graph: `traverse-links`, `find-path`
+Graph: `find-path` (BFS shortest path)
 
-Vault: `list-vaults`, `get-vault-description`, `update-vault-description`
+Vault: `vault-info` (get/update description + stats)
 
 
 ## Bun-native

--- a/README.md
+++ b/README.md
@@ -67,14 +67,12 @@ parachute vault config set KEY value       # set a config value
 parachute vault restart                    # apply changes
 ```
 
-## MCP tools
+## MCP tools (9)
 
-**Notes**: `get-note`, `create-note`, `update-note`, `delete-note`, `read-notes`, `search-notes`
-**Tags**: `tag-note`, `untag-note`, `list-tags`
-**Links**: `create-link`, `delete-link`, `get-links`
-**Bulk**: `create-notes`, `batch-tag`, `batch-untag`
-**Graph**: `traverse-links`, `find-path`
-**Vault**: `list-vaults`, `get-vault-description`, `update-vault-description`, `get-vault-stats`
+**Notes**: `query-notes` (universal read — single by ID/path, filter, search, graph neighborhood), `create-note` (single or batch), `update-note` (single or batch — content, tags, links, metadata), `delete-note`
+**Tags**: `list-tags` (with optional schema detail), `update-tag` (upsert description + schema fields), `delete-tag`
+**Graph**: `find-path` (BFS between two notes)
+**Vault**: `vault-info` (get/update description + stats)
 
 ### Vault descriptions
 

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -233,22 +233,18 @@ describe("vault stats", () => {
     expect(stats).toHaveProperty("tagCount");
   });
 
-  it("get-vault-stats MCP tool works", () => {
+  it("getVaultStats returns correct stats", () => {
     store.createNote("one", { tags: ["x"], created_at: "2025-05-01T00:00:00.000Z" });
     store.createNote("two", { tags: ["x", "y"], created_at: "2025-06-01T00:00:00.000Z" });
 
-    const tools = generateMcpTools(db);
-    const tool = tools.find((t) => t.name === "get-vault-stats")!;
-    expect(tool).toBeTruthy();
-
-    const result = tool.execute({}) as any;
+    const result = store.getVaultStats();
     expect(result.totalNotes).toBe(2);
     expect(result.tagCount).toBe(2);
     expect(result.topTags[0].tag).toBe("x");
     expect(result.topTags[0].count).toBe(2);
     expect(result.notesByMonth).toHaveLength(2);
-    expect(result.earliestNote.createdAt).toBe("2025-05-01T00:00:00.000Z");
-    expect(result.latestNote.createdAt).toBe("2025-06-01T00:00:00.000Z");
+    expect(result.earliestNote!.createdAt).toBe("2025-05-01T00:00:00.000Z");
+    expect(result.latestNote!.createdAt).toBe("2025-06-01T00:00:00.000Z");
   });
 });
 
@@ -442,46 +438,59 @@ describe("attachments", () => {
 // ---- MCP Tools ----
 
 describe("MCP tools", () => {
-  it("generates all expected tools", () => {
-    const tools = generateMcpTools(db);
+  it("generates all 9 consolidated tools", () => {
+    const tools = generateMcpTools(store);
     const names = tools.map((t) => t.name);
 
+    expect(names).toContain("query-notes");
     expect(names).toContain("create-note");
     expect(names).toContain("update-note");
     expect(names).toContain("delete-note");
-    expect(names).toContain("read-notes");
-    expect(names).toContain("search-notes");
-    expect(names).toContain("tag-note");
-    expect(names).toContain("untag-note");
-    expect(names).toContain("create-link");
-    expect(names).toContain("delete-link");
-    expect(names).toContain("get-links");
     expect(names).toContain("list-tags");
-    expect(names).toContain("create-notes");
-    expect(names).toContain("batch-tag");
-    expect(names).toContain("batch-untag");
-    expect(names).toContain("traverse-links");
-    expect(names).toContain("find-path");
-    expect(names).toContain("get-note");
-    expect(names).toContain("get-vault-stats");
+    expect(names).toContain("update-tag");
     expect(names).toContain("delete-tag");
-    expect(names).toContain("resolve-wikilink");
-    expect(names).toContain("list-unresolved-wikilinks");
-    expect(names).toContain("get-graph");
-    expect(tools).toHaveLength(22);
+    expect(names).toContain("find-path");
+    expect(names).toContain("vault-info");
+    expect(tools).toHaveLength(9);
   });
 
   it("create-note tool works", () => {
-    const tools = generateMcpTools(db);
+    const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
     const result = createNote.execute({ content: "Hello", tags: ["daily"] }) as any;
     expect(result.content).toBe("Hello");
     expect(result.tags).toContain("daily");
   });
 
+  it("create-note batch mode works", () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    const result = createNote.execute({
+      notes: [
+        { content: "A", tags: ["daily"] },
+        { content: "B", tags: ["doc"] },
+      ],
+    }) as any[];
+    expect(result).toHaveLength(2);
+    expect(result[0].tags).toContain("daily");
+    expect(result[1].tags).toContain("doc");
+  });
+
+  it("create-note with links resolves targets by path", () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    store.createNote("Target", { path: "People/Alice" });
+    const result = createNote.execute({
+      content: "Links to Alice",
+      links: [{ target: "People/Alice", relationship: "mentions" }],
+    }) as any;
+    const links = store.getLinks(result.id, { direction: "outbound" });
+    expect(links.some((l) => l.relationship === "mentions")).toBe(true);
+  });
+
   it("update-note tool updates created_at", () => {
     const note = store.createNote("Test");
-    const tools = generateMcpTools(db);
+    const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
     const newDate = "2025-03-01T00:00:00.000Z";
     const result = updateNote.execute({ id: note.id, created_at: newDate }) as any;
@@ -489,188 +498,234 @@ describe("MCP tools", () => {
     expect(result.content).toBe("Test");
   });
 
-  it("update-note tool updates metadata", () => {
-    const note = store.createNote("Test");
-    const tools = generateMcpTools(db);
+  it("update-note tool merges metadata", () => {
+    const note = store.createNote("Test", { metadata: { existing: "value" } });
+    const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
-    const meta = { importance: "high" };
-    const result = updateNote.execute({ id: note.id, metadata: meta }) as any;
-    expect(result.metadata).toEqual(meta);
+    const result = updateNote.execute({ id: note.id, metadata: { importance: "high" } }) as any;
+    expect(result.metadata).toEqual({ existing: "value", importance: "high" });
   });
 
-  it("read-notes tool works", () => {
+  it("update-note tags add/remove works", () => {
+    const note = store.createNote("Test");
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // Add tags
+    updateNote.execute({ id: note.id, tags: { add: ["pinned", "daily"] } });
+    expect(store.getNote(note.id)!.tags).toContain("pinned");
+    expect(store.getNote(note.id)!.tags).toContain("daily");
+
+    // Remove tags
+    updateNote.execute({ id: note.id, tags: { remove: ["pinned"] } });
+    expect(store.getNote(note.id)!.tags).not.toContain("pinned");
+    expect(store.getNote(note.id)!.tags).toContain("daily");
+  });
+
+  it("update-note links add/remove works", () => {
+    store.createNote("A", { id: "a" });
+    store.createNote("B", { id: "b" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // Add link
+    updateNote.execute({ id: "a", links: { add: [{ target: "b", relationship: "mentions" }] } });
+    expect(store.getLinks("a", { direction: "outbound" })).toHaveLength(1);
+
+    // Remove link
+    updateNote.execute({ id: "a", links: { remove: [{ target: "b", relationship: "mentions" }] } });
+    expect(store.getLinks("a", { direction: "outbound" })).toHaveLength(0);
+  });
+
+  it("update-note removes wikilink brackets when removing wikilink-type link", () => {
+    store.createNote("Target", { id: "target", path: "People/Alice" });
+    const source = store.createNote("See [[People/Alice]] for details", { id: "source" });
+    store.createLink("source", "target", "wikilink");
+
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = updateNote.execute({
+      id: "source",
+      links: { remove: [{ target: "target", relationship: "wikilink" }] },
+    }) as any;
+    expect(result.content).toBe("See People/Alice for details");
+  });
+
+  it("update-note batch mode works", () => {
+    const a = store.createNote("A", { id: "a" });
+    const b = store.createNote("B", { id: "b" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = updateNote.execute({
+      notes: [
+        { id: "a", content: "A updated" },
+        { id: "b", tags: { add: ["pinned"] } },
+      ],
+    }) as any[];
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe("A updated");
+    expect(store.getNote("b")!.tags).toContain("pinned");
+  });
+
+  it("update-note resolves note by path", () => {
+    store.createNote("Test", { path: "Projects/README" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = updateNote.execute({ id: "Projects/README", content: "Updated" }) as any;
+    expect(result.content).toBe("Updated");
+  });
+
+  it("query-notes single note by id", () => {
+    const note = store.createNote("Hello", { path: "test/note" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ id: note.id }) as any;
+    expect(result.content).toBe("Hello");
+    expect(result.path).toBe("test/note");
+  });
+
+  it("query-notes single note by path", () => {
+    store.createNote("By Path", { path: "Projects/README" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ id: "Projects/README" }) as any;
+    expect(result.content).toBe("By Path");
+  });
+
+  it("query-notes by tag", () => {
     store.createNote("Test", { tags: ["daily"] });
-    const tools = generateMcpTools(db);
-    const readNotes = tools.find((t) => t.name === "read-notes")!;
-    const result = readNotes.execute({ tags: ["daily"] }) as any[];
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ tag: ["daily"] }) as any[];
     expect(result).toHaveLength(1);
   });
 
-  it("read-notes defaults to including content (backwards compatible)", () => {
-    store.createNote("Full body content here", { tags: ["daily"] });
-    const tools = generateMcpTools(db);
-    const readNotes = tools.find((t) => t.name === "read-notes")!;
-    const result = readNotes.execute({ tags: ["daily"] }) as any[];
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toBe("Full body content here");
-    expect(result[0].byteSize).toBeUndefined();
-    expect(result[0].preview).toBeUndefined();
-  });
-
-  it("read-notes with include_content: true returns full content", () => {
-    store.createNote("Explicit include", { tags: ["daily"] });
-    const tools = generateMcpTools(db);
-    const readNotes = tools.find((t) => t.name === "read-notes")!;
-    const result = readNotes.execute({ tags: ["daily"], include_content: true }) as any[];
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toBe("Explicit include");
-  });
-
-  it("read-notes with include_content: false returns index metadata without content", () => {
-    const content = "This is the note body that should not come back in index mode.";
-    store.createNote(content, { tags: ["daily"], path: "Notes/index-test", metadata: { status: "draft" } });
-    const tools = generateMcpTools(db);
-    const readNotes = tools.find((t) => t.name === "read-notes")!;
-    const result = readNotes.execute({ tags: ["daily"], include_content: false }) as any[];
+  it("query-notes list defaults to no content (index mode)", () => {
+    const content = "This is the note body.";
+    store.createNote(content, { tags: ["daily"], path: "Notes/test", metadata: { status: "draft" } });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ tag: ["daily"] }) as any[];
     expect(result).toHaveLength(1);
     const entry = result[0];
     expect(entry.content).toBeUndefined();
     expect(entry.id).toBeTruthy();
-    expect(entry.path).toBe("Notes/index-test");
-    expect(entry.createdAt).toBeTruthy();
-    expect(entry.tags).toContain("daily");
-    expect(entry.metadata).toEqual({ status: "draft" });
+    expect(entry.path).toBe("Notes/test");
     expect(entry.byteSize).toBe(Buffer.byteLength(content, "utf8"));
-    expect(entry.preview).toBe(content);
   });
 
-  it("read-notes index mode truncates preview and counts utf-8 bytes", () => {
-    // Multi-byte chars: each "✨" is 3 bytes in utf-8
+  it("query-notes list with include_content: true returns full content", () => {
+    store.createNote("Full body", { tags: ["daily"] });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ tag: ["daily"], include_content: true }) as any[];
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("Full body");
+  });
+
+  it("query-notes index mode truncates preview and counts utf-8 bytes", () => {
     const longContent = "line one\nline two has\tlots    of   whitespace\n" + "x".repeat(300) + " ✨✨✨";
     store.createNote(longContent, { tags: ["long"] });
-    const tools = generateMcpTools(db);
-    const readNotes = tools.find((t) => t.name === "read-notes")!;
-    const result = readNotes.execute({ tags: ["long"], include_content: false }) as any[];
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ tag: ["long"] }) as any[];
     expect(result).toHaveLength(1);
     const entry = result[0];
     expect(entry.byteSize).toBe(Buffer.byteLength(longContent, "utf8"));
-    expect(entry.byteSize).toBeGreaterThan(longContent.length); // multi-byte chars
+    expect(entry.byteSize).toBeGreaterThan(longContent.length);
     expect(entry.preview.length).toBeLessThanOrEqual(120);
-    expect(entry.preview.includes("\n")).toBe(false); // whitespace collapsed
+    expect(entry.preview.includes("\n")).toBe(false);
   });
 
-  it("read-notes index mode preview does not split astral-plane surrogate pairs", () => {
-    // "😀" is U+1F600 — outside the BMP, encoded as a UTF-16 surrogate pair.
-    // A naive .slice(0, 120) would cut on code unit 120, landing mid-pair
-    // and producing a lone surrogate. Iterating by code points avoids this.
+  it("query-notes index mode does not split astral-plane surrogate pairs", () => {
     const emoji = "😀";
     const longContent = emoji.repeat(130);
     store.createNote(longContent, { tags: ["astral"] });
-    const tools = generateMcpTools(db);
-    const readNotes = tools.find((t) => t.name === "read-notes")!;
-    const result = readNotes.execute({ tags: ["astral"], include_content: false }) as any[];
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ tag: ["astral"] }) as any[];
     expect(result).toHaveLength(1);
     const preview = result[0].preview as string;
-
-    // Must be truncated to at most 120 code points (not code units).
     const codePoints = Array.from(preview);
     expect(codePoints.length).toBeLessThanOrEqual(120);
-
-    // Every code point should be the full emoji — no lone surrogates.
     for (const cp of codePoints) {
       expect(cp).toBe(emoji);
     }
-
-    // No unpaired surrogates anywhere in the string.
-    for (let i = 0; i < preview.length; i++) {
-      const code = preview.charCodeAt(i);
-      if (code >= 0xd800 && code <= 0xdbff) {
-        // high surrogate — must be followed by a low surrogate
-        const next = preview.charCodeAt(i + 1);
-        expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
-        i++;
-      } else {
-        // must not be a lone low surrogate
-        expect(code >= 0xdc00 && code <= 0xdfff).toBe(false);
-      }
-    }
   });
 
-  it("read-notes index mode honors existing filters (date range, path_prefix, limit, offset)", () => {
+  it("query-notes honors filters (date range, path_prefix, limit, offset)", () => {
     store.createNote("A", { tags: ["keep"], path: "Projects/a", created_at: "2025-03-05T00:00:00.000Z" });
     store.createNote("B", { tags: ["keep"], path: "Projects/b", created_at: "2025-03-10T00:00:00.000Z" });
     store.createNote("C", { tags: ["keep"], path: "Other/c",    created_at: "2025-03-15T00:00:00.000Z" });
     store.createNote("D", { tags: ["keep"], path: "Projects/d", created_at: "2025-04-02T00:00:00.000Z" });
 
-    const tools = generateMcpTools(db);
-    const readNotes = tools.find((t) => t.name === "read-notes")!;
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
 
     // date range filter
-    const inMarch = readNotes.execute({
+    const inMarch = query.execute({
       date_from: "2025-03-01",
       date_to: "2025-04-01",
       sort: "asc",
-      include_content: false,
     }) as any[];
     expect(inMarch).toHaveLength(3);
     expect(inMarch.every((n) => n.content === undefined)).toBe(true);
-    expect(inMarch.every((n) => typeof n.byteSize === "number")).toBe(true);
 
     // path_prefix filter
-    const projects = readNotes.execute({
-      path_prefix: "Projects",
-      include_content: false,
-    }) as any[];
+    const projects = query.execute({ path_prefix: "Projects" }) as any[];
     expect(projects).toHaveLength(3);
     expect(projects.every((n) => n.path!.startsWith("Projects"))).toBe(true);
 
     // limit + offset
-    const page = readNotes.execute({
+    const page = query.execute({
       path_prefix: "Projects",
       sort: "asc",
       limit: 2,
       offset: 1,
-      include_content: false,
     }) as any[];
     expect(page).toHaveLength(2);
   });
 
-  it("search-notes tool works", () => {
+  it("query-notes full-text search works", () => {
     store.createNote("Flagstaff trail");
-    const tools = generateMcpTools(db);
-    const searchNotes = tools.find((t) => t.name === "search-notes")!;
-    const result = searchNotes.execute({ query: "Flagstaff" }) as any[];
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ search: "Flagstaff" }) as any[];
     expect(result).toHaveLength(1);
   });
 
-  it("tag/untag tools work", () => {
-    const note = store.createNote("Test");
-    const tools = generateMcpTools(db);
-
-    const tagTool = tools.find((t) => t.name === "tag-note")!;
-    tagTool.execute({ id: note.id, tags: ["pinned"] });
-    expect(store.getNote(note.id)!.tags).toContain("pinned");
-
-    const untagTool = tools.find((t) => t.name === "untag-note")!;
-    untagTool.execute({ id: note.id, tags: ["pinned"] });
-    expect(store.getNote(note.id)!.tags).not.toContain("pinned");
+  it("query-notes with include_links enriches results", () => {
+    store.createNote("A", { id: "a", path: "alpha" });
+    store.createNote("B", { id: "b", path: "beta" });
+    store.createLink("a", "b", "mentions");
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ id: "a", include_links: true }) as any;
+    expect(result.links).toBeDefined();
+    expect(result.links).toHaveLength(1);
   });
 
-  it("link tools work", () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
-    const tools = generateMcpTools(db);
+  it("query-notes near param scopes results to graph neighborhood", () => {
+    store.createNote("Center", { id: "center" });
+    store.createNote("Near", { id: "near", tags: ["t"] });
+    store.createNote("Far", { id: "far", tags: ["t"] });
+    store.createLink("center", "near", "mentions");
+    // "far" is not linked to "center"
 
-    const createLink = tools.find((t) => t.name === "create-link")!;
-    createLink.execute({ source_id: "a", target_id: "b", relationship: "mentions" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ tag: "t", near: { note_id: "center", depth: 1 } }) as any[];
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("near");
+  });
 
-    const getLinks = tools.find((t) => t.name === "get-links")!;
-    const links = getLinks.execute({ id: "a" }) as any[];
-    expect(links).toHaveLength(1);
-
-    const deleteLink = tools.find((t) => t.name === "delete-link")!;
-    deleteLink.execute({ source_id: "a", target_id: "b", relationship: "mentions" });
-    expect((getLinks.execute({ id: "a" }) as any[]).length).toBe(0);
+  it("delete-note accepts path", () => {
+    store.createNote("To delete", { path: "Temp/note" });
+    const tools = generateMcpTools(store);
+    const deleteTool = tools.find((t) => t.name === "delete-note")!;
+    const result = deleteTool.execute({ id: "Temp/note" }) as any;
+    expect(result.deleted).toBe(true);
+    expect(store.getNoteByPath("Temp/note")).toBeNull();
   });
 
   it("delete-tag with zero notes removes tag from list", () => {
@@ -707,7 +762,7 @@ describe("MCP tools", () => {
   });
 
   it("delete-tag MCP tool works", () => {
-    const tools = generateMcpTools(db);
+    const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
     createNote.execute({ content: "Test", tags: ["mcp-tag"] });
 
@@ -721,158 +776,106 @@ describe("MCP tools", () => {
     expect(tags.some((t: any) => t.name === "mcp-tag")).toBe(false);
   });
 
-  it("resolve-wikilink: exact match", () => {
-    store.createNote("Mickey doc", { path: "People/Mickey Myers" });
+  it("list-tags single tag detail with schema", () => {
+    store.createNote("Test", { tags: ["person"] });
+    store.upsertTagSchema("person", {
+      description: "A person",
+      fields: { name: { type: "string" } },
+    });
     const tools = generateMcpTools(store);
-    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
-    const result = resolve.execute({ target: "People/Mickey Myers" }) as any;
-    expect(result.resolved).toBe(true);
-    expect(result.path).toBe("People/Mickey Myers");
-    expect(result.note_id).toBeTruthy();
-    expect(result.candidates).toEqual([]);
+    const listTags = tools.find((t) => t.name === "list-tags")!;
+    const result = listTags.execute({ tag: "person" }) as any;
+    expect(result.name).toBe("person");
+    expect(result.count).toBe(1);
+    expect(result.description).toBe("A person");
+    expect(result.fields.name.type).toBe("string");
   });
 
-  it("resolve-wikilink: basename match", () => {
-    store.createNote("Mickey doc", { path: "People/Mickey" });
+  it("list-tags include_schema returns schemas for all tags", () => {
+    store.createNote("A", { tags: ["person"] });
+    store.createNote("B", { tags: ["project"] });
+    store.upsertTagSchema("person", { description: "A person" });
     const tools = generateMcpTools(store);
-    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
-    const result = resolve.execute({ target: "Mickey" }) as any;
-    expect(result.resolved).toBe(true);
-    expect(result.path).toBe("People/Mickey");
+    const listTags = tools.find((t) => t.name === "list-tags")!;
+    const result = listTags.execute({ include_schema: true }) as any[];
+    const person = result.find((t: any) => t.name === "person");
+    expect(person.description).toBe("A person");
+    const project = result.find((t: any) => t.name === "project");
+    expect(project.description).toBeNull();
   });
 
-  it("resolve-wikilink: ambiguous — multiple basename matches", () => {
-    store.createNote("Atlas person", { path: "People/Atlas" });
-    store.createNote("Atlas project", { path: "Projects/Atlas" });
+  it("update-tag creates schema if not exists", () => {
     const tools = generateMcpTools(store);
-    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
-    const result = resolve.execute({ target: "Atlas" }) as any;
-    expect(result.resolved).toBe(false);
-    expect(result.ambiguous).toBe(true);
-    expect(result.candidates).toHaveLength(2);
-    expect(result.candidates.map((c: any) => c.path).sort()).toEqual(["People/Atlas", "Projects/Atlas"]);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    const result = updateTag.execute({
+      tag: "person",
+      description: "A person",
+      fields: { name: { type: "string" } },
+    }) as any;
+    expect(result.tag).toBe("person");
+    expect(result.description).toBe("A person");
   });
 
-  it("resolve-wikilink: no match", () => {
+  it("update-tag merges fields with existing", () => {
+    store.upsertTagSchema("person", {
+      description: "A person",
+      fields: { name: { type: "string" } },
+    });
     const tools = generateMcpTools(store);
-    const resolve = tools.find((t) => t.name === "resolve-wikilink")!;
-    const result = resolve.execute({ target: "Nonexistent" }) as any;
-    expect(result.resolved).toBe(false);
-    expect(result.ambiguous).toBe(false);
-    expect(result.candidates).toEqual([]);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    const result = updateTag.execute({
+      tag: "person",
+      fields: { age: { type: "integer" } },
+    }) as any;
+    expect(result.fields.name.type).toBe("string");
+    expect(result.fields.age.type).toBe("integer");
   });
 
-  it("list-unresolved-wikilinks: returns unresolved entries", () => {
-    store.createNote("See [[Ghost Note]]", { path: "Source" });
-    const tools = generateMcpTools(store);
-    const listUnresolved = tools.find((t) => t.name === "list-unresolved-wikilinks")!;
-    const result = listUnresolved.execute({}) as any;
-    expect(result.count).toBeGreaterThanOrEqual(1);
-    const ghost = result.unresolved.find((u: any) => u.target_path === "Ghost Note");
-    expect(ghost).toBeTruthy();
-    expect(ghost.source_path).toBe("Source");
-  });
-
-  it("list-unresolved-wikilinks: empty when all resolved", () => {
-    const tools = generateMcpTools(store);
-    const listUnresolved = tools.find((t) => t.name === "list-unresolved-wikilinks")!;
-    const result = listUnresolved.execute({}) as any;
-    expect(result.count).toBe(0);
-    expect(result.unresolved).toEqual([]);
-  });
-
-  it("get-links returns all links when id is omitted", () => {
-    store.createNote("A", { id: "a" });
+  it("find-path works with ID/path resolution", () => {
+    store.createNote("A", { id: "a", path: "People/Alice" });
     store.createNote("B", { id: "b" });
-    store.createNote("C", { id: "c" });
+    store.createNote("C", { id: "c", path: "Projects/X" });
     store.createLink("a", "b", "mentions");
-    store.createLink("b", "c", "cites");
-    const tools = generateMcpTools(db);
-    const getLinks = tools.find((t) => t.name === "get-links")!;
+    store.createLink("b", "c", "related-to");
 
-    const all = getLinks.execute({}) as any[];
-    expect(all).toHaveLength(2);
-
-    const cites = getLinks.execute({ relationship: "cites" }) as any[];
-    expect(cites).toHaveLength(1);
-    expect(cites[0].relationship).toBe("cites");
-  });
-
-  it("get-links returns bare Link[] (no hydration)", () => {
-    store.createNote("A", { id: "a", path: "alpha" });
-    store.createNote("B", { id: "b", path: "beta" });
-    store.createLink("a", "b", "mentions");
-    const tools = generateMcpTools(db);
-    const getLinks = tools.find((t) => t.name === "get-links")!;
-    const result = getLinks.execute({ id: "a" }) as any[];
-    expect(result[0]).not.toHaveProperty("sourceNote");
-    expect(result[0]).not.toHaveProperty("targetNote");
-    expect(result[0].sourceId).toBe("a");
-    expect(result[0].targetId).toBe("b");
-  });
-
-  it("get-graph returns notes, links, tags, meta with lean notes by default", () => {
-    store.createNote("first", { id: "a", tags: ["proj"] });
-    store.createNote("second", { id: "b", tags: ["proj"] });
-    store.createNote("third", { id: "c", tags: ["other"] });
-    store.createLink("a", "b", "mentions");
-
-    const tools = generateMcpTools(db);
-    const getGraph = tools.find((t) => t.name === "get-graph")!;
-    const graph = getGraph.execute({}) as any;
-
-    expect(graph.notes).toHaveLength(3);
-    expect(graph.links).toHaveLength(1);
-    expect(graph.meta.totalNotes).toBe(3);
-    expect(graph.meta.totalLinks).toBe(1);
-    expect(graph.meta.includeContent).toBe(false);
-    expect(graph.notes[0]).not.toHaveProperty("content");
-    expect(graph.notes[0]).toHaveProperty("byteSize");
-    expect(graph.notes[0]).toHaveProperty("preview");
-  });
-
-  it("get-graph include_content=true returns full notes", () => {
-    store.createNote("body text", { id: "a" });
-    const tools = generateMcpTools(db);
-    const getGraph = tools.find((t) => t.name === "get-graph")!;
-    const graph = getGraph.execute({ include_content: true }) as any;
-    expect(graph.notes[0].content).toBe("body text");
-    expect(graph.meta.includeContent).toBe(true);
-  });
-
-  it("get-graph tag filter restricts notes and links to subgraph", () => {
-    store.createNote("a", { id: "a", tags: ["proj"] });
-    store.createNote("b", { id: "b", tags: ["proj"] });
-    store.createNote("c", { id: "c", tags: ["other"] });
-    store.createLink("a", "b", "mentions");
-    store.createLink("a", "c", "mentions");
-
-    const tools = generateMcpTools(db);
-    const getGraph = tools.find((t) => t.name === "get-graph")!;
-    const graph = getGraph.execute({ tags: ["proj"] }) as any;
-
-    expect(graph.notes).toHaveLength(2);
-    expect(graph.links).toHaveLength(1);
-    expect(graph.links[0].targetId).toBe("b");
-    expect(graph.meta.totalNotes).toBe(3);
-    expect(graph.meta.totalLinks).toBe(2);
-    expect(graph.meta.filteredNotes).toBe(2);
-    expect(graph.meta.filteredLinks).toBe(1);
+    const tools = generateMcpTools(store);
+    const findPath = tools.find((t) => t.name === "find-path")!;
+    const result = findPath.execute({ source: "People/Alice", target: "Projects/X" }) as any;
+    expect(result).not.toBeNull();
+    expect(result.path).toEqual(["a", "b", "c"]);
+    expect(result.relationships).toEqual(["mentions", "related-to"]);
   });
 
   it("create-note via store triggers wikilink sync", () => {
-    // When MCP tools are generated with a Store, wikilinks should auto-sync
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
 
-    // Create target note first
     store.createNote("Target", { path: "Target Note" });
-
-    // Create source via MCP tool with a wikilink
     const source = createNote.execute({ content: "See [[Target Note]]" }) as any;
 
-    // Wikilink should have been resolved into a link
     const links = store.getLinks(source.id, { direction: "outbound" });
     expect(links.some((l) => l.relationship === "wikilink")).toBe(true);
+  });
+
+  it("create-note with schema tag auto-populates defaults", () => {
+    store.upsertTagSchema("person", {
+      description: "A person",
+      fields: {
+        first_appeared: { type: "string" },
+        active: { type: "boolean" },
+        priority: { type: "integer" },
+        status: { type: "string", enum: ["active", "archived"] },
+      },
+    });
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = createNote.execute({ content: "Alice", tags: ["person"] }) as any;
+    const fresh = query.execute({ id: result.id }) as any;
+    expect(fresh.metadata.first_appeared).toBe("");
+    expect(fresh.metadata.active).toBe(false);
+    expect(fresh.metadata.priority).toBe(0);
+    expect(fresh.metadata.status).toBe("active");
   });
 });

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1,8 +1,8 @@
 import { Database } from "bun:sqlite";
-import type { Store } from "./types.js";
-import * as notes from "./notes.js";
-import * as links from "./links.js";
-import { resolveWikilinkDetailed, listUnresolvedWikilinks } from "./wikilinks.js";
+import type { Store, Note } from "./types.js";
+import * as noteOps from "./notes.js";
+import * as linkOps from "./links.js";
+import * as tagSchemaOps from "./tag-schemas.js";
 
 export interface McpToolDef {
   name: string;
@@ -11,269 +11,530 @@ export interface McpToolDef {
   execute: (params: Record<string, unknown>) => unknown;
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 /**
- * Generate MCP tools for a vault.
- *
- * Accepts a Store so that create/update/delete operations go through
- * the store's hooks (wikilink sync, path normalization, etc.).
- * Read-only operations use the db directly for efficiency.
+ * Resolve a note identifier — tries ID first, then case-insensitive path match.
+ * Works everywhere a note reference is accepted.
  */
-export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
-  // Support both Store and raw Database for backwards compat (tests)
-  const store: Store | null = 'createNote' in storeOrDb ? storeOrDb as Store : null;
-  const db: Database = store ? (store as any).db : storeOrDb as Database;
+function resolveNote(db: Database, idOrPath: string): Note | null {
+  // Try ID match first (fast, indexed)
+  const byId = noteOps.getNote(db, idOrPath);
+  if (byId) return byId;
+  // Fallback to path match
+  return noteOps.getNoteByPath(db, idOrPath);
+}
+
+function requireNote(db: Database, idOrPath: string): Note {
+  const note = resolveNote(db, idOrPath);
+  if (!note) throw new Error(`Note not found: "${idOrPath}"`);
+  return note;
+}
+
+/**
+ * Remove [[wikilink]] brackets from note content for a specific target.
+ * Handles [[Target]], [[Target|alias]], [[Target#section]].
+ */
+function removeWikilinkBrackets(content: string, targetPath: string): string {
+  // Match [[TargetPath...]] with optional alias/anchor, replace with display text
+  const escaped = targetPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // [[Target|alias]] → alias
+  content = content.replace(
+    new RegExp(`\\[\\[${escaped}\\|([^\\]]+)\\]\\]`, "gi"),
+    "$1",
+  );
+  // [[Target#section]] → Target#section (just remove brackets)
+  content = content.replace(
+    new RegExp(`\\[\\[${escaped}(#[^\\]]+)?\\]\\]`, "gi"),
+    `${targetPath}$1`,
+  );
+  return content;
+}
+
+// ---------------------------------------------------------------------------
+// Tool generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the 9 consolidated MCP tools for a vault.
+ */
+export function generateMcpTools(store: Store): McpToolDef[] {
+  const db: Database = (store as any).db;
+
   return [
+
+    // =====================================================================
+    // 1. query-notes — the universal read tool
+    // =====================================================================
     {
-      name: "get-note",
-      description: "Get a note by ID or path. Use this to look up a specific note when you have its ID (e.g., from link results) or its path (e.g., 'Projects/Parachute/README').",
+      name: "query-notes",
+      description: `Query notes. Returns notes matching the given filters.
+
+- **Single note**: pass \`id\` (accepts note ID or path, e.g., "Projects/README")
+- **Filter**: pass \`tag\`, \`path\`, \`path_prefix\`, \`search\`, \`metadata\`, date range
+- **Graph neighborhood**: pass \`near\` to scope results to notes within N hops of an anchor note
+- **No filters**: returns all notes (paginated)
+
+Defaults: include_content=true for single note, false for lists. include_links=false. tag_match="any".`,
       inputSchema: {
         type: "object",
         properties: {
-          id: { type: "string", description: "Note ID" },
-          path: { type: "string", description: "Note path (e.g., 'Projects/Parachute/README')" },
-          ids: { type: "array", items: { type: "string" }, description: "Multiple note IDs to fetch at once" },
-        },
-      },
-      execute: (params) => {
-        if (params.ids) {
-          return notes.getNotes(db, params.ids as string[]);
-        }
-        if (params.path) {
-          const note = notes.getNoteByPath(db, params.path as string);
-          if (!note) return { error: "Note not found", path: params.path };
-          return note;
-        }
-        if (params.id) {
-          const note = notes.getNote(db, params.id as string);
-          if (!note) return { error: "Note not found", id: params.id };
-          return note;
-        }
-        return { error: "Provide id, path, or ids" };
-      },
-    },
-    {
-      name: "create-note",
-      description: `Create a new note with optional tags, path, and metadata. Path works like a filesystem (e.g., 'Projects/Parachute/README'). Metadata is a JSON object for structured properties (e.g., { "status": "draft", "priority": "high" }).`,
-      inputSchema: {
-        type: "object",
-        properties: {
-          content: { type: "string", description: "Note content (markdown)" },
-          tags: { type: "array", items: { type: "string" }, description: "Tags to apply" },
-          path: { type: "string", description: "Optional path/name (e.g., 'Grocery List', 'Blog/My Post')" },
-          metadata: { type: "object", description: "Structured metadata (e.g., { status: 'draft', priority: 'high' })" },
-          created_at: { type: "string", description: "ISO-8601 timestamp (defaults to now). Use when the note was taken at a different time than when it's being created." },
-        },
-        required: ["content"],
-      },
-      execute: (params) => {
-        const fn = store ? store.createNote.bind(store) : (c: string, o?: any) => notes.createNote(db, c, o);
-        return fn(params.content as string, {
-          tags: params.tags as string[] | undefined,
-          path: params.path as string | undefined,
-          metadata: params.metadata as Record<string, unknown> | undefined,
-          created_at: params.created_at as string | undefined,
-        });
-      },
-    },
-    {
-      name: "update-note",
-      description: "Update a note's content, path, metadata, or created_at.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "Note ID" },
-          content: { type: "string", description: "New content" },
-          path: { type: "string", description: "New path/name" },
-          metadata: { type: "object", description: "New metadata (replaces existing)" },
-          created_at: { type: "string", description: "New created_at timestamp (ISO 8601)" },
-        },
-        required: ["id"],
-      },
-      execute: (params) => {
-        const fn = store ? store.updateNote.bind(store) : (id: string, u: any) => notes.updateNote(db, id, u);
-        return fn(params.id as string, {
-          content: params.content as string | undefined,
-          path: params.path as string | undefined,
-          metadata: params.metadata as Record<string, unknown> | undefined,
-          created_at: params.created_at as string | undefined,
-        });
-      },
-    },
-    {
-      name: "delete-note",
-      description: "Permanently delete a note and all its tags and links.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "Note ID" },
-        },
-        required: ["id"],
-      },
-      execute: (params) => {
-        if (store) {
-          store.deleteNote(params.id as string);
-        } else {
-          notes.deleteNote(db, params.id as string);
-        }
-        return { deleted: true };
-      },
-    },
-    {
-      name: "read-notes",
-      description: `Read notes, filtered by tags, path prefix, metadata, and/or date range. Use path_prefix to browse like a filesystem. Use metadata to filter by structured properties (e.g., { "status": "in-progress" }). Set include_content: false to get a lightweight index (metadata + preview + byteSize) instead of full content — useful for planning batched reads over large date ranges.`,
-      inputSchema: {
-        type: "object",
-        properties: {
-          tags: { type: "array", items: { type: "string" }, description: "Filter by tags" },
-          tag_match: { type: "string", enum: ["all", "any"], description: "How to match tags: 'all' = must have ALL (default), 'any' = must have ANY" },
+          id: { type: "string", description: "Get one note by ID or path" },
+          tag: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+            description: "Filter by tag(s)",
+          },
+          tag_match: { type: "string", enum: ["any", "all"], description: "How to match multiple tags: 'any' (OR, default) or 'all' (AND)" },
           exclude_tags: { type: "array", items: { type: "string" }, description: "Exclude notes with these tags" },
-          path_prefix: { type: "string", description: "Filter by path prefix (e.g., 'Projects/Parachute')" },
+          path: { type: "string", description: "Exact path match (case-insensitive)" },
+          path_prefix: { type: "string", description: "Path prefix match (e.g., 'Projects/')" },
+          search: { type: "string", description: "Full-text search query" },
           metadata: { type: "object", description: "Filter by metadata values (exact match per key)" },
           date_from: { type: "string", description: "Start date (ISO, inclusive)" },
-          date_to: { type: "string", description: "End date (ISO, exclusive — use the day after your range)" },
+          date_to: { type: "string", description: "End date (ISO, exclusive)" },
+          near: {
+            type: "object",
+            properties: {
+              note_id: { type: "string", description: "Anchor note ID or path" },
+              depth: { type: "number", description: "Max hops from anchor (default 2, max 5)" },
+              relationship: { type: "string", description: "Only follow links with this relationship" },
+            },
+            required: ["note_id"],
+            description: "Scope results to notes within N hops of an anchor note",
+          },
           sort: { type: "string", enum: ["asc", "desc"], description: "Sort by created_at" },
-          limit: { type: "number", description: "Max results (default 100)" },
-          offset: { type: "number", description: "Skip this many results (for pagination, default 0)" },
-          include_content: { type: "boolean", description: "Include full note content (default true). Set false for an index-mode response: each note becomes { id, path, createdAt, updatedAt, tags, metadata, byteSize, preview } with no content field." },
+          limit: { type: "number", description: "Max results (default 50)" },
+          offset: { type: "number", description: "Pagination offset (default 0)" },
+          include_content: { type: "boolean", description: "Include note content (default: true for single, false for list)" },
+          include_links: { type: "boolean", description: "Include inbound + outbound links per note (default: false)" },
+          include_attachments: { type: "boolean", description: "Include attachment records (default: false)" },
         },
       },
       execute: (params) => {
-        const results = notes.queryNotes(db, {
-          tags: params.tags as string[] | undefined,
-          tagMatch: params.tag_match as "all" | "any" | undefined,
-          excludeTags: params.exclude_tags as string[] | undefined,
-          pathPrefix: params.path_prefix as string | undefined,
-          metadata: params.metadata as Record<string, unknown> | undefined,
-          dateFrom: params.date_from as string | undefined,
-          dateTo: params.date_to as string | undefined,
-          sort: params.sort as "asc" | "desc" | undefined,
-          limit: params.limit as number | undefined,
-          offset: params.offset as number | undefined,
-        });
-        if (params.include_content === false) {
-          return results.map(notes.toNoteIndex);
+        // --- Single note by ID/path ---
+        if (params.id) {
+          const note = resolveNote(db, params.id as string);
+          if (!note) return { error: "Note not found", id: params.id };
+          const includeContent = params.include_content !== false; // default true for single
+          const result: any = includeContent ? { ...note } : noteOps.toNoteIndex(note);
+          if (params.include_links) {
+            result.links = linkOps.getLinksHydrated(db, note.id);
+          }
+          if (params.include_attachments) {
+            result.attachments = store.getAttachments(note.id);
+          }
+          return result;
         }
-        return results;
+
+        // --- Build near-scope (graph-filtered set of allowed IDs) ---
+        let nearScope: Set<string> | null = null;
+        if (params.near) {
+          const near = params.near as { note_id: string; depth?: number; relationship?: string };
+          const anchor = resolveNote(db, near.note_id);
+          if (!anchor) return { error: "Anchor note not found", note_id: near.note_id };
+          const depth = Math.min(near.depth ?? 2, 5);
+          const traversed = linkOps.traverseLinks(db, anchor.id, {
+            max_depth: depth,
+            relationship: near.relationship,
+          });
+          nearScope = new Set([anchor.id, ...traversed.map((t) => t.noteId)]);
+        }
+
+        // --- Full-text search ---
+        let results: Note[];
+        if (params.search) {
+          // Normalize tag param
+          const tags = normalizeTags(params.tag);
+          results = noteOps.searchNotes(db, params.search as string, {
+            tags,
+            limit: (params.limit as number) ?? 50,
+          });
+        } else {
+          // --- Structured query ---
+          const tags = normalizeTags(params.tag);
+          results = noteOps.queryNotes(db, {
+            tags,
+            tagMatch: (params.tag_match as "all" | "any") ?? (tags && tags.length > 1 ? "any" : undefined),
+            excludeTags: params.exclude_tags as string[] | undefined,
+            path: params.path as string | undefined,
+            pathPrefix: params.path_prefix as string | undefined,
+            metadata: params.metadata as Record<string, unknown> | undefined,
+            dateFrom: params.date_from as string | undefined,
+            dateTo: params.date_to as string | undefined,
+            sort: params.sort as "asc" | "desc" | undefined,
+            limit: (params.limit as number) ?? 50,
+            offset: params.offset as number | undefined,
+          });
+        }
+
+        // --- Apply near-scope filter ---
+        if (nearScope) {
+          results = results.filter((n) => nearScope!.has(n.id));
+        }
+
+        // --- Format output ---
+        const includeContent = params.include_content === true; // default false for list
+        const output = includeContent ? results : results.map(noteOps.toNoteIndex);
+
+        // --- Hydrate links/attachments per note if requested ---
+        if (params.include_links || params.include_attachments) {
+          return output.map((n: any) => {
+            const enriched = { ...n };
+            if (params.include_links) enriched.links = linkOps.getLinksHydrated(db, n.id);
+            if (params.include_attachments) enriched.attachments = store.getAttachments(n.id);
+            return enriched;
+          });
+        }
+
+        return output;
       },
     },
+
+    // =====================================================================
+    // 2. create-note — single or batch
+    // =====================================================================
     {
-      name: "search-notes",
-      description: "Full-text search across all notes.",
+      name: "create-note",
+      description: `Create one or more notes. Pass a single note's fields directly, or pass a \`notes\` array for batch creation. Each note accepts content, path, metadata, tags, links, and created_at.`,
       inputSchema: {
         type: "object",
         properties: {
-          query: { type: "string", description: "Search query" },
-          tags: { type: "array", items: { type: "string" }, description: "Optional tag filter" },
-          limit: { type: "number", default: 20 },
+          // Single note fields
+          content: { type: "string", description: "Note content (markdown). Wikilinks like [[Target]] auto-resolve." },
+          path: { type: "string", description: "Note path (e.g., 'Projects/README')" },
+          metadata: { type: "object", description: "Metadata fields" },
+          tags: { type: "array", items: { type: "string" }, description: "Tags to apply" },
+          links: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                target: { type: "string", description: "Target note ID or path" },
+                relationship: { type: "string", description: "Relationship type (e.g., mentions, related-to)" },
+              },
+              required: ["target", "relationship"],
+            },
+            description: "Links to create from this note",
+          },
+          created_at: { type: "string", description: "ISO timestamp (defaults to now)" },
+          // Batch
+          notes: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                content: { type: "string" },
+                path: { type: "string" },
+                metadata: { type: "object" },
+                tags: { type: "array", items: { type: "string" } },
+                links: { type: "array" },
+                created_at: { type: "string" },
+              },
+              required: ["content"],
+            },
+            description: "Array of notes for batch creation",
+          },
         },
-        required: ["query"],
-      },
-      execute: (params) => notes.searchNotes(db, params.query as string, {
-        tags: params.tags as string[] | undefined,
-        limit: params.limit as number | undefined,
-      }),
-    },
-    {
-      name: "tag-note",
-      description: "Add tags to a note. Tags are created automatically if they don't exist.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "Note ID" },
-          tags: { type: "array", items: { type: "string" }, description: "Tags to add" },
-        },
-        required: ["id", "tags"],
       },
       execute: (params) => {
-        notes.tagNote(db, params.id as string, params.tags as string[]);
-        return { tagged: true };
+        const batch = params.notes as any[] | undefined;
+        const items = batch ?? [params];
+
+        const created: Note[] = [];
+        for (const item of items) {
+          const note = store.createNote(item.content as string ?? "", {
+            path: item.path as string | undefined,
+            tags: item.tags as string[] | undefined,
+            metadata: item.metadata as Record<string, unknown> | undefined,
+            created_at: item.created_at as string | undefined,
+          });
+
+          // Create explicit links (not wikilinks — those are automatic)
+          if (item.links) {
+            for (const link of item.links as { target: string; relationship: string }[]) {
+              const target = resolveNote(db, link.target);
+              if (target) {
+                store.createLink(note.id, target.id, link.relationship);
+              }
+            }
+          }
+
+          created.push(noteOps.getNote(db, note.id) ?? note);
+        }
+
+        // Apply tag schema effects
+        for (const note of created) {
+          if (note.tags && note.tags.length > 0) {
+            applySchemaDefaults(store, db, [note.id], note.tags);
+          }
+        }
+
+        return batch ? created : created[0];
       },
     },
+
+    // =====================================================================
+    // 3. update-note — single or batch, absorbs tag/untag + link add/remove
+    // =====================================================================
     {
-      name: "untag-note",
-      description: "Remove tags from a note.",
+      name: "update-note",
+      description: `Update one or more notes. Accepts ID or path. Supports content, path, metadata updates plus tag and link mutations.
+
+- \`tags: { add: ["x"], remove: ["y"] }\` — add/remove tags
+- \`links: { add: [{ target, relationship }], remove: [{ target, relationship }] }\` — add/remove links
+- When removing a wikilink-type link, \`[[brackets]]\` are also removed from content.
+- For batch: pass a \`notes\` array, each with an \`id\` field.`,
       inputSchema: {
         type: "object",
         properties: {
-          id: { type: "string", description: "Note ID" },
-          tags: { type: "array", items: { type: "string" }, description: "Tags to remove" },
+          id: { type: "string", description: "Note ID or path" },
+          content: { type: "string", description: "New content" },
+          path: { type: "string", description: "New path" },
+          metadata: { type: "object", description: "Metadata to merge (keys are merged, not replaced wholesale)" },
+          created_at: { type: "string", description: "New created_at timestamp" },
+          tags: {
+            type: "object",
+            properties: {
+              add: { type: "array", items: { type: "string" } },
+              remove: { type: "array", items: { type: "string" } },
+            },
+            description: "Tags to add/remove",
+          },
+          links: {
+            type: "object",
+            properties: {
+              add: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    target: { type: "string", description: "Target note ID or path" },
+                    relationship: { type: "string" },
+                  },
+                  required: ["target", "relationship"],
+                },
+              },
+              remove: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    target: { type: "string", description: "Target note ID or path" },
+                    relationship: { type: "string" },
+                  },
+                  required: ["target", "relationship"],
+                },
+              },
+            },
+            description: "Links to add/remove",
+          },
+          // Batch
+          notes: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                content: { type: "string" },
+                path: { type: "string" },
+                metadata: { type: "object" },
+                created_at: { type: "string" },
+                tags: { type: "object" },
+                links: { type: "object" },
+              },
+              required: ["id"],
+            },
+            description: "Array of note updates for batch",
+          },
         },
-        required: ["id", "tags"],
       },
       execute: (params) => {
-        notes.untagNote(db, params.id as string, params.tags as string[]);
-        return { untagged: true };
+        const batch = params.notes as any[] | undefined;
+        const items = batch ?? [params];
+
+        const updated: Note[] = [];
+        for (const item of items) {
+          const note = requireNote(db, item.id as string);
+          let contentOverride = item.content as string | undefined;
+
+          // --- Remove links (before content update, so bracket removal applies) ---
+          const linksRemove = (item.links as any)?.remove as { target: string; relationship: string }[] | undefined;
+          if (linksRemove) {
+            for (const link of linksRemove) {
+              const target = resolveNote(db, link.target);
+              if (target) {
+                store.deleteLink(note.id, target.id, link.relationship);
+                // Remove [[brackets]] from content if this was a wikilink
+                if (link.relationship === "wikilink" && target.path) {
+                  const currentContent = contentOverride ?? note.content;
+                  const cleaned = removeWikilinkBrackets(currentContent, target.path);
+                  if (cleaned !== currentContent) {
+                    contentOverride = cleaned;
+                  }
+                }
+              }
+            }
+          }
+
+          // --- Core update (content, path, metadata, created_at) ---
+          const updates: any = {};
+          if (contentOverride !== undefined) updates.content = contentOverride;
+          if (item.path !== undefined) updates.path = item.path;
+          if (item.metadata !== undefined) {
+            // Merge metadata (don't replace wholesale)
+            const existing = (note.metadata as Record<string, unknown>) ?? {};
+            updates.metadata = { ...existing, ...(item.metadata as Record<string, unknown>) };
+          }
+          if (item.created_at !== undefined) updates.created_at = item.created_at;
+
+          let result: Note;
+          if (Object.keys(updates).length > 0) {
+            result = store.updateNote(note.id, updates);
+          } else {
+            result = note;
+          }
+
+          // --- Tags ---
+          const tagsOp = item.tags as { add?: string[]; remove?: string[] } | undefined;
+          if (tagsOp?.add?.length) {
+            store.tagNote(note.id, tagsOp.add);
+            applySchemaDefaults(store, db, [note.id], tagsOp.add);
+          }
+          if (tagsOp?.remove?.length) {
+            store.untagNote(note.id, tagsOp.remove);
+          }
+
+          // --- Add links ---
+          const linksAdd = (item.links as any)?.add as { target: string; relationship: string; metadata?: Record<string, unknown> }[] | undefined;
+          if (linksAdd) {
+            for (const link of linksAdd) {
+              const target = resolveNote(db, link.target);
+              if (target) {
+                store.createLink(note.id, target.id, link.relationship, link.metadata);
+              }
+            }
+          }
+
+          // Re-read for final state
+          updated.push(noteOps.getNote(db, note.id) ?? result);
+        }
+
+        return batch ? updated : updated[0];
       },
     },
+
+    // =====================================================================
+    // 4. delete-note
+    // =====================================================================
     {
-      name: "create-link",
-      description: "Create a directed link between two notes (e.g., mentions, quotes, related-to). Optional metadata for context (e.g., { confidence: 0.9, context: 'mentioned in meeting' }).",
+      name: "delete-note",
+      description: "Permanently delete a note and all its tags and links. Accepts ID or path.",
       inputSchema: {
         type: "object",
         properties: {
-          source_id: { type: "string", description: "Source note ID" },
-          target_id: { type: "string", description: "Target note ID" },
-          relationship: { type: "string", description: "Relationship type (e.g., mentions, related-to)" },
-          metadata: { type: "object", description: "Optional link metadata" },
+          id: { type: "string", description: "Note ID or path" },
         },
-        required: ["source_id", "target_id", "relationship"],
-      },
-      execute: (params) => links.createLink(
-        db,
-        params.source_id as string,
-        params.target_id as string,
-        params.relationship as string,
-        params.metadata as Record<string, unknown> | undefined,
-      ),
-    },
-    {
-      name: "delete-link",
-      description: "Delete a link between two notes.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          source_id: { type: "string", description: "Source note ID" },
-          target_id: { type: "string", description: "Target note ID" },
-          relationship: { type: "string", description: "Relationship type" },
-        },
-        required: ["source_id", "target_id", "relationship"],
+        required: ["id"],
       },
       execute: (params) => {
-        links.deleteLink(
-          db,
-          params.source_id as string,
-          params.target_id as string,
-          params.relationship as string,
-        );
-        return { deleted: true };
+        const note = requireNote(db, params.id as string);
+        store.deleteNote(note.id);
+        return { deleted: true, id: note.id };
       },
     },
-    {
-      name: "get-links",
-      description: "List links in the vault. Returns bare link edges ({sourceId, targetId, relationship, metadata, createdAt}) — no hydration. Omit `id` to list every link (optionally filtered by `relationship`). Pass `id` to get links touching that note (with `direction`: outbound, inbound, both). Pair with get-note when you need the connected notes' content.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "Note ID. If omitted, returns all links in the vault." },
-          direction: { type: "string", enum: ["outbound", "inbound", "both"], default: "both", description: "Only meaningful when `id` is provided." },
-          relationship: { type: "string", description: "Filter to links with this relationship type." },
-        },
-      },
-      execute: (params) => links.listLinks(db, {
-        noteId: params.id as string | undefined,
-        direction: params.direction as "outbound" | "inbound" | "both" | undefined,
-        relationship: params.relationship as string | undefined,
-      }),
-    },
+
+    // =====================================================================
+    // 5. list-tags — with optional single-tag detail + schema
+    // =====================================================================
     {
       name: "list-tags",
-      description: "List all tags with usage counts.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => notes.listTags(db),
+      description: `List tags with usage counts. Pass \`tag\` to get a single tag's details including its schema (description + fields). Pass \`include_schema: true\` to include schemas for all tags.`,
+      inputSchema: {
+        type: "object",
+        properties: {
+          tag: { type: "string", description: "Get details for a single tag" },
+          include_schema: { type: "boolean", description: "Include schema (description + fields) for each tag (default: false)" },
+        },
+      },
+      execute: (params) => {
+        const singleTag = params.tag as string | undefined;
+
+        if (singleTag) {
+          // Single tag detail
+          const allTags = noteOps.listTags(db);
+          const found = allTags.find((t) => t.name === singleTag);
+          const schema = tagSchemaOps.getTagSchema(db, singleTag);
+          return {
+            name: singleTag,
+            count: found?.count ?? 0,
+            description: schema?.description ?? null,
+            fields: schema?.fields ?? null,
+          };
+        }
+
+        // All tags
+        const tags = noteOps.listTags(db);
+        if (params.include_schema) {
+          const schemas = tagSchemaOps.getTagSchemaMap(db);
+          return tags.map((t) => ({
+            ...t,
+            description: schemas[t.name]?.description ?? null,
+            fields: schemas[t.name]?.fields ?? null,
+          }));
+        }
+        return tags;
+      },
     },
+
+    // =====================================================================
+    // 6. update-tag — create/update tag description + schema fields
+    // =====================================================================
+    {
+      name: "update-tag",
+      description: "Create or update a tag's description and schema fields. If the tag doesn't exist, it's created. Fields are merged — new keys are added, existing keys are replaced.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          tag: { type: "string", description: "Tag name" },
+          description: { type: "string", description: "Human-readable description of what this tag means" },
+          fields: {
+            type: "object",
+            description: 'Metadata fields notes with this tag should have. E.g., { "status": { "type": "string", "enum": ["active", "archived"] } }',
+            additionalProperties: {
+              type: "object",
+              properties: {
+                type: { type: "string", description: "Field type: string, boolean, integer" },
+                description: { type: "string" },
+                enum: { type: "array", items: { type: "string" }, description: "Allowed values (first is default)" },
+              },
+              required: ["type"],
+            },
+          },
+        },
+        required: ["tag"],
+      },
+      execute: (params) => {
+        const tag = params.tag as string;
+        const existing = tagSchemaOps.getTagSchema(db, tag);
+        const mergedFields = { ...existing?.fields, ...(params.fields as any) };
+        return tagSchemaOps.upsertTagSchema(db, tag, {
+          description: (params.description as string | undefined) ?? existing?.description,
+          fields: Object.keys(mergedFields).length > 0 ? mergedFields : undefined,
+        });
+      },
+    },
+
+    // =====================================================================
+    // 7. delete-tag — delete tag + schema from all notes
+    // =====================================================================
     {
       name: "delete-tag",
-      description: "Delete a tag and remove it from all notes. Notes themselves are NOT deleted — just untagged. Use this to clean up unused or obsolete tags.",
+      description: "Delete a tag, remove it from all notes, and delete its schema. Notes themselves are NOT deleted — just untagged.",
       inputSchema: {
         type: "object",
         properties: {
@@ -282,192 +543,114 @@ export function generateMcpTools(storeOrDb: Store | Database): McpToolDef[] {
         required: ["tag"],
       },
       execute: (params) => {
-        const fn = store ? store.deleteTag.bind(store) : (name: string) => notes.deleteTag(db, name);
-        return fn(params.tag as string);
-      },
-    },
-    {
-      name: "get-graph",
-      description: "Get the whole vault as a graph in one call: {notes, links, tags, meta}. Default returns lean note indexes (id, path, tags, createdAt, updatedAt, metadata, byteSize, preview) — no content. Pass include_content: true to include full content on each note. Optional tag filter (tags + tag_match + exclude_tags) restricts notes to a subgraph; links are filtered to edges between notes in the subgraph. Useful for rendering visualizations, exports, or bird's-eye analysis.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          tags: { type: "array", items: { type: "string" }, description: "Optional: only include notes with these tags" },
-          tag_match: { type: "string", enum: ["all", "any"], description: "How to match tags (default: all)" },
-          exclude_tags: { type: "array", items: { type: "string" }, description: "Exclude notes with these tags" },
-          include_content: { type: "boolean", description: "Include full note content instead of the lean index shape (default false)" },
-        },
-      },
-      execute: (params) => {
-        const hasTagFilter = (params.tags as string[] | undefined)?.length
-          || (params.exclude_tags as string[] | undefined)?.length;
-        const filteredNotes = notes.queryNotes(db, {
-          tags: params.tags as string[] | undefined,
-          tagMatch: params.tag_match as "all" | "any" | undefined,
-          excludeTags: params.exclude_tags as string[] | undefined,
-          limit: 1_000_000,
-        });
-        const includeContent = params.include_content === true;
-        const outNotes = includeContent ? filteredNotes : filteredNotes.map(notes.toNoteIndex);
-
-        // Links: if no tag filter, return all links in the vault.
-        // Otherwise, only edges between notes in the filtered set.
-        let outLinks = links.listLinks(db);
-        if (hasTagFilter) {
-          const ids = new Set(filteredNotes.map((n) => n.id));
-          outLinks = outLinks.filter((l) => ids.has(l.sourceId) && ids.has(l.targetId));
-        }
-
-        const totalRow = db.prepare("SELECT COUNT(*) as c FROM notes").get() as { c: number };
-        const linkRow = db.prepare("SELECT COUNT(*) as c FROM links").get() as { c: number };
-
-        return {
-          notes: outNotes,
-          links: outLinks,
-          tags: notes.listTags(db),
-          meta: {
-            totalNotes: totalRow.c,
-            totalLinks: linkRow.c,
-            filteredNotes: outNotes.length,
-            filteredLinks: outLinks.length,
-            includeContent,
-          },
-        };
-      },
-    },
-    {
-      name: "get-vault-stats",
-      description: "Get a birds-eye view of the vault: total note count, earliest/latest note, note distribution by month, top tags, and tag count. Read-only, cheap aggregation. Call once at the start of a session to orient before doing vault-wide work (monthly summaries, reviews, trend tracking). For filtered queries use read-notes; for a full tag list use list-tags.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => notes.getVaultStats(db),
-    },
-
-    // ---- Bulk Operations ----
-
-    {
-      name: "create-notes",
-      description: `Create multiple notes in one call. Much more efficient than calling create-note repeatedly. Each note accepts the same fields as create-note: content (required), path, tags, metadata, and created_at (ISO timestamp; supports backdating for imports).`,
-      inputSchema: {
-        type: "object",
-        properties: {
-          notes: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                content: { type: "string", description: "Note content (markdown)" },
-                tags: { type: "array", items: { type: "string" }, description: "Tags to apply" },
-                path: { type: "string", description: "Optional path/name" },
-                metadata: { type: "object", description: "Optional metadata object (JSON-serializable)" },
-                created_at: { type: "string", description: "Optional ISO timestamp; defaults to now if omitted" },
-              },
-              required: ["content"],
-            },
-            description: "Array of notes to create",
-          },
-        },
-        required: ["notes"],
-      },
-      execute: (params) => notes.createNotes(db, params.notes as any[]),
-    },
-    {
-      name: "batch-tag",
-      description: "Add tags to multiple notes at once. More efficient than tagging one at a time.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          note_ids: { type: "array", items: { type: "string" }, description: "Note IDs to tag" },
-          tags: { type: "array", items: { type: "string" }, description: "Tags to add" },
-        },
-        required: ["note_ids", "tags"],
-      },
-      execute: (params) => {
-        const count = notes.batchTag(db, params.note_ids as string[], params.tags as string[]);
-        return { tagged: true, count };
-      },
-    },
-    {
-      name: "batch-untag",
-      description: "Remove tags from multiple notes at once.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          note_ids: { type: "array", items: { type: "string" }, description: "Note IDs to untag" },
-          tags: { type: "array", items: { type: "string" }, description: "Tags to remove" },
-        },
-        required: ["note_ids", "tags"],
-      },
-      execute: (params) => {
-        const count = notes.batchUntag(db, params.note_ids as string[], params.tags as string[]);
-        return { untagged: true, count };
+        const tag = params.tag as string;
+        // Delete schema first (FK cascade would handle it, but be explicit)
+        tagSchemaOps.deleteTagSchema(db, tag);
+        return store.deleteTag(tag);
       },
     },
 
-    // ---- Deeper Link Queries ----
-
-    {
-      name: "traverse-links",
-      description: "Traverse the link graph from a note. Returns all notes reachable within N hops, with their path, tags, and metadata. Useful for exploring knowledge clusters.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "Starting note ID" },
-          max_depth: { type: "number", description: "Maximum hops to traverse (default 2, max 5)" },
-          relationship: { type: "string", description: "Optional: only follow links with this relationship type" },
-        },
-        required: ["id"],
-      },
-      execute: (params) => links.traverseLinks(db, params.id as string, {
-        max_depth: Math.min((params.max_depth as number) ?? 2, 5),
-        relationship: params.relationship as string | undefined,
-      }),
-    },
+    // =====================================================================
+    // 8. find-path — BFS between two notes
+    // =====================================================================
     {
       name: "find-path",
-      description: "Find the shortest path between two notes in the link graph. Returns the chain of note IDs and relationships connecting them, or null if no path exists.",
+      description: "Find the shortest path between two notes in the link graph. Accepts IDs or paths. Returns the chain of note IDs and relationships, or null if no path exists.",
       inputSchema: {
         type: "object",
         properties: {
-          source_id: { type: "string", description: "Starting note ID" },
-          target_id: { type: "string", description: "Target note ID" },
-          max_depth: { type: "number", description: "Maximum path length to search (default 5)" },
+          source: { type: "string", description: "Starting note ID or path" },
+          target: { type: "string", description: "Destination note ID or path" },
+          max_depth: { type: "number", description: "Max path length (default 5)" },
         },
-        required: ["source_id", "target_id"],
+        required: ["source", "target"],
       },
-      execute: (params) => links.findPath(
-        db,
-        params.source_id as string,
-        params.target_id as string,
-        { max_depth: Math.min((params.max_depth as number) ?? 5, 10) },
-      ),
+      execute: (params) => {
+        const source = requireNote(db, params.source as string);
+        const target = requireNote(db, params.target as string);
+        return linkOps.findPath(db, source.id, target.id, {
+          max_depth: Math.min((params.max_depth as number) ?? 5, 10),
+        });
+      },
     },
 
-    // ---- Wikilink Tools ----
-
+    // =====================================================================
+    // 9. vault-info — get/update vault description + stats
+    // =====================================================================
     {
-      name: "resolve-wikilink",
-      description: "Resolve a [[wikilink]] target to a note. Returns the matched note (resolved), multiple candidates (ambiguous), or empty (unresolved). Uses the same resolution logic as vault's write-time wikilink sync.",
+      name: "vault-info",
+      description: "Get vault description and optionally stats (note/tag/link counts, distribution). Pass `description` to update the vault description (changes how AI agents behave in future sessions).",
       inputSchema: {
         type: "object",
         properties: {
-          target: { type: "string", description: "Wikilink target (e.g., 'Mickey', 'Projects/Atlas')" },
-        },
-        required: ["target"],
-      },
-      execute: (params) => resolveWikilinkDetailed(db, params.target as string),
-    },
-    {
-      name: "list-unresolved-wikilinks",
-      description: "List wikilinks that couldn't be resolved to any note. Useful for graph health audits and finding broken links.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          limit: { type: "number", description: "Max results (default 50)" },
+          include_stats: { type: "boolean", description: "Include note count, tag count, distribution by month (default: false)" },
+          description: { type: "string", description: "If provided, updates the vault description" },
         },
       },
-      execute: (params) => listUnresolvedWikilinks(db, (params.limit as number) ?? 50),
+      // execute is overridden in mcp-tools.ts where vault config is available
+      execute: () => {
+        // This is a placeholder — vault-info needs access to vault config,
+        // which is only available in the server layer (mcp-tools.ts).
+        return { error: "vault-info must be configured by the server layer" };
+      },
     },
 
   ];
 }
 
+// ---------------------------------------------------------------------------
+// Tag schema effects — auto-populate defaults when tags are applied
+// ---------------------------------------------------------------------------
+
+function applySchemaDefaults(store: Store, db: Database, noteIds: string[], tags: string[]): void {
+  const schemas = tagSchemaOps.getTagSchemaMap(db);
+  if (Object.keys(schemas).length === 0) return;
+
+  const defaults: Record<string, unknown> = {};
+  for (const tag of tags) {
+    const schema = schemas[tag];
+    if (!schema?.fields) continue;
+    for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+      if (!(field in defaults)) {
+        defaults[field] = defaultForField(fieldSchema);
+      }
+    }
+  }
+  if (Object.keys(defaults).length === 0) return;
+
+  for (const noteId of noteIds) {
+    const note = noteOps.getNote(db, noteId);
+    if (!note) continue;
+    const existing = (note.metadata as Record<string, unknown>) ?? {};
+    const missing: Record<string, unknown> = {};
+    for (const [field, value] of Object.entries(defaults)) {
+      if (!(field in existing)) {
+        missing[field] = value;
+      }
+    }
+    if (Object.keys(missing).length === 0) continue;
+    store.updateNote(noteId, {
+      metadata: { ...existing, ...missing },
+      skipUpdatedAt: true,
+    });
+  }
+}
+
+function defaultForField(field: { type: string; enum?: string[] }): unknown {
+  if (field.enum && field.enum.length > 0) return field.enum[0];
+  switch (field.type) {
+    case "boolean": return false;
+    case "integer": return 0;
+    default: return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeTags(tag: unknown): string[] | undefined {
+  if (!tag) return undefined;
+  if (Array.isArray(tag)) return tag;
+  return [tag as string];
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -23,21 +23,11 @@ export interface AuthResult {
 
 /** Read-only tools (allowed for scope: "read"). */
 const READ_TOOLS = new Set([
-  "get-note",
-  "read-notes",
-  "search-notes",
-  "get-links",
-  "get-graph",
-  "traverse-links",
-  "find-path",
+  "query-notes",
   "list-tags",
+  "find-path",
+  "vault-info",
   "list-vaults",
-  "get-vault-description",
-  "get-vault-stats",
-  "resolve-wikilink",
-  "list-unresolved-wikilinks",
-  "list-tag-schemas",
-  "describe-tag",
 ]);
 
 /** Check if a tool call is allowed for a given scope. */

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,12 +1,8 @@
 /**
- * Unified MCP tool generation for multi-vault.
+ * MCP tool generation for multi-vault.
  *
- * Every tool gets an optional `vault` parameter. Defaults to the
- * configured default vault. Single-vault users never notice it.
- *
- * Vault description is sent as the MCP server instruction (not
- * prepended to each tool). Agents get the guidance once at session
- * start.
+ * Wraps core tools with vault resolution (optional `vault` param) and
+ * overrides vault-info with actual vault config access.
  */
 
 import { generateMcpTools } from "../core/src/mcp.ts";
@@ -16,7 +12,7 @@ import { getVaultStore } from "./vault-store.ts";
 
 /**
  * Get the MCP server instruction for a vault (or the default vault).
- * This is sent once at session init — not per tool.
+ * Sent once at session init — not per tool.
  */
 export function getServerInstruction(vaultName?: string): string {
   const globalConfig = readGlobalConfig();
@@ -80,61 +76,16 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
         const vaultTools = generateMcpTools(store);
         const tool = vaultTools.find((t) => t.name === coreTool.name)!;
         const { vault: _, ...rest } = params;
-        const result = tool.execute(rest);
-
-        const schemas = store.getTagSchemaMap();
-        if (Object.keys(schemas).length > 0) {
-          applyTagSchemaEffects(coreTool.name, result, rest, store, schemas);
-        }
-
-        return result;
+        return tool.execute(rest);
       },
     };
   });
 
-  // Vault management tools
-  addVaultManagementTools(tools, defaultVault);
+  // Override vault-info with actual vault config access
+  overrideVaultInfo(tools, defaultVault);
 
-  // Tag schema tools
-  addTagSchemaTools(tools, defaultVault, multiVault);
-
-  return tools;
-}
-
-/**
- * Generate MCP tools scoped to a single vault.
- * No vault param — tools operate on that vault only.
- */
-export function generateScopedMcpTools(vaultName: string): McpToolDef[] {
-  const store = getVaultStore(vaultName);
-  const tools = generateMcpTools(store);
-
-  // Wrap tools with schema effects (defaults + warnings) for scoped mode
-  for (const tool of tools) {
-    if (SCHEMA_EFFECT_TOOLS.has(tool.name)) {
-      const originalExecute = tool.execute;
-      const toolName = tool.name;
-      tool.execute = (params) => {
-        const result = originalExecute(params);
-        const schemas = store.getTagSchemaMap();
-        if (Object.keys(schemas).length > 0) {
-          applyTagSchemaEffects(toolName, result, params, store, schemas);
-        }
-        return result;
-      };
-    }
-  }
-
-  addVaultManagementTools(tools, vaultName, true);
-  addTagSchemaTools(tools, vaultName, false, true);
-  return tools;
-}
-
-/**
- * Add vault management tools (list-vaults, get/update description).
- */
-function addVaultManagementTools(tools: McpToolDef[], defaultVault: string, scoped = false) {
-  if (!scoped) {
+  // Add list-vaults (multi-vault only, not in core)
+  if (multiVault) {
     tools.push({
       name: "list-vaults",
       description: "List all available vaults with their descriptions.",
@@ -154,312 +105,51 @@ function addVaultManagementTools(tools: McpToolDef[], defaultVault: string, scop
     });
   }
 
-  tools.push({
-    name: "get-vault-description",
-    description: "Get the description/instructions for a vault. The description tells agents how to use this vault — what tags to use, what conventions to follow, etc.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...(scoped ? {} : {
-          vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
-        }),
-      },
-    },
-    execute: (params) => {
-      const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
-      const config = readVaultConfig(name);
-      if (!config) throw new Error(`Vault "${name}" not found`);
-      return {
-        name: config.name,
-        description: config.description ?? null,
-      };
-    },
-  });
+  return tools;
+}
 
-  tools.push({
-    name: "update-vault-description",
-    description: "Update the description/instructions for a vault. The description guides how AI agents use this vault — tag conventions, writing guidelines, etc. IMPORTANT: Only update when the user explicitly asks you to change the vault's configuration. Never modify unprompted.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...(scoped ? {} : {
-          vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
-        }),
-        description: { type: "string", description: "New vault description/instructions" },
-      },
-      required: ["description"],
-    },
-    execute: (params) => {
-      const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
-      const config = readVaultConfig(name);
-      if (!config) throw new Error(`Vault "${name}" not found`);
+/**
+ * Generate MCP tools scoped to a single vault.
+ * No vault param — tools operate on that vault only.
+ */
+export function generateScopedMcpTools(vaultName: string): McpToolDef[] {
+  const store = getVaultStore(vaultName);
+  const tools = generateMcpTools(store);
+
+  // Override vault-info with actual vault config access
+  overrideVaultInfo(tools, vaultName);
+
+  return tools;
+}
+
+/**
+ * Override vault-info's placeholder execute with real vault config access.
+ */
+function overrideVaultInfo(tools: McpToolDef[], defaultVault: string): void {
+  const vaultInfo = tools.find((t) => t.name === "vault-info");
+  if (!vaultInfo) return;
+
+  vaultInfo.execute = (params) => {
+    const vaultName = (params.vault as string) ?? defaultVault;
+    const config = readVaultConfig(vaultName);
+    if (!config) throw new Error(`Vault "${vaultName}" not found`);
+
+    // Update description if provided
+    if (params.description !== undefined) {
       config.description = params.description as string;
       writeVaultConfig(config);
-      return { updated: true, name, description: config.description };
-    },
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Tag schema validation (soft)
-// ---------------------------------------------------------------------------
-
-import type { TagFieldSchema } from "../core/src/tag-schemas.ts";
-import type { Store } from "../core/src/types.ts";
-
-type TagSchema = { description?: string; fields?: Record<string, TagFieldSchema> };
-
-/** Tools that can trigger schema effects (defaults + warnings). */
-const SCHEMA_EFFECT_TOOLS = new Set([
-  "create-note", "create-notes", "tag-note", "batch-tag",
-]);
-
-/**
- * Unified schema effects: auto-populate defaults + attach warnings.
- * Handles all tool shapes: note-returning (create-note), array-returning
- * (create-notes), and non-note-returning (tag-note, batch-tag).
- */
-function applyTagSchemaEffects(
-  toolName: string,
-  result: unknown,
-  params: Record<string, unknown>,
-  store: Store,
-  schemas: Record<string, TagSchema>,
-): void {
-  if (toolName === "create-note") {
-    // create-note returns a Note with tags — populate defaults + warn
-    const note = result as { id: string; tags?: string[]; metadata?: Record<string, unknown> };
-    if (note.tags) {
-      populateSchemaDefaults(store, [note.id], note.tags, schemas);
-      // Re-read for accurate warnings after defaults are populated
-      const fresh = store.getNote(note.id);
-      if (fresh) {
-        const warnings = checkTagSchemaWarnings(
-          { tags: fresh.tags, metadata: fresh.metadata as Record<string, unknown> | undefined },
-          schemas,
-        );
-        if (warnings.length > 0) (result as any)._schema_warnings = warnings;
-      }
     }
-  } else if (toolName === "create-notes") {
-    // create-notes returns an array of Notes
-    const notes = result as Array<{ id: string; tags?: string[] }>;
-    for (const note of notes) {
-      if (note.tags) {
-        populateSchemaDefaults(store, [note.id], note.tags, schemas);
-      }
+
+    const result: any = {
+      name: config.name,
+      description: config.description ?? null,
+    };
+
+    if (params.include_stats) {
+      const store = getVaultStore(vaultName);
+      result.stats = store.getVaultStats();
     }
-  } else if (toolName === "tag-note") {
-    const noteId = params.id as string;
-    const tags = params.tags as string[] | undefined;
-    if (tags) {
-      populateSchemaDefaults(store, [noteId], tags, schemas);
-      const fresh = store.getNote(noteId);
-      if (fresh) {
-        const warnings = checkTagSchemaWarnings(
-          { tags: fresh.tags, metadata: fresh.metadata as Record<string, unknown> | undefined },
-          schemas,
-        );
-        if (warnings.length > 0) (result as any)._schema_warnings = warnings;
-      }
-    }
-  } else if (toolName === "batch-tag") {
-    const noteIds = (params.note_ids as string[]) ?? [];
-    const tags = params.tags as string[] | undefined;
-    if (tags) {
-      populateSchemaDefaults(store, noteIds, tags, schemas);
-    }
-  }
-}
 
-/**
- * Auto-populate metadata defaults for notes when tags with schemas are applied.
- * Only adds fields that are missing — never overwrites existing values.
- * Uses skipUpdatedAt since this is system enrichment, not a user edit.
- */
-function populateSchemaDefaults(
-  store: Store,
-  noteIds: string[],
-  tags: string[],
-  schemas: Record<string, TagSchema>,
-): void {
-  // Collect all default fields from the applied tags' schemas
-  const defaults: Record<string, unknown> = {};
-  for (const tag of tags) {
-    const schema = schemas[tag];
-    if (!schema?.fields) continue;
-    for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-      if (!(field in defaults)) {
-        defaults[field] = defaultForField(fieldSchema);
-      }
-    }
-  }
-  if (Object.keys(defaults).length === 0) return;
-
-  for (const noteId of noteIds) {
-    const note = store.getNote(noteId);
-    if (!note) continue;
-    const existing = (note.metadata as Record<string, unknown> | undefined) ?? {};
-    const missing: Record<string, unknown> = {};
-    for (const [field, value] of Object.entries(defaults)) {
-      if (!(field in existing)) {
-        missing[field] = value;
-      }
-    }
-    if (Object.keys(missing).length === 0) continue;
-    store.updateNote(noteId, {
-      metadata: { ...existing, ...missing },
-      skipUpdatedAt: true,
-    });
-  }
-}
-
-function defaultForField(field: TagFieldSchema): unknown {
-  if (field.enum && field.enum.length > 0) return field.enum[0];
-  switch (field.type) {
-    case "boolean": return false;
-    case "integer": return 0;
-    default: return "";
-  }
-}
-
-/**
- * Check a note's tags against tag schemas and return warnings for missing
- * metadata fields. Purely advisory — never rejects a write.
- */
-function checkTagSchemaWarnings(
-  note: { tags?: string[]; metadata?: Record<string, unknown> },
-  schemas: Record<string, TagSchema>,
-): string[] {
-  const warnings: string[] = [];
-  if (!note.tags) return warnings;
-
-  for (const tag of note.tags) {
-    const schema = schemas[tag];
-    if (!schema?.fields) continue;
-    const meta = note.metadata ?? {};
-    const missing = Object.keys(schema.fields).filter((f) => !(f in meta));
-    if (missing.length > 0) {
-      warnings.push(`Tag "${tag}" expects metadata fields: ${missing.join(", ")}`);
-    }
-  }
-
-  return warnings;
-}
-
-// ---------------------------------------------------------------------------
-// Tag schema tools
-// ---------------------------------------------------------------------------
-
-function addTagSchemaTools(tools: McpToolDef[], defaultVault: string, multiVault = false, scoped = false) {
-  const vaultProp = scoped ? {} : {
-    vault: { type: "string", description: `Vault name (default: "${defaultVault}")` },
+    return result;
   };
-
-  function resolveStore(params: Record<string, unknown>) {
-    const name = scoped ? defaultVault : ((params.vault as string) ?? defaultVault);
-    return getVaultStore(name);
-  }
-
-  tools.push({
-    name: "list-tag-schemas",
-    description: "List all tag schemas defined for this vault. Tag schemas describe the expected metadata fields for notes with specific tags.",
-    inputSchema: { type: "object", properties: { ...vaultProp } },
-    execute: (params) => resolveStore(params).listTagSchemas(),
-  });
-
-  tools.push({
-    name: "describe-tag",
-    description: "Get the schema for a specific tag — its description and expected metadata fields. Returns null if no schema is defined for the tag.",
-    inputSchema: {
-      type: "object",
-      properties: { ...vaultProp, tag: { type: "string", description: "Tag name to describe" } },
-      required: ["tag"],
-    },
-    execute: (params) => resolveStore(params).getTagSchema(params.tag as string),
-  });
-
-  tools.push({
-    name: "create-tag-schema",
-    description: "Create or replace a tag's schema. Defines what metadata fields notes with this tag should have. Fields get auto-populated with defaults when the tag is applied to a note.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...vaultProp,
-        tag: { type: "string", description: "Tag name" },
-        description: { type: "string", description: "Human-readable description of what this tag means" },
-        fields: {
-          type: "object",
-          description: 'Metadata fields. Each key maps to { type, description?, enum? }. Example: { "status": { "type": "string", "enum": ["active", "archived"] } }',
-          additionalProperties: {
-            type: "object",
-            properties: {
-              type: { type: "string", description: "Field type: string, boolean, integer" },
-              description: { type: "string", description: "What this field means" },
-              enum: { type: "array", items: { type: "string" }, description: "Allowed values (first is the default)" },
-            },
-            required: ["type"],
-          },
-        },
-      },
-      required: ["tag"],
-    },
-    execute: (params) => resolveStore(params).upsertTagSchema(
-      params.tag as string,
-      { description: params.description as string | undefined, fields: params.fields as any },
-    ),
-  });
-
-  tools.push({
-    name: "update-tag-schema",
-    description: "Update an existing tag schema. Merges provided fields with existing ones. Pass description to update it, fields to add/replace field definitions.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...vaultProp,
-        tag: { type: "string", description: "Tag name" },
-        description: { type: "string", description: "Updated description" },
-        fields: {
-          type: "object",
-          description: "Fields to add or update (merged with existing)",
-          additionalProperties: {
-            type: "object",
-            properties: {
-              type: { type: "string" },
-              description: { type: "string" },
-              enum: { type: "array", items: { type: "string" } },
-            },
-            required: ["type"],
-          },
-        },
-      },
-      required: ["tag"],
-    },
-    execute: (params) => {
-      const store = resolveStore(params);
-      const tag = params.tag as string;
-      const existing = store.getTagSchema(tag);
-      if (!existing) throw new Error(`No schema defined for tag "${tag}". Use create-tag-schema to create one.`);
-      const mergedFields = { ...existing.fields, ...(params.fields as any) };
-      return store.upsertTagSchema(tag, {
-        description: (params.description as string | undefined) ?? existing.description,
-        fields: Object.keys(mergedFields).length > 0 ? mergedFields : undefined,
-      });
-    },
-  });
-
-  tools.push({
-    name: "delete-tag-schema",
-    description: "Remove a tag's schema. Does not delete the tag itself or remove it from notes — only removes the metadata schema definition.",
-    inputSchema: {
-      type: "object",
-      properties: { ...vaultProp, tag: { type: "string", description: "Tag name" } },
-      required: ["tag"],
-    },
-    execute: (params) => {
-      const deleted = resolveStore(params).deleteTagSchema(params.tag as string);
-      return { deleted };
-    },
-  });
 }
-

--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -46,6 +46,14 @@ function makeStore(notes: Record<string, { content: string; tags?: string[]; met
         updatedAt: "2025-01-01T00:00:00Z",
       };
     },
+    getNoteByPath(path: string) {
+      for (const [id, n] of Object.entries(notes)) {
+        if (n.path?.toLowerCase() === path.toLowerCase()) {
+          return this.getNote(id);
+        }
+      }
+      return null;
+    },
   } as any;
 }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,20 +1,24 @@
 /**
  * REST API route handlers for the multi-vault server.
  *
+ * Mirrors the 9 MCP tools:
+ *   /api/notes          — query-notes, create-note, update-note, delete-note
+ *   /api/tags           — list-tags, update-tag, delete-tag
+ *   /api/find-path      — find-path
+ *   /api/vault          — vault-info
+ *
  * Each handler receives a Store instance (already resolved for the vault)
  * and the Request, and returns a Response.
  */
 
-import type { Store } from "../core/src/types.ts";
-import { resolveWikilinkDetailed, listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
+import type { Store, Note } from "../core/src/types.ts";
+import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
 import { toNoteIndex } from "../core/src/notes.ts";
+import * as linkOps from "../core/src/links.ts";
+import * as tagSchemaOps from "../core/src/tag-schemas.ts";
 import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { vaultDir } from "./config.ts";
-function parseBool(val: string | null, defaultVal: boolean): boolean {
-  if (val === null) return defaultVal;
-  return val === "true" || val === "1";
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -22,6 +26,11 @@ function parseBool(val: string | null, defaultVal: boolean): boolean {
 
 function json(data: unknown, status = 200): Response {
   return Response.json(data, { status });
+}
+
+function parseBool(val: string | null, defaultVal: boolean): boolean {
+  if (val === null) return defaultVal;
+  return val === "true" || val === "1";
 }
 
 function parseQuery(url: URL, key: string): string | null {
@@ -33,323 +42,405 @@ function parseQueryList(url: URL, key: string): string[] | undefined {
   return val ? val.split(",") : undefined;
 }
 
+function parseInt10(val: string | null): number | undefined {
+  if (!val) return undefined;
+  const n = parseInt(val, 10);
+  return isNaN(n) ? undefined : n;
+}
+
+/**
+ * Resolve a note by ID or path. Tries ID first, then case-insensitive path.
+ */
+function resolveNote(store: Store, idOrPath: string): Note | null {
+  const byId = store.getNote(idOrPath);
+  if (byId) return byId;
+  return store.getNoteByPath(idOrPath);
+}
+
+function requireNote(store: Store, idOrPath: string): Note {
+  const note = resolveNote(store, idOrPath);
+  if (!note) throw new NotFoundError(`Note not found: "${idOrPath}"`);
+  return note;
+}
+
+class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Notes
+// Notes — GET/POST/PATCH/DELETE /api/notes[/:idOrPath]
 // ---------------------------------------------------------------------------
 
 export async function handleNotes(
   req: Request,
   store: Store,
-  path: string,
+  subpath: string,
 ): Promise<Response> {
   const url = new URL(req.url);
   const method = req.method;
+  const db = (store as any).db;
 
-  // GET /notes — Query notes.
-  // Default response is the lean index shape (no content). Pass
-  // ?include_content=true to get full notes. Pass ?ids=a,b,c to fetch
-  // specific notes by ID (still honors include_content).
-  if (method === "GET" && path === "") {
-    const includeContent = parseBool(parseQuery(url, "include_content"), false);
-    const ids = parseQueryList(url, "ids");
-    const fetched = ids
-      ? store.getNotes(ids)
-      : store.queryNotes({
-          tags: parseQueryList(url, "tag"),
-          tagMatch: (parseQuery(url, "tag_match") as "all" | "any") ?? undefined,
-          excludeTags: parseQueryList(url, "exclude_tag"),
-          path: parseQuery(url, "path") ?? undefined,
-          pathPrefix: parseQuery(url, "path_prefix") ?? undefined,
-          dateFrom: parseQuery(url, "date_from") ?? undefined,
-          dateTo: parseQuery(url, "date_to") ?? undefined,
-          sort: (parseQuery(url, "sort") as "asc" | "desc") ?? undefined,
-          limit: parseQuery(url, "limit") ? parseInt(parseQuery(url, "limit")!, 10) : undefined,
-          offset: parseQuery(url, "offset") ? parseInt(parseQuery(url, "offset")!, 10) : undefined,
+  // ---- Collection routes (no ID in path) ----
+  if (subpath === "") {
+    // GET /notes — query (all filters as query params)
+    if (method === "GET") {
+      const id = parseQuery(url, "id");
+      const search = parseQuery(url, "search");
+
+      // Single note by id/path
+      if (id) {
+        const note = resolveNote(store, id);
+        if (!note) return json({ error: "Note not found", id }, 404);
+        const includeContent = parseBool(parseQuery(url, "include_content"), true);
+        const result: any = includeContent ? { ...note } : toNoteIndex(note);
+        if (parseBool(parseQuery(url, "include_links"), false)) {
+          result.links = linkOps.getLinksHydrated(db, note.id);
+        }
+        if (parseBool(parseQuery(url, "include_attachments"), false)) {
+          result.attachments = store.getAttachments(note.id);
+        }
+        return json(result);
+      }
+
+      // Full-text search
+      if (search) {
+        const tags = parseQueryList(url, "tag");
+        const limit = parseInt10(parseQuery(url, "limit")) ?? 50;
+        const results = store.searchNotes(search, { tags, limit });
+        const includeContent = parseBool(parseQuery(url, "include_content"), false);
+        return json(includeContent ? results : results.map(toNoteIndex));
+      }
+
+      // Structured query
+      const tags = parseQueryList(url, "tag");
+      const results = store.queryNotes({
+        tags,
+        tagMatch: (parseQuery(url, "tag_match") as "all" | "any") ?? (tags && tags.length > 1 ? "any" : undefined),
+        excludeTags: parseQueryList(url, "exclude_tag"),
+        path: parseQuery(url, "path") ?? undefined,
+        pathPrefix: parseQuery(url, "path_prefix") ?? undefined,
+        metadata: undefined, // metadata filter not practical in query params
+        dateFrom: parseQuery(url, "date_from") ?? undefined,
+        dateTo: parseQuery(url, "date_to") ?? undefined,
+        sort: (parseQuery(url, "sort") as "asc" | "desc") ?? undefined,
+        limit: parseInt10(parseQuery(url, "limit")) ?? 50,
+        offset: parseInt10(parseQuery(url, "offset")),
+      });
+
+      const includeContent = parseBool(parseQuery(url, "include_content"), false);
+      const output = includeContent ? results : results.map(toNoteIndex);
+
+      if (parseBool(parseQuery(url, "include_links"), false) || parseBool(parseQuery(url, "include_attachments"), false)) {
+        const includeLinks = parseBool(parseQuery(url, "include_links"), false);
+        const includeAttachments = parseBool(parseQuery(url, "include_attachments"), false);
+        return json(output.map((n: any) => {
+          const enriched = { ...n };
+          if (includeLinks) enriched.links = linkOps.getLinksHydrated(db, n.id);
+          if (includeAttachments) enriched.attachments = store.getAttachments(n.id);
+          return enriched;
+        }));
+      }
+
+      return json(output);
+    }
+
+    // POST /notes — create (single or batch)
+    if (method === "POST") {
+      const body = await req.json() as any;
+      const items: any[] = body.notes ?? [body];
+
+      const created: Note[] = [];
+      for (const item of items) {
+        const note = store.createNote(item.content ?? "", {
+          id: item.id,
+          path: item.path,
+          tags: item.tags,
+          metadata: item.metadata,
+          created_at: item.createdAt ?? item.created_at,
         });
-    return json(includeContent ? fetched : fetched.map(toNoteIndex));
+
+        // Create explicit links
+        if (item.links) {
+          for (const link of item.links as { target: string; relationship: string }[]) {
+            const target = resolveNote(store, link.target);
+            if (target) store.createLink(note.id, target.id, link.relationship);
+          }
+        }
+
+        created.push(store.getNote(note.id) ?? note);
+      }
+
+      // Apply tag schema defaults
+      for (const note of created) {
+        if (note.tags?.length) {
+          applySchemaDefaults(store, db, [note.id], note.tags);
+        }
+      }
+
+      return json(body.notes ? created : created[0], 201);
+    }
+
+    return json({ error: "Method not allowed" }, 405);
   }
 
-  // POST /notes — Create note
-  if (method === "POST" && path === "") {
-    const body = await req.json() as {
-      content: string;
-      id?: string;
-      path?: string;
-      tags?: string[];
-      metadata?: Record<string, unknown>;
-      createdAt?: string;
-    };
-    const note = store.createNote(body.content ?? "", {
-      id: body.id,
-      path: body.path,
-      tags: body.tags,
-      metadata: body.metadata,
-      created_at: body.createdAt,
-    });
-    return json(note, 201);
-  }
-
-  // Routes with note ID
-  const idMatch = path.match(/^\/([^/]+)(\/.*)?$/);
+  // ---- Note-level routes (/notes/:idOrPath[/attachments]) ----
+  const idMatch = subpath.match(/^\/([^/]+)(\/.*)?$/);
   if (!idMatch) return json({ error: "Not found" }, 404);
 
-  const noteId = idMatch[1];
-  const subpath = idMatch[2] ?? "";
+  const idOrPath = decodeURIComponent(idMatch[1]);
+  const sub = idMatch[2] ?? "";
 
-  // GET /notes/:id
-  // Defaults to full content (the point-read case). Pass
-  // ?include_content=false to get the lean index shape.
-  if (method === "GET" && subpath === "") {
-    const note = store.getNote(noteId);
+  // Attachments sub-routes (keep as-is — Daily needs them)
+  if (sub === "/attachments") {
+    if (method === "POST") {
+      const note = resolveNote(store, idOrPath);
+      if (!note) return json({ error: "Not found" }, 404);
+      const body = await req.json() as { path: string; mimeType: string };
+      if (!body.path || !body.mimeType) return json({ error: "path and mimeType are required" }, 400);
+      return json(store.addAttachment(note.id, body.path, body.mimeType), 201);
+    }
+    if (method === "GET") {
+      const note = resolveNote(store, idOrPath);
+      if (!note) return json({ error: "Not found" }, 404);
+      return json(store.getAttachments(note.id));
+    }
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  if (sub !== "") return json({ error: "Not found" }, 404);
+
+  // GET /notes/:idOrPath — single note
+  if (method === "GET") {
+    const note = resolveNote(store, idOrPath);
     if (!note) return json({ error: "Not found" }, 404);
     const includeContent = parseBool(parseQuery(url, "include_content"), true);
-    return json(includeContent ? note : toNoteIndex(note));
-  }
-
-  // PATCH /notes/:id
-  if (method === "PATCH" && subpath === "") {
-    const existing = store.getNote(noteId);
-    if (!existing) return json({ error: "Not found" }, 404);
-    const body = await req.json() as { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string };
-    const updated = store.updateNote(noteId, { content: body.content, path: body.path, metadata: body.metadata, created_at: body.created_at });
-    return json(updated);
-  }
-
-  // DELETE /notes/:id
-  if (method === "DELETE" && subpath === "") {
-    const existing = store.getNote(noteId);
-    if (!existing) return json({ error: "Not found" }, 404);
-    store.deleteNote(noteId);
-    return json({ deleted: true });
-  }
-
-  // POST /notes/:id/tags
-  if (method === "POST" && subpath === "/tags") {
-    const existing = store.getNote(noteId);
-    if (!existing) return json({ error: "Not found" }, 404);
-    const body = await req.json() as { tags: string[] };
-    store.tagNote(noteId, body.tags);
-    return json(store.getNote(noteId));
-  }
-
-  // DELETE /notes/:id/tags
-  if (method === "DELETE" && subpath === "/tags") {
-    const existing = store.getNote(noteId);
-    if (!existing) return json({ error: "Not found" }, 404);
-    const body = await req.json() as { tags: string[] };
-    store.untagNote(noteId, body.tags);
-    return json(store.getNote(noteId));
-  }
-
-  // POST /notes/:id/attachments
-  if (method === "POST" && subpath === "/attachments") {
-    const existing = store.getNote(noteId);
-    if (!existing) return json({ error: "Not found" }, 404);
-    const body = await req.json() as { path: string; mimeType: string };
-    if (!body.path || !body.mimeType) {
-      return json({ error: "path and mimeType are required" }, 400);
+    const result: any = includeContent ? { ...note } : toNoteIndex(note);
+    if (parseBool(parseQuery(url, "include_links"), false)) {
+      result.links = linkOps.getLinksHydrated(db, note.id);
     }
-    const attachment = store.addAttachment(noteId, body.path, body.mimeType);
-    return json(attachment, 201);
-  }
-
-  // GET /notes/:id/attachments
-  if (method === "GET" && subpath === "/attachments") {
-    const attachments = store.getAttachments(noteId);
-    return json(attachments);
-  }
-
-  return json({ error: "Not found" }, 404);
-}
-
-// ---------------------------------------------------------------------------
-// Tags
-// ---------------------------------------------------------------------------
-
-export function handleTags(req: Request, store: Store, subpath = ""): Response {
-  if (req.method === "GET" && subpath === "") {
-    return json(store.listTags());
-  }
-
-  // DELETE /tags/:name
-  const nameMatch = subpath.match(/^\/(.+)$/);
-  if (req.method === "DELETE" && nameMatch) {
-    const tagName = decodeURIComponent(nameMatch[1]);
-    const result = store.deleteTag(tagName);
+    if (parseBool(parseQuery(url, "include_attachments"), false)) {
+      result.attachments = store.getAttachments(note.id);
+    }
     return json(result);
   }
 
+  // PATCH /notes/:idOrPath — update (content, path, metadata, tags, links)
+  if (method === "PATCH") {
+    try {
+      const note = requireNote(store, idOrPath);
+      const body = await req.json() as any;
+
+      // Remove links first (before content update for bracket removal)
+      const linksRemove = body.links?.remove as { target: string; relationship: string }[] | undefined;
+      let contentOverride = body.content as string | undefined;
+      if (linksRemove) {
+        for (const link of linksRemove) {
+          const target = resolveNote(store, link.target);
+          if (target) {
+            store.deleteLink(note.id, target.id, link.relationship);
+            if (link.relationship === "wikilink" && target.path) {
+              const current = contentOverride ?? note.content;
+              const cleaned = removeWikilinkBrackets(current, target.path);
+              if (cleaned !== current) contentOverride = cleaned;
+            }
+          }
+        }
+      }
+
+      // Core update
+      const updates: any = {};
+      if (contentOverride !== undefined) updates.content = contentOverride;
+      if (body.path !== undefined) updates.path = body.path;
+      if (body.metadata !== undefined) {
+        const existing = (note.metadata as Record<string, unknown>) ?? {};
+        updates.metadata = { ...existing, ...body.metadata };
+      }
+      if (body.created_at !== undefined || body.createdAt !== undefined) {
+        updates.created_at = body.created_at ?? body.createdAt;
+      }
+
+      if (Object.keys(updates).length > 0) {
+        store.updateNote(note.id, updates);
+      }
+
+      // Tags
+      if (body.tags?.add?.length) {
+        store.tagNote(note.id, body.tags.add);
+        applySchemaDefaults(store, db, [note.id], body.tags.add);
+      }
+      if (body.tags?.remove?.length) {
+        store.untagNote(note.id, body.tags.remove);
+      }
+
+      // Add links
+      if (body.links?.add) {
+        for (const link of body.links.add as { target: string; relationship: string; metadata?: Record<string, unknown> }[]) {
+          const target = resolveNote(store, link.target);
+          if (target) store.createLink(note.id, target.id, link.relationship, link.metadata);
+        }
+      }
+
+      return json(store.getNote(note.id));
+    } catch (e: any) {
+      if (e instanceof NotFoundError) return json({ error: e.message }, 404);
+      throw e;
+    }
+  }
+
+  // DELETE /notes/:idOrPath
+  if (method === "DELETE") {
+    const note = resolveNote(store, idOrPath);
+    if (!note) return json({ error: "Not found" }, 404);
+    store.deleteNote(note.id);
+    return json({ deleted: true, id: note.id });
+  }
+
   return json({ error: "Method not allowed" }, 405);
 }
 
 // ---------------------------------------------------------------------------
-// Tag Schemas
+// Tags — GET/PUT/DELETE /api/tags[/:name]
 // ---------------------------------------------------------------------------
 
-export async function handleTagSchemas(req: Request, store: Store, subpath = ""): Promise<Response> {
-  // GET /tag-schemas — list all
+export async function handleTags(req: Request, store: Store, subpath = ""): Promise<Response> {
+  const url = new URL(req.url);
+  const db = (store as any).db;
+
+  // GET /tags — list all, or get single tag detail
   if (req.method === "GET" && subpath === "") {
-    return json(store.listTagSchemas());
+    const singleTag = parseQuery(url, "tag");
+
+    if (singleTag) {
+      const allTags = store.listTags();
+      const found = allTags.find((t) => t.name === singleTag);
+      const schema = store.getTagSchema(singleTag);
+      return json({
+        name: singleTag,
+        count: found?.count ?? 0,
+        description: schema?.description ?? null,
+        fields: schema?.fields ?? null,
+      });
+    }
+
+    const tags = store.listTags();
+    if (parseBool(parseQuery(url, "include_schema"), false)) {
+      const schemas = store.getTagSchemaMap();
+      return json(tags.map((t) => ({
+        ...t,
+        description: schemas[t.name]?.description ?? null,
+        fields: schemas[t.name]?.fields ?? null,
+      })));
+    }
+    return json(tags);
   }
 
-  const tagMatch = subpath.match(/^\/([^/]+)$/);
-  if (!tagMatch) return json({ error: "Not found" }, 404);
-  const tagName = decodeURIComponent(tagMatch[1]);
+  // Routes with tag name
+  const nameMatch = subpath.match(/^\/([^/]+)$/);
+  if (!nameMatch) return json({ error: "Not found" }, 404);
+  const tagName = decodeURIComponent(nameMatch[1]);
 
-  // GET /tag-schemas/:tag
+  // GET /tags/:name — single tag detail
   if (req.method === "GET") {
+    const allTags = store.listTags();
+    const found = allTags.find((t) => t.name === tagName);
     const schema = store.getTagSchema(tagName);
-    if (!schema) return json({ error: "No schema for tag" }, 404);
-    return json(schema);
+    return json({
+      name: tagName,
+      count: found?.count ?? 0,
+      description: schema?.description ?? null,
+      fields: schema?.fields ?? null,
+    });
   }
 
-  // PUT /tag-schemas/:tag — create or update
+  // PUT /tags/:name — upsert tag schema (description + fields)
   if (req.method === "PUT") {
     const body = await req.json() as { description?: string; fields?: Record<string, unknown> };
-    const schema = store.upsertTagSchema(tagName, body as any);
+    const existing = store.getTagSchema(tagName);
+    const mergedFields = { ...existing?.fields, ...(body.fields as any) };
+    const schema = store.upsertTagSchema(tagName, {
+      description: body.description ?? existing?.description,
+      fields: Object.keys(mergedFields).length > 0 ? mergedFields : undefined,
+    });
     return json(schema);
   }
 
-  // DELETE /tag-schemas/:tag
+  // DELETE /tags/:name — delete tag + schema from all notes
   if (req.method === "DELETE") {
-    const deleted = store.deleteTagSchema(tagName);
-    return json({ deleted });
+    store.deleteTagSchema(tagName);
+    return json(store.deleteTag(tagName));
   }
 
   return json({ error: "Method not allowed" }, 405);
 }
 
 // ---------------------------------------------------------------------------
-// Links
+// Find-path — GET /api/find-path?source=...&target=...
 // ---------------------------------------------------------------------------
 
-export async function handleLinks(
+export function handleFindPath(req: Request, store: Store): Response {
+  if (req.method !== "GET") return json({ error: "Method not allowed" }, 405);
+
+  const url = new URL(req.url);
+  const source = parseQuery(url, "source");
+  const target = parseQuery(url, "target");
+  if (!source || !target) return json({ error: "source and target parameters are required" }, 400);
+
+  const db = (store as any).db;
+  try {
+    const sourceNote = requireNote(store, source);
+    const targetNote = requireNote(store, target);
+    const maxDepth = Math.min(parseInt10(parseQuery(url, "max_depth")) ?? 5, 10);
+    const result = linkOps.findPath(db, sourceNote.id, targetNote.id, { max_depth: maxDepth });
+    return json(result);
+  } catch (e: any) {
+    if (e instanceof NotFoundError) return json({ error: e.message }, 404);
+    throw e;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Vault info — GET/PATCH /api/vault
+// ---------------------------------------------------------------------------
+
+export async function handleVault(
   req: Request,
   store: Store,
+  vaultConfig: { name: string; description?: string },
+  updateDescription?: (description: string) => void,
 ): Promise<Response> {
-  // GET /links — list edges.
-  // Filters: ?note_id (only links touching this note), ?direction
-  // (outbound|inbound|both, only meaningful with note_id), ?relationship.
-  // Returns bare Link[], no hydration. Pair with GET /notes?ids=... if you
-  // need the connected notes' details.
+  const url = new URL(req.url);
+
   if (req.method === "GET") {
-    const url = new URL(req.url);
-    const noteId = parseQuery(url, "note_id") ?? undefined;
-    const direction = (parseQuery(url, "direction") as "outbound" | "inbound" | "both" | null) ?? undefined;
-    const relationship = parseQuery(url, "relationship") ?? undefined;
-    return json(store.listLinks({ noteId, direction: direction ?? undefined, relationship }));
-  }
-
-  if (req.method === "POST") {
-    const body = await req.json() as {
-      sourceId: string;
-      targetId: string;
-      relationship: string;
-      metadata?: Record<string, unknown>;
+    const result: any = {
+      name: vaultConfig.name,
+      description: vaultConfig.description ?? null,
     };
-    if (!body.sourceId || !body.targetId || !body.relationship) {
-      return json({ error: "sourceId, targetId, and relationship are required" }, 400);
+    if (parseBool(parseQuery(url, "include_stats"), false)) {
+      result.stats = store.getVaultStats();
     }
-    const link = store.createLink(body.sourceId, body.targetId, body.relationship, body.metadata);
-    return json(link, 201);
+    return json(result);
   }
 
-  if (req.method === "DELETE") {
-    const body = await req.json() as {
-      sourceId: string;
-      targetId: string;
-      relationship: string;
-    };
-    store.deleteLink(body.sourceId, body.targetId, body.relationship);
-    return json({ deleted: true });
+  if (req.method === "PATCH") {
+    const body = await req.json() as { description?: string };
+    if (body.description !== undefined && updateDescription) {
+      updateDescription(body.description);
+    }
+    return json({
+      name: vaultConfig.name,
+      description: body.description ?? vaultConfig.description ?? null,
+    });
   }
 
-  // GET handled in the new polymorphic path below
   return json({ error: "Method not allowed" }, 405);
 }
 
 // ---------------------------------------------------------------------------
-// Graph
+// Unresolved wikilinks — REST-only (admin/maintenance)
 // ---------------------------------------------------------------------------
-
-/**
- * GET /graph — one-shot knowledge graph payload.
- *
- * Returns { notes, links, tags, meta }. Lean notes by default (NoteIndex),
- * include_content=true fattens them. Optional tag filter restricts notes
- * to a subgraph; links are filtered to edges between notes in the subset.
- */
-export function handleGraph(req: Request, store: Store): Response {
-  if (req.method !== "GET") {
-    return json({ error: "Method not allowed" }, 405);
-  }
-  const url = new URL(req.url);
-  const tags = parseQueryList(url, "tag");
-  const tagMatch = (parseQuery(url, "tag_match") as "all" | "any") ?? undefined;
-  const excludeTags = parseQueryList(url, "exclude_tag");
-  const includeContent = parseBool(parseQuery(url, "include_content"), false);
-
-  const hasTagFilter = !!(tags?.length || excludeTags?.length);
-  const filteredNotes = store.queryNotes({
-    tags,
-    tagMatch,
-    excludeTags,
-    limit: 1_000_000,
-  });
-  const outNotes = includeContent ? filteredNotes : filteredNotes.map(toNoteIndex);
-
-  const allLinks = store.listLinks();
-  const outLinks = hasTagFilter
-    ? (() => {
-        const ids = new Set(filteredNotes.map((n) => n.id));
-        return allLinks.filter((l) => ids.has(l.sourceId) && ids.has(l.targetId));
-      })()
-    : allLinks;
-
-  const stats = store.getVaultStats({ topTagsLimit: 1_000_000 });
-
-  return json({
-    notes: outNotes,
-    links: outLinks,
-    tags: store.listTags(),
-    meta: {
-      totalNotes: stats.totalNotes,
-      totalLinks: allLinks.length,
-      filteredNotes: outNotes.length,
-      filteredLinks: outLinks.length,
-      includeContent,
-    },
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Search
-// ---------------------------------------------------------------------------
-
-export function handleSearch(req: Request, store: Store): Response {
-  const url = new URL(req.url);
-  const query = url.searchParams.get("q");
-  if (!query) return json({ error: "q parameter is required" }, 400);
-
-  const tags = parseQueryList(url, "tag");
-  const limitStr = url.searchParams.get("limit");
-  const limit = limitStr ? parseInt(limitStr, 10) : undefined;
-
-  const results = store.searchNotes(query, { tags, limit });
-  return json(results);
-}
-
-// ---------------------------------------------------------------------------
-// Wikilinks
-// ---------------------------------------------------------------------------
-
-export function handleResolveWikilink(req: Request, store: Store): Response {
-  const url = new URL(req.url);
-  const target = url.searchParams.get("target");
-  if (!target) return json({ error: "target parameter is required" }, 400);
-  const db = (store as any).db;
-  return json(resolveWikilinkDetailed(db, target));
-}
 
 export function handleUnresolvedWikilinks(req: Request, store: Store): Response {
   const url = new URL(req.url);
@@ -357,100 +448,6 @@ export function handleUnresolvedWikilinks(req: Request, store: Store): Response 
   const limit = limitStr ? parseInt(limitStr, 10) : 50;
   const db = (store as any).db;
   return json(listUnresolvedWikilinks(db, limit));
-}
-
-// ---------------------------------------------------------------------------
-// Storage (file upload/serve)
-// ---------------------------------------------------------------------------
-
-export function assetsDir(vault: string): string {
-  return process.env.ASSETS_DIR ?? join(vaultDir(vault), "assets");
-}
-const MAX_UPLOAD_BYTES = 100 * 1024 * 1024; // 100MB
-
-const ALLOWED_EXTENSIONS = new Set([
-  ".wav", ".mp3", ".m4a", ".ogg", ".webm",
-  ".png", ".jpg", ".jpeg", ".gif", ".webp",
-]);
-
-const MIME_TYPES: Record<string, string> = {
-  ".wav": "audio/wav",
-  ".mp3": "audio/mpeg",
-  ".m4a": "audio/mp4",
-  ".ogg": "audio/ogg",
-  ".webm": "audio/webm",
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".gif": "image/gif",
-  ".webp": "image/webp",
-};
-
-export async function handleStorage(req: Request, path: string, vault: string): Promise<Response> {
-  const assets = assetsDir(vault);
-
-  // POST /storage/upload
-  if (req.method === "POST" && path === "/upload") {
-    const form = await req.formData();
-    const file = form.get("file");
-    if (!(file instanceof File)) {
-      return json({ error: "file is required" }, 400);
-    }
-    if (file.size > MAX_UPLOAD_BYTES) {
-      return json({ error: `File too large (${Math.round(file.size / 1024 / 1024)}MB). Max: 100MB` }, 413);
-    }
-    const ext = extname(file.name).toLowerCase();
-    if (!ALLOWED_EXTENSIONS.has(ext)) {
-      return json({ error: `File type ${ext} not allowed` }, 400);
-    }
-
-    // Store the file
-    const date = new Date().toISOString().split("T")[0];
-    const dir = join(assets, date);
-    mkdirSync(dir, { recursive: true });
-
-    const filename = `${Date.now()}-${crypto.randomUUID()}${ext}`;
-    const filePath = join(dir, filename);
-    const buffer = Buffer.from(await file.arrayBuffer());
-    writeFileSync(filePath, buffer);
-
-    const relativePath = `${date}/${filename}`;
-    const mimeType = MIME_TYPES[ext] ?? "application/octet-stream";
-
-    return json({
-      path: relativePath,
-      size: buffer.length,
-      mimeType,
-    }, 201);
-  }
-
-  // GET /storage/:date/:file
-  const fileMatch = path.match(/^\/([^/]+)\/(.+)$/);
-  if (req.method === "GET" && fileMatch) {
-    const reqPath = `${fileMatch[1]}/${fileMatch[2]}`;
-    const filePath = normalize(join(assets, reqPath));
-
-    if (!filePath.startsWith(normalize(assets))) {
-      return json({ error: "Invalid path" }, 403);
-    }
-    if (!existsSync(filePath)) {
-      return json({ error: "Not found" }, 404);
-    }
-
-    const stat = statSync(filePath);
-    const ext = extname(filePath).toLowerCase();
-    const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
-    const fileBuffer = readFileSync(filePath);
-
-    return new Response(fileBuffer, {
-      headers: {
-        "Content-Type": contentType,
-        "Content-Length": String(stat.size),
-      },
-    });
-  }
-
-  return json({ error: "Not found" }, 404);
 }
 
 // ---------------------------------------------------------------------------
@@ -465,17 +462,6 @@ function escapeHtml(s: string): string {
     .replace(/"/g, "&quot;");
 }
 
-/**
- * Minimal markdown-to-HTML for published notes. Handles:
- * - Paragraphs (blank-line separated)
- * - Headers (# through ######)
- * - Bold (**text**), italic (*text*), inline code (`code`)
- * - Unordered lists (- item)
- * - Fenced code blocks (```...```)
- * - Links [text](url)
- *
- * This is intentionally simple — we don't pull in a markdown library.
- */
 function renderMarkdown(md: string): string {
   const lines = md.split("\n");
   const out: string[] = [];
@@ -484,7 +470,6 @@ function renderMarkdown(md: string): string {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
-    // Fenced code blocks
     if (line.trimStart().startsWith("```")) {
       if (inCodeBlock) {
         out.push("</code></pre>");
@@ -502,13 +487,11 @@ function renderMarkdown(md: string): string {
 
     const trimmed = line.trim();
 
-    // Empty line
     if (!trimmed) {
       out.push("");
       continue;
     }
 
-    // Headers
     const headerMatch = trimmed.match(/^(#{1,6})\s+(.+)/);
     if (headerMatch) {
       const level = headerMatch[1].length;
@@ -516,9 +499,7 @@ function renderMarkdown(md: string): string {
       continue;
     }
 
-    // Unordered list items
     if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
-      // Collect consecutive list items
       const items: string[] = [trimmed.slice(2)];
       while (i + 1 < lines.length) {
         const next = lines[i + 1].trim();
@@ -535,7 +516,6 @@ function renderMarkdown(md: string): string {
       continue;
     }
 
-    // Paragraph
     out.push(`<p>${inlineMarkdown(escapeHtml(trimmed))}</p>`);
   }
 
@@ -544,28 +524,19 @@ function renderMarkdown(md: string): string {
 }
 
 function inlineMarkdown(html: string): string {
-  // Bold
   html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-  // Italic
   html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
-  // Inline code
   html = html.replace(/`(.+?)`/g, "<code>$1</code>");
-  // Links [text](url) — sanitize href to prevent javascript:/data: XSS
   html = html.replace(/\[(.+?)\]\((.+?)\)/g, (_match, text, url) => {
     const decoded = url.replace(/&amp;/g, "&");
     if (/^(https?:|mailto:|#|\/)/i.test(decoded)) {
       return `<a href="${url}">${text}</a>`;
     }
-    return text; // strip unsafe links, keep text
+    return text;
   });
   return html;
 }
 
-/**
- * Check if a note is published. A note is published if:
- * 1. It has the configured published tag (default: "publish"), OR
- * 2. It has metadata.published === true (always honored regardless of custom tag)
- */
 function isNotePublished(note: { tags?: string[]; metadata?: unknown }, publishedTag: string = "publish"): boolean {
   if (note.tags?.includes(publishedTag)) return true;
   const meta = note.metadata as Record<string, unknown> | undefined;
@@ -574,18 +545,16 @@ function isNotePublished(note: { tags?: string[]; metadata?: unknown }, publishe
 }
 
 /**
- * GET /view/:noteId — serve a note as clean HTML.
- *
- * Without auth: only serves notes marked as published (via tag or metadata).
- * With auth: serves any note in the vault.
+ * GET /view/:idOrPath — serve a note as clean HTML.
+ * Supports ID or path resolution.
  */
 export function handleViewNote(
   store: Store,
-  noteId: string,
+  idOrPath: string,
   options: { authenticated?: boolean; publishedTag?: string } = {},
 ): Response {
   const { authenticated = false, publishedTag = "publish" } = options;
-  const note = store.getNote(noteId);
+  const note = resolveNote(store, idOrPath);
   if (!note) {
     return new Response("Not Found", { status: 404, headers: { "Content-Type": "text/plain" } });
   }
@@ -650,3 +619,141 @@ ${rendered}
   });
 }
 
+// ---------------------------------------------------------------------------
+// Storage (file upload/serve) — kept as-is, Daily needs it
+// ---------------------------------------------------------------------------
+
+export function assetsDir(vault: string): string {
+  return process.env.ASSETS_DIR ?? join(vaultDir(vault), "assets");
+}
+const MAX_UPLOAD_BYTES = 100 * 1024 * 1024; // 100MB
+
+const ALLOWED_EXTENSIONS = new Set([
+  ".wav", ".mp3", ".m4a", ".ogg", ".webm",
+  ".png", ".jpg", ".jpeg", ".gif", ".webp",
+]);
+
+const MIME_TYPES: Record<string, string> = {
+  ".wav": "audio/wav",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".ogg": "audio/ogg",
+  ".webm": "audio/webm",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+export async function handleStorage(req: Request, path: string, vault: string): Promise<Response> {
+  const assets = assetsDir(vault);
+
+  if (req.method === "POST" && path === "/upload") {
+    const form = await req.formData();
+    const file = form.get("file");
+    if (!(file instanceof File)) {
+      return json({ error: "file is required" }, 400);
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      return json({ error: `File too large (${Math.round(file.size / 1024 / 1024)}MB). Max: 100MB` }, 413);
+    }
+    const ext = extname(file.name).toLowerCase();
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      return json({ error: `File type ${ext} not allowed` }, 400);
+    }
+
+    const date = new Date().toISOString().split("T")[0];
+    const dir = join(assets, date);
+    mkdirSync(dir, { recursive: true });
+
+    const filename = `${Date.now()}-${crypto.randomUUID()}${ext}`;
+    const filePath = join(dir, filename);
+    const buffer = Buffer.from(await file.arrayBuffer());
+    writeFileSync(filePath, buffer);
+
+    const relativePath = `${date}/${filename}`;
+    const mimeType = MIME_TYPES[ext] ?? "application/octet-stream";
+
+    return json({ path: relativePath, size: buffer.length, mimeType }, 201);
+  }
+
+  const fileMatch = path.match(/^\/([^/]+)\/(.+)$/);
+  if (req.method === "GET" && fileMatch) {
+    const reqPath = `${fileMatch[1]}/${fileMatch[2]}`;
+    const filePath = normalize(join(assets, reqPath));
+
+    if (!filePath.startsWith(normalize(assets))) {
+      return json({ error: "Invalid path" }, 403);
+    }
+    if (!existsSync(filePath)) {
+      return json({ error: "Not found" }, 404);
+    }
+
+    const stat = statSync(filePath);
+    const ext = extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
+    const fileBuffer = readFileSync(filePath);
+
+    return new Response(fileBuffer, {
+      headers: {
+        "Content-Type": contentType,
+        "Content-Length": String(stat.size),
+      },
+    });
+  }
+
+  return json({ error: "Not found" }, 404);
+}
+
+// ---------------------------------------------------------------------------
+// Tag schema defaults — same logic as core/src/mcp.ts applySchemaDefaults
+// ---------------------------------------------------------------------------
+
+function applySchemaDefaults(store: Store, db: any, noteIds: string[], tags: string[]): void {
+  const schemas = tagSchemaOps.getTagSchemaMap(db);
+  if (Object.keys(schemas).length === 0) return;
+
+  const defaults: Record<string, unknown> = {};
+  for (const tag of tags) {
+    const schema = schemas[tag];
+    if (!schema?.fields) continue;
+    for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+      if (!(field in defaults)) {
+        defaults[field] = defaultForField(fieldSchema);
+      }
+    }
+  }
+  if (Object.keys(defaults).length === 0) return;
+
+  for (const noteId of noteIds) {
+    const note = store.getNote(noteId);
+    if (!note) continue;
+    const existing = (note.metadata as Record<string, unknown>) ?? {};
+    const missing: Record<string, unknown> = {};
+    for (const [field, value] of Object.entries(defaults)) {
+      if (!(field in existing)) missing[field] = value;
+    }
+    if (Object.keys(missing).length === 0) continue;
+    store.updateNote(noteId, {
+      metadata: { ...existing, ...missing },
+      skipUpdatedAt: true,
+    });
+  }
+}
+
+function defaultForField(field: { type: string; enum?: string[] }): unknown {
+  if (field.enum && field.enum.length > 0) return field.enum[0];
+  switch (field.type) {
+    case "boolean": return false;
+    case "integer": return 0;
+    default: return "";
+  }
+}
+
+function removeWikilinkBrackets(content: string, targetPath: string): string {
+  const escaped = targetPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  content = content.replace(new RegExp(`\\[\\[${escaped}\\|([^\\]]+)\\]\\]`, "gi"), "$1");
+  content = content.replace(new RegExp(`\\[\\[${escaped}(#[^\\]]+)?\\]\\]`, "gi"), `${targetPath}$1`);
+  return content;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import { authenticateVaultRequest, authenticateGlobalRequest, isMethodAllowed, e
 import type { VaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
-import { handleNotes, handleTags, handleTagSchemas, handleLinks, handleGraph, handleSearch, handleResolveWikilink, handleUnresolvedWikilinks, handleStorage, handleViewNote } from "./routes.ts";
+import { handleNotes, handleTags, handleFindPath, handleVault, handleUnresolvedWikilinks, handleStorage, handleViewNote } from "./routes.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTriggers } from "./triggers.ts";
 
@@ -186,8 +186,8 @@ async function route(req: Request, path: string): Promise<Response> {
     return handleUnifiedMcp(req, auth.scope);
   }
 
-  // View endpoint — serves notes as HTML (auth-aware)
-  const viewMatch = path.match(/^\/view\/([^/]+)$/);
+  // View endpoint — serves notes as HTML (auth-aware, supports ID or path)
+  const viewMatch = path.match(/^\/view\/(.+)$/);
   if (viewMatch && req.method === "GET") {
     const defaultVault = readGlobalConfig().default_vault ?? "default";
     const vaultConfig = readVaultConfig(defaultVault);
@@ -196,7 +196,7 @@ async function route(req: Request, path: string): Promise<Response> {
     }
     const store = getVaultStore(defaultVault);
     const authenticated = isViewAuthenticated(req, vaultConfig);
-    return handleViewNote(store, viewMatch[1], {
+    return handleViewNote(store, decodeURIComponent(viewMatch[1]), {
       authenticated,
       publishedTag: vaultConfig.published_tag,
     });
@@ -242,12 +242,12 @@ async function route(req: Request, path: string): Promise<Response> {
     const store = getVaultStore(defaultVault);
     const apiPath = path.slice(4); // strip "/api"
     if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6));
-    if (apiPath.startsWith("/tag-schemas")) return handleTagSchemas(req, store, apiPath.slice(12));
     if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
-    if (apiPath === "/links") return handleLinks(req, store);
-    if (apiPath === "/graph") return handleGraph(req, store);
-    if (apiPath === "/search") return handleSearch(req, store);
-    if (apiPath === "/resolve-wikilink") return handleResolveWikilink(req, store);
+    if (apiPath === "/find-path") return handleFindPath(req, store);
+    if (apiPath === "/vault") return handleVault(req, store, vaultConfig, (desc) => {
+      vaultConfig.description = desc;
+      writeVaultConfig(vaultConfig);
+    });
     if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store);
     if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), defaultVault);
     if (apiPath === "/health") return Response.json({ status: "ok", vault: defaultVault });
@@ -278,12 +278,12 @@ async function route(req: Request, path: string): Promise<Response> {
     return Response.redirect(dest.toString(), 301);
   }
 
-  // View endpoint — serves notes as HTML (auth-aware, vault-scoped)
-  const vaultViewMatch = subpath.match(/^\/view\/([^/]+)$/);
+  // View endpoint — serves notes as HTML (auth-aware, vault-scoped, supports ID or path)
+  const vaultViewMatch = subpath.match(/^\/view\/(.+)$/);
   if (vaultViewMatch && req.method === "GET") {
     const store = getVaultStore(vaultName);
     const authenticated = isViewAuthenticated(req, vaultConfig);
-    return handleViewNote(store, vaultViewMatch[1], {
+    return handleViewNote(store, decodeURIComponent(vaultViewMatch[1]), {
       authenticated,
       publishedTag: vaultConfig.published_tag,
     });
@@ -333,23 +333,17 @@ async function route(req: Request, path: string): Promise<Response> {
   if (apiPath.startsWith("/notes")) {
     return handleNotes(req, store, apiPath.slice(6));
   }
-  if (apiPath.startsWith("/tag-schemas")) {
-    return handleTagSchemas(req, store, apiPath.slice(12));
-  }
   if (apiPath.startsWith("/tags")) {
     return handleTags(req, store, apiPath.slice(5));
   }
-  if (apiPath === "/links") {
-    return handleLinks(req, store);
+  if (apiPath === "/find-path") {
+    return handleFindPath(req, store);
   }
-  if (apiPath === "/graph") {
-    return handleGraph(req, store);
-  }
-  if (apiPath === "/search") {
-    return handleSearch(req, store);
-  }
-  if (apiPath === "/resolve-wikilink") {
-    return handleResolveWikilink(req, store);
+  if (apiPath === "/vault") {
+    return handleVault(req, store, vaultConfig, (desc) => {
+      vaultConfig.description = desc;
+      writeVaultConfig(vaultConfig);
+    });
   }
   if (apiPath === "/unresolved-wikilinks") {
     return handleUnresolvedWikilinks(req, store);

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "os";
 import { BunStore } from "./vault-store.ts";
 import { generateMcpTools } from "../core/src/mcp.ts";
 import { getLinksHydrated } from "../core/src/links.ts";
-import { handleNotes, handleLinks, handleGraph } from "./routes.ts";
+import { handleNotes, handleTags, handleFindPath, handleVault } from "./routes.ts";
 
 let db: Database;
 let store: BunStore;
@@ -814,15 +814,12 @@ describe("HTTP /notes", () => {
     expect(body[0].content).toBe("full body");
   });
 
-  test("GET /notes?ids=a,b bulk fetch", async () => {
-    const n1 = store.createNote("one", { id: "id-1" });
-    const n2 = store.createNote("two", { id: "id-2" });
-    store.createNote("three", { id: "id-3" });
-    const res = await handleNotes(mkReq("GET", "/notes?ids=id-1,id-2"), store, "");
+  test("GET /notes?search=fox full-text search", async () => {
+    store.createNote("The quick brown fox");
+    store.createNote("A lazy dog");
+    const res = await handleNotes(mkReq("GET", "/notes?search=fox"), store, "");
     const body = await res.json() as any[];
-    expect(body).toHaveLength(2);
-    const ids = body.map((n) => n.id).sort();
-    expect(ids).toEqual(["id-1", "id-2"]);
+    expect(body).toHaveLength(1);
   });
 
   test("GET /notes/:id defaults to full content", async () => {
@@ -864,108 +861,142 @@ describe("HTTP /notes", () => {
   });
 });
 
-describe("HTTP /links (polymorphic)", () => {
-  test("GET /links returns all edges", async () => {
-    store.createNote("a", { id: "a" });
-    store.createNote("b", { id: "b" });
-    store.createNote("c", { id: "c" });
-    store.createLink("a", "b", "mentions");
-    store.createLink("b", "c", "cites");
-    const res = await handleLinks(mkReq("GET", "/links"), store);
-    const body = await res.json() as any[];
-    expect(body).toHaveLength(2);
-  });
-
-  test("GET /links?note_id=a restricts to links touching a", async () => {
-    store.createNote("a", { id: "a" });
-    store.createNote("b", { id: "b" });
-    store.createNote("c", { id: "c" });
-    store.createLink("a", "b", "mentions");
-    store.createLink("b", "c", "cites");
-    const res = await handleLinks(mkReq("GET", "/links?note_id=a"), store);
-    const body = await res.json() as any[];
-    expect(body).toHaveLength(1);
-    expect(body[0].sourceId).toBe("a");
-  });
-
-  test("GET /links?relationship=cites filters by type", async () => {
-    store.createNote("a", { id: "a" });
-    store.createNote("b", { id: "b" });
-    store.createLink("a", "b", "mentions");
-    store.createLink("a", "b", "cites");
-    const res = await handleLinks(mkReq("GET", "/links?relationship=cites"), store);
-    const body = await res.json() as any[];
-    expect(body).toHaveLength(1);
-    expect(body[0].relationship).toBe("cites");
-  });
-
-  test("POST /links accepts sourceId/targetId (camelCase) in body", async () => {
-    store.createNote("a", { id: "a" });
-    store.createNote("b", { id: "b" });
-    const res = await handleLinks(
-      mkReq("POST", "/links", { sourceId: "a", targetId: "b", relationship: "cites" }),
+describe("HTTP PATCH /notes/:idOrPath (update)", () => {
+  test("PATCH updates content and merges metadata", async () => {
+    const note = store.createNote("original", { id: "x", metadata: { a: 1 } });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", { content: "updated", metadata: { b: 2 } }),
       store,
+      "/x",
     );
-    expect(res.status).toBe(201);
     const body = await res.json() as any;
-    expect(body.sourceId).toBe("a");
-    expect(body.targetId).toBe("b");
+    expect(body.content).toBe("updated");
+    expect(body.metadata).toEqual({ a: 1, b: 2 });
   });
 
-  test("POST /links rejects snake_case body fields", async () => {
+  test("PATCH adds/removes tags", async () => {
+    store.createNote("x", { id: "x", tags: ["old"] });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", { tags: { add: ["new"], remove: ["old"] } }),
+      store,
+      "/x",
+    );
+    const body = await res.json() as any;
+    expect(body.tags).toContain("new");
+    expect(body.tags).not.toContain("old");
+  });
+
+  test("PATCH adds/removes links", async () => {
     store.createNote("a", { id: "a" });
     store.createNote("b", { id: "b" });
-    const res = await handleLinks(
-      mkReq("POST", "/links", { source_id: "a", target_id: "b", relationship: "cites" }),
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/a", { links: { add: [{ target: "b", relationship: "mentions" }] } }),
       store,
+      "/a",
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    const links = store.getLinks("a", { direction: "outbound" });
+    expect(links).toHaveLength(1);
+
+    // Remove
+    await handleNotes(
+      mkReq("PATCH", "/notes/a", { links: { remove: [{ target: "b", relationship: "mentions" }] } }),
+      store,
+      "/a",
+    );
+    expect(store.getLinks("a", { direction: "outbound" })).toHaveLength(0);
+  });
+
+  test("PATCH resolves note by path", async () => {
+    store.createNote("x", { path: "Projects/README" });
+    const res = await handleNotes(
+      mkReq("PATCH", `/notes/${encodeURIComponent("Projects/README")}`, { content: "updated" }),
+      store,
+      `/${encodeURIComponent("Projects/README")}`,
+    );
+    const body = await res.json() as any;
+    expect(body.content).toBe("updated");
+  });
+
+  test("DELETE resolves note by path", async () => {
+    store.createNote("x", { path: "Temp/note" });
+    const res = await handleNotes(
+      mkReq("DELETE", `/notes/${encodeURIComponent("Temp/note")}`),
+      store,
+      `/${encodeURIComponent("Temp/note")}`,
+    );
+    const body = await res.json() as any;
+    expect(body.deleted).toBe(true);
+    expect(store.getNoteByPath("Temp/note")).toBeNull();
   });
 });
 
-describe("HTTP /graph", () => {
-  test("returns notes, links, tags, meta", async () => {
-    store.createNote("a", { id: "a", tags: ["proj"] });
-    store.createNote("b", { id: "b", tags: ["proj"] });
-    store.createNote("c", { id: "c", tags: ["other"] });
+describe("HTTP /tags", () => {
+  test("GET /tags lists all tags", async () => {
+    store.createNote("A", { tags: ["daily"] });
+    store.createNote("B", { tags: ["daily", "pinned"] });
+    const res = await handleTags(mkReq("GET", "/tags"), store);
+    const body = await res.json() as any[];
+    const daily = body.find((t: any) => t.name === "daily");
+    expect(daily.count).toBe(2);
+  });
+
+  test("GET /tags?tag=name returns single tag detail with schema", async () => {
+    store.createNote("A", { tags: ["person"] });
+    store.upsertTagSchema("person", { description: "A person", fields: { name: { type: "string" } } });
+    const res = await handleTags(mkReq("GET", "/tags?tag=person"), store);
+    const body = await res.json() as any;
+    expect(body.name).toBe("person");
+    expect(body.count).toBe(1);
+    expect(body.description).toBe("A person");
+    expect(body.fields.name.type).toBe("string");
+  });
+
+  test("PUT /tags/:name upserts schema", async () => {
+    const res = await handleTags(
+      mkReq("PUT", "/tags/person", { description: "A person", fields: { name: { type: "string" } } }),
+      store,
+      "/person",
+    );
+    const body = await res.json() as any;
+    expect(body.tag).toBe("person");
+    expect(body.description).toBe("A person");
+  });
+
+  test("DELETE /tags/:name removes tag and schema", async () => {
+    store.createNote("A", { tags: ["doomed"] });
+    store.upsertTagSchema("doomed", { description: "will be deleted" });
+    const res = await handleTags(mkReq("DELETE", "/tags/doomed"), store, "/doomed");
+    const body = await res.json() as any;
+    expect(body.deleted).toBe(true);
+    expect(store.listTags().some((t) => t.name === "doomed")).toBe(false);
+  });
+});
+
+describe("HTTP /find-path", () => {
+  test("finds path between two notes", async () => {
+    store.createNote("a", { id: "a" });
+    store.createNote("b", { id: "b" });
+    store.createNote("c", { id: "c" });
     store.createLink("a", "b", "mentions");
-    const res = await handleGraph(mkReq("GET", "/graph"), store);
+    store.createLink("b", "c", "related-to");
+    const res = handleFindPath(mkReq("GET", "/find-path?source=a&target=c"), store);
     const body = await res.json() as any;
-    expect(body.notes).toHaveLength(3);
-    expect(body.links).toHaveLength(1);
-    expect(body.tags.length).toBeGreaterThan(0);
-    expect(body.meta.totalNotes).toBe(3);
-    expect(body.meta.totalLinks).toBe(1);
-    expect(body.meta.includeContent).toBe(false);
-    // Lean by default
-    expect(body.notes[0]).not.toHaveProperty("content");
-    expect(body.notes[0]).toHaveProperty("byteSize");
+    expect(body.path).toEqual(["a", "b", "c"]);
+    expect(body.relationships).toEqual(["mentions", "related-to"]);
   });
 
-  test("?include_content=true returns full note content", async () => {
-    store.createNote("has body", { id: "a" });
-    const res = await handleGraph(mkReq("GET", "/graph?include_content=true"), store);
+  test("returns null when no path exists", async () => {
+    store.createNote("a", { id: "a" });
+    store.createNote("b", { id: "b" });
+    const res = handleFindPath(mkReq("GET", "/find-path?source=a&target=b"), store);
     const body = await res.json() as any;
-    expect(body.notes[0].content).toBe("has body");
-    expect(body.meta.includeContent).toBe(true);
+    expect(body).toBeNull();
   });
 
-  test("?tag=proj filters notes and links to the subgraph", async () => {
-    store.createNote("a", { id: "a", tags: ["proj"] });
-    store.createNote("b", { id: "b", tags: ["proj"] });
-    store.createNote("c", { id: "c", tags: ["other"] });
-    store.createLink("a", "b", "mentions"); // inside subgraph
-    store.createLink("a", "c", "mentions"); // crosses subgraph boundary
-    const res = await handleGraph(mkReq("GET", "/graph?tag=proj"), store);
-    const body = await res.json() as any;
-    expect(body.notes).toHaveLength(2);
-    expect(body.links).toHaveLength(1);
-    expect(body.links[0].sourceId).toBe("a");
-    expect(body.links[0].targetId).toBe("b");
-    expect(body.meta.totalNotes).toBe(3);
-    expect(body.meta.totalLinks).toBe(2);
-    expect(body.meta.filteredNotes).toBe(2);
-    expect(body.meta.filteredLinks).toBe(1);
+  test("requires source and target params", async () => {
+    const res = handleFindPath(mkReq("GET", "/find-path?source=a"), store);
+    expect(res.status).toBe(400);
   });
 });
 

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -469,62 +469,51 @@ describe("deeper link queries", () => {
 });
 
 describe("MCP tools", () => {
-  test("generates all 22 core tools", () => {
-    const tools = generateMcpTools(db);
-    expect(tools.length).toBe(22);
+  test("generates all 9 core tools", () => {
+    const tools = generateMcpTools(store);
+    expect(tools.length).toBe(9);
 
     const names = tools.map((t) => t.name);
-    expect(names).toContain("get-note");
+    expect(names).toContain("query-notes");
     expect(names).toContain("create-note");
-    expect(names).toContain("create-notes");
-    expect(names).toContain("batch-tag");
-    expect(names).toContain("batch-untag");
-    expect(names).toContain("traverse-links");
-    expect(names).toContain("find-path");
+    expect(names).toContain("update-note");
+    expect(names).toContain("delete-note");
     expect(names).toContain("list-tags");
-    expect(names).toContain("get-vault-stats");
-    expect(names).toContain("get-graph");
+    expect(names).toContain("update-tag");
+    expect(names).toContain("delete-tag");
+    expect(names).toContain("find-path");
+    expect(names).toContain("vault-info");
   });
 
-  test("get-note tool works by id", () => {
-    const tools = generateMcpTools(db);
+  test("query-notes by id works", () => {
+    const tools = generateMcpTools(store);
     const note = store.createNote("By ID", { path: "test/note" });
 
-    const getTool = tools.find((t) => t.name === "get-note")!;
-    const result = getTool.execute({ id: note.id }) as any;
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ id: note.id }) as any;
     expect(result.content).toBe("By ID");
     expect(result.path).toBe("test/note");
   });
 
-  test("get-note tool works by path", () => {
-    const tools = generateMcpTools(db);
+  test("query-notes by path works", () => {
+    const tools = generateMcpTools(store);
     store.createNote("By Path", { path: "Projects/README" });
 
-    const getTool = tools.find((t) => t.name === "get-note")!;
-    const result = getTool.execute({ path: "Projects/README" }) as any;
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = query.execute({ id: "Projects/README" }) as any;
     expect(result.content).toBe("By Path");
   });
 
-  test("get-note tool fetches multiple by ids", () => {
-    const tools = generateMcpTools(db);
-    const a = store.createNote("A");
-    const b = store.createNote("B");
-
-    const getTool = tools.find((t) => t.name === "get-note")!;
-    const result = getTool.execute({ ids: [a.id, b.id] }) as any[];
-    expect(result.length).toBe(2);
-  });
-
   test("create-note tool works via execute", () => {
-    const tools = generateMcpTools(db);
+    const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
     const result = createNote.execute({ content: "MCP note", tags: ["daily"] }) as any;
     expect(result.content).toBe("MCP note");
     expect(result.tags).toContain("daily");
   });
 
-  test("every tool has vault param in unified wrapper schema", () => {
-    const tools = generateMcpTools(db);
+  test("every tool has inputSchema and execute", () => {
+    const tools = generateMcpTools(store);
     for (const tool of tools) {
       expect(tool.inputSchema).toBeDefined();
       expect(tool.execute).toBeFunction();
@@ -533,40 +522,38 @@ describe("MCP tools", () => {
 });
 
 describe("unified MCP wrapper", () => {
-  test("routes get-vault-stats through vault param", async () => {
+  test("vault-info routes through vault param", async () => {
     const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
     const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
 
-    // Seed a unique vault on disk under the preload-provided PARACHUTE_HOME.
     const vaultName = `unified-stats-${Date.now()}`;
     writeVaultConfig({
       name: vaultName,
       api_keys: [],
       created_at: new Date().toISOString(),
+      description: "Test vault",
     });
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
-    // Populate the vault with notes/tags the stats tool should observe.
     const vaultStore = getVaultStore(vaultName);
     vaultStore.createNote("alpha", { tags: ["x", "y"] });
     vaultStore.createNote("beta", { tags: ["x"] });
 
     const tools = generateUnifiedMcpTools();
-    const statsTool = tools.find((t) => t.name === "get-vault-stats");
-    expect(statsTool).toBeTruthy();
-    // Routed explicitly via the vault param, mirroring how a multi-vault
-    // client targets a specific vault.
-    const result = statsTool!.execute({ vault: vaultName }) as any;
-    expect(result.totalNotes).toBe(2);
-    expect(result.tagCount).toBe(2);
-    expect(result.topTags[0].tag).toBe("x");
-    expect(result.topTags[0].count).toBe(2);
+    const vaultInfo = tools.find((t) => t.name === "vault-info");
+    expect(vaultInfo).toBeTruthy();
+
+    const result = vaultInfo!.execute({ vault: vaultName, include_stats: true }) as any;
+    expect(result.name).toBe(vaultName);
+    expect(result.description).toBe("Test vault");
+    expect(result.stats.totalNotes).toBe(2);
+    expect(result.stats.tagCount).toBe(2);
 
     closeAllStores();
   });
 
-  test("list-tag-schemas and describe-tag tools work", async () => {
+  test("list-tags with schema works through unified wrapper", async () => {
     const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
     const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
@@ -579,39 +566,27 @@ describe("unified MCP wrapper", () => {
     });
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
-    // Insert schemas into DB
-    const store = getVaultStore(vaultName);
-    store.upsertTagSchema("person", {
+    const vaultStore = getVaultStore(vaultName);
+    vaultStore.createNote("A", { tags: ["person"] });
+    vaultStore.upsertTagSchema("person", {
       description: "A person",
       fields: { name: { type: "string", description: "Full name" } },
     });
-    store.upsertTagSchema("project", { description: "A project" });
 
     const tools = generateUnifiedMcpTools();
 
-    const listTool = tools.find((t) => t.name === "list-tag-schemas");
-    expect(listTool).toBeTruthy();
-    const schemas = listTool!.execute({ vault: vaultName }) as any[];
-    expect(schemas.length).toBe(2);
-    const personSchema = schemas.find((s: any) => s.tag === "person");
-    expect(personSchema).toBeDefined();
-    expect(personSchema.description).toBe("A person");
-    const projectSchema = schemas.find((s: any) => s.tag === "project");
-    expect(projectSchema).toBeDefined();
-
-    const describeTool = tools.find((t) => t.name === "describe-tag");
-    expect(describeTool).toBeTruthy();
-    const described = describeTool!.execute({ vault: vaultName, tag: "person" }) as any;
-    expect(described.description).toBe("A person");
-    expect(described.fields.name.type).toBe("string");
-
-    const unknown = describeTool!.execute({ vault: vaultName, tag: "nonexistent" }) as any;
-    expect(unknown).toBeNull();
+    // list-tags with tag param for single tag detail
+    const listTags = tools.find((t) => t.name === "list-tags")!;
+    const detail = listTags.execute({ vault: vaultName, tag: "person" }) as any;
+    expect(detail.name).toBe("person");
+    expect(detail.count).toBe(1);
+    expect(detail.description).toBe("A person");
+    expect(detail.fields.name.type).toBe("string");
 
     closeAllStores();
   });
 
-  test("create-note with schema tag auto-populates defaults and produces no warnings", async () => {
+  test("create-note with schema tag auto-populates defaults", async () => {
     const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
     const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
@@ -624,8 +599,8 @@ describe("unified MCP wrapper", () => {
     });
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
-    const store = getVaultStore(vaultName);
-    store.upsertTagSchema("person", {
+    const vaultStore = getVaultStore(vaultName);
+    vaultStore.upsertTagSchema("person", {
       description: "A person",
       fields: {
         first_appeared: { type: "string", description: "When" },
@@ -635,67 +610,36 @@ describe("unified MCP wrapper", () => {
 
     const tools = generateUnifiedMcpTools();
     const createNote = tools.find((t) => t.name === "create-note")!;
-    const getNote = tools.find((t) => t.name === "get-note")!;
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
-    // Create a note tagged person with no metadata — defaults auto-populated, no warnings
+    // Create a note tagged person with no metadata — defaults auto-populated
     const result = createNote.execute({
       vault: vaultName,
       content: "Alice",
       tags: ["person"],
     }) as any;
     expect(result.content).toBe("Alice");
-    expect(result._schema_warnings).toBeUndefined(); // defaults cover all fields
 
     // Verify defaults were written
-    const fresh = getNote.execute({ vault: vaultName, id: result.id }) as any;
+    const fresh = queryNotes.execute({ vault: vaultName, id: result.id }) as any;
     expect(fresh.metadata.first_appeared).toBe("");
     expect(fresh.metadata.relationship).toBe("");
 
-    // Create with explicit metadata — preserved, no warnings
+    // Create with explicit metadata — preserved
     const result2 = createNote.execute({
       vault: vaultName,
       content: "Bob",
       tags: ["person"],
       metadata: { first_appeared: "2024-01", relationship: "friend" },
     }) as any;
-    expect(result2._schema_warnings).toBeUndefined();
-    const fresh2 = getNote.execute({ vault: vaultName, id: result2.id }) as any;
+    const fresh2 = queryNotes.execute({ vault: vaultName, id: result2.id }) as any;
     expect(fresh2.metadata.first_appeared).toBe("2024-01");
     expect(fresh2.metadata.relationship).toBe("friend");
 
     closeAllStores();
   });
 
-  test("tag-note with schema tag produces warnings for remaining missing fields", async () => {
-    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
-    const { closeAllStores } = await import("./vault-store.ts");
-
-    const vaultName = `schema-tagwarn-${Date.now()}`;
-    writeVaultConfig({
-      name: vaultName,
-      api_keys: [],
-      created_at: new Date().toISOString(),
-    });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
-
-    const { getVaultStore } = await import("./vault-store.ts");
-    const store = getVaultStore(vaultName);
-    store.upsertTagSchema("empty", { description: "No fields" });
-
-    const tools = generateUnifiedMcpTools();
-    const createNote = tools.find((t) => t.name === "create-note")!;
-    const tagNote = tools.find((t) => t.name === "tag-note")!;
-
-    // tag-note: tag with schema that has no fields → no warnings
-    const note = createNote.execute({ vault: vaultName, content: "Test" }) as any;
-    const tagResult = tagNote.execute({ vault: vaultName, id: note.id, tags: ["empty"] }) as any;
-    expect(tagResult._schema_warnings).toBeUndefined();
-
-    closeAllStores();
-  });
-
-  test("tag-note auto-populates metadata defaults from tag schema", async () => {
+  test("update-note tags.add with schema auto-populates defaults", async () => {
     const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
     const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores: close } = await import("./vault-store.ts");
@@ -726,13 +670,13 @@ describe("unified MCP wrapper", () => {
     });
     const tools = generateUnifiedMcpTools();
     const createNote = tools.find((t) => t.name === "create-note")!;
-    const tagNote = tools.find((t) => t.name === "tag-note")!;
-    const getNote = tools.find((t) => t.name === "get-note")!;
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
-    // Create a note, then tag it with #person
+    // Create a note, then add #person tag via update-note
     const note = createNote.execute({ vault: vaultName, content: "Alice" }) as any;
-    tagNote.execute({ vault: vaultName, id: note.id, tags: ["person"] });
-    const after = getNote.execute({ vault: vaultName, id: note.id }) as any;
+    updateNote.execute({ vault: vaultName, id: note.id, tags: { add: ["person"] } });
+    const after = queryNotes.execute({ vault: vaultName, id: note.id }) as any;
     expect(after.metadata.first_appeared).toBe("");
     expect(after.metadata.relationship).toBe("");
 
@@ -742,29 +686,23 @@ describe("unified MCP wrapper", () => {
       content: "Bob",
       metadata: { first_appeared: "2023-11" },
     }) as any;
-    tagNote.execute({ vault: vaultName, id: note2.id, tags: ["person"] });
-    const after2 = getNote.execute({ vault: vaultName, id: note2.id }) as any;
+    updateNote.execute({ vault: vaultName, id: note2.id, tags: { add: ["person"] } });
+    const after2 = queryNotes.execute({ vault: vaultName, id: note2.id }) as any;
     expect(after2.metadata.first_appeared).toBe("2023-11"); // preserved
     expect(after2.metadata.relationship).toBe(""); // added
 
-    // Tag with no schema — no metadata changes
-    const note3 = createNote.execute({ vault: vaultName, content: "No schema" }) as any;
-    tagNote.execute({ vault: vaultName, id: note3.id, tags: ["random"] });
-    const after3 = getNote.execute({ vault: vaultName, id: note3.id }) as any;
-    expect(after3.metadata).toBeUndefined();
-
     // Tag with #project — enum defaults to first value, boolean to false, integer to 0
     const note4 = createNote.execute({ vault: vaultName, content: "My Project" }) as any;
-    tagNote.execute({ vault: vaultName, id: note4.id, tags: ["project"] });
-    const after4 = getNote.execute({ vault: vaultName, id: note4.id }) as any;
+    updateNote.execute({ vault: vaultName, id: note4.id, tags: { add: ["project"] } });
+    const after4 = queryNotes.execute({ vault: vaultName, id: note4.id }) as any;
     expect(after4.metadata.status).toBe("active");
     expect(after4.metadata.active).toBe(false);
     expect(after4.metadata.priority).toBe(0);
 
     // Multiple schema tags at once — all defaults merged
     const note5 = createNote.execute({ vault: vaultName, content: "Multi" }) as any;
-    tagNote.execute({ vault: vaultName, id: note5.id, tags: ["person", "project"] });
-    const after5 = getNote.execute({ vault: vaultName, id: note5.id }) as any;
+    updateNote.execute({ vault: vaultName, id: note5.id, tags: { add: ["person", "project"] } });
+    const after5 = queryNotes.execute({ vault: vaultName, id: note5.id }) as any;
     expect(after5.metadata.first_appeared).toBe("");
     expect(after5.metadata.relationship).toBe("");
     expect(after5.metadata.status).toBe("active");
@@ -773,7 +711,7 @@ describe("unified MCP wrapper", () => {
     close();
   });
 
-  test("tag-note auto-populate does not bump updatedAt", async () => {
+  test("update-note tags.add auto-populate does not bump updatedAt", async () => {
     const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
     const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores: close } = await import("./vault-store.ts");
@@ -794,13 +732,13 @@ describe("unified MCP wrapper", () => {
 
     const tools = generateUnifiedMcpTools();
     const createNote = tools.find((t) => t.name === "create-note")!;
-    const tagNote = tools.find((t) => t.name === "tag-note")!;
-    const getNote = tools.find((t) => t.name === "get-note")!;
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
     const note = createNote.execute({ vault: vaultName, content: "Test" }) as any;
     const originalUpdatedAt = note.updatedAt;
-    tagNote.execute({ vault: vaultName, id: note.id, tags: ["person"] });
-    const after = getNote.execute({ vault: vaultName, id: note.id }) as any;
+    updateNote.execute({ vault: vaultName, id: note.id, tags: { add: ["person"] } });
+    const after = queryNotes.execute({ vault: vaultName, id: note.id }) as any;
     expect(after.updatedAt).toBe(originalUpdatedAt);
     expect(after.metadata.name).toBe("");
 
@@ -811,41 +749,27 @@ describe("unified MCP wrapper", () => {
 describe("auth scopes", () => {
   test("read scope allows read tools", () => {
     const { isToolAllowed } = require("./auth.ts");
-    expect(isToolAllowed("get-note", "read")).toBe(true);
-    expect(isToolAllowed("read-notes", "read")).toBe(true);
-    expect(isToolAllowed("search-notes", "read")).toBe(true);
-    expect(isToolAllowed("get-links", "read")).toBe(true);
-    expect(isToolAllowed("traverse-links", "read")).toBe(true);
-    expect(isToolAllowed("find-path", "read")).toBe(true);
+    expect(isToolAllowed("query-notes", "read")).toBe(true);
     expect(isToolAllowed("list-tags", "read")).toBe(true);
-    expect(isToolAllowed("get-vault-stats", "read")).toBe(true);
+    expect(isToolAllowed("find-path", "read")).toBe(true);
+    expect(isToolAllowed("vault-info", "read")).toBe(true);
     expect(isToolAllowed("list-vaults", "read")).toBe(true);
-    expect(isToolAllowed("list-tag-schemas", "read")).toBe(true);
-    expect(isToolAllowed("describe-tag", "read")).toBe(true);
   });
 
   test("read scope blocks write tools", () => {
     const { isToolAllowed } = require("./auth.ts");
     expect(isToolAllowed("create-note", "read")).toBe(false);
-    expect(isToolAllowed("create-tag-schema", "read")).toBe(false);
-    expect(isToolAllowed("update-tag-schema", "read")).toBe(false);
-    expect(isToolAllowed("delete-tag-schema", "read")).toBe(false);
     expect(isToolAllowed("update-note", "read")).toBe(false);
     expect(isToolAllowed("delete-note", "read")).toBe(false);
-    expect(isToolAllowed("tag-note", "read")).toBe(false);
-    expect(isToolAllowed("untag-note", "read")).toBe(false);
-    expect(isToolAllowed("create-link", "read")).toBe(false);
-    expect(isToolAllowed("delete-link", "read")).toBe(false);
-    expect(isToolAllowed("create-notes", "read")).toBe(false);
-    expect(isToolAllowed("batch-tag", "read")).toBe(false);
-    expect(isToolAllowed("batch-untag", "read")).toBe(false);
+    expect(isToolAllowed("update-tag", "read")).toBe(false);
+    expect(isToolAllowed("delete-tag", "read")).toBe(false);
   });
 
   test("write scope allows everything", () => {
     const { isToolAllowed } = require("./auth.ts");
     expect(isToolAllowed("create-note", "write")).toBe(true);
     expect(isToolAllowed("delete-note", "write")).toBe(true);
-    expect(isToolAllowed("get-note", "write")).toBe(true);
+    expect(isToolAllowed("query-notes", "write")).toBe(true);
   });
 
   test("read scope allows GET but not POST/PATCH/DELETE", () => {
@@ -855,11 +779,6 @@ describe("auth scopes", () => {
     expect(isMethodAllowed("POST", "read")).toBe(false);
     expect(isMethodAllowed("PATCH", "read")).toBe(false);
     expect(isMethodAllowed("DELETE", "read")).toBe(false);
-  });
-
-  test("get-graph is a read tool", () => {
-    const { isToolAllowed } = require("./auth.ts");
-    expect(isToolAllowed("get-graph", "read")).toBe(true);
   });
 });
 
@@ -1078,7 +997,7 @@ describe("stateless MCP transport", () => {
         jsonrpc: "2.0",
         id: 1,
         method: "tools/call",
-        params: { name: "get-vault-stats", arguments: { vault: vaultName } },
+        params: { name: "vault-info", arguments: { vault: vaultName, include_stats: true } },
       }),
     });
 
@@ -1088,7 +1007,7 @@ describe("stateless MCP transport", () => {
     const body = await res.json() as any;
     expect(body.result).toBeDefined();
     const content = JSON.parse(body.result.content[0].text);
-    expect(content.totalNotes).toBe(1);
+    expect(content.stats.totalNotes).toBe(1);
 
     closeAllStores();
   });
@@ -1128,7 +1047,7 @@ describe("stateless MCP transport", () => {
     expect(body.result.tools.length).toBeGreaterThan(0);
     const toolNames = body.result.tools.map((t: any) => t.name);
     expect(toolNames).toContain("create-note");
-    expect(toolNames).toContain("get-vault-stats");
+    expect(toolNames).toContain("vault-info");
 
     closeAllStores();
   });


### PR DESCRIPTION
> **Depends on PR #71** (tag-schemas-in-db) — merge that first.

## Summary

- Rewrites the MCP tool surface from 30 tools (22 core + 8 wrapper) to **9 composable tools**
- Every note parameter accepts ID or path (resolved via ID first, then case-insensitive path match)
- `create-note` and `update-note` handle single or batch operations
- `update-note` absorbs tag/untag/link add/remove via `tags: {add, remove}` and `links: {add, remove}`
- `query-notes` absorbs get-note, read-notes, search-notes, get-links, get-graph, traverse-links
- Tag schema auto-populate defaults moved into core (no longer in wrapper layer)
- Metadata merge (not replace) on update-note
- Net -216 lines

## New tool set

| Tool | Replaces |
|---|---|
| `query-notes` | get-note, read-notes, search-notes, get-links, get-graph, traverse-links |
| `create-note` | create-note, create-notes |
| `update-note` | update-note, tag-note, untag-note, create-link, delete-link, batch-tag, batch-untag |
| `delete-note` | delete-note |
| `list-tags` | list-tags, list-tag-schemas, describe-tag |
| `update-tag` | create-tag-schema, update-tag-schema |
| `delete-tag` | delete-tag, delete-tag-schema |
| `find-path` | find-path |
| `vault-info` | get-vault-description, update-vault-description, get-vault-stats |

## Test plan

- [x] All 146 core + vault tests pass (0 failures)
- [x] Auth scope tests updated for new tool names
- [x] Schema effect tests rewritten for update-note tags.add pattern
- [x] Stateless MCP transport tests updated for vault-info
- [x] Self-review: no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)