### PR TITLE
feat: support API key via ?key= query param

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -62,14 +62,19 @@ export function isMethodAllowed(method: string, permission: TokenPermission): bo
 }
 
 /**
- * Extract API key/token from request headers.
+ * Extract API key/token from request.
+ * Priority: Authorization header → X-API-Key header → ?key= query param.
  */
 export function extractApiKey(req: Request): string | null {
   const authHeader = req.headers.get("authorization");
   if (authHeader?.startsWith("Bearer ")) {
     return authHeader.slice(7);
   }
-  return req.headers.get("x-api-key");
+  const xApiKey = req.headers.get("x-api-key");
+  if (xApiKey) return xApiKey;
+  // Query param fallback — enables URL-only auth for MCP clients (e.g. Claude Web)
+  const url = new URL(req.url);
+  return url.searchParams.get("key");
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -173,20 +173,11 @@ process.on("SIGTERM", () => void shutdown("SIGTERM"));
  * requests still get public notes.
  */
 function isViewAuthenticated(req: Request, vaultConfig: VaultConfig | null, vaultDb?: import("bun:sqlite").Database): boolean {
-  // Check query param first (convenient for browsers)
-  const url = new URL(req.url);
-  const queryKey = url.searchParams.get("key");
-  const headerKey = extractApiKey(req);
-  const key = queryKey ?? headerKey;
-  if (!key || !vaultConfig) return false;
-
-  const auth = authenticateVaultRequest(
-    queryKey && !headerKey
-      ? new Request(req.url, { headers: { ...Object.fromEntries(req.headers), "x-api-key": key } })
-      : req,
-    vaultConfig,
-    vaultDb,
-  );
+  if (!vaultConfig) return false;
+  // extractApiKey now checks headers AND ?key= query param
+  const key = extractApiKey(req);
+  if (!key) return false;
+  const auth = authenticateVaultRequest(req, vaultConfig, vaultDb);
   return !("error" in auth);
 }
 

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -11,6 +11,7 @@ import { BunStore } from "./vault-store.ts";
 import { generateMcpTools } from "../core/src/mcp.ts";
 import { getLinksHydrated } from "../core/src/links.ts";
 import { handleNotes, handleTags, handleFindPath, handleVault } from "./routes.ts";
+import { extractApiKey } from "./auth.ts";
 
 let db: Database;
 let store: BunStore;
@@ -1272,6 +1273,53 @@ describe("stateless MCP transport", () => {
     expect(body.result.capabilities.tools).toBeDefined();
 
     closeAllStores();
+  });
+});
+
+describe("extractApiKey", () => {
+  test("extracts from Authorization: Bearer header", () => {
+    const req = new Request("http://localhost/api/notes", {
+      headers: { Authorization: "Bearer pvt_abc123" },
+    });
+    expect(extractApiKey(req)).toBe("pvt_abc123");
+  });
+
+  test("extracts from X-API-Key header", () => {
+    const req = new Request("http://localhost/api/notes", {
+      headers: { "X-API-Key": "pvk_xyz789" },
+    });
+    expect(extractApiKey(req)).toBe("pvk_xyz789");
+  });
+
+  test("extracts from ?key= query parameter", () => {
+    const req = new Request("http://localhost/mcp?key=pvt_querykey");
+    expect(extractApiKey(req)).toBe("pvt_querykey");
+  });
+
+  test("prefers Authorization header over query param", () => {
+    const req = new Request("http://localhost/mcp?key=pvt_query", {
+      headers: { Authorization: "Bearer pvt_header" },
+    });
+    expect(extractApiKey(req)).toBe("pvt_header");
+  });
+
+  test("prefers X-API-Key header over query param", () => {
+    const req = new Request("http://localhost/mcp?key=pvt_query", {
+      headers: { "X-API-Key": "pvk_header" },
+    });
+    expect(extractApiKey(req)).toBe("pvk_header");
+  });
+
+  test("prefers Authorization header over X-API-Key header", () => {
+    const req = new Request("http://localhost/api/notes", {
+      headers: { Authorization: "Bearer pvt_bearer", "X-API-Key": "pvk_xapi" },
+    });
+    expect(extractApiKey(req)).toBe("pvt_bearer");
+  });
+
+  test("returns null when no key provided", () => {
+    const req = new Request("http://localhost/api/notes");
+    expect(extractApiKey(req)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Extends `extractApiKey` to check `?key=` query parameter as lowest-priority fallback (after Authorization header and X-API-Key header)
- Enables URL-only auth for MCP clients like Claude Web: `https://vault.example.com/mcp?key=pvt_...`
- Simplifies `isViewAuthenticated` in server.ts — removes synthetic request construction now that `extractApiKey` handles query params natively

## Test plan

- [x] 178 core tests pass
- [x] 324 server tests pass (7 new for `extractApiKey` priority chain)
- [ ] Manual: `curl localhost:1940/api/notes?key=pvt_...` authenticates
- [ ] Manual: `curl -H "Authorization: Bearer pvt_..." localhost:1940/api/notes?key=pvt_other` uses header key (priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)