### PR TITLE
feat: simplify tokens to two permission tiers — full and read

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,10 @@ parachute vault keys create --vault work   # new key for one vault
 parachute vault keys create --read-only    # read-only key
 parachute vault keys revoke <key-id>       # revoke a key by ID
 
-# Tokens (per-vault, with permission tiers)
+# Tokens (per-vault)
 parachute vault tokens                     # list all tokens
-parachute vault tokens create --vault work                    # new admin token
+parachute vault tokens create --vault work                    # new full-access token
 parachute vault tokens create --vault work --permission read  # read-only token
-parachute vault tokens create --vault work --permission write # write token (no delete)
 parachute vault tokens create --vault work --expires 30d      # token with expiry
 parachute vault tokens create --vault work --label mobile     # labeled token
 parachute vault tokens revoke <token-id> --vault work         # revoke a token
@@ -259,23 +258,22 @@ Settings → Integrations → Add MCP → URL: `https://vault.yourdomain.com/mcp
 
 ### Key management
 
-**Tokens** (recommended) — per-vault, with three permission tiers:
+**Tokens** (recommended) — per-vault, two permission levels:
 
 | Permission | Can do |
 |---|---|
-| `admin` | Everything (CRUD + delete + token management) |
-| `write` | Read + create/update notes, tags |
+| `full` | Everything (CRUD + delete + token management) |
 | `read` | Query, list, find-path, vault-info only |
 
 ```bash
 parachute vault tokens                                        # list all tokens
-parachute vault tokens create --vault work                    # admin token
+parachute vault tokens create --vault work                    # full-access token
 parachute vault tokens create --vault work --permission read  # read-only
 parachute vault tokens create --vault work --expires 30d      # with expiry
 parachute vault tokens revoke <token-id> --vault work         # revoke
 ```
 
-**Legacy API keys** — global or per-vault, stored in config.yaml/vault.yaml. Still work as admin tokens. `vault init` creates one automatically.
+**Legacy API keys** — global or per-vault, stored in config.yaml/vault.yaml. Still work as full-access tokens. `vault init` creates one automatically.
 
 ```bash
 parachute vault keys                       # list legacy keys

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,15 +1,15 @@
 /**
  * Authentication and authorization for the vault server.
  *
- * Token-based auth with three permission levels:
- *   - "admin" — full access (CRUD + delete + token management)
- *   - "write" — read + create/update notes
- *   - "read"  — read-only (query, list, find-path, vault-info)
+ * Token-based auth with two permission levels:
+ *   - "full" — unrestricted access (CRUD + delete + token management)
+ *   - "read" — read-only (query, list, find-path, vault-info)
  *
  * Tokens live in each vault's SQLite database (tokens table, schema v7).
  *
  * Backward compatibility: config.yaml API keys are still checked as a fallback.
- * Those keys resolve as admin tokens.
+ * Those keys resolve as full-access tokens. Legacy "admin" and "write" values
+ * in the DB are normalized to "full" at read time.
  *
  * The unified /mcp endpoint uses only legacy global config.yaml keys, since
  * tokens are per-vault and the unified endpoint spans all vaults.
@@ -26,7 +26,7 @@ export interface AuthResult {
   permission: TokenPermission;
 }
 
-/** Read-only tools (allowed for "read" permission). */
+/** Read-only tools (the only tools allowed for "read" permission). */
 const READ_TOOLS = new Set([
   "query-notes",
   "list-tags",
@@ -35,29 +35,18 @@ const READ_TOOLS = new Set([
   "list-vaults",
 ]);
 
-/** Write tools (allowed for "write" and "admin" permission). */
-const WRITE_TOOLS = new Set([
-  "create-note",
-  "update-note",
-  "update-tag",
-]);
-
 /** Check if a tool call is allowed for a given permission level. */
 export function isToolAllowed(toolName: string, permission: TokenPermission): boolean {
-  if (permission === "admin") return true;
-  if (permission === "write") return READ_TOOLS.has(toolName) || WRITE_TOOLS.has(toolName);
+  if (permission === "full") return true;
   return READ_TOOLS.has(toolName);
 }
 
 /** Read-only HTTP methods. */
 const READ_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
-/** Write HTTP methods (not DELETE). */
-const WRITE_METHODS = new Set(["POST", "PATCH", "PUT"]);
 
 /** Check if an HTTP method is allowed for a given permission level. */
 export function isMethodAllowed(method: string, permission: TokenPermission): boolean {
-  if (permission === "admin") return true;
-  if (permission === "write") return READ_METHODS.has(method) || WRITE_METHODS.has(method);
+  if (permission === "full") return true;
   return READ_METHODS.has(method);
 }
 
@@ -121,7 +110,7 @@ export function authenticateVaultRequest(
   const vaultKey = validateKey(vaultConfig.api_keys, key);
   if (vaultKey) {
     try { writeVaultConfig(vaultConfig); } catch {}
-    return { permission: vaultKey.scope === "read" ? "read" : "admin" };
+    return { permission: vaultKey.scope === "read" ? "read" : "full" };
   }
 
   // Legacy: check global keys from config.yaml
@@ -130,7 +119,7 @@ export function authenticateVaultRequest(
     const globalKey = validateKey(globalConfig.api_keys, key);
     if (globalKey) {
       try { writeGlobalConfig(globalConfig); } catch {}
-      return { permission: globalKey.scope === "read" ? "read" : "admin" };
+      return { permission: globalKey.scope === "read" ? "read" : "full" };
     }
   }
 
@@ -156,7 +145,7 @@ export function authenticateGlobalRequest(
     const matched = validateKey(globalConfig.api_keys, key);
     if (matched) {
       try { writeGlobalConfig(globalConfig); } catch {}
-      return { permission: matched.scope === "read" ? "read" : "admin" };
+      return { permission: matched.scope === "read" ? "read" : "full" };
     }
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -543,14 +543,14 @@ function cmdTokens(args: string[]) {
     return;
   }
 
-  // parachute vault tokens create --vault <name> [--permission admin|write|read]
+  // parachute vault tokens create --vault <name> [--permission full|read]
   //   [--expires <duration>] [--label <label>]
   if (subcmd === "create") {
     const vaultFlag = args.indexOf("--vault");
     const vaultName = vaultFlag !== -1 ? args[vaultFlag + 1] : null;
     if (!vaultName) {
       console.error("--vault is required. Tokens are per-vault.");
-      console.error("Usage: parachute vault tokens create --vault <name> [--permission admin|write|read]");
+      console.error("Usage: parachute vault tokens create --vault <name> [--permission full|read]");
       process.exit(1);
     }
 
@@ -561,9 +561,11 @@ function cmdTokens(args: string[]) {
     }
 
     const permFlag = args.indexOf("--permission");
-    const permission = (permFlag !== -1 ? args[permFlag + 1] : "admin") as TokenPermission;
-    if (!["admin", "write", "read"].includes(permission)) {
-      console.error(`Invalid permission: ${permission}. Must be admin, write, or read.`);
+    const rawPerm = permFlag !== -1 ? args[permFlag + 1] : "full";
+    // Accept legacy values for backward compat
+    const permission: TokenPermission = rawPerm === "read" ? "read" : "full";
+    if (!["full", "read", "admin", "write"].includes(rawPerm)) {
+      console.error(`Invalid permission: ${rawPerm}. Must be full or read.`);
       process.exit(1);
     }
 
@@ -992,10 +994,8 @@ Keys (legacy):
 
 Tokens (recommended):
   parachute vault tokens                   List all tokens (all vaults)
-  parachute vault tokens create --vault <name>     Create an admin token
+  parachute vault tokens create --vault <name>     Create a full-access token
   parachute vault tokens create --vault <name> --permission read  Read-only token
-  parachute vault tokens create --vault <name> --scope-tag publish  Tag-scoped
-  parachute vault tokens create --vault <name> --scope-path-prefix Projects/
   parachute vault tokens create --vault <name> --expires 30d  Expiring token
   parachute vault tokens revoke <token-id> --vault <name>  Revoke a token
 

--- a/src/token-store.test.ts
+++ b/src/token-store.test.ts
@@ -26,13 +26,13 @@ afterEach(() => {
 });
 
 describe("token CRUD", () => {
-  test("create and resolve a token", () => {
+  test("create and resolve a full-access token", () => {
     const { fullToken } = generateToken();
-    createToken(db, fullToken, { label: "test-token", permission: "admin" });
+    createToken(db, fullToken, { label: "test-token", permission: "full" });
 
     const resolved = resolveToken(db, fullToken);
     expect(resolved).not.toBeNull();
-    expect(resolved!.permission).toBe("admin");
+    expect(resolved!.permission).toBe("full");
   });
 
   test("token with read permission", () => {
@@ -46,22 +46,40 @@ describe("token CRUD", () => {
     expect(resolved!.permission).toBe("read");
   });
 
-  test("token with write permission", () => {
+  test("default permission is full", () => {
     const { fullToken } = generateToken();
-    createToken(db, fullToken, {
-      label: "writer",
-      permission: "write",
-    });
+    createToken(db, fullToken, { label: "default-perm" });
 
     const resolved = resolveToken(db, fullToken);
-    expect(resolved!.permission).toBe("write");
+    expect(resolved!.permission).toBe("full");
+  });
+
+  test("legacy admin permission normalizes to full", () => {
+    const { fullToken } = generateToken();
+    // Simulate a legacy token by writing "admin" directly to DB
+    const hash = require("./config.ts").hashKey(fullToken);
+    db.prepare("INSERT INTO tokens (token_hash, label, permission, created_at) VALUES (?, ?, ?, ?)")
+      .run(hash, "legacy-admin", "admin", new Date().toISOString());
+
+    const resolved = resolveToken(db, fullToken);
+    expect(resolved!.permission).toBe("full");
+  });
+
+  test("legacy write permission normalizes to full", () => {
+    const { fullToken } = generateToken();
+    const hash = require("./config.ts").hashKey(fullToken);
+    db.prepare("INSERT INTO tokens (token_hash, label, permission, created_at) VALUES (?, ?, ?, ?)")
+      .run(hash, "legacy-write", "write", new Date().toISOString());
+
+    const resolved = resolveToken(db, fullToken);
+    expect(resolved!.permission).toBe("full");
   });
 
   test("expired token is rejected", () => {
     const { fullToken } = generateToken();
     createToken(db, fullToken, {
       label: "expired",
-      permission: "admin",
+      permission: "full",
       expires_at: "2020-01-01T00:00:00.000Z", // in the past
     });
 
@@ -91,7 +109,7 @@ describe("token CRUD", () => {
   test("list tokens shows all tokens", () => {
     const { fullToken: t1 } = generateToken();
     const { fullToken: t2 } = generateToken();
-    createToken(db, t1, { label: "first", permission: "admin" });
+    createToken(db, t1, { label: "first", permission: "full" });
     createToken(db, t2, { label: "second", permission: "read" });
 
     const tokens = listTokens(db);

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -5,8 +5,12 @@
  * the vault schema as of v7). All functions take a Database parameter — the
  * vault's own DB connection.
  *
- * Tokens support three permission levels (admin/write/read) and optional
- * scope filtering by tag or path prefix.
+ * Two permission levels:
+ *   - "full"  — unrestricted access (CRUD, delete, token management)
+ *   - "read"  — query-only (no mutations)
+ *
+ * Legacy "admin" and "write" values in the DB are normalized to "full" at
+ * read time for backward compatibility.
  */
 
 import { Database } from "bun:sqlite";
@@ -17,7 +21,16 @@ import { hashKey } from "./config.ts";
 // Types
 // ---------------------------------------------------------------------------
 
-export type TokenPermission = "admin" | "write" | "read";
+export type TokenPermission = "full" | "read";
+
+/**
+ * Normalize legacy permission values ("admin", "write") to the current
+ * two-tier model. Existing DB rows may contain the old values.
+ */
+export function normalizePermission(p: string): TokenPermission {
+  if (p === "read") return "read";
+  return "full"; // "admin", "write", or anything else → full
+}
 
 export interface Token {
   token_hash: string;
@@ -61,7 +74,7 @@ export function createToken(
 ): Token {
   const tokenHash = hashKey(fullToken);
   const now = new Date().toISOString();
-  const permission = opts.permission ?? "admin";
+  const permission = opts.permission ?? "full";
 
   db.prepare(`
     INSERT INTO tokens (token_hash, label, permission, scope_tag, scope_path_prefix, expires_at, created_at)
@@ -103,7 +116,7 @@ export function resolveToken(db: Database, providedToken: string): ResolvedToken
     FROM tokens WHERE token_hash = ?
   `).get(candidateHash) as {
     token_hash: string;
-    permission: TokenPermission;
+    permission: string;
     expires_at: string | null;
   } | null;
 
@@ -118,7 +131,7 @@ export function resolveToken(db: Database, providedToken: string): ResolvedToken
   db.prepare("UPDATE tokens SET last_used_at = ? WHERE token_hash = ?")
     .run(new Date().toISOString(), row.token_hash);
 
-  return { permission: row.permission };
+  return { permission: normalizePermission(row.permission) };
 }
 
 /**
@@ -134,6 +147,7 @@ export function listTokens(db: Database): (Token & { id: string })[] {
 
   return rows.map((r) => ({
     ...r,
+    permission: normalizePermission(r.permission),
     // Derive a short display ID from the hash (first 12 chars after "sha256:")
     id: `t_${r.token_hash.slice(7, 19)}`,
   }));
@@ -176,7 +190,7 @@ export function revokeToken(db: Database, idOrHash: string): boolean {
  *
  * Imports:
  * - Per-vault keys from vault.yaml (direct match)
- * - Global keys from config.yaml (they become admin tokens in every vault)
+ * - Global keys from config.yaml (they become full-access tokens in every vault)
  */
 export function migrateVaultKeys(
   db: Database,
@@ -195,7 +209,7 @@ export function migrateVaultKeys(
       `).run(
         key.key_hash,
         key.label,
-        key.scope === "read" ? "read" : "admin",
+        key.scope === "read" ? "read" : "full",
         key.created_at,
         key.last_used_at ?? null,
       );
@@ -203,7 +217,7 @@ export function migrateVaultKeys(
     }
   }
 
-  // Import global keys as admin tokens
+  // Import global keys as full-access tokens
   if (globalKeys) {
     for (const key of globalKeys) {
       const exists = db.prepare("SELECT 1 FROM tokens WHERE token_hash = ?").get(key.key_hash);
@@ -214,7 +228,7 @@ export function migrateVaultKeys(
         `).run(
           key.key_hash,
           key.label,
-          "admin",
+          "full",
           key.created_at,
           key.last_used_at ?? null,
         );

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -748,7 +748,7 @@ describe("unified MCP wrapper", () => {
 });
 
 describe("auth permissions", () => {
-  test("read permission allows read tools", () => {
+  test("read permission allows read-only tools", () => {
     const { isToolAllowed } = require("./auth.ts");
     expect(isToolAllowed("query-notes", "read")).toBe(true);
     expect(isToolAllowed("list-tags", "read")).toBe(true);
@@ -757,7 +757,7 @@ describe("auth permissions", () => {
     expect(isToolAllowed("list-vaults", "read")).toBe(true);
   });
 
-  test("read permission blocks write and admin tools", () => {
+  test("read permission blocks mutation tools", () => {
     const { isToolAllowed } = require("./auth.ts");
     expect(isToolAllowed("create-note", "read")).toBe(false);
     expect(isToolAllowed("update-note", "read")).toBe(false);
@@ -766,23 +766,14 @@ describe("auth permissions", () => {
     expect(isToolAllowed("delete-tag", "read")).toBe(false);
   });
 
-  test("write permission allows read + write tools but not admin-only", () => {
+  test("full permission allows all tools", () => {
     const { isToolAllowed } = require("./auth.ts");
-    expect(isToolAllowed("create-note", "write")).toBe(true);
-    expect(isToolAllowed("update-note", "write")).toBe(true);
-    expect(isToolAllowed("update-tag", "write")).toBe(true);
-    expect(isToolAllowed("query-notes", "write")).toBe(true);
-    // delete-note and delete-tag are admin-only
-    expect(isToolAllowed("delete-note", "write")).toBe(false);
-    expect(isToolAllowed("delete-tag", "write")).toBe(false);
-  });
-
-  test("admin permission allows everything", () => {
-    const { isToolAllowed } = require("./auth.ts");
-    expect(isToolAllowed("create-note", "admin")).toBe(true);
-    expect(isToolAllowed("delete-note", "admin")).toBe(true);
-    expect(isToolAllowed("delete-tag", "admin")).toBe(true);
-    expect(isToolAllowed("query-notes", "admin")).toBe(true);
+    expect(isToolAllowed("create-note", "full")).toBe(true);
+    expect(isToolAllowed("update-note", "full")).toBe(true);
+    expect(isToolAllowed("delete-note", "full")).toBe(true);
+    expect(isToolAllowed("update-tag", "full")).toBe(true);
+    expect(isToolAllowed("delete-tag", "full")).toBe(true);
+    expect(isToolAllowed("query-notes", "full")).toBe(true);
   });
 
   test("read permission allows GET but not POST/PATCH/DELETE", () => {
@@ -794,19 +785,12 @@ describe("auth permissions", () => {
     expect(isMethodAllowed("DELETE", "read")).toBe(false);
   });
 
-  test("write permission allows GET/POST/PATCH but not DELETE", () => {
+  test("full permission allows all methods", () => {
     const { isMethodAllowed } = require("./auth.ts");
-    expect(isMethodAllowed("GET", "write")).toBe(true);
-    expect(isMethodAllowed("POST", "write")).toBe(true);
-    expect(isMethodAllowed("PATCH", "write")).toBe(true);
-    expect(isMethodAllowed("DELETE", "write")).toBe(false);
-  });
-
-  test("admin permission allows all methods", () => {
-    const { isMethodAllowed } = require("./auth.ts");
-    expect(isMethodAllowed("GET", "admin")).toBe(true);
-    expect(isMethodAllowed("POST", "admin")).toBe(true);
-    expect(isMethodAllowed("DELETE", "admin")).toBe(true);
+    expect(isMethodAllowed("GET", "full")).toBe(true);
+    expect(isMethodAllowed("POST", "full")).toBe(true);
+    expect(isMethodAllowed("PATCH", "full")).toBe(true);
+    expect(isMethodAllowed("DELETE", "full")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Collapses the three permission tiers (admin/write/read) into two: **full** and **read**.

- `full` — unrestricted access (replaces both `admin` and `write`)
- `read` — query-only, no mutations

The `write` tier added complexity without clear value. In practice, tokens are either read-only (monitoring, dashboards) or full-access (agents, apps). Nobody used `write` to mean "can create but not delete."

**Backward compatible**: legacy `"admin"` and `"write"` values in the DB are normalized to `"full"` at read time via `normalizePermission()`. No migration needed. The CLI also accepts `--permission admin` and `--permission write` as aliases.

### Changes
- `src/token-store.ts`: `TokenPermission = "full" | "read"`, added `normalizePermission()`
- `src/auth.ts`: simplified `isToolAllowed` and `isMethodAllowed` (removed WRITE_TOOLS/WRITE_METHODS sets)
- `src/cli.ts`: `--permission` accepts `full` or `read` (default `full`)
- `src/token-store.test.ts`: updated tests, added legacy normalization tests
- `src/vault.test.ts`: simplified permission test matrix
- `README.md`: updated docs

## Test plan

- [x] 178 core tests pass
- [x] 324 server tests pass (including 2 new legacy normalization tests)
- [ ] Manual: create token with `--permission full`, verify full access
- [ ] Manual: create token with `--permission read`, verify read-only
- [ ] Manual: existing tokens with `admin`/`write` in DB still work as `full`

🤖 Generated with [Claude Code](https://claude.com/claude-code)