### PR TITLE
fix: require owner token on OAuth consent page

### DIFF
--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import crypto from "node:crypto";
 import { initSchema } from "../core/src/schema.ts";
-import { resolveToken } from "./token-store.ts";
+import { generateToken, createToken, resolveToken } from "./token-store.ts";
 import {
   handleProtectedResource,
   handleAuthorizationServer,
@@ -42,6 +42,13 @@ function generatePkce(): { codeVerifier: string; codeChallenge: string } {
   return { codeVerifier, codeChallenge };
 }
 
+/** Create a valid owner token in the DB and return the raw token string. */
+function createOwnerToken(): string {
+  const { fullToken } = generateToken();
+  createToken(db, fullToken, { label: "owner", permission: "full" });
+  return fullToken;
+}
+
 /** Register a client and return the client_id. */
 async function registerClient(name = "Test Client", redirectUris = ["https://example.com/callback"]): Promise<string> {
   const req = makeRequest("https://vault.test/oauth/register", {
@@ -56,12 +63,13 @@ async function registerClient(name = "Test Client", redirectUris = ["https://exa
 
 /** Run the full OAuth flow and return the access_token. */
 async function fullOAuthFlow(opts?: { scope?: string }): Promise<string> {
+  const ownerToken = createOwnerToken();
   const clientId = await registerClient();
   const { codeVerifier, codeChallenge } = generatePkce();
   const redirectUri = "https://example.com/callback";
   const scope = opts?.scope || "full";
 
-  // POST authorize (simulate user clicking Authorize)
+  // POST authorize (simulate user clicking Authorize with valid owner token)
   const authReq = makeRequest("https://vault.test/oauth/authorize", {
     method: "POST",
     body: new URLSearchParams({
@@ -72,6 +80,7 @@ async function fullOAuthFlow(opts?: { scope?: string }): Promise<string> {
       code_challenge_method: "S256",
       scope,
       state: "test-state",
+      owner_token: ownerToken,
     }),
   });
   const authRes = await handleAuthorizePost(authReq, db);
@@ -233,6 +242,7 @@ describe("OAuth authorization", () => {
   });
 
   test("POST authorize (approve) redirects with code", async () => {
+    const ownerToken = createOwnerToken();
     const clientId = await registerClient();
     const { codeChallenge } = generatePkce();
 
@@ -246,6 +256,7 @@ describe("OAuth authorization", () => {
         code_challenge_method: "S256",
         scope: "full",
         state: "mystate",
+        owner_token: ownerToken,
       }),
     });
     const res = await handleAuthorizePost(req, db);
@@ -310,6 +321,48 @@ describe("OAuth authorization", () => {
     const res = await handleAuthorizePost(req, db);
     expect(res.status).toBe(400);
   });
+
+  test("POST authorize rejects missing owner token", async () => {
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const req = makeRequest("https://vault.test/oauth/authorize", {
+      method: "POST",
+      body: new URLSearchParams({
+        action: "authorize",
+        client_id: clientId,
+        redirect_uri: "https://example.com/callback",
+        code_challenge: codeChallenge,
+        code_challenge_method: "S256",
+        scope: "full",
+      }),
+    });
+    const res = await handleAuthorizePost(req, db, "default");
+    // Should re-render consent page with error, not redirect
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Vault token is required");
+  });
+
+  test("POST authorize rejects invalid owner token", async () => {
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const req = makeRequest("https://vault.test/oauth/authorize", {
+      method: "POST",
+      body: new URLSearchParams({
+        action: "authorize",
+        client_id: clientId,
+        redirect_uri: "https://example.com/callback",
+        code_challenge: codeChallenge,
+        code_challenge_method: "S256",
+        scope: "full",
+        owner_token: "pvt_invalid_token_value",
+      }),
+    });
+    const res = await handleAuthorizePost(req, db, "default");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Invalid vault token");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -353,6 +406,7 @@ describe("OAuth token exchange", () => {
   });
 
   test("rejects wrong PKCE verifier", async () => {
+    const ownerToken = createOwnerToken();
     const clientId = await registerClient();
     const { codeChallenge } = generatePkce();
     const redirectUri = "https://example.com/callback";
@@ -367,6 +421,7 @@ describe("OAuth token exchange", () => {
         code_challenge: codeChallenge,
         code_challenge_method: "S256",
         scope: "full",
+        owner_token: ownerToken,
       }),
     });
     const authRes = await handleAuthorizePost(authReq, db);
@@ -392,6 +447,7 @@ describe("OAuth token exchange", () => {
   });
 
   test("rejects already-used code", async () => {
+    const ownerToken = createOwnerToken();
     const clientId = await registerClient();
     const { codeVerifier, codeChallenge } = generatePkce();
     const redirectUri = "https://example.com/callback";
@@ -406,6 +462,7 @@ describe("OAuth token exchange", () => {
         code_challenge: codeChallenge,
         code_challenge_method: "S256",
         scope: "full",
+        owner_token: ownerToken,
       }),
     });
     const authRes = await handleAuthorizePost(authReq, db);
@@ -476,6 +533,7 @@ describe("OAuth token exchange", () => {
   });
 
   test("rejects mismatched client_id", async () => {
+    const ownerToken = createOwnerToken();
     const clientId = await registerClient();
     const otherClientId = await registerClient("Other Client");
     const { codeVerifier, codeChallenge } = generatePkce();
@@ -492,6 +550,7 @@ describe("OAuth token exchange", () => {
           code_challenge: codeChallenge,
           code_challenge_method: "S256",
           scope: "full",
+          owner_token: ownerToken,
         }),
       }),
       db,

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -15,7 +15,7 @@
 
 import crypto from "node:crypto";
 import type { Database } from "bun:sqlite";
-import { generateToken, createToken } from "./token-store.ts";
+import { generateToken, createToken, resolveToken } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
 
 // ---------------------------------------------------------------------------
@@ -179,7 +179,7 @@ export function handleAuthorizeGet(req: Request, db: Database, vaultName: string
   });
 }
 
-export async function handleAuthorizePost(req: Request, db: Database): Promise<Response> {
+export async function handleAuthorizePost(req: Request, db: Database, vaultName?: string): Promise<Response> {
   let form: FormData;
   try {
     form = await req.formData();
@@ -225,6 +225,23 @@ export async function handleAuthorizePost(req: Request, db: Database): Promise<R
   if (action === "deny") {
     redirect.searchParams.set("error", "access_denied");
     return Response.redirect(redirect.toString(), 302);
+  }
+
+  // Verify vault owner identity via token
+  const ownerToken = form.get("owner_token") as string;
+  if (!ownerToken) {
+    return renderConsentWithError(db, vaultName || "vault", {
+      clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, state,
+      error: "Vault token is required.",
+    });
+  }
+
+  const resolved = resolveToken(db, ownerToken);
+  if (!resolved) {
+    return renderConsentWithError(db, vaultName || "vault", {
+      clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, state,
+      error: "Invalid vault token.",
+    });
   }
 
   // Generate auth code
@@ -347,6 +364,46 @@ export async function handleToken(req: Request, db: Database): Promise<Response>
 }
 
 // ---------------------------------------------------------------------------
+// Consent page re-render with error
+// ---------------------------------------------------------------------------
+
+function renderConsentWithError(
+  db: Database,
+  vaultName: string,
+  params: {
+    clientId: string;
+    redirectUri: string;
+    codeChallenge: string;
+    codeChallengeMethod: string;
+    scope: string;
+    state: string;
+    error: string;
+  },
+): Response {
+  const client = db.prepare("SELECT client_name FROM oauth_clients WHERE client_id = ?")
+    .get(params.clientId) as { client_name: string } | null;
+  const clientName = client?.client_name || "Unknown Client";
+  const normalizedScope: TokenPermission = params.scope === "read" ? "read" : "full";
+
+  const html = renderConsentPage({
+    vaultName,
+    clientName,
+    scope: normalizedScope,
+    clientId: params.clientId,
+    redirectUri: params.redirectUri,
+    codeChallenge: params.codeChallenge,
+    codeChallengeMethod: params.codeChallengeMethod,
+    state: params.state,
+    error: params.error,
+  });
+
+  return new Response(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Consent page HTML
 // ---------------------------------------------------------------------------
 
@@ -359,6 +416,7 @@ interface ConsentParams {
   codeChallenge: string;
   codeChallengeMethod: string;
   state: string;
+  error?: string;
 }
 
 function renderConsentPage(p: ConsentParams): string {
@@ -397,6 +455,29 @@ function renderConsentPage(p: ConsentParams): string {
   }
   .scope-label { font-weight: 600; }
   .scope-desc { font-size: 0.9rem; color: #666; }
+  .token-field {
+    margin-top: 1rem;
+  }
+  .token-field label {
+    display: block;
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+  }
+  .token-field input {
+    width: 100%;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    font-family: monospace;
+    box-sizing: border-box;
+  }
+  .error-msg {
+    color: #cc3333;
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
+  }
   .buttons {
     display: flex;
     gap: 0.75rem;
@@ -424,6 +505,8 @@ function renderConsentPage(p: ConsentParams): string {
     .scope { background: #2a2a2a; }
     .scope-desc { color: #999; }
     .client { color: #66b3ff; }
+    .token-field input { background: #2a2a2a; color: #e0e0e0; border-color: #444; }
+    .error-msg { color: #ff6666; }
     button { background: #2a2a2a; color: #e0e0e0; border-color: #444; }
     button[value="authorize"] { background: #0066cc; color: #fff; border-color: #0066cc; }
     button[value="deny"]:hover { background: #333; }
@@ -445,6 +528,11 @@ function renderConsentPage(p: ConsentParams): string {
     <input type="hidden" name="code_challenge_method" value="${escapeHtml(p.codeChallengeMethod)}">
     <input type="hidden" name="scope" value="${escapeHtml(p.scope)}">
     <input type="hidden" name="state" value="${escapeHtml(p.state)}">
+    <div class="token-field">
+      <label for="owner_token">Enter your vault token to authorize</label>
+      <input type="password" id="owner_token" name="owner_token" placeholder="pvt_..." required autocomplete="off">
+      ${p.error ? `<div class="error-msg">${escapeHtml(p.error)}</div>` : ""}
+    </div>
     <div class="buttons">
       <button type="submit" name="action" value="deny">Deny</button>
       <button type="submit" name="action" value="authorize">Authorize</button>

--- a/src/server.ts
+++ b/src/server.ts
@@ -208,7 +208,7 @@ async function route(req: Request, path: string): Promise<Response> {
         return handleAuthorizeGet(req, store.db, vaultConfig.name);
       }
       if (req.method === "POST") {
-        return handleAuthorizePost(req, store.db);
+        return handleAuthorizePost(req, store.db, vaultConfig.name);
       }
       return Response.json({ error: "method_not_allowed" }, { status: 405 });
     }
@@ -342,7 +342,7 @@ async function route(req: Request, path: string): Promise<Response> {
     if (subpath === "/oauth/register") return handleRegister(req, store.db);
     if (subpath === "/oauth/authorize") {
       if (req.method === "GET") return handleAuthorizeGet(req, store.db, vaultConfig.name);
-      if (req.method === "POST") return handleAuthorizePost(req, store.db);
+      if (req.method === "POST") return handleAuthorizePost(req, store.db, vaultConfig.name);
       return Response.json({ error: "method_not_allowed" }, { status: 405 });
     }
     if (subpath === "/oauth/token") return handleToken(req, store.db);


### PR DESCRIPTION
## Summary
- The OAuth consent page now requires vault owner to enter a valid `pvt_`/`pvk_` token before an auth code is issued
- Prevents unauthorized users from granting OAuth access by simply clicking Authorize
- On invalid/missing token, re-renders consent page with inline error message (no redirect)

## Changes
- `src/oauth.ts`: Added `resolveToken` import, password-type `owner_token` input field in consent HTML, token validation in `handleAuthorizePost`, `renderConsentWithError` helper
- `src/server.ts`: Pass `vaultName` to `handleAuthorizePost` for error page re-rendering
- `src/oauth.test.ts`: Added `createOwnerToken` helper, updated all authorize POST tests to include valid owner token, 2 new tests for missing/invalid token rejection

## Security
Only someone who already has a valid vault token can grant OAuth access to a new client. This closes the gap where anyone who reached the consent page could click Authorize.

## Test plan
- [x] 28 OAuth tests pass (was 26 — +2 new owner token tests)
- [x] 352 server + 178 core = 530 total, 0 failures
- [ ] Manual: open consent page, try to authorize without token — should see error
- [ ] Manual: enter valid pvt_ token — should redirect with auth code

🤖 Generated with [Claude Code](https://claude.com/claude-code)