### PR TITLE
feat(oauth): password auth + rate limiting + scope selection (Phase 1)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,10 +42,16 @@ import {
 import type { VaultConfig } from "./config.ts";
 import { installAgent, uninstallAgent, isAgentLoaded, restartAgent } from "./launchd.ts";
 import { installSystemdService, restartSystemdService, isSystemdAvailable, isServiceActive } from "./systemd.ts";
-import { confirm, ask, choose } from "./prompt.ts";
+import { confirm, ask, askPassword, choose } from "./prompt.ts";
 import { generateToken, createToken, listTokens, revokeToken, migrateVaultKeys } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
 import { getVaultStore } from "./vault-store.ts";
+import {
+  hasOwnerPassword,
+  setOwnerPassword,
+  clearOwnerPassword,
+  validatePasswordStrength,
+} from "./owner-auth.ts";
 
 // ---------------------------------------------------------------------------
 // Argument parsing
@@ -92,6 +98,9 @@ switch (command) {
     break;
   case "tokens":
     cmdTokens(cmdArgs);
+    break;
+  case "set-password":
+    await cmdSetPassword(cmdArgs);
     break;
   case "serve":
     await cmdServe();
@@ -180,6 +189,11 @@ async function cmdInit() {
     console.log();
   }
 
+  // 5b. Offer to set an owner password for OAuth consent, unless one is already set.
+  if (!hasOwnerPassword()) {
+    await promptForOwnerPassword("Set an owner password for OAuth consent?");
+  }
+
   // 6. Install daemon (platform-aware)
   console.log("Installing daemon...");
   if (isMac) {
@@ -220,6 +234,60 @@ async function cmdInit() {
   console.log(`\nNext steps:`);
   console.log(`  parachute vault status            check everything is running`);
   console.log(`  parachute vault config             view/edit configuration`);
+}
+
+async function promptForOwnerPassword(purpose: string): Promise<boolean> {
+  console.log(`\n${purpose}`);
+  console.log("  Used on the OAuth consent page to authorize third-party clients");
+  console.log("  (Claude Web, Claude Desktop, etc.) to access this vault.");
+  console.log(`  Minimum 12 characters.\n`);
+
+  while (true) {
+    const pw = await askPassword("  Password (or leave blank to skip)");
+    if (!pw) {
+      console.log("  Skipped — you can set one later with `parachute vault set-password`.");
+      return false;
+    }
+
+    const err = validatePasswordStrength(pw);
+    if (err) {
+      console.log(`  ${err} Try again.`);
+      continue;
+    }
+
+    const confirmPw = await askPassword("  Confirm password");
+    if (pw !== confirmPw) {
+      console.log("  Passwords don't match. Try again.");
+      continue;
+    }
+
+    await setOwnerPassword(pw);
+    console.log("  Password set.");
+    return true;
+  }
+}
+
+async function cmdSetPassword(args: string[]) {
+  const wantsClear = args.includes("--clear") || args.includes("--unset");
+  if (wantsClear) {
+    if (!hasOwnerPassword()) {
+      console.log("No owner password is set.");
+      return;
+    }
+    const ok = await confirm("Remove the owner password? OAuth consent will fall back to vault-token auth.", false);
+    if (!ok) {
+      console.log("Cancelled.");
+      return;
+    }
+    clearOwnerPassword();
+    console.log("Owner password cleared.");
+    return;
+  }
+
+  const purpose = hasOwnerPassword()
+    ? "Change owner password"
+    : "Set owner password";
+  await promptForOwnerPassword(purpose);
 }
 
 function cmdCreate(args: string[]) {
@@ -841,11 +909,16 @@ Vaults:
 
 Tokens:
   parachute vault tokens                          List all tokens
-  parachute vault tokens create --vault <name>    Create a token (default: full access)
-  parachute vault tokens create --vault <name> --read   Read-only token
-  parachute vault tokens create --vault <name> --label x   Set a label
-  parachute vault tokens create --vault <name> --expires 30d  Expiring token
-  parachute vault tokens revoke <token-id> --vault <name>  Revoke a token
+  parachute vault tokens create                   Create a full-access token in the default vault
+  parachute vault tokens create --vault <name>    Create a token in a specific vault
+  parachute vault tokens create --read            Read-only token
+  parachute vault tokens create --label x         Set a label
+  parachute vault tokens create --expires 30d     Expiring token
+  parachute vault tokens revoke <token-id>        Revoke a token (default vault)
+
+OAuth:
+  parachute vault set-password             Set/change the owner password (for consent page)
+  parachute vault set-password --clear     Remove the owner password
 
 Config:
   parachute vault config                   Show current configuration

--- a/src/config.ts
+++ b/src/config.ts
@@ -131,6 +131,8 @@ export interface GlobalConfig {
   default_vault?: string;
   api_keys?: StoredKey[];
   triggers?: TriggerConfig[];
+  /** Bcrypt hash of the vault owner's password for OAuth consent. */
+  owner_password_hash?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -444,9 +446,11 @@ export function readGlobalConfig(): GlobalConfig {
       const yaml = readFileSync(GLOBAL_CONFIG_PATH, "utf-8");
       const portMatch = yaml.match(/^port:\s*(\d+)/m);
       const defaultVaultMatch = yaml.match(/^default_vault:\s*(\S+)/m);
+      const passwordHashMatch = yaml.match(/^owner_password_hash:\s*"([^"]+)"/m);
       const config: GlobalConfig = {
         port: portMatch ? parseInt(portMatch[1], 10) : DEFAULT_PORT,
         default_vault: defaultVaultMatch?.[1],
+        owner_password_hash: passwordHashMatch?.[1],
       };
 
       // Parse global api_keys
@@ -484,6 +488,9 @@ export function writeGlobalConfig(config: GlobalConfig): void {
   ensureConfigDirSync();
   const lines = [`port: ${config.port}`];
   if (config.default_vault) lines.push(`default_vault: ${config.default_vault}`);
+  if (config.owner_password_hash) {
+    lines.push(`owner_password_hash: "${config.owner_password_hash}"`);
+  }
 
   if (config.api_keys && config.api_keys.length > 0) {
     lines.push("api_keys:");

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -343,7 +343,7 @@ describe("OAuth authorization", () => {
         scope: "full",
       }),
     });
-    const res = await handleAuthorizePost(req, db, "default");
+    const res = await handleAuthorizePost(req, db, { vaultName: "default" });
     // Should re-render consent page with error, not redirect
     expect(res.status).toBe(200);
     const html = await res.text();
@@ -365,7 +365,7 @@ describe("OAuth authorization", () => {
         owner_token: "pvt_invalid_token_value",
       }),
     });
-    const res = await handleAuthorizePost(req, db, "default");
+    const res = await handleAuthorizePost(req, db, { vaultName: "default" });
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("Invalid vault token");
@@ -630,5 +630,371 @@ describe("OAuth token exchange", () => {
       db,
     );
     expect(res.status).toBe(405);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Password-based owner auth
+// ---------------------------------------------------------------------------
+
+describe("OAuth consent — password mode", () => {
+  // Use bcrypt cost 4 in tests to keep them fast
+  async function hashPassword(pw: string): Promise<string> {
+    return await Bun.password.hash(pw, { algorithm: "bcrypt", cost: 4 });
+  }
+
+  test("GET renders password field when password is set", async () => {
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const url = new URL("https://vault.test/oauth/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://example.com/callback");
+    url.searchParams.set("code_challenge", codeChallenge);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("scope", "full");
+    const res = handleAuthorizeGet(makeRequest(url.toString()), db, "default", "$2a$fake");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('name="password"');
+    expect(html).not.toContain('name="owner_token"');
+  });
+
+  test("GET renders owner_token field when no password is set", async () => {
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const url = new URL("https://vault.test/oauth/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://example.com/callback");
+    url.searchParams.set("code_challenge", codeChallenge);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("scope", "full");
+    const res = handleAuthorizeGet(makeRequest(url.toString()), db, "default", null);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('name="owner_token"');
+    expect(html).not.toContain('name="password"');
+  });
+
+  test("POST accepts correct password and mints a token", async () => {
+    const password = "correcthorsebatterystaple";
+    const passwordHash = await hashPassword(password);
+    const clientId = await registerClient();
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",
+          password,
+        }),
+      }),
+      db,
+      { ownerPasswordHash: passwordHash },
+    );
+
+    expect(authRes.status).toBe(302);
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+    expect(code).toBeTruthy();
+
+    const tokenRes = await handleToken(
+      makeRequest("https://vault.test/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+        }).toString(),
+      }),
+      db,
+    );
+    const body = await tokenRes.json();
+    expect(body.access_token.startsWith("pvt_")).toBe(true);
+  });
+
+  test("POST rejects wrong password with re-rendered consent", async () => {
+    const passwordHash = await hashPassword("correcthorsebatterystaple");
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+
+    const res = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: "https://example.com/callback",
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",
+          password: "wrongpassword",
+        }),
+      }),
+      db,
+      { ownerPasswordHash: passwordHash },
+    );
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Incorrect password");
+    // Should render password field, not owner_token
+    expect(html).toContain('name="password"');
+  });
+
+  test("POST rejects missing password in password mode", async () => {
+    const passwordHash = await hashPassword("correcthorsebatterystaple");
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+
+    const res = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: "https://example.com/callback",
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",
+        }),
+      }),
+      db,
+      { ownerPasswordHash: passwordHash },
+    );
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Password is required");
+  });
+
+  test("owner_token is ignored when password is configured", async () => {
+    const passwordHash = await hashPassword("correcthorsebatterystaple");
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+
+    // In password mode, providing a valid owner_token is insufficient —
+    // only the password is accepted.
+    const res = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: "https://example.com/callback",
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",
+          owner_token: ownerToken,
+          // no password
+        }),
+      }),
+      db,
+      { ownerPasswordHash: passwordHash },
+    );
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Password is required");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+
+describe("OAuth consent — rate limiting", () => {
+  test("locks out an IP after threshold failures", async () => {
+    const { RateLimiter } = await import("./owner-auth.ts");
+    const limiter = new RateLimiter(3, 60_000, 60_000); // 3 fails = lock
+    const passwordHash = await Bun.password.hash("correcthorsebatterystaple", {
+      algorithm: "bcrypt",
+      cost: 4,
+    });
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const clientIp = "192.0.2.42";
+
+    const makeAttempt = () => handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: "https://example.com/callback",
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",
+          password: "wrongwrongwrong",
+        }),
+      }),
+      db,
+      { ownerPasswordHash: passwordHash, clientIp, rateLimiter: limiter },
+    );
+
+    // First 3 attempts: 200 with "Incorrect password"
+    for (let i = 0; i < 3; i++) {
+      const res = await makeAttempt();
+      expect(res.status).toBe(200);
+    }
+    // 4th attempt should be locked out with 429
+    const res = await makeAttempt();
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  test("successful auth clears the failure counter", async () => {
+    const { RateLimiter } = await import("./owner-auth.ts");
+    const limiter = new RateLimiter(3, 60_000, 60_000);
+    const password = "correcthorsebatterystaple";
+    const passwordHash = await Bun.password.hash(password, { algorithm: "bcrypt", cost: 4 });
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const clientIp = "192.0.2.43";
+
+    const attempt = (pw: string) => handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: "https://example.com/callback",
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",
+          password: pw,
+        }),
+      }),
+      db,
+      { ownerPasswordHash: passwordHash, clientIp, rateLimiter: limiter },
+    );
+
+    await attempt("wrong1");
+    await attempt("wrong2");
+    const good = await attempt(password);
+    expect(good.status).toBe(302);
+
+    // Counter reset — we can still do more wrong attempts without lockout
+    const r1 = await attempt("wrong3");
+    expect(r1.status).toBe(200);
+    const r2 = await attempt("wrong4");
+    expect(r2.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope selection
+// ---------------------------------------------------------------------------
+
+describe("OAuth consent — scope selection", () => {
+  test("user can downgrade from full to read via radio", async () => {
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",           // requested
+          selected_scope: "read",  // user chose read-only
+          owner_token: ownerToken,
+        }),
+      }),
+      db,
+    );
+    expect(authRes.status).toBe(302);
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      makeRequest("https://vault.test/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+        }).toString(),
+      }),
+      db,
+    );
+    const body = await tokenRes.json();
+    expect(body.scope).toBe("read");
+  });
+
+  test("defaults selected_scope to requested scope when not provided", async () => {
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "read",  // requested only, no radio selection
+          owner_token: ownerToken,
+        }),
+      }),
+      db,
+    );
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      makeRequest("https://vault.test/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+        }).toString(),
+      }),
+      db,
+    );
+    const body = await tokenRes.json();
+    expect(body.scope).toBe("read");
+  });
+
+  test("consent HTML includes both scope radio buttons", async () => {
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const url = new URL("https://vault.test/oauth/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://example.com/callback");
+    url.searchParams.set("code_challenge", codeChallenge);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("scope", "full");
+    const res = handleAuthorizeGet(makeRequest(url.toString()), db, "default");
+    const html = await res.text();
+    expect(html).toContain('name="selected_scope"');
+    expect(html).toContain('value="full"');
+    expect(html).toContain('value="read"');
+    // The requested scope should be pre-checked
+    expect(html).toMatch(/value="full"\s+checked/);
   });
 });

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -17,6 +17,22 @@ import crypto from "node:crypto";
 import type { Database } from "bun:sqlite";
 import { generateToken, createToken, resolveToken } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
+import { verifyOwnerPassword, authorizeRateLimit, type RateLimiter } from "./owner-auth.ts";
+
+/** Options for handleAuthorizePost. */
+export interface AuthorizePostOptions {
+  vaultName?: string;
+  /** Client IP address (from Bun server.requestIP). If provided, rate limiting is applied. */
+  clientIp?: string;
+  /**
+   * Bcrypt hash of the owner password. When set, the consent form requires a
+   * `password` field. When null/undefined, falls back to legacy `owner_token`
+   * auth (vault token in the consent form).
+   */
+  ownerPasswordHash?: string | null;
+  /** Override for testing; defaults to the module singleton. */
+  rateLimiter?: RateLimiter;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -113,7 +129,12 @@ export async function handleRegister(req: Request, db: Database): Promise<Respon
 // Authorization endpoint
 // ---------------------------------------------------------------------------
 
-export function handleAuthorizeGet(req: Request, db: Database, vaultName: string): Response {
+export function handleAuthorizeGet(
+  req: Request,
+  db: Database,
+  vaultName: string,
+  ownerPasswordHash?: string | null,
+): Response {
   const url = new URL(req.url);
   const clientId = url.searchParams.get("client_id");
   const redirectUri = url.searchParams.get("redirect_uri");
@@ -158,19 +179,21 @@ export function handleAuthorizeGet(req: Request, db: Database, vaultName: string
     });
   }
 
-  // Normalize scope
-  const normalizedScope: TokenPermission = scope === "read" ? "read" : "full";
+  // Normalize requested scope. The user can change it via the radio buttons.
+  const requestedScope: TokenPermission = scope === "read" ? "read" : "full";
 
   // Render consent page
   const html = renderConsentPage({
     vaultName,
     clientName: client.client_name,
-    scope: normalizedScope,
+    requestedScope,
+    selectedScope: requestedScope,
     clientId,
     redirectUri,
     codeChallenge,
     codeChallengeMethod,
     state,
+    passwordMode: typeof ownerPasswordHash === "string" && ownerPasswordHash.length > 0,
   });
 
   return new Response(html, {
@@ -179,7 +202,13 @@ export function handleAuthorizeGet(req: Request, db: Database, vaultName: string
   });
 }
 
-export async function handleAuthorizePost(req: Request, db: Database, vaultName?: string): Promise<Response> {
+export async function handleAuthorizePost(
+  req: Request,
+  db: Database,
+  opts: AuthorizePostOptions = {},
+): Promise<Response> {
+  const { vaultName, clientIp, ownerPasswordHash, rateLimiter = authorizeRateLimit } = opts;
+
   let form: FormData;
   try {
     form = await req.formData();
@@ -192,7 +221,13 @@ export async function handleAuthorizePost(req: Request, db: Database, vaultName?
   const redirectUri = form.get("redirect_uri") as string;
   const codeChallenge = form.get("code_challenge") as string;
   const codeChallengeMethod = form.get("code_challenge_method") as string || "S256";
-  const scope = form.get("scope") as string || "full";
+  // Requested scope (from hidden field, carried from GET) and selected scope
+  // (from radio button on the consent page). Default selected to requested.
+  const requestedScope = form.get("scope") as string || "full";
+  const selectedScopeRaw = form.get("selected_scope") as string | null;
+  const selectedScope = selectedScopeRaw === "read" || selectedScopeRaw === "full"
+    ? selectedScopeRaw
+    : (requestedScope === "read" ? "read" : "full");
   const state = form.get("state") as string || "";
 
   if (!clientId || !redirectUri || !codeChallenge) {
@@ -227,31 +262,66 @@ export async function handleAuthorizePost(req: Request, db: Database, vaultName?
     return Response.redirect(redirect.toString(), 302);
   }
 
-  // Verify vault owner identity via token
-  const ownerToken = form.get("owner_token") as string;
-  if (!ownerToken) {
+  // Rate-limit the owner-auth step. Applied before any credential check so
+  // brute-force attempts are capped regardless of which path (password or
+  // legacy token) is being used.
+  if (clientIp) {
+    const gate = rateLimiter.check(clientIp);
+    if (!gate.allowed) {
+      return new Response(renderErrorPage(
+        `Too many failed attempts. Try again in ${Math.ceil(gate.retryAfterSec / 60)} minute(s).`,
+      ), {
+        status: 429,
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          "Retry-After": String(gate.retryAfterSec),
+        },
+      });
+    }
+  }
+
+  // Verify owner identity — password if configured, else legacy vault token.
+  const passwordMode = typeof ownerPasswordHash === "string" && ownerPasswordHash.length > 0;
+  let ownerOk = false;
+  let errorMsg = "";
+
+  if (passwordMode) {
+    const password = form.get("password") as string;
+    if (!password) {
+      errorMsg = "Password is required.";
+    } else {
+      ownerOk = await verifyOwnerPassword(password, ownerPasswordHash!);
+      if (!ownerOk) errorMsg = "Incorrect password.";
+    }
+  } else {
+    const ownerToken = form.get("owner_token") as string;
+    if (!ownerToken) {
+      errorMsg = "Vault token is required.";
+    } else {
+      ownerOk = resolveToken(db, ownerToken) !== null;
+      if (!ownerOk) errorMsg = "Invalid vault token.";
+    }
+  }
+
+  if (!ownerOk) {
+    if (clientIp) rateLimiter.recordFailure(clientIp);
     return renderConsentWithError(db, vaultName || "vault", {
-      clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, state,
-      error: "Vault token is required.",
+      clientId, redirectUri, codeChallenge, codeChallengeMethod,
+      requestedScope, selectedScope, state, passwordMode,
+      error: errorMsg,
     });
   }
 
-  const resolved = resolveToken(db, ownerToken);
-  if (!resolved) {
-    return renderConsentWithError(db, vaultName || "vault", {
-      clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, state,
-      error: "Invalid vault token.",
-    });
-  }
+  if (clientIp) rateLimiter.recordSuccess(clientIp);
 
-  // Generate auth code
+  // Generate auth code — persist the user-selected scope (not the requested one)
   const code = crypto.randomBytes(32).toString("base64url");
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString(); // 10 minutes
 
   db.prepare(`
     INSERT INTO oauth_codes (code, client_id, code_challenge, code_challenge_method, scope, redirect_uri, expires_at, created_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(code, clientId, codeChallenge, codeChallengeMethod, scope, redirectUri, expiresAt, new Date().toISOString());
+  `).run(code, clientId, codeChallenge, codeChallengeMethod, selectedScope, redirectUri, expiresAt, new Date().toISOString());
 
   redirect.searchParams.set("code", code);
   return Response.redirect(redirect.toString(), 302);
@@ -375,25 +445,30 @@ function renderConsentWithError(
     redirectUri: string;
     codeChallenge: string;
     codeChallengeMethod: string;
-    scope: string;
+    requestedScope: string;
+    selectedScope: string;
     state: string;
+    passwordMode: boolean;
     error: string;
   },
 ): Response {
   const client = db.prepare("SELECT client_name FROM oauth_clients WHERE client_id = ?")
     .get(params.clientId) as { client_name: string } | null;
   const clientName = client?.client_name || "Unknown Client";
-  const normalizedScope: TokenPermission = params.scope === "read" ? "read" : "full";
+  const requested: TokenPermission = params.requestedScope === "read" ? "read" : "full";
+  const selected: TokenPermission = params.selectedScope === "read" ? "read" : "full";
 
   const html = renderConsentPage({
     vaultName,
     clientName,
-    scope: normalizedScope,
+    requestedScope: requested,
+    selectedScope: selected,
     clientId: params.clientId,
     redirectUri: params.redirectUri,
     codeChallenge: params.codeChallenge,
     codeChallengeMethod: params.codeChallengeMethod,
     state: params.state,
+    passwordMode: params.passwordMode,
     error: params.error,
   });
 
@@ -410,20 +485,33 @@ function renderConsentWithError(
 interface ConsentParams {
   vaultName: string;
   clientName: string;
-  scope: TokenPermission;
+  /** Scope originally requested by the client. */
+  requestedScope: TokenPermission;
+  /** Scope currently selected in the radio buttons (defaults to requested). */
+  selectedScope: TokenPermission;
   clientId: string;
   redirectUri: string;
   codeChallenge: string;
   codeChallengeMethod: string;
   state: string;
+  /** When true, render a password field; when false, render a vault-token field (legacy). */
+  passwordMode: boolean;
   error?: string;
 }
 
 function renderConsentPage(p: ConsentParams): string {
-  const scopeLabel = p.scope === "read" ? "Read-only access" : "Full access";
-  const scopeDesc = p.scope === "read"
-    ? "Query notes, list tags, and view vault info"
-    : "Read, create, update, and delete notes, tags, and links";
+  const fullChecked = p.selectedScope === "full" ? " checked" : "";
+  const readChecked = p.selectedScope === "read" ? " checked" : "";
+
+  const credentialField = p.passwordMode
+    ? `<div class="cred-field">
+      <label for="password">Owner password</label>
+      <input type="password" id="password" name="password" placeholder="Enter your vault password" required autocomplete="current-password">
+    </div>`
+    : `<div class="cred-field">
+      <label for="owner_token">Vault token</label>
+      <input type="password" id="owner_token" name="owner_token" placeholder="pvt_..." required autocomplete="off">
+    </div>`;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -447,24 +535,34 @@ function renderConsentPage(p: ConsentParams): string {
   }
   h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
   .client { color: #0066cc; font-weight: 600; }
-  .scope {
+  .scope-options {
     background: #f5f5f5;
     border-radius: 4px;
     padding: 0.75rem 1rem;
     margin: 1rem 0;
   }
-  .scope-label { font-weight: 600; }
-  .scope-desc { font-size: 0.9rem; color: #666; }
-  .token-field {
+  .scope-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.3rem 0;
+    cursor: pointer;
+  }
+  .scope-option input[type="radio"] {
+    margin-top: 0.35rem;
+  }
+  .scope-option-label { font-weight: 600; }
+  .scope-option-desc { font-size: 0.85rem; color: #666; }
+  .cred-field {
     margin-top: 1rem;
   }
-  .token-field label {
+  .cred-field label {
     display: block;
     font-size: 0.9rem;
     font-weight: 600;
     margin-bottom: 0.3rem;
   }
-  .token-field input {
+  .cred-field input {
     width: 100%;
     padding: 0.5rem 0.6rem;
     border: 1px solid #ccc;
@@ -476,7 +574,7 @@ function renderConsentPage(p: ConsentParams): string {
   .error-msg {
     color: #cc3333;
     font-size: 0.9rem;
-    margin-top: 0.5rem;
+    margin-top: 0.75rem;
   }
   .buttons {
     display: flex;
@@ -502,10 +600,10 @@ function renderConsentPage(p: ConsentParams): string {
   @media (prefers-color-scheme: dark) {
     body { background: #1a1a1a; color: #e0e0e0; }
     .card { border-color: #333; }
-    .scope { background: #2a2a2a; }
-    .scope-desc { color: #999; }
+    .scope-options { background: #2a2a2a; }
+    .scope-option-desc { color: #999; }
     .client { color: #66b3ff; }
-    .token-field input { background: #2a2a2a; color: #e0e0e0; border-color: #444; }
+    .cred-field input { background: #2a2a2a; color: #e0e0e0; border-color: #444; }
     .error-msg { color: #ff6666; }
     button { background: #2a2a2a; color: #e0e0e0; border-color: #444; }
     button[value="authorize"] { background: #0066cc; color: #fff; border-color: #0066cc; }
@@ -517,22 +615,31 @@ function renderConsentPage(p: ConsentParams): string {
 <div class="card">
   <h1>Authorize access</h1>
   <p><span class="client">${escapeHtml(p.clientName)}</span> wants to access your <strong>${escapeHtml(p.vaultName)}</strong> vault.</p>
-  <div class="scope">
-    <div class="scope-label">${escapeHtml(scopeLabel)}</div>
-    <div class="scope-desc">${escapeHtml(scopeDesc)}</div>
-  </div>
   <form method="POST" action="/oauth/authorize">
     <input type="hidden" name="client_id" value="${escapeHtml(p.clientId)}">
     <input type="hidden" name="redirect_uri" value="${escapeHtml(p.redirectUri)}">
     <input type="hidden" name="code_challenge" value="${escapeHtml(p.codeChallenge)}">
     <input type="hidden" name="code_challenge_method" value="${escapeHtml(p.codeChallengeMethod)}">
-    <input type="hidden" name="scope" value="${escapeHtml(p.scope)}">
+    <input type="hidden" name="scope" value="${escapeHtml(p.requestedScope)}">
     <input type="hidden" name="state" value="${escapeHtml(p.state)}">
-    <div class="token-field">
-      <label for="owner_token">Enter your vault token to authorize</label>
-      <input type="password" id="owner_token" name="owner_token" placeholder="pvt_..." required autocomplete="off">
-      ${p.error ? `<div class="error-msg">${escapeHtml(p.error)}</div>` : ""}
+    <div class="scope-options">
+      <label class="scope-option">
+        <input type="radio" name="selected_scope" value="full"${fullChecked}>
+        <span>
+          <span class="scope-option-label">Full access</span><br>
+          <span class="scope-option-desc">Read, create, update, and delete notes, tags, and links.</span>
+        </span>
+      </label>
+      <label class="scope-option">
+        <input type="radio" name="selected_scope" value="read"${readChecked}>
+        <span>
+          <span class="scope-option-label">Read-only access</span><br>
+          <span class="scope-option-desc">Query notes, list tags, and view vault info.</span>
+        </span>
+      </label>
     </div>
+    ${credentialField}
+    ${p.error ? `<div class="error-msg">${escapeHtml(p.error)}</div>` : ""}
     <div class="buttons">
       <button type="submit" name="action" value="deny">Deny</button>
       <button type="submit" name="action" value="authorize">Authorize</button>

--- a/src/owner-auth.ts
+++ b/src/owner-auth.ts
@@ -20,9 +20,11 @@ const MIN_PASSWORD_LENGTH = 12;
 // Password storage
 // ---------------------------------------------------------------------------
 
-/** Read the stored bcrypt hash, or null if none set. */
+/** Read the stored bcrypt hash, or null if none set (or set to empty string). */
 export function getOwnerPasswordHash(): string | null {
-  return readGlobalConfig().owner_password_hash ?? null;
+  const hash = readGlobalConfig().owner_password_hash;
+  if (typeof hash !== "string" || hash.length === 0) return null;
+  return hash;
 }
 
 /** Whether a password has been set. */

--- a/src/owner-auth.ts
+++ b/src/owner-auth.ts
@@ -1,0 +1,157 @@
+/**
+ * Owner authentication for the OAuth consent page.
+ *
+ * The "owner" is the person who set up this vault — identified by a password
+ * stored globally in config.yaml (owner_password_hash). The password is used
+ * to prove ownership when authorizing third-party OAuth clients.
+ *
+ * Password hashing uses Bun.password (bcrypt, cost 12 by default) — no deps.
+ *
+ * Rate limiting is per-IP, in-memory. Acceptable for v1: resets on restart,
+ * doesn't handle multi-process deployments. Tighten later if needed.
+ */
+
+import { readGlobalConfig, writeGlobalConfig } from "./config.ts";
+
+const BCRYPT_COST = 12;
+const MIN_PASSWORD_LENGTH = 12;
+
+// ---------------------------------------------------------------------------
+// Password storage
+// ---------------------------------------------------------------------------
+
+/** Read the stored bcrypt hash, or null if none set. */
+export function getOwnerPasswordHash(): string | null {
+  return readGlobalConfig().owner_password_hash ?? null;
+}
+
+/** Whether a password has been set. */
+export function hasOwnerPassword(): boolean {
+  return getOwnerPasswordHash() !== null;
+}
+
+/** Validate password strength. Returns error message or null. */
+export function validatePasswordStrength(password: string): string | null {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+  }
+  return null;
+}
+
+/** Hash and store the owner password. Throws on weak passwords. */
+export async function setOwnerPassword(password: string): Promise<void> {
+  const err = validatePasswordStrength(password);
+  if (err) throw new Error(err);
+
+  const hash = await Bun.password.hash(password, {
+    algorithm: "bcrypt",
+    cost: BCRYPT_COST,
+  });
+
+  const config = readGlobalConfig();
+  config.owner_password_hash = hash;
+  writeGlobalConfig(config);
+}
+
+/** Remove the stored password (disables password-based consent auth). */
+export function clearOwnerPassword(): void {
+  const config = readGlobalConfig();
+  delete config.owner_password_hash;
+  writeGlobalConfig(config);
+}
+
+/** Verify a provided password against the given hash. */
+export async function verifyOwnerPassword(password: string, hash: string): Promise<boolean> {
+  try {
+    return await Bun.password.verify(password, hash);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+
+interface RateLimitEntry {
+  failures: number;
+  firstFailureAt: number;
+  lockedUntil: number | null;
+}
+
+/**
+ * Per-IP rate limiter for consent-page attempts.
+ *
+ * Policy:
+ *   - Up to MAX_FAILURES failed attempts within WINDOW_MS → lockout
+ *   - Lockout lasts LOCKOUT_MS
+ *   - A successful attempt clears the IP's counter
+ */
+export class RateLimiter {
+  private entries = new Map<string, RateLimitEntry>();
+
+  constructor(
+    private readonly maxFailures = 10,
+    private readonly windowMs = 60_000,
+    private readonly lockoutMs = 15 * 60_000,
+  ) {}
+
+  /**
+   * Check whether an IP is currently allowed to attempt auth.
+   * Returns `{ allowed: false, retryAfterSec }` if locked out.
+   */
+  check(ip: string): { allowed: true } | { allowed: false; retryAfterSec: number } {
+    const entry = this.entries.get(ip);
+    if (!entry) return { allowed: true };
+
+    const now = Date.now();
+    if (entry.lockedUntil && entry.lockedUntil > now) {
+      return { allowed: false, retryAfterSec: Math.ceil((entry.lockedUntil - now) / 1000) };
+    }
+
+    // Expired lockout or old window — reset and allow
+    if (entry.lockedUntil && entry.lockedUntil <= now) {
+      this.entries.delete(ip);
+      return { allowed: true };
+    }
+    if (now - entry.firstFailureAt > this.windowMs) {
+      this.entries.delete(ip);
+      return { allowed: true };
+    }
+
+    return { allowed: true };
+  }
+
+  /** Record a failed attempt. Triggers lockout if threshold reached. */
+  recordFailure(ip: string): void {
+    const now = Date.now();
+    const entry = this.entries.get(ip);
+
+    if (!entry || now - entry.firstFailureAt > this.windowMs) {
+      this.entries.set(ip, {
+        failures: 1,
+        firstFailureAt: now,
+        lockedUntil: null,
+      });
+      return;
+    }
+
+    entry.failures += 1;
+    if (entry.failures >= this.maxFailures) {
+      entry.lockedUntil = now + this.lockoutMs;
+    }
+  }
+
+  /** Record a successful attempt. Clears the IP's counter. */
+  recordSuccess(ip: string): void {
+    this.entries.delete(ip);
+  }
+
+  /** For tests: drop all state. */
+  reset(): void {
+    this.entries.clear();
+  }
+}
+
+/** Singleton rate limiter for the OAuth consent endpoint. */
+export const authorizeRateLimit = new RateLimiter();

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -34,6 +34,60 @@ export async function ask(question: string, defaultValue = ""): Promise<string> 
 }
 
 /**
+ * Ask for a password with masked input (shows "*" per character).
+ * Falls back to plain echo if stdin isn't a TTY (e.g. piped input in CI).
+ */
+export async function askPassword(question: string): Promise<string> {
+  const stdin = process.stdin;
+  if (!stdin.isTTY || typeof stdin.setRawMode !== "function") {
+    return ask(question);
+  }
+
+  process.stdout.write(`${question}: `);
+
+  return new Promise<string>((resolve) => {
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+
+    let buf = "";
+    const onData = (data: string) => {
+      for (const ch of data) {
+        // Enter — done
+        if (ch === "\r" || ch === "\n") {
+          stdin.setRawMode(false);
+          stdin.pause();
+          stdin.removeListener("data", onData);
+          process.stdout.write("\n");
+          resolve(buf);
+          return;
+        }
+        // Ctrl-C — abort
+        if (ch === "\u0003") {
+          stdin.setRawMode(false);
+          process.stdout.write("\n");
+          process.exit(130);
+        }
+        // Backspace / DEL
+        if (ch === "\u0008" || ch === "\u007f") {
+          if (buf.length > 0) {
+            buf = buf.slice(0, -1);
+            process.stdout.write("\b \b");
+          }
+          continue;
+        }
+        // Printable
+        if (ch >= " ") {
+          buf += ch;
+          process.stdout.write("*");
+        }
+      }
+    };
+    stdin.on("data", onData);
+  });
+}
+
+/**
  * Ask user to pick from options. Returns the chosen value.
  */
 export async function choose(question: string, options: { label: string; value: string; description?: string }[]): Promise<string> {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -45,45 +45,70 @@ export async function askPassword(question: string): Promise<string> {
 
   process.stdout.write(`${question}: `);
 
-  return new Promise<string>((resolve) => {
+  return new Promise<string>((resolve, reject) => {
     stdin.setRawMode(true);
     stdin.resume();
     stdin.setEncoding("utf8");
 
     let buf = "";
-    const onData = (data: string) => {
-      for (const ch of data) {
-        // Enter — done
-        if (ch === "\r" || ch === "\n") {
-          stdin.setRawMode(false);
-          stdin.pause();
-          stdin.removeListener("data", onData);
-          process.stdout.write("\n");
-          resolve(buf);
-          return;
-        }
-        // Ctrl-C — abort
-        if (ch === "\u0003") {
-          stdin.setRawMode(false);
-          process.stdout.write("\n");
-          process.exit(130);
-        }
-        // Backspace / DEL
-        if (ch === "\u0008" || ch === "\u007f") {
-          if (buf.length > 0) {
-            buf = buf.slice(0, -1);
-            process.stdout.write("\b \b");
-          }
-          continue;
-        }
-        // Printable
-        if (ch >= " ") {
-          buf += ch;
-          process.stdout.write("*");
-        }
+    let settled = false;
+
+    // Always restore terminal state on exit, success or failure.
+    const cleanup = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        stdin.removeListener("data", onData);
+        stdin.removeListener("error", onError);
+        stdin.setRawMode(false);
+        stdin.pause();
+      } catch {
+        // Best-effort; don't mask the underlying completion.
       }
     };
+
+    const onData = (data: string) => {
+      try {
+        for (const ch of data) {
+          // Enter — done
+          if (ch === "\r" || ch === "\n") {
+            process.stdout.write("\n");
+            cleanup();
+            resolve(buf);
+            return;
+          }
+          // Ctrl-C — abort
+          if (ch === "\u0003") {
+            process.stdout.write("\n");
+            cleanup();
+            process.exit(130);
+          }
+          // Backspace / DEL
+          if (ch === "\u0008" || ch === "\u007f") {
+            if (buf.length > 0) {
+              buf = buf.slice(0, -1);
+              process.stdout.write("\b \b");
+            }
+            continue;
+          }
+          // Printable
+          if (ch >= " ") {
+            buf += ch;
+            process.stdout.write("*");
+          }
+        }
+      } catch (err) {
+        cleanup();
+        reject(err);
+      }
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+
     stdin.on("data", onData);
+    stdin.on("error", onError);
   });
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -117,7 +117,7 @@ const server = Bun.serve({
   port,
   hostname: "0.0.0.0",
   idleTimeout: 120, // seconds — webhook triggers can take a while
-  async fetch(req) {
+  async fetch(req, server) {
     const url = new URL(req.url);
     const path = url.pathname;
 
@@ -131,9 +131,16 @@ const server = Bun.serve({
       return new Response(null, { status: 204, headers: corsHeaders });
     }
 
+    // Derive client IP. Prefer X-Forwarded-For (trusting first hop for
+    // reverse-proxy deployments), fall back to the direct socket IP.
+    const forwardedFor = req.headers.get("x-forwarded-for");
+    const clientIp = forwardedFor
+      ? forwardedFor.split(",")[0].trim()
+      : server.requestIP(req)?.address;
+
     try {
       const start = Date.now();
-      const response = await route(req, path);
+      const response = await route(req, path, clientIp);
       const ms = Date.now() - start;
       console.log(`${req.method} ${path} ${response.status} ${ms}ms`);
       for (const [k, v] of Object.entries(corsHeaders)) {
@@ -182,7 +189,7 @@ function isViewAuthenticated(req: Request, vaultConfig: VaultConfig | null, vaul
   return !("error" in auth);
 }
 
-async function route(req: Request, path: string): Promise<Response> {
+async function route(req: Request, path: string, clientIp?: string): Promise<Response> {
   // OAuth discovery endpoints (no auth required)
   if (path === "/.well-known/oauth-protected-resource") {
     return handleProtectedResource(req);
@@ -204,11 +211,16 @@ async function route(req: Request, path: string): Promise<Response> {
       return handleRegister(req, store.db);
     }
     if (path === "/oauth/authorize") {
+      const ownerPasswordHash = readGlobalConfig().owner_password_hash ?? null;
       if (req.method === "GET") {
-        return handleAuthorizeGet(req, store.db, vaultConfig.name);
+        return handleAuthorizeGet(req, store.db, vaultConfig.name, ownerPasswordHash);
       }
       if (req.method === "POST") {
-        return handleAuthorizePost(req, store.db, vaultConfig.name);
+        return handleAuthorizePost(req, store.db, {
+          vaultName: vaultConfig.name,
+          clientIp,
+          ownerPasswordHash,
+        });
       }
       return Response.json({ error: "method_not_allowed" }, { status: 405 });
     }
@@ -341,8 +353,13 @@ async function route(req: Request, path: string): Promise<Response> {
     const store = getVaultStore(vaultName);
     if (subpath === "/oauth/register") return handleRegister(req, store.db);
     if (subpath === "/oauth/authorize") {
-      if (req.method === "GET") return handleAuthorizeGet(req, store.db, vaultConfig.name);
-      if (req.method === "POST") return handleAuthorizePost(req, store.db, vaultConfig.name);
+      const ownerPasswordHash = readGlobalConfig().owner_password_hash ?? null;
+      if (req.method === "GET") return handleAuthorizeGet(req, store.db, vaultConfig.name, ownerPasswordHash);
+      if (req.method === "POST") return handleAuthorizePost(req, store.db, {
+        vaultName: vaultConfig.name,
+        clientIp,
+        ownerPasswordHash,
+      });
       return Response.json({ error: "method_not_allowed" }, { status: 405 });
     }
     if (subpath === "/oauth/token") return handleToken(req, store.db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,9 +131,13 @@ const server = Bun.serve({
       return new Response(null, { status: 204, headers: corsHeaders });
     }
 
-    // Derive client IP. Prefer X-Forwarded-For (trusting first hop for
-    // reverse-proxy deployments), fall back to the direct socket IP.
-    const forwardedFor = req.headers.get("x-forwarded-for");
+    // Derive client IP. Default: socket IP only (safe for direct-internet
+    // deployments). If TRUST_PROXY=1 is set, honor X-Forwarded-For — use
+    // this only when a reverse proxy (Cloudflare Tunnel, nginx, etc.) is
+    // terminating the connection, otherwise attackers can spoof the header
+    // to evade per-IP rate limiting.
+    const trustProxy = process.env.TRUST_PROXY === "1" || process.env.TRUST_PROXY === "true";
+    const forwardedFor = trustProxy ? req.headers.get("x-forwarded-for") : null;
     const clientIp = forwardedFor
       ? forwardedFor.split(",")[0].trim()
       : server.requestIP(req)?.address;


### PR DESCRIPTION
## Summary

Phase 1 of the OAuth hardening task. Replaces the vault-token field on the OAuth consent page with a proper owner password, adds per-IP rate limiting, and lets the user downgrade the scope at consent time.

### What changed

- **Owner password** (new `src/owner-auth.ts`)
  - `Bun.password` (bcrypt, cost 12) — no extra dep
  - Stored as `owner_password_hash` in `~/.parachute/config.yaml` (global, not per-vault)
  - Set via `parachute vault set-password` or interactively during `vault init`
  - 12-char minimum

- **Rate limiting** (in-memory, per-IP)
  - 10 failures / 60s → 15 min lockout
  - Returns `429` with `Retry-After`
  - Gated on `server.requestIP()` by default; respects `X-Forwarded-For` only when `TRUST_PROXY=1` (so direct-internet deployments can't be bypassed via header spoofing)

- **Scope selection** on consent page
  - Radio buttons: Full access / Read-only
  - Defaults to the scope the client requested
  - The user's chosen scope is what gets persisted on the auth code and minted into the final `pvt_` token

- **Legacy fallback**: If no password is configured, the consent page still accepts a vault `pvt_` token (the pre-existing behavior). This means existing deployments keep working, and the fix for #87's follow-up isn't blocking on users running `set-password`.

### Files

| file | what |
|---|---|
| `src/owner-auth.ts` | **new** — password hash storage, RateLimiter class |
| `src/oauth.ts` | `handleAuthorizePost` takes options object; password vs. token branch; new consent HTML |
| `src/server.ts` | derives client IP (socket or XFF), threads it + password hash to OAuth |
| `src/config.ts` | persists `owner_password_hash` in global config |
| `src/cli.ts` | `set-password` command, optional prompt during `init` |
| `src/prompt.ts` | `askPassword()` with masked input + raw-mode cleanup |
| `src/oauth.test.ts` | +11 tests (password mode, rate limit, scope selection) |

### Test plan

- [x] 364 server tests pass (11 new)
- [x] Self-review by `reviewer` subagent — LGTM with nits; all meaningful nits applied (TRUST_PROXY gate, empty-hash guard, prompt cleanup hardening)
- [ ] Manual: set a password via `parachute vault set-password`, walk the OAuth flow in a browser, confirm password is required
- [ ] Manual: walk the OAuth flow without a password set — vault-token field still works
- [ ] Manual: 10 wrong passwords → lockout + 429
- [ ] Manual: choose "Read-only" on consent, confirm minted token has `read` scope

### Follow-ups (filed as issues, not in this PR)

- Per-vault rate limiter separation (currently global across all vaults)
- Memory cap / LRU eviction for rate-limit map
- Server-side binding of requested scope to prevent POST-body escalation beyond what GET requested

### Phase 2 (next PR)

TOTP 2FA + backup codes — will build on this foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)