### PR TITLE
refactor(store): async Store interface + rename to BunSqliteStore

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -709,7 +709,7 @@ describe("MCP tools", async () => {
     await store.createNote("Body", { metadata: { summary: "short", status: "draft", priority: 1 } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = await query.execute({ id: (await store.queryNotes({}))[0].id, include_metadata: true }) as any;
+    const result = await query.execute({ id: (await store.queryNotes({}))[0]!.id, include_metadata: true }) as any;
     expect(result.metadata).toEqual({ summary: "short", status: "draft", priority: 1 });
   });
 
@@ -717,7 +717,7 @@ describe("MCP tools", async () => {
     await store.createNote("Body", { metadata: { summary: "short", status: "draft" } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = await query.execute({ id: (await store.queryNotes({}))[0].id, include_metadata: false }) as any;
+    const result = await query.execute({ id: (await store.queryNotes({}))[0]!.id, include_metadata: false }) as any;
     expect(result.metadata).toBeUndefined();
     expect(result.content).toBe("Body"); // other fields unaffected
   });
@@ -726,7 +726,7 @@ describe("MCP tools", async () => {
     await store.createNote("Body", { metadata: { summary: "short", status: "draft", priority: 1 } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = await query.execute({ id: (await store.queryNotes({}))[0].id, include_metadata: ["summary"] }) as any;
+    const result = await query.execute({ id: (await store.queryNotes({}))[0]!.id, include_metadata: ["summary"] }) as any;
     expect(result.metadata).toEqual({ summary: "short" });
   });
 

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -13,150 +13,150 @@ beforeEach(() => {
 
 // ---- Notes CRUD ----
 
-describe("notes", () => {
-  it("creates a note", () => {
-    const note = store.createNote("Morning walk");
+describe("notes", async () => {
+  it("creates a note", async () => {
+    const note = await store.createNote("Morning walk");
     expect(note.content).toBe("Morning walk");
     expect(note.id).toBeTruthy();
     expect(note.createdAt).toBeTruthy();
   });
 
-  it("creates a note with custom id", () => {
-    const note = store.createNote("Test", { id: "custom-id" });
+  it("creates a note with custom id", async () => {
+    const note = await store.createNote("Test", { id: "custom-id" });
     expect(note.id).toBe("custom-id");
   });
 
-  it("creates a note with path", () => {
-    const note = store.createNote("# Grocery List", { path: "Grocery List" });
+  it("creates a note with path", async () => {
+    const note = await store.createNote("# Grocery List", { path: "Grocery List" });
     expect(note.path).toBe("Grocery List");
   });
 
-  it("creates a note with tags", () => {
-    const note = store.createNote("Voice memo", { tags: ["daily", "voice"] });
+  it("creates a note with tags", async () => {
+    const note = await store.createNote("Voice memo", { tags: ["daily", "voice"] });
     expect(note.tags).toContain("daily");
     expect(note.tags).toContain("voice");
   });
 
-  it("gets a note by id", () => {
-    const created = store.createNote("Test");
-    const found = store.getNote(created.id);
+  it("gets a note by id", async () => {
+    const created = await store.createNote("Test");
+    const found = await store.getNote(created.id);
     expect(found).toBeTruthy();
     expect(found!.id).toBe(created.id);
     expect(found!.content).toBe("Test");
   });
 
-  it("returns null for missing note", () => {
-    expect(store.getNote("nonexistent")).toBeNull();
+  it("returns null for missing note", async () => {
+    expect(await store.getNote("nonexistent")).toBeNull();
   });
 
-  it("updates note content", () => {
-    const note = store.createNote("Original");
-    const updated = store.updateNote(note.id, { content: "Updated" });
+  it("updates note content", async () => {
+    const note = await store.createNote("Original");
+    const updated = await store.updateNote(note.id, { content: "Updated" });
     expect(updated.content).toBe("Updated");
     expect(updated.updatedAt).toBeTruthy();
   });
 
-  it("updates note path", () => {
-    const note = store.createNote("Test");
-    const updated = store.updateNote(note.id, { path: "Notes/Test" });
+  it("updates note path", async () => {
+    const note = await store.createNote("Test");
+    const updated = await store.updateNote(note.id, { path: "Notes/Test" });
     expect(updated.path).toBe("Notes/Test");
   });
 
-  it("updates created_at", () => {
-    const note = store.createNote("Test");
+  it("updates created_at", async () => {
+    const note = await store.createNote("Test");
     const newDate = "2025-01-15T12:00:00.000Z";
-    const updated = store.updateNote(note.id, { created_at: newDate });
+    const updated = await store.updateNote(note.id, { created_at: newDate });
     expect(updated.createdAt).toBe(newDate);
     expect(updated.content).toBe("Test"); // content unchanged
     expect(updated.updatedAt).not.toBe(note.updatedAt); // updated_at bumped
   });
 
-  it("updates metadata and created_at together", () => {
-    const note = store.createNote("Test");
+  it("updates metadata and created_at together", async () => {
+    const note = await store.createNote("Test");
     const newDate = "2025-06-30T23:59:59.000Z";
     const meta = { source: "import", version: 2 };
-    const updated = store.updateNote(note.id, { metadata: meta, created_at: newDate });
+    const updated = await store.updateNote(note.id, { metadata: meta, created_at: newDate });
     expect(updated.createdAt).toBe(newDate);
     expect(updated.metadata).toEqual(meta);
     expect(updated.content).toBe("Test");
   });
 
-  it("leaves created_at unchanged when not provided", () => {
-    const note = store.createNote("Test");
-    const updated = store.updateNote(note.id, { content: "Updated" });
+  it("leaves created_at unchanged when not provided", async () => {
+    const note = await store.createNote("Test");
+    const updated = await store.updateNote(note.id, { content: "Updated" });
     expect(updated.createdAt).toBe(note.createdAt);
   });
 
-  it("deletes a note", () => {
-    const note = store.createNote("Delete me");
-    store.deleteNote(note.id);
-    expect(store.getNote(note.id)).toBeNull();
+  it("deletes a note", async () => {
+    const note = await store.createNote("Delete me");
+    await store.deleteNote(note.id);
+    expect(await store.getNote(note.id)).toBeNull();
   });
 
-  it("cascade deletes tags and links", () => {
-    store.createNote("A", { id: "a", tags: ["daily"] });
-    store.createNote("B", { id: "b" });
-    store.createLink("a", "b", "mentions");
+  it("cascade deletes tags and links", async () => {
+    await store.createNote("A", { id: "a", tags: ["daily"] });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions");
 
-    store.deleteNote("a");
-    expect(store.getLinks("b")).toHaveLength(0);
+    await store.deleteNote("a");
+    expect(await store.getLinks("b")).toHaveLength(0);
   });
 });
 
 // ---- Tags ----
 
-describe("tags", () => {
-  it("starts with no tags", () => {
-    const tags = store.listTags();
+describe("tags", async () => {
+  it("starts with no tags", async () => {
+    const tags = await store.listTags();
     expect(tags).toHaveLength(0);
   });
 
-  it("tags a note", () => {
-    const note = store.createNote("Test");
-    store.tagNote(note.id, ["daily", "voice"]);
-    const found = store.getNote(note.id);
+  it("tags a note", async () => {
+    const note = await store.createNote("Test");
+    await store.tagNote(note.id, ["daily", "voice"]);
+    const found = await store.getNote(note.id);
     expect(found!.tags).toContain("daily");
     expect(found!.tags).toContain("voice");
   });
 
-  it("untags a note", () => {
-    const note = store.createNote("Test", { tags: ["daily", "voice"] });
-    store.untagNote(note.id, ["voice"]);
-    const found = store.getNote(note.id);
+  it("untags a note", async () => {
+    const note = await store.createNote("Test", { tags: ["daily", "voice"] });
+    await store.untagNote(note.id, ["voice"]);
+    const found = await store.getNote(note.id);
     expect(found!.tags).toContain("daily");
     expect(found!.tags).not.toContain("voice");
   });
 
-  it("creates tags automatically", () => {
-    const note = store.createNote("Test");
-    store.tagNote(note.id, ["custom-tag"]);
-    const tags = store.listTags();
+  it("creates tags automatically", async () => {
+    const note = await store.createNote("Test");
+    await store.tagNote(note.id, ["custom-tag"]);
+    const tags = await store.listTags();
     expect(tags.some((t) => t.name === "custom-tag")).toBe(true);
   });
 
-  it("counts tag usage", () => {
-    store.createNote("A", { tags: ["daily"] });
-    store.createNote("B", { tags: ["daily"] });
-    store.createNote("C", { tags: ["doc"] });
+  it("counts tag usage", async () => {
+    await store.createNote("A", { tags: ["daily"] });
+    await store.createNote("B", { tags: ["daily"] });
+    await store.createNote("C", { tags: ["doc"] });
 
-    const tags = store.listTags();
+    const tags = await store.listTags();
     const daily = tags.find((t) => t.name === "daily");
     expect(daily!.count).toBe(2);
   });
 
-  it("tagging is idempotent", () => {
-    const note = store.createNote("Test", { tags: ["daily"] });
-    store.tagNote(note.id, ["daily"]); // duplicate
-    const found = store.getNote(note.id);
+  it("tagging is idempotent", async () => {
+    const note = await store.createNote("Test", { tags: ["daily"] });
+    await store.tagNote(note.id, ["daily"]); // duplicate
+    const found = await store.getNote(note.id);
     expect(found!.tags!.filter((t) => t === "daily")).toHaveLength(1);
   });
 });
 
 // ---- Vault Stats ----
 
-describe("vault stats", () => {
-  it("handles empty vault gracefully", () => {
-    const stats = store.getVaultStats();
+describe("vault stats", async () => {
+  it("handles empty vault gracefully", async () => {
+    const stats = await store.getVaultStats();
     expect(stats.totalNotes).toBe(0);
     expect(stats.earliestNote).toBeNull();
     expect(stats.latestNote).toBeNull();
@@ -165,34 +165,34 @@ describe("vault stats", () => {
     expect(stats.tagCount).toBe(0);
   });
 
-  it("counts total notes and tagCount", () => {
-    store.createNote("A", { tags: ["daily", "voice"] });
-    store.createNote("B", { tags: ["daily"] });
-    store.createNote("C");
+  it("counts total notes and tagCount", async () => {
+    await store.createNote("A", { tags: ["daily", "voice"] });
+    await store.createNote("B", { tags: ["daily"] });
+    await store.createNote("C");
 
-    const stats = store.getVaultStats();
+    const stats = await store.getVaultStats();
     expect(stats.totalNotes).toBe(3);
     expect(stats.tagCount).toBe(2); // "daily" and "voice"
   });
 
-  it("reports earliest and latest notes correctly", () => {
-    store.createNote("oldest", { id: "n1", created_at: "2025-01-15T10:00:00.000Z" });
-    store.createNote("middle", { id: "n2", created_at: "2025-06-20T10:00:00.000Z" });
-    store.createNote("newest", { id: "n3", created_at: "2026-03-01T10:00:00.000Z" });
+  it("reports earliest and latest notes correctly", async () => {
+    await store.createNote("oldest", { id: "n1", created_at: "2025-01-15T10:00:00.000Z" });
+    await store.createNote("middle", { id: "n2", created_at: "2025-06-20T10:00:00.000Z" });
+    await store.createNote("newest", { id: "n3", created_at: "2026-03-01T10:00:00.000Z" });
 
-    const stats = store.getVaultStats();
+    const stats = await store.getVaultStats();
     expect(stats.earliestNote).toEqual({ id: "n1", createdAt: "2025-01-15T10:00:00.000Z" });
     expect(stats.latestNote).toEqual({ id: "n3", createdAt: "2026-03-01T10:00:00.000Z" });
   });
 
-  it("groups notes by month across all present months", () => {
-    store.createNote("a", { created_at: "2025-02-28T12:00:00.000Z" });
-    store.createNote("b", { created_at: "2025-03-01T08:00:00.000Z" });
-    store.createNote("c", { created_at: "2025-03-15T09:00:00.000Z" });
-    store.createNote("d", { created_at: "2025-03-20T11:00:00.000Z" });
-    store.createNote("e", { created_at: "2026-01-10T10:00:00.000Z" });
+  it("groups notes by month across all present months", async () => {
+    await store.createNote("a", { created_at: "2025-02-28T12:00:00.000Z" });
+    await store.createNote("b", { created_at: "2025-03-01T08:00:00.000Z" });
+    await store.createNote("c", { created_at: "2025-03-15T09:00:00.000Z" });
+    await store.createNote("d", { created_at: "2025-03-20T11:00:00.000Z" });
+    await store.createNote("e", { created_at: "2026-01-10T10:00:00.000Z" });
 
-    const stats = store.getVaultStats();
+    const stats = await store.getVaultStats();
     expect(stats.notesByMonth).toEqual([
       { month: "2025-02", count: 1 },
       { month: "2025-03", count: 3 },
@@ -200,31 +200,31 @@ describe("vault stats", () => {
     ]);
   });
 
-  it("returns topTags ordered by count desc, capped", () => {
+  it("returns topTags ordered by count desc, capped", async () => {
     // Create notes with varying tag frequencies
-    for (let i = 0; i < 5; i++) store.createNote(`captured-${i}`, { tags: ["captured"] });
-    for (let i = 0; i < 3; i++) store.createNote(`reader-${i}`, { tags: ["reader"] });
-    store.createNote("one", { tags: ["rare"] });
+    for (let i = 0; i < 5; i++) await store.createNote(`captured-${i}`, { tags: ["captured"] });
+    for (let i = 0; i < 3; i++) await store.createNote(`reader-${i}`, { tags: ["reader"] });
+    await store.createNote("one", { tags: ["rare"] });
 
-    const stats = store.getVaultStats();
+    const stats = await store.getVaultStats();
     expect(stats.topTags[0]).toEqual({ tag: "captured", count: 5 });
     expect(stats.topTags[1]).toEqual({ tag: "reader", count: 3 });
     expect(stats.topTags[2]).toEqual({ tag: "rare", count: 1 });
   });
 
-  it("caps topTags at the requested limit", () => {
+  it("caps topTags at the requested limit", async () => {
     // 25 distinct tags, one per note
     for (let i = 0; i < 25; i++) {
-      store.createNote(`n-${i}`, { tags: [`tag-${String(i).padStart(2, "0")}`] });
+      await store.createNote(`n-${i}`, { tags: [`tag-${String(i).padStart(2, "0")}`] });
     }
-    const stats = store.getVaultStats({ topTagsLimit: 20 });
+    const stats = await store.getVaultStats({ topTagsLimit: 20 });
     expect(stats.topTags).toHaveLength(20);
     expect(stats.tagCount).toBe(25);
   });
 
-  it("response shape is complete", () => {
-    store.createNote("hello", { tags: ["a"] });
-    const stats = store.getVaultStats();
+  it("response shape is complete", async () => {
+    await store.createNote("hello", { tags: ["a"] });
+    const stats = await store.getVaultStats();
     expect(stats).toHaveProperty("totalNotes");
     expect(stats).toHaveProperty("earliestNote");
     expect(stats).toHaveProperty("latestNote");
@@ -233,11 +233,11 @@ describe("vault stats", () => {
     expect(stats).toHaveProperty("tagCount");
   });
 
-  it("getVaultStats returns correct stats", () => {
-    store.createNote("one", { tags: ["x"], created_at: "2025-05-01T00:00:00.000Z" });
-    store.createNote("two", { tags: ["x", "y"], created_at: "2025-06-01T00:00:00.000Z" });
+  it("getVaultStats returns correct stats", async () => {
+    await store.createNote("one", { tags: ["x"], created_at: "2025-05-01T00:00:00.000Z" });
+    await store.createNote("two", { tags: ["x", "y"], created_at: "2025-06-01T00:00:00.000Z" });
 
-    const result = store.getVaultStats();
+    const result = await store.getVaultStats();
     expect(result.totalNotes).toBe(2);
     expect(result.tagCount).toBe(2);
     expect(result.topTags[0].tag).toBe("x");
@@ -250,194 +250,194 @@ describe("vault stats", () => {
 
 // ---- Query ----
 
-describe("queryNotes", () => {
-  it("queries by tag", () => {
-    store.createNote("Daily 1", { tags: ["daily"] });
-    store.createNote("Doc 1", { tags: ["doc"] });
+describe("queryNotes", async () => {
+  it("queries by tag", async () => {
+    await store.createNote("Daily 1", { tags: ["daily"] });
+    await store.createNote("Doc 1", { tags: ["doc"] });
 
-    const results = store.queryNotes({ tags: ["daily"] });
+    const results = await store.queryNotes({ tags: ["daily"] });
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe("Daily 1");
   });
 
-  it("queries by multiple tags (AND)", () => {
-    store.createNote("Voice daily", { tags: ["daily", "voice"] });
-    store.createNote("Text daily", { tags: ["daily"] });
+  it("queries by multiple tags (AND)", async () => {
+    await store.createNote("Voice daily", { tags: ["daily", "voice"] });
+    await store.createNote("Text daily", { tags: ["daily"] });
 
-    const results = store.queryNotes({ tags: ["daily", "voice"] });
+    const results = await store.queryNotes({ tags: ["daily", "voice"] });
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe("Voice daily");
   });
 
-  it("queries by multiple tags (OR)", () => {
-    store.createNote("Voice daily", { tags: ["daily", "voice"] });
-    store.createNote("Text daily", { tags: ["daily"] });
-    store.createNote("A doc", { tags: ["doc"] });
+  it("queries by multiple tags (OR)", async () => {
+    await store.createNote("Voice daily", { tags: ["daily", "voice"] });
+    await store.createNote("Text daily", { tags: ["daily"] });
+    await store.createNote("A doc", { tags: ["doc"] });
 
-    const results = store.queryNotes({ tags: ["voice", "doc"], tagMatch: "any" });
+    const results = await store.queryNotes({ tags: ["voice", "doc"], tagMatch: "any" });
     expect(results).toHaveLength(2);
     const contents = results.map((n) => n.content).sort();
     expect(contents).toEqual(["A doc", "Voice daily"]);
   });
 
-  it("excludes tags", () => {
-    store.createNote("Active", { tags: ["digest"] });
-    store.createNote("Archived", { tags: ["digest", "archived"] });
+  it("excludes tags", async () => {
+    await store.createNote("Active", { tags: ["digest"] });
+    await store.createNote("Archived", { tags: ["digest", "archived"] });
 
-    const results = store.queryNotes({ tags: ["digest"], excludeTags: ["archived"] });
+    const results = await store.queryNotes({ tags: ["digest"], excludeTags: ["archived"] });
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe("Active");
   });
 
-  it("filters by date range", () => {
-    store.createNote("Test");
-    const results = store.queryNotes({
+  it("filters by date range", async () => {
+    await store.createNote("Test");
+    const results = await store.queryNotes({
       dateFrom: new Date(Date.now() - 60000).toISOString(),
       dateTo: new Date(Date.now() + 60000).toISOString(),
     });
     expect(results.length).toBeGreaterThan(0);
   });
 
-  it("sorts ascending and descending", () => {
-    store.createNote("First", { id: "first" });
-    store.createNote("Second", { id: "second" });
+  it("sorts ascending and descending", async () => {
+    await store.createNote("First", { id: "first" });
+    await store.createNote("Second", { id: "second" });
 
-    const asc = store.queryNotes({ sort: "asc" });
+    const asc = await store.queryNotes({ sort: "asc" });
     expect(asc[0].content).toBe("First");
 
-    const desc = store.queryNotes({ sort: "desc" });
+    const desc = await store.queryNotes({ sort: "desc" });
     expect(desc[0].content).toBe("Second");
   });
 
-  it("limits results", () => {
-    for (let i = 0; i < 5; i++) store.createNote(`Note ${i}`);
-    const results = store.queryNotes({ limit: 3 });
+  it("limits results", async () => {
+    for (let i = 0; i < 5; i++) await store.createNote(`Note ${i}`);
+    const results = await store.queryNotes({ limit: 3 });
     expect(results).toHaveLength(3);
   });
 });
 
 // ---- Search ----
 
-describe("searchNotes", () => {
-  it("finds notes by content", () => {
-    store.createNote("Walked up Flagstaff trail");
-    store.createNote("Meeting about Horizon");
+describe("searchNotes", async () => {
+  it("finds notes by content", async () => {
+    await store.createNote("Walked up Flagstaff trail");
+    await store.createNote("Meeting about Horizon");
 
-    const results = store.searchNotes("Flagstaff");
+    const results = await store.searchNotes("Flagstaff");
     expect(results).toHaveLength(1);
     expect(results[0].content).toContain("Flagstaff");
   });
 
-  it("filters search by tag", () => {
-    store.createNote("Daily Flagstaff", { tags: ["daily"] });
-    store.createNote("Doc Flagstaff", { tags: ["doc"] });
+  it("filters search by tag", async () => {
+    await store.createNote("Daily Flagstaff", { tags: ["daily"] });
+    await store.createNote("Doc Flagstaff", { tags: ["doc"] });
 
-    const results = store.searchNotes("Flagstaff", { tags: ["daily"] });
+    const results = await store.searchNotes("Flagstaff", { tags: ["daily"] });
     expect(results).toHaveLength(1);
     expect(results[0].tags).toContain("daily");
   });
 
-  it("returns empty for no match", () => {
-    store.createNote("Hello world");
-    const results = store.searchNotes("nonexistent");
+  it("returns empty for no match", async () => {
+    await store.createNote("Hello world");
+    const results = await store.searchNotes("nonexistent");
     expect(results).toHaveLength(0);
   });
 });
 
 // ---- Links ----
 
-describe("links", () => {
-  it("creates a link", () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
+describe("links", async () => {
+  it("creates a link", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
 
-    const link = store.createLink("a", "b", "mentions");
+    const link = await store.createLink("a", "b", "mentions");
     expect(link.sourceId).toBe("a");
     expect(link.targetId).toBe("b");
     expect(link.relationship).toBe("mentions");
   });
 
-  it("deletes a link", () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
-    store.createLink("a", "b", "mentions");
-    store.deleteLink("a", "b", "mentions");
+  it("deletes a link", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions");
+    await store.deleteLink("a", "b", "mentions");
 
-    const links = store.getLinks("a");
+    const links = await store.getLinks("a");
     expect(links).toHaveLength(0);
   });
 
-  it("gets outbound links", () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
-    store.createNote("C", { id: "c" });
-    store.createLink("a", "b", "mentions");
-    store.createLink("c", "a", "quotes");
+  it("gets outbound links", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createNote("C", { id: "c" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("c", "a", "quotes");
 
-    const outbound = store.getLinks("a", { direction: "outbound" });
+    const outbound = await store.getLinks("a", { direction: "outbound" });
     expect(outbound).toHaveLength(1);
     expect(outbound[0].targetId).toBe("b");
   });
 
-  it("gets inbound links", () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
-    store.createLink("a", "b", "mentions");
+  it("gets inbound links", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions");
 
-    const inbound = store.getLinks("b", { direction: "inbound" });
+    const inbound = await store.getLinks("b", { direction: "inbound" });
     expect(inbound).toHaveLength(1);
     expect(inbound[0].sourceId).toBe("a");
   });
 
-  it("gets all links (both directions)", () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
-    store.createNote("C", { id: "c" });
-    store.createLink("a", "b", "mentions");
-    store.createLink("c", "a", "quotes");
+  it("gets all links (both directions)", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createNote("C", { id: "c" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("c", "a", "quotes");
 
-    const all = store.getLinks("a", { direction: "both" });
+    const all = await store.getLinks("a", { direction: "both" });
     expect(all).toHaveLength(2);
   });
 
-  it("link creation is idempotent", () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
-    store.createLink("a", "b", "mentions");
-    store.createLink("a", "b", "mentions"); // duplicate
-    const links = store.getLinks("a");
+  it("link creation is idempotent", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("a", "b", "mentions"); // duplicate
+    const links = await store.getLinks("a");
     expect(links.filter((l) => l.relationship === "mentions")).toHaveLength(1);
   });
 });
 
 // ---- Attachments ----
 
-describe("attachments", () => {
-  it("adds and retrieves attachments", () => {
-    const note = store.createNote("Voice memo", { tags: ["daily", "voice"] });
-    const attachment = store.addAttachment(note.id, "2026-03-31/audio.wav", "audio/wav");
+describe("attachments", async () => {
+  it("adds and retrieves attachments", async () => {
+    const note = await store.createNote("Voice memo", { tags: ["daily", "voice"] });
+    const attachment = await store.addAttachment(note.id, "2026-03-31/audio.wav", "audio/wav");
 
     expect(attachment.noteId).toBe(note.id);
     expect(attachment.mimeType).toBe("audio/wav");
 
-    const attachments = store.getAttachments(note.id);
+    const attachments = await store.getAttachments(note.id);
     expect(attachments).toHaveLength(1);
     expect(attachments[0].path).toBe("2026-03-31/audio.wav");
   });
 
-  it("cascade deletes attachments with note", () => {
-    const note = store.createNote("Test");
-    store.addAttachment(note.id, "file.png", "image/png");
-    store.deleteNote(note.id);
+  it("cascade deletes attachments with note", async () => {
+    const note = await store.createNote("Test");
+    await store.addAttachment(note.id, "file.png", "image/png");
+    await store.deleteNote(note.id);
 
-    const attachments = store.getAttachments(note.id);
+    const attachments = await store.getAttachments(note.id);
     expect(attachments).toHaveLength(0);
   });
 });
 
 // ---- MCP Tools ----
 
-describe("MCP tools", () => {
+describe("MCP tools", async () => {
   it("generates all 9 consolidated tools", () => {
     const tools = generateMcpTools(store);
     const names = tools.map((t) => t.name);
@@ -454,18 +454,18 @@ describe("MCP tools", () => {
     expect(tools).toHaveLength(9);
   });
 
-  it("create-note tool works", () => {
+  it("create-note tool works", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
-    const result = createNote.execute({ content: "Hello", tags: ["daily"] }) as any;
+    const result = await createNote.execute({ content: "Hello", tags: ["daily"] }) as any;
     expect(result.content).toBe("Hello");
     expect(result.tags).toContain("daily");
   });
 
-  it("create-note batch mode works", () => {
+  it("create-note batch mode works", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
-    const result = createNote.execute({
+    const result = await createNote.execute({
       notes: [
         { content: "A", tags: ["daily"] },
         { content: "B", tags: ["doc"] },
@@ -476,87 +476,87 @@ describe("MCP tools", () => {
     expect(result[1].tags).toContain("doc");
   });
 
-  it("create-note with links resolves targets by path", () => {
+  it("create-note with links resolves targets by path", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
-    store.createNote("Target", { path: "People/Alice" });
-    const result = createNote.execute({
+    await store.createNote("Target", { path: "People/Alice" });
+    const result = await createNote.execute({
       content: "Links to Alice",
       links: [{ target: "People/Alice", relationship: "mentions" }],
     }) as any;
-    const links = store.getLinks(result.id, { direction: "outbound" });
+    const links = await store.getLinks(result.id, { direction: "outbound" });
     expect(links.some((l) => l.relationship === "mentions")).toBe(true);
   });
 
-  it("update-note tool updates created_at", () => {
-    const note = store.createNote("Test");
+  it("update-note tool updates created_at", async () => {
+    const note = await store.createNote("Test");
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
     const newDate = "2025-03-01T00:00:00.000Z";
-    const result = updateNote.execute({ id: note.id, created_at: newDate }) as any;
+    const result = await updateNote.execute({ id: note.id, created_at: newDate }) as any;
     expect(result.createdAt).toBe(newDate);
     expect(result.content).toBe("Test");
   });
 
-  it("update-note tool merges metadata", () => {
-    const note = store.createNote("Test", { metadata: { existing: "value" } });
+  it("update-note tool merges metadata", async () => {
+    const note = await store.createNote("Test", { metadata: { existing: "value" } });
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
-    const result = updateNote.execute({ id: note.id, metadata: { importance: "high" } }) as any;
+    const result = await updateNote.execute({ id: note.id, metadata: { importance: "high" } }) as any;
     expect(result.metadata).toEqual({ existing: "value", importance: "high" });
   });
 
-  it("update-note tags add/remove works", () => {
-    const note = store.createNote("Test");
+  it("update-note tags add/remove works", async () => {
+    const note = await store.createNote("Test");
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
 
     // Add tags
-    updateNote.execute({ id: note.id, tags: { add: ["pinned", "daily"] } });
-    expect(store.getNote(note.id)!.tags).toContain("pinned");
-    expect(store.getNote(note.id)!.tags).toContain("daily");
+    await updateNote.execute({ id: note.id, tags: { add: ["pinned", "daily"] } });
+    expect((await store.getNote(note.id))!.tags).toContain("pinned");
+    expect((await store.getNote(note.id))!.tags).toContain("daily");
 
     // Remove tags
-    updateNote.execute({ id: note.id, tags: { remove: ["pinned"] } });
-    expect(store.getNote(note.id)!.tags).not.toContain("pinned");
-    expect(store.getNote(note.id)!.tags).toContain("daily");
+    await updateNote.execute({ id: note.id, tags: { remove: ["pinned"] } });
+    expect((await store.getNote(note.id))!.tags).not.toContain("pinned");
+    expect((await store.getNote(note.id))!.tags).toContain("daily");
   });
 
-  it("update-note links add/remove works", () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
+  it("update-note links add/remove works", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
 
     // Add link
-    updateNote.execute({ id: "a", links: { add: [{ target: "b", relationship: "mentions" }] } });
-    expect(store.getLinks("a", { direction: "outbound" })).toHaveLength(1);
+    await updateNote.execute({ id: "a", links: { add: [{ target: "b", relationship: "mentions" }] } });
+    expect(await store.getLinks("a", { direction: "outbound" })).toHaveLength(1);
 
     // Remove link
-    updateNote.execute({ id: "a", links: { remove: [{ target: "b", relationship: "mentions" }] } });
-    expect(store.getLinks("a", { direction: "outbound" })).toHaveLength(0);
+    await updateNote.execute({ id: "a", links: { remove: [{ target: "b", relationship: "mentions" }] } });
+    expect(await store.getLinks("a", { direction: "outbound" })).toHaveLength(0);
   });
 
-  it("update-note removes wikilink brackets when removing wikilink-type link", () => {
-    store.createNote("Target", { id: "target", path: "People/Alice" });
-    const source = store.createNote("See [[People/Alice]] for details", { id: "source" });
-    store.createLink("source", "target", "wikilink");
+  it("update-note removes wikilink brackets when removing wikilink-type link", async () => {
+    await store.createNote("Target", { id: "target", path: "People/Alice" });
+    const source = await store.createNote("See [[People/Alice]] for details", { id: "source" });
+    await store.createLink("source", "target", "wikilink");
 
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
-    const result = updateNote.execute({
+    const result = await updateNote.execute({
       id: "source",
       links: { remove: [{ target: "target", relationship: "wikilink" }] },
     }) as any;
     expect(result.content).toBe("See People/Alice for details");
   });
 
-  it("update-note batch mode works", () => {
-    const a = store.createNote("A", { id: "a" });
-    const b = store.createNote("B", { id: "b" });
+  it("update-note batch mode works", async () => {
+    const a = await store.createNote("A", { id: "a" });
+    const b = await store.createNote("B", { id: "b" });
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
-    const result = updateNote.execute({
+    const result = await updateNote.execute({
       notes: [
         { id: "a", content: "A updated" },
         { id: "b", tags: { add: ["pinned"] } },
@@ -564,48 +564,48 @@ describe("MCP tools", () => {
     }) as any[];
     expect(result).toHaveLength(2);
     expect(result[0].content).toBe("A updated");
-    expect(store.getNote("b")!.tags).toContain("pinned");
+    expect((await store.getNote("b"))!.tags).toContain("pinned");
   });
 
-  it("update-note resolves note by path", () => {
-    store.createNote("Test", { path: "Projects/README" });
+  it("update-note resolves note by path", async () => {
+    await store.createNote("Test", { path: "Projects/README" });
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
-    const result = updateNote.execute({ id: "Projects/README", content: "Updated" }) as any;
+    const result = await updateNote.execute({ id: "Projects/README", content: "Updated" }) as any;
     expect(result.content).toBe("Updated");
   });
 
-  it("query-notes single note by id", () => {
-    const note = store.createNote("Hello", { path: "test/note" });
+  it("query-notes single note by id", async () => {
+    const note = await store.createNote("Hello", { path: "test/note" });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ id: note.id }) as any;
+    const result = await query.execute({ id: note.id }) as any;
     expect(result.content).toBe("Hello");
     expect(result.path).toBe("test/note");
   });
 
-  it("query-notes single note by path", () => {
-    store.createNote("By Path", { path: "Projects/README" });
+  it("query-notes single note by path", async () => {
+    await store.createNote("By Path", { path: "Projects/README" });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ id: "Projects/README" }) as any;
+    const result = await query.execute({ id: "Projects/README" }) as any;
     expect(result.content).toBe("By Path");
   });
 
-  it("query-notes by tag", () => {
-    store.createNote("Test", { tags: ["daily"] });
+  it("query-notes by tag", async () => {
+    await store.createNote("Test", { tags: ["daily"] });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: ["daily"] }) as any[];
+    const result = await query.execute({ tag: ["daily"] }) as any[];
     expect(result).toHaveLength(1);
   });
 
-  it("query-notes list defaults to no content (index mode)", () => {
+  it("query-notes list defaults to no content (index mode)", async () => {
     const content = "This is the note body.";
-    store.createNote(content, { tags: ["daily"], path: "Notes/test", metadata: { status: "draft" } });
+    await store.createNote(content, { tags: ["daily"], path: "Notes/test", metadata: { status: "draft" } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: ["daily"] }) as any[];
+    const result = await query.execute({ tag: ["daily"] }) as any[];
     expect(result).toHaveLength(1);
     const entry = result[0];
     expect(entry.content).toBeUndefined();
@@ -614,21 +614,21 @@ describe("MCP tools", () => {
     expect(entry.byteSize).toBe(Buffer.byteLength(content, "utf8"));
   });
 
-  it("query-notes list with include_content: true returns full content", () => {
-    store.createNote("Full body", { tags: ["daily"] });
+  it("query-notes list with include_content: true returns full content", async () => {
+    await store.createNote("Full body", { tags: ["daily"] });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: ["daily"], include_content: true }) as any[];
+    const result = await query.execute({ tag: ["daily"], include_content: true }) as any[];
     expect(result).toHaveLength(1);
     expect(result[0].content).toBe("Full body");
   });
 
-  it("query-notes index mode truncates preview and counts utf-8 bytes", () => {
+  it("query-notes index mode truncates preview and counts utf-8 bytes", async () => {
     const longContent = "line one\nline two has\tlots    of   whitespace\n" + "x".repeat(300) + " ✨✨✨";
-    store.createNote(longContent, { tags: ["long"] });
+    await store.createNote(longContent, { tags: ["long"] });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: ["long"] }) as any[];
+    const result = await query.execute({ tag: ["long"] }) as any[];
     expect(result).toHaveLength(1);
     const entry = result[0];
     expect(entry.byteSize).toBe(Buffer.byteLength(longContent, "utf8"));
@@ -637,13 +637,13 @@ describe("MCP tools", () => {
     expect(entry.preview.includes("\n")).toBe(false);
   });
 
-  it("query-notes index mode does not split astral-plane surrogate pairs", () => {
+  it("query-notes index mode does not split astral-plane surrogate pairs", async () => {
     const emoji = "😀";
     const longContent = emoji.repeat(130);
-    store.createNote(longContent, { tags: ["astral"] });
+    await store.createNote(longContent, { tags: ["astral"] });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: ["astral"] }) as any[];
+    const result = await query.execute({ tag: ["astral"] }) as any[];
     expect(result).toHaveLength(1);
     const preview = result[0].preview as string;
     const codePoints = Array.from(preview);
@@ -653,17 +653,17 @@ describe("MCP tools", () => {
     }
   });
 
-  it("query-notes honors filters (date range, path_prefix, limit, offset)", () => {
-    store.createNote("A", { tags: ["keep"], path: "Projects/a", created_at: "2025-03-05T00:00:00.000Z" });
-    store.createNote("B", { tags: ["keep"], path: "Projects/b", created_at: "2025-03-10T00:00:00.000Z" });
-    store.createNote("C", { tags: ["keep"], path: "Other/c",    created_at: "2025-03-15T00:00:00.000Z" });
-    store.createNote("D", { tags: ["keep"], path: "Projects/d", created_at: "2025-04-02T00:00:00.000Z" });
+  it("query-notes honors filters (date range, path_prefix, limit, offset)", async () => {
+    await store.createNote("A", { tags: ["keep"], path: "Projects/a", created_at: "2025-03-05T00:00:00.000Z" });
+    await store.createNote("B", { tags: ["keep"], path: "Projects/b", created_at: "2025-03-10T00:00:00.000Z" });
+    await store.createNote("C", { tags: ["keep"], path: "Other/c",    created_at: "2025-03-15T00:00:00.000Z" });
+    await store.createNote("D", { tags: ["keep"], path: "Projects/d", created_at: "2025-04-02T00:00:00.000Z" });
 
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
 
     // date range filter
-    const inMarch = query.execute({
+    const inMarch = await query.execute({
       date_from: "2025-03-01",
       date_to: "2025-04-01",
       sort: "asc",
@@ -672,12 +672,12 @@ describe("MCP tools", () => {
     expect(inMarch.every((n) => n.content === undefined)).toBe(true);
 
     // path_prefix filter
-    const projects = query.execute({ path_prefix: "Projects" }) as any[];
+    const projects = await query.execute({ path_prefix: "Projects" }) as any[];
     expect(projects).toHaveLength(3);
     expect(projects.every((n) => n.path!.startsWith("Projects"))).toBe(true);
 
     // limit + offset
-    const page = query.execute({
+    const page = await query.execute({
       path_prefix: "Projects",
       sort: "asc",
       limit: 2,
@@ -686,68 +686,68 @@ describe("MCP tools", () => {
     expect(page).toHaveLength(2);
   });
 
-  it("query-notes full-text search works", () => {
-    store.createNote("Flagstaff trail");
+  it("query-notes full-text search works", async () => {
+    await store.createNote("Flagstaff trail");
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ search: "Flagstaff" }) as any[];
+    const result = await query.execute({ search: "Flagstaff" }) as any[];
     expect(result).toHaveLength(1);
   });
 
-  it("query-notes with include_links enriches results", () => {
-    store.createNote("A", { id: "a", path: "alpha" });
-    store.createNote("B", { id: "b", path: "beta" });
-    store.createLink("a", "b", "mentions");
+  it("query-notes with include_links enriches results", async () => {
+    await store.createNote("A", { id: "a", path: "alpha" });
+    await store.createNote("B", { id: "b", path: "beta" });
+    await store.createLink("a", "b", "mentions");
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ id: "a", include_links: true }) as any;
+    const result = await query.execute({ id: "a", include_links: true }) as any;
     expect(result.links).toBeDefined();
     expect(result.links).toHaveLength(1);
   });
 
-  it("query-notes include_metadata: true returns all metadata (single)", () => {
-    store.createNote("Body", { metadata: { summary: "short", status: "draft", priority: 1 } });
+  it("query-notes include_metadata: true returns all metadata (single)", async () => {
+    await store.createNote("Body", { metadata: { summary: "short", status: "draft", priority: 1 } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ id: store.queryNotes({})[0].id, include_metadata: true }) as any;
+    const result = await query.execute({ id: (await store.queryNotes({}))[0].id, include_metadata: true }) as any;
     expect(result.metadata).toEqual({ summary: "short", status: "draft", priority: 1 });
   });
 
-  it("query-notes include_metadata: false strips metadata (single)", () => {
-    store.createNote("Body", { metadata: { summary: "short", status: "draft" } });
+  it("query-notes include_metadata: false strips metadata (single)", async () => {
+    await store.createNote("Body", { metadata: { summary: "short", status: "draft" } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ id: store.queryNotes({})[0].id, include_metadata: false }) as any;
+    const result = await query.execute({ id: (await store.queryNotes({}))[0].id, include_metadata: false }) as any;
     expect(result.metadata).toBeUndefined();
     expect(result.content).toBe("Body"); // other fields unaffected
   });
 
-  it("query-notes include_metadata: string[] returns only specified fields (single)", () => {
-    store.createNote("Body", { metadata: { summary: "short", status: "draft", priority: 1 } });
+  it("query-notes include_metadata: string[] returns only specified fields (single)", async () => {
+    await store.createNote("Body", { metadata: { summary: "short", status: "draft", priority: 1 } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ id: store.queryNotes({})[0].id, include_metadata: ["summary"] }) as any;
+    const result = await query.execute({ id: (await store.queryNotes({}))[0].id, include_metadata: ["summary"] }) as any;
     expect(result.metadata).toEqual({ summary: "short" });
   });
 
-  it("query-notes include_metadata: false strips metadata (list)", () => {
-    store.createNote("A", { tags: ["meta-test"], metadata: { summary: "a" } });
-    store.createNote("B", { tags: ["meta-test"], metadata: { summary: "b" } });
+  it("query-notes include_metadata: false strips metadata (list)", async () => {
+    await store.createNote("A", { tags: ["meta-test"], metadata: { summary: "a" } });
+    await store.createNote("B", { tags: ["meta-test"], metadata: { summary: "b" } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: "meta-test", include_metadata: false }) as any[];
+    const result = await query.execute({ tag: "meta-test", include_metadata: false }) as any[];
     expect(result).toHaveLength(2);
     for (const n of result) {
       expect(n.metadata).toBeUndefined();
     }
   });
 
-  it("query-notes include_metadata: string[] filters fields (list)", () => {
-    store.createNote("A", { tags: ["meta-filter"], metadata: { summary: "a", status: "ok", extra: true } });
-    store.createNote("B", { tags: ["meta-filter"], metadata: { summary: "b", extra: false } });
+  it("query-notes include_metadata: string[] filters fields (list)", async () => {
+    await store.createNote("A", { tags: ["meta-filter"], metadata: { summary: "a", status: "ok", extra: true } });
+    await store.createNote("B", { tags: ["meta-filter"], metadata: { summary: "b", extra: false } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: "meta-filter", include_metadata: ["summary", "status"] }) as any[];
+    const result = await query.execute({ tag: "meta-filter", include_metadata: ["summary", "status"] }) as any[];
     expect(result).toHaveLength(2);
     const a = result.find((n: any) => n.metadata?.summary === "a");
     const b = result.find((n: any) => n.metadata?.summary === "b");
@@ -755,118 +755,118 @@ describe("MCP tools", () => {
     expect(b.metadata).toEqual({ summary: "b" }); // status absent → omitted
   });
 
-  it("query-notes include_metadata: string[] with no matching fields returns undefined metadata", () => {
-    store.createNote("A", { tags: ["no-match-meta"], metadata: { summary: "a" } });
+  it("query-notes include_metadata: string[] with no matching fields returns undefined metadata", async () => {
+    await store.createNote("A", { tags: ["no-match-meta"], metadata: { summary: "a" } });
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: "no-match-meta", include_metadata: ["nonexistent"] }) as any[];
+    const result = await query.execute({ tag: "no-match-meta", include_metadata: ["nonexistent"] }) as any[];
     expect(result).toHaveLength(1);
     expect(result[0].metadata).toBeUndefined();
   });
 
-  it("query-notes near param scopes results to graph neighborhood", () => {
-    store.createNote("Center", { id: "center" });
-    store.createNote("Near", { id: "near", tags: ["t"] });
-    store.createNote("Far", { id: "far", tags: ["t"] });
-    store.createLink("center", "near", "mentions");
+  it("query-notes near param scopes results to graph neighborhood", async () => {
+    await store.createNote("Center", { id: "center" });
+    await store.createNote("Near", { id: "near", tags: ["t"] });
+    await store.createNote("Far", { id: "far", tags: ["t"] });
+    await store.createLink("center", "near", "mentions");
     // "far" is not linked to "center"
 
     const tools = generateMcpTools(store);
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ tag: "t", near: { note_id: "center", depth: 1 } }) as any[];
+    const result = await query.execute({ tag: "t", near: { note_id: "center", depth: 1 } }) as any[];
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("near");
   });
 
-  it("delete-note accepts path", () => {
-    store.createNote("To delete", { path: "Temp/note" });
+  it("delete-note accepts path", async () => {
+    await store.createNote("To delete", { path: "Temp/note" });
     const tools = generateMcpTools(store);
     const deleteTool = tools.find((t) => t.name === "delete-note")!;
-    const result = deleteTool.execute({ id: "Temp/note" }) as any;
+    const result = await deleteTool.execute({ id: "Temp/note" }) as any;
     expect(result.deleted).toBe(true);
-    expect(store.getNoteByPath("Temp/note")).toBeNull();
+    expect(await store.getNoteByPath("Temp/note")).toBeNull();
   });
 
-  it("delete-tag with zero notes removes tag from list", () => {
-    store.createNote("Test", { tags: ["ephemeral"] });
-    store.untagNote(store.queryNotes({}).find((n) => n.tags?.includes("ephemeral"))!.id, ["ephemeral"]);
-    const before = store.listTags();
+  it("delete-tag with zero notes removes tag from list", async () => {
+    await store.createNote("Test", { tags: ["ephemeral"] });
+    await store.untagNote((await store.queryNotes({})).find((n) => n.tags?.includes("ephemeral"))!.id, ["ephemeral"]);
+    const before = await store.listTags();
     expect(before.some((t) => t.name === "ephemeral")).toBe(true);
 
-    const result = store.deleteTag("ephemeral");
+    const result = await store.deleteTag("ephemeral");
     expect(result).toEqual({ deleted: true, notes_untagged: 0 });
 
-    const after = store.listTags();
+    const after = await store.listTags();
     expect(after.some((t) => t.name === "ephemeral")).toBe(false);
   });
 
-  it("delete-tag with N notes untags all but preserves notes", () => {
-    const n1 = store.createNote("A", { tags: ["doomed"] });
-    const n2 = store.createNote("B", { tags: ["doomed", "keeper"] });
+  it("delete-tag with N notes untags all but preserves notes", async () => {
+    const n1 = await store.createNote("A", { tags: ["doomed"] });
+    const n2 = await store.createNote("B", { tags: ["doomed", "keeper"] });
 
-    const result = store.deleteTag("doomed");
+    const result = await store.deleteTag("doomed");
     expect(result).toEqual({ deleted: true, notes_untagged: 2 });
 
-    expect(store.getNote(n1.id)).not.toBeNull();
-    expect(store.getNote(n2.id)).not.toBeNull();
-    expect(store.getNote(n1.id)!.tags).not.toContain("doomed");
-    expect(store.getNote(n2.id)!.tags).not.toContain("doomed");
-    expect(store.getNote(n2.id)!.tags).toContain("keeper");
-    expect(store.listTags().some((t) => t.name === "doomed")).toBe(false);
+    expect(await store.getNote(n1.id)).not.toBeNull();
+    expect(await store.getNote(n2.id)).not.toBeNull();
+    expect((await store.getNote(n1.id))!.tags).not.toContain("doomed");
+    expect((await store.getNote(n2.id))!.tags).not.toContain("doomed");
+    expect((await store.getNote(n2.id))!.tags).toContain("keeper");
+    expect((await store.listTags()).some((t) => t.name === "doomed")).toBe(false);
   });
 
-  it("delete-tag nonexistent returns deleted: false", () => {
-    const result = store.deleteTag("never-existed");
+  it("delete-tag nonexistent returns deleted: false", async () => {
+    const result = await store.deleteTag("never-existed");
     expect(result).toEqual({ deleted: false, notes_untagged: 0 });
   });
 
-  it("delete-tag MCP tool works", () => {
+  it("delete-tag MCP tool works", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
-    createNote.execute({ content: "Test", tags: ["mcp-tag"] });
+    await createNote.execute({ content: "Test", tags: ["mcp-tag"] });
 
     const deleteTool = tools.find((t) => t.name === "delete-tag")!;
-    const result = deleteTool.execute({ tag: "mcp-tag" }) as any;
+    const result = await deleteTool.execute({ tag: "mcp-tag" }) as any;
     expect(result.deleted).toBe(true);
     expect(result.notes_untagged).toBe(1);
 
     const listTool = tools.find((t) => t.name === "list-tags")!;
-    const tags = listTool.execute({}) as any[];
+    const tags = await listTool.execute({}) as any[];
     expect(tags.some((t: any) => t.name === "mcp-tag")).toBe(false);
   });
 
-  it("list-tags single tag detail with schema", () => {
-    store.createNote("Test", { tags: ["person"] });
-    store.upsertTagSchema("person", {
+  it("list-tags single tag detail with schema", async () => {
+    await store.createNote("Test", { tags: ["person"] });
+    await store.upsertTagSchema("person", {
       description: "A person",
       fields: { name: { type: "string" } },
     });
     const tools = generateMcpTools(store);
     const listTags = tools.find((t) => t.name === "list-tags")!;
-    const result = listTags.execute({ tag: "person" }) as any;
+    const result = await listTags.execute({ tag: "person" }) as any;
     expect(result.name).toBe("person");
     expect(result.count).toBe(1);
     expect(result.description).toBe("A person");
     expect(result.fields.name.type).toBe("string");
   });
 
-  it("list-tags include_schema returns schemas for all tags", () => {
-    store.createNote("A", { tags: ["person"] });
-    store.createNote("B", { tags: ["project"] });
-    store.upsertTagSchema("person", { description: "A person" });
+  it("list-tags include_schema returns schemas for all tags", async () => {
+    await store.createNote("A", { tags: ["person"] });
+    await store.createNote("B", { tags: ["project"] });
+    await store.upsertTagSchema("person", { description: "A person" });
     const tools = generateMcpTools(store);
     const listTags = tools.find((t) => t.name === "list-tags")!;
-    const result = listTags.execute({ include_schema: true }) as any[];
+    const result = await listTags.execute({ include_schema: true }) as any[];
     const person = result.find((t: any) => t.name === "person");
     expect(person.description).toBe("A person");
     const project = result.find((t: any) => t.name === "project");
     expect(project.description).toBeNull();
   });
 
-  it("update-tag creates schema if not exists", () => {
+  it("update-tag creates schema if not exists", async () => {
     const tools = generateMcpTools(store);
     const updateTag = tools.find((t) => t.name === "update-tag")!;
-    const result = updateTag.execute({
+    const result = await updateTag.execute({
       tag: "person",
       description: "A person",
       fields: { name: { type: "string" } },
@@ -875,14 +875,14 @@ describe("MCP tools", () => {
     expect(result.description).toBe("A person");
   });
 
-  it("update-tag merges fields with existing", () => {
-    store.upsertTagSchema("person", {
+  it("update-tag merges fields with existing", async () => {
+    await store.upsertTagSchema("person", {
       description: "A person",
       fields: { name: { type: "string" } },
     });
     const tools = generateMcpTools(store);
     const updateTag = tools.find((t) => t.name === "update-tag")!;
-    const result = updateTag.execute({
+    const result = await updateTag.execute({
       tag: "person",
       fields: { age: { type: "integer" } },
     }) as any;
@@ -890,34 +890,34 @@ describe("MCP tools", () => {
     expect(result.fields.age.type).toBe("integer");
   });
 
-  it("find-path works with ID/path resolution", () => {
-    store.createNote("A", { id: "a", path: "People/Alice" });
-    store.createNote("B", { id: "b" });
-    store.createNote("C", { id: "c", path: "Projects/X" });
-    store.createLink("a", "b", "mentions");
-    store.createLink("b", "c", "related-to");
+  it("find-path works with ID/path resolution", async () => {
+    await store.createNote("A", { id: "a", path: "People/Alice" });
+    await store.createNote("B", { id: "b" });
+    await store.createNote("C", { id: "c", path: "Projects/X" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("b", "c", "related-to");
 
     const tools = generateMcpTools(store);
     const findPath = tools.find((t) => t.name === "find-path")!;
-    const result = findPath.execute({ source: "People/Alice", target: "Projects/X" }) as any;
+    const result = await findPath.execute({ source: "People/Alice", target: "Projects/X" }) as any;
     expect(result).not.toBeNull();
     expect(result.path).toEqual(["a", "b", "c"]);
     expect(result.relationships).toEqual(["mentions", "related-to"]);
   });
 
-  it("create-note via store triggers wikilink sync", () => {
+  it("create-note via store triggers wikilink sync", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
 
-    store.createNote("Target", { path: "Target Note" });
-    const source = createNote.execute({ content: "See [[Target Note]]" }) as any;
+    await store.createNote("Target", { path: "Target Note" });
+    const source = await createNote.execute({ content: "See [[Target Note]]" }) as any;
 
-    const links = store.getLinks(source.id, { direction: "outbound" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links.some((l) => l.relationship === "wikilink")).toBe(true);
   });
 
-  it("create-note with schema tag auto-populates defaults", () => {
-    store.upsertTagSchema("person", {
+  it("create-note with schema tag auto-populates defaults", async () => {
+    await store.upsertTagSchema("person", {
       description: "A person",
       fields: {
         first_appeared: { type: "string" },
@@ -930,8 +930,8 @@ describe("MCP tools", () => {
     const createNote = tools.find((t) => t.name === "create-note")!;
     const query = tools.find((t) => t.name === "query-notes")!;
 
-    const result = createNote.execute({ content: "Alice", tags: ["person"] }) as any;
-    const fresh = query.execute({ id: result.id }) as any;
+    const result = await createNote.execute({ content: "Alice", tags: ["person"] }) as any;
+    const fresh = await query.execute({ id: result.id }) as any;
     expect(fresh.metadata.first_appeared).toBe("");
     expect(fresh.metadata.active).toBe(false);
     expect(fresh.metadata.priority).toBe(0);

--- a/core/src/hooks.test.ts
+++ b/core/src/hooks.test.ts
@@ -26,7 +26,7 @@ async function settle(): Promise<void> {
   await hooks.drain();
 }
 
-describe("HookRegistry", () => {
+describe("HookRegistry", async () => {
   it("fires registered hook on createNote", async () => {
     const fired: string[] = [];
     hooks.onNote({
@@ -36,7 +36,7 @@ describe("HookRegistry", () => {
       },
     });
 
-    const note = store.createNote("hello");
+    const note = await store.createNote("hello");
     expect(fired).toEqual([]); // async — not yet
     await settle();
     expect(fired).toEqual([note.id]);
@@ -51,11 +51,11 @@ describe("HookRegistry", () => {
       },
     });
 
-    const note = store.createNote("hello");
+    const note = await store.createNote("hello");
     await settle();
     expect(fired).toEqual([]); // we only subscribed to updated
 
-    store.updateNote(note.id, { content: "world" });
+    await store.updateNote(note.id, { content: "world" });
     await settle();
     expect(fired).toEqual([{ event: "updated", id: note.id }]);
   });
@@ -68,7 +68,7 @@ describe("HookRegistry", () => {
       },
     });
 
-    const notes = store.createNotes([
+    const notes = await store.createNotes([
       { content: "a", id: "a1" },
       { content: "b", id: "b1" },
       { content: "c", id: "c1" },
@@ -87,8 +87,8 @@ describe("HookRegistry", () => {
       },
     });
 
-    const skipped = store.createNote("plain", { tags: ["journal"] });
-    const matched = store.createNote("reader-note", { tags: ["reader"] });
+    const skipped = await store.createNote("plain", { tags: ["journal"] });
+    const matched = await store.createNote("reader-note", { tags: ["reader"] });
     await settle();
 
     expect(fired).toEqual([matched.id]);
@@ -103,14 +103,14 @@ describe("HookRegistry", () => {
       },
     });
 
-    const note = store.createNote("one");
+    const note = await store.createNote("one");
     await settle();
     expect(fired).toEqual([note.id]);
 
     fired.length = 0;
-    store.getNote(note.id);
-    store.getNotes([note.id]);
-    store.queryNotes({});
+    await store.getNote(note.id);
+    await store.getNotes([note.id]);
+    await store.queryNotes({});
     await settle();
     expect(fired).toEqual([]);
   });
@@ -128,14 +128,14 @@ describe("HookRegistry", () => {
       },
     });
 
-    const note = store.createNote("work me");
+    const note = await store.createNote("work me");
     await settle();
     // The handler ran once for "created"; its updateNote triggered an
     // "updated" dispatch, but the predicate excluded it because the
     // marker is now set. So exactly one call.
     expect(handlerCalls).toBe(1);
 
-    const refreshed = store.getNote(note.id)!;
+    const refreshed = await store.getNote(note.id)!;
     expect(refreshed.metadata?.processed_at).toBeTruthy();
   });
 
@@ -155,10 +155,10 @@ describe("HookRegistry", () => {
       },
     });
 
-    const note = localStore.createNote("survive");
+    const note = await localStore.createNote("survive");
     expect(note.id).toBeTruthy();
     // Original mutation still persisted
-    expect(localStore.getNote(note.id)?.content).toBe("survive");
+    expect((await localStore.getNote(note.id))?.content).toBe("survive");
 
     await Promise.resolve();
     await Promise.resolve();
@@ -184,9 +184,9 @@ describe("HookRegistry", () => {
       },
     });
 
-    localStore.createNote("a");
-    localStore.createNote("b");
-    localStore.createNote("c");
+    await localStore.createNote("a");
+    await localStore.createNote("b");
+    await localStore.createNote("c");
 
     // Let dispatch microtasks enqueue tasks and the semaphore start one.
     await Promise.resolve();
@@ -216,12 +216,12 @@ describe("HookRegistry", () => {
       },
     });
 
-    store.createNote("first");
+    await store.createNote("first");
     await settle();
     expect(fired.length).toBe(1);
 
     off();
-    store.createNote("second");
+    await store.createNote("second");
     await settle();
     expect(fired.length).toBe(1);
   });
@@ -231,7 +231,7 @@ describe("HookRegistry", () => {
     hooks.onNote({ name: "one", handler: () => void order.push("one") });
     hooks.onNote({ name: "two", handler: () => void order.push("two") });
 
-    store.createNote("both");
+    await store.createNote("both");
     await settle();
     expect(order.sort()).toEqual(["one", "two"]);
   });
@@ -244,7 +244,7 @@ describe("HookRegistry", () => {
         done = true;
       },
     });
-    store.createNote("slow");
+    await store.createNote("slow");
     // Let dispatch schedule
     await Promise.resolve();
     await Promise.resolve();
@@ -278,7 +278,7 @@ describe("HookRegistry", () => {
       },
     });
 
-    loggingStore.createNote("hi");
+    await loggingStore.createNote("hi");
     await Promise.resolve();
     await Promise.resolve();
     await loggingHooks.drain();
@@ -292,7 +292,7 @@ describe("HookRegistry", () => {
   });
 });
 
-describe("HookRegistry — HOOK_CONCURRENCY env var parsing", () => {
+describe("HookRegistry — HOOK_CONCURRENCY env var parsing", async () => {
   const original = process.env.HOOK_CONCURRENCY;
   const restore = () => {
     if (original === undefined) delete process.env.HOOK_CONCURRENCY;
@@ -344,9 +344,9 @@ describe("HookRegistry — HOOK_CONCURRENCY env var parsing", () => {
       },
     });
 
-    s.createNote("a");
-    s.createNote("b");
-    s.createNote("c");
+    await s.createNote("a");
+    await s.createNote("b");
+    await s.createNote("c");
     await Promise.resolve();
     await Promise.resolve();
     // Release them one at a time and let each drain through the semaphore.

--- a/core/src/hooks.test.ts
+++ b/core/src/hooks.test.ts
@@ -135,7 +135,7 @@ describe("HookRegistry", async () => {
     // marker is now set. So exactly one call.
     expect(handlerCalls).toBe(1);
 
-    const refreshed = await store.getNote(note.id)!;
+    const refreshed = (await store.getNote(note.id))!;
     expect(refreshed.metadata?.processed_at).toBeTruthy();
   });
 

--- a/core/src/hooks.ts
+++ b/core/src/hooks.ts
@@ -203,7 +203,7 @@ export class HookRegistry {
       // Re-read the note so the handler sees the latest state (another
       // handler may have written back in between). If the note was
       // deleted, silently drop.
-      const fresh = store.getNote(note.id) ?? note;
+      const fresh = (await store.getNote(note.id)) ?? note;
       await hook.handler(fresh, store, event);
     } catch (err) {
       this.logger.error(

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -9,7 +9,7 @@ export interface McpToolDef {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
-  execute: (params: Record<string, unknown>) => unknown;
+  execute: (params: Record<string, unknown>) => unknown | Promise<unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,7 +123,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
           include_attachments: { type: "boolean", description: "Include attachment records (default: false)" },
         },
       },
-      execute: (params) => {
+      execute: async (params) => {
         // --- Single note by ID/path ---
         if (params.id) {
           const note = resolveNote(db, params.id as string);
@@ -135,7 +135,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
             result.links = linkOps.getLinksHydrated(db, note.id);
           }
           if (params.include_attachments) {
-            result.attachments = store.getAttachments(note.id);
+            result.attachments = await store.getAttachments(note.id);
           }
           return result;
         }
@@ -198,12 +198,14 @@ Defaults: include_content=true for single note, false for lists. include_links=f
 
         // --- Hydrate links/attachments per note if requested ---
         if (params.include_links || params.include_attachments) {
-          return output.map((n: any) => {
-            const enriched = { ...n };
+          const enrichedOut: any[] = [];
+          for (const n of output as any[]) {
+            const enriched: any = { ...n };
             if (params.include_links) enriched.links = linkOps.getLinksHydrated(db, n.id);
-            if (params.include_attachments) enriched.attachments = store.getAttachments(n.id);
-            return enriched;
-          });
+            if (params.include_attachments) enriched.attachments = await store.getAttachments(n.id);
+            enrichedOut.push(enriched);
+          }
+          return enrichedOut;
         }
 
         return output;
@@ -256,13 +258,13 @@ Defaults: include_content=true for single note, false for lists. include_links=f
           },
         },
       },
-      execute: (params) => {
+      execute: async (params) => {
         const batch = params.notes as any[] | undefined;
         const items = batch ?? [params];
 
         const created: Note[] = [];
         for (const item of items) {
-          const note = store.createNote(item.content as string ?? "", {
+          const note = await store.createNote(item.content as string ?? "", {
             path: item.path as string | undefined,
             tags: item.tags as string[] | undefined,
             metadata: item.metadata as Record<string, unknown> | undefined,
@@ -274,7 +276,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
             for (const link of item.links as { target: string; relationship: string }[]) {
               const target = resolveNote(db, link.target);
               if (target) {
-                store.createLink(note.id, target.id, link.relationship);
+                await store.createLink(note.id, target.id, link.relationship);
               }
             }
           }
@@ -285,7 +287,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
         // Apply tag schema effects
         for (const note of created) {
           if (note.tags && note.tags.length > 0) {
-            applySchemaDefaults(store, db, [note.id], note.tags);
+            await applySchemaDefaults(store, db, [note.id], note.tags);
           }
         }
 
@@ -368,7 +370,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
           },
         },
       },
-      execute: (params) => {
+      execute: async (params) => {
         const batch = params.notes as any[] | undefined;
         const items = batch ?? [params];
 
@@ -383,7 +385,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
             for (const link of linksRemove) {
               const target = resolveNote(db, link.target);
               if (target) {
-                store.deleteLink(note.id, target.id, link.relationship);
+                await store.deleteLink(note.id, target.id, link.relationship);
                 // Remove [[brackets]] from content if this was a wikilink
                 if (link.relationship === "wikilink" && target.path) {
                   const currentContent = contentOverride ?? note.content;
@@ -409,7 +411,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
 
           let result: Note;
           if (Object.keys(updates).length > 0) {
-            result = store.updateNote(note.id, updates);
+            result = await store.updateNote(note.id, updates);
           } else {
             result = note;
           }
@@ -417,11 +419,11 @@ Defaults: include_content=true for single note, false for lists. include_links=f
           // --- Tags ---
           const tagsOp = item.tags as { add?: string[]; remove?: string[] } | undefined;
           if (tagsOp?.add?.length) {
-            store.tagNote(note.id, tagsOp.add);
-            applySchemaDefaults(store, db, [note.id], tagsOp.add);
+            await store.tagNote(note.id, tagsOp.add);
+            await applySchemaDefaults(store, db, [note.id], tagsOp.add);
           }
           if (tagsOp?.remove?.length) {
-            store.untagNote(note.id, tagsOp.remove);
+            await store.untagNote(note.id, tagsOp.remove);
           }
 
           // --- Add links ---
@@ -430,7 +432,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
             for (const link of linksAdd) {
               const target = resolveNote(db, link.target);
               if (target) {
-                store.createLink(note.id, target.id, link.relationship, link.metadata);
+                await store.createLink(note.id, target.id, link.relationship, link.metadata);
               }
             }
           }
@@ -456,9 +458,9 @@ Defaults: include_content=true for single note, false for lists. include_links=f
         },
         required: ["id"],
       },
-      execute: (params) => {
+      execute: async (params) => {
         const note = requireNote(db, params.id as string);
-        store.deleteNote(note.id);
+        await store.deleteNote(note.id);
         return { deleted: true, id: note.id };
       },
     },
@@ -557,11 +559,11 @@ Defaults: include_content=true for single note, false for lists. include_links=f
         },
         required: ["tag"],
       },
-      execute: (params) => {
+      execute: async (params) => {
         const tag = params.tag as string;
         // Delete schema first (FK cascade would handle it, but be explicit)
         tagSchemaOps.deleteTagSchema(db, tag);
-        return store.deleteTag(tag);
+        return await store.deleteTag(tag);
       },
     },
 
@@ -617,7 +619,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
 // Tag schema effects — auto-populate defaults when tags are applied
 // ---------------------------------------------------------------------------
 
-function applySchemaDefaults(store: Store, db: Database, noteIds: string[], tags: string[]): void {
+async function applySchemaDefaults(store: Store, db: Database, noteIds: string[], tags: string[]): Promise<void> {
   const schemas = tagSchemaOps.getTagSchemaMap(db);
   if (Object.keys(schemas).length === 0) return;
 
@@ -644,7 +646,7 @@ function applySchemaDefaults(store: Store, db: Database, noteIds: string[], tags
       }
     }
     if (Object.keys(missing).length === 0) continue;
-    store.updateNote(noteId, {
+    await store.updateNote(noteId, {
       metadata: { ...existing, ...missing },
       skipUpdatedAt: true,
     });

--- a/core/src/obsidian.test.ts
+++ b/core/src/obsidian.test.ts
@@ -315,7 +315,7 @@ describe("exportFilePath", () => {
 // Round-trip: import → export
 // ---------------------------------------------------------------------------
 
-describe("round-trip", () => {
+describe("round-trip", async () => {
   const tmpBase = join(tmpdir(), "parachute-test-roundtrip");
   let store: SqliteStore;
 
@@ -325,7 +325,7 @@ describe("round-trip", () => {
     store = new SqliteStore(new Database(":memory:"));
   });
 
-  it("preserves content through import → vault → export", () => {
+  it("preserves content through import → vault → export", async () => {
     // Create source files
     writeFileSync(join(tmpBase, "Note.md"), `---
 tags: [daily]
@@ -338,7 +338,7 @@ Hello world.`);
     expect(notes).toHaveLength(1);
 
     // Import into vault
-    const note = store.createNote(notes[0].content, {
+    const note = await store.createNote(notes[0].content, {
       path: notes[0].path,
       tags: notes[0].tags,
       metadata: notes[0].frontmatter,
@@ -357,7 +357,7 @@ Hello world.`);
     expect(md).toContain("Hello world.");
   });
 
-  it("resolves wikilinks during import", () => {
+  it("resolves wikilinks during import", async () => {
     writeFileSync(join(tmpBase, "A.md"), "See [[B]] for details.");
     writeFileSync(join(tmpBase, "B.md"), "I am note B.");
 
@@ -365,16 +365,16 @@ Hello world.`);
 
     // Import all notes
     for (const n of notes) {
-      store.createNote(n.content, {
+      await store.createNote(n.content, {
         path: n.path,
         tags: n.tags.length > 0 ? n.tags : undefined,
       });
     }
 
     // Check that A links to B
-    const noteA = store.getNoteByPath("A")!;
-    const noteB = store.getNoteByPath("B")!;
-    const links = store.getLinks(noteA.id, { direction: "outbound" });
+    const noteA = await store.getNoteByPath("A")!;
+    const noteB = await store.getNoteByPath("B")!;
+    const links = await store.getLinks(noteA.id, { direction: "outbound" });
     expect(links.some((l) => l.targetId === noteB.id && l.relationship === "wikilink")).toBe(true);
   });
 });

--- a/core/src/obsidian.test.ts
+++ b/core/src/obsidian.test.ts
@@ -338,10 +338,10 @@ Hello world.`);
     expect(notes).toHaveLength(1);
 
     // Import into vault
-    const note = await store.createNote(notes[0].content, {
-      path: notes[0].path,
-      tags: notes[0].tags,
-      metadata: notes[0].frontmatter,
+    const note = await store.createNote(notes[0]!.content, {
+      path: notes[0]!.path,
+      tags: notes[0]!.tags,
+      metadata: notes[0]!.frontmatter,
     });
 
     expect(note.content).toBe("Hello world.");
@@ -372,8 +372,8 @@ Hello world.`);
     }
 
     // Check that A links to B
-    const noteA = await store.getNoteByPath("A")!;
-    const noteB = await store.getNoteByPath("B")!;
+    const noteA = (await store.getNoteByPath("A"))!;
+    const noteB = (await store.getNoteByPath("B"))!;
     const links = await store.getLinks(noteA.id, { direction: "outbound" });
     expect(links.some((l) => l.targetId === noteB.id && l.relationship === "wikilink")).toBe(true);
   });

--- a/core/src/paths.test.ts
+++ b/core/src/paths.test.ts
@@ -155,7 +155,7 @@ describe("rename cascading", async () => {
     await store.updateNote(target.id, { path: "New Name" });
 
     // Source content should be updated
-    const updatedSource = await store.getNote(source.id)!;
+    const updatedSource = (await store.getNote(source.id))!;
     expect(updatedSource.content).toBe("See [[New Name]] for details.");
 
     // Link should still work
@@ -170,7 +170,7 @@ describe("rename cascading", async () => {
 
     await store.updateNote(target.id, { path: "New" });
 
-    const updated = await store.getNote(source.id)!;
+    const updated = (await store.getNote(source.id))!;
     expect(updated.content).toBe("See [[New|click here]] for info.");
   });
 
@@ -180,7 +180,7 @@ describe("rename cascading", async () => {
 
     await store.updateNote(target.id, { path: "New" });
 
-    const updated = await store.getNote(source.id)!;
+    const updated = (await store.getNote(source.id))!;
     expect(updated.content).toBe("See [[New#Section]].");
   });
 
@@ -191,7 +191,7 @@ describe("rename cascading", async () => {
 
     await store.updateNote((await store.getNoteByPath("Old"))!.id, { path: "New" });
 
-    const updated = await store.getNote(source.id)!;
+    const updated = (await store.getNote(source.id))!;
     expect(updated.content).toBe("See [[Other]] and [[New]].");
   });
 });

--- a/core/src/paths.test.ts
+++ b/core/src/paths.test.ts
@@ -76,37 +76,37 @@ describe("hasInvalidChars", () => {
 // Path uniqueness
 // ---------------------------------------------------------------------------
 
-describe("path uniqueness", () => {
+describe("path uniqueness", async () => {
   let store: SqliteStore;
 
   beforeEach(() => {
     store = new SqliteStore(new Database(":memory:"));
   });
 
-  it("allows multiple notes without paths", () => {
-    store.createNote("A");
-    store.createNote("B");
+  it("allows multiple notes without paths", async () => {
+    await store.createNote("A");
+    await store.createNote("B");
     // Both should exist
-    const notes = store.queryNotes({ limit: 10 });
+    const notes = await store.queryNotes({ limit: 10 });
     expect(notes).toHaveLength(2);
   });
 
-  it("rejects duplicate paths", () => {
-    store.createNote("A", { path: "My Note" });
-    expect(() => store.createNote("B", { path: "My Note" })).toThrow();
+  it("rejects duplicate paths", async () => {
+    await store.createNote("A", { path: "My Note" });
+    expect(async () => await store.createNote("B", { path: "My Note" })).toThrow();
   });
 
-  it("normalizes before checking uniqueness", () => {
-    store.createNote("A", { path: "My Note.md" });
+  it("normalizes before checking uniqueness", async () => {
+    await store.createNote("A", { path: "My Note.md" });
     // "My Note.md" normalizes to "My Note" — should conflict
-    expect(() => store.createNote("B", { path: "My Note" })).toThrow();
+    expect(async () => await store.createNote("B", { path: "My Note" })).toThrow();
   });
 
-  it("allows different paths", () => {
-    store.createNote("A", { path: "Note A" });
-    store.createNote("B", { path: "Note B" });
-    expect(store.getNoteByPath("Note A")).toBeTruthy();
-    expect(store.getNoteByPath("Note B")).toBeTruthy();
+  it("allows different paths", async () => {
+    await store.createNote("A", { path: "Note A" });
+    await store.createNote("B", { path: "Note B" });
+    expect(await store.getNoteByPath("Note A")).toBeTruthy();
+    expect(await store.getNoteByPath("Note B")).toBeTruthy();
   });
 });
 
@@ -114,21 +114,21 @@ describe("path uniqueness", () => {
 // Path normalization in store operations
 // ---------------------------------------------------------------------------
 
-describe("path normalization in store", () => {
+describe("path normalization in store", async () => {
   let store: SqliteStore;
 
   beforeEach(() => {
     store = new SqliteStore(new Database(":memory:"));
   });
 
-  it("normalizes path on create", () => {
-    const note = store.createNote("Test", { path: "  Projects//README.md  " });
+  it("normalizes path on create", async () => {
+    const note = await store.createNote("Test", { path: "  Projects//README.md  " });
     expect(note.path).toBe("Projects/README");
   });
 
-  it("normalizes path on update", () => {
-    const note = store.createNote("Test", { path: "Old Path" });
-    const updated = store.updateNote(note.id, { path: "New Path.md" });
+  it("normalizes path on update", async () => {
+    const note = await store.createNote("Test", { path: "Old Path" });
+    const updated = await store.updateNote(note.id, { path: "New Path.md" });
     expect(updated.path).toBe("New Path");
   });
 });
@@ -137,61 +137,61 @@ describe("path normalization in store", () => {
 // Rename cascading
 // ---------------------------------------------------------------------------
 
-describe("rename cascading", () => {
+describe("rename cascading", async () => {
   let store: SqliteStore;
 
   beforeEach(() => {
     store = new SqliteStore(new Database(":memory:"));
   });
 
-  it("updates wikilinks in other notes when path changes", () => {
-    const target = store.createNote("I am the target", { path: "Old Name" });
-    const source = store.createNote("See [[Old Name]] for details.");
+  it("updates wikilinks in other notes when path changes", async () => {
+    const target = await store.createNote("I am the target", { path: "Old Name" });
+    const source = await store.createNote("See [[Old Name]] for details.");
 
     // Verify link exists
-    expect(store.getLinks(source.id, { direction: "outbound" })).toHaveLength(1);
+    expect(await store.getLinks(source.id, { direction: "outbound" })).toHaveLength(1);
 
     // Rename the target
-    store.updateNote(target.id, { path: "New Name" });
+    await store.updateNote(target.id, { path: "New Name" });
 
     // Source content should be updated
-    const updatedSource = store.getNote(source.id)!;
+    const updatedSource = await store.getNote(source.id)!;
     expect(updatedSource.content).toBe("See [[New Name]] for details.");
 
     // Link should still work
-    const links = store.getLinks(source.id, { direction: "outbound" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links).toHaveLength(1);
     expect(links[0].targetId).toBe(target.id);
   });
 
-  it("updates aliased wikilinks", () => {
-    const target = store.createNote("Target", { path: "Old" });
-    const source = store.createNote("See [[Old|click here]] for info.");
+  it("updates aliased wikilinks", async () => {
+    const target = await store.createNote("Target", { path: "Old" });
+    const source = await store.createNote("See [[Old|click here]] for info.");
 
-    store.updateNote(target.id, { path: "New" });
+    await store.updateNote(target.id, { path: "New" });
 
-    const updated = store.getNote(source.id)!;
+    const updated = await store.getNote(source.id)!;
     expect(updated.content).toBe("See [[New|click here]] for info.");
   });
 
-  it("updates wikilinks with anchors", () => {
-    const target = store.createNote("Target", { path: "Old" });
-    const source = store.createNote("See [[Old#Section]].");
+  it("updates wikilinks with anchors", async () => {
+    const target = await store.createNote("Target", { path: "Old" });
+    const source = await store.createNote("See [[Old#Section]].");
 
-    store.updateNote(target.id, { path: "New" });
+    await store.updateNote(target.id, { path: "New" });
 
-    const updated = store.getNote(source.id)!;
+    const updated = await store.getNote(source.id)!;
     expect(updated.content).toBe("See [[New#Section]].");
   });
 
-  it("does not update unrelated wikilinks", () => {
-    store.createNote("Target", { path: "Old" });
-    const other = store.createNote("Other", { path: "Other" });
-    const source = store.createNote("See [[Other]] and [[Old]].");
+  it("does not update unrelated wikilinks", async () => {
+    await store.createNote("Target", { path: "Old" });
+    const other = await store.createNote("Other", { path: "Other" });
+    const source = await store.createNote("See [[Other]] and [[Old]].");
 
-    store.updateNote(store.getNoteByPath("Old")!.id, { path: "New" });
+    await store.updateNote((await store.getNoteByPath("Old"))!.id, { path: "New" });
 
-    const updated = store.getNote(source.id)!;
+    const updated = await store.getNote(source.id)!;
     expect(updated.content).toBe("See [[Other]] and [[New]].");
   });
 });

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -5,13 +5,15 @@ import * as noteOps from "./notes.js";
 import * as linkOps from "./links.js";
 import * as tagSchemaOps from "./tag-schemas.js";
 import { syncWikilinks, resolveUnresolvedWikilinks } from "./wikilinks.js";
-import { normalizePath, pathTitle } from "./paths.js";
+import { pathTitle } from "./paths.js";
 import { HookRegistry } from "./hooks.js";
 
 /**
- * SQLite-backed Store implementation.
+ * bun:sqlite-backed Store implementation. Internally everything is
+ * synchronous; the public Store API is async so the same interface
+ * can back an async runtime (e.g. Cloudflare Durable Objects SQLite).
  */
-export class SqliteStore implements Store {
+export class BunSqliteStore implements Store {
   public readonly hooks: HookRegistry;
 
   constructor(public readonly db: Database, opts?: { hooks?: HookRegistry }) {
@@ -21,39 +23,35 @@ export class SqliteStore implements Store {
 
   // ---- Notes ----
 
-  createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Note {
+  async createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Promise<Note> {
     const note = noteOps.createNote(this.db, content, opts);
 
-    // Auto-sync wikilinks from content
     if (content) {
       syncWikilinks(this.db, note.id, content);
     }
 
-    // If this note has a path, resolve any pending wikilinks targeting it
     if (note.path) {
       resolveUnresolvedWikilinks(this.db, note.path, note.id);
     }
 
-    // Dispatch async hooks post-commit. Never blocks the caller.
     this.hooks.dispatch("created", note, this);
 
     return note;
   }
 
-  getNote(id: string): Note | null {
+  async getNote(id: string): Promise<Note | null> {
     return noteOps.getNote(this.db, id);
   }
 
-  getNoteByPath(path: string): Note | null {
+  async getNoteByPath(path: string): Promise<Note | null> {
     return noteOps.getNoteByPath(this.db, path);
   }
 
-  getNotes(ids: string[]): Note[] {
+  async getNotes(ids: string[]): Promise<Note[]> {
     return noteOps.getNotes(this.db, ids);
   }
 
-  updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean }): Note {
-    // Capture old path before update for rename cascading
+  async updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean }): Promise<Note> {
     let oldPath: string | undefined;
     if (updates.path !== undefined) {
       const existing = noteOps.getNote(this.db, id);
@@ -62,12 +60,10 @@ export class SqliteStore implements Store {
 
     const note = noteOps.updateNote(this.db, id, updates);
 
-    // Re-sync wikilinks if content changed
     if (updates.content !== undefined) {
       syncWikilinks(this.db, id, updates.content);
     }
 
-    // If path changed, cascade rename through wikilinks in other notes
     if (updates.path !== undefined && note.path) {
       if (oldPath && oldPath !== note.path) {
         this.cascadeRename(oldPath, note.path);
@@ -75,7 +71,6 @@ export class SqliteStore implements Store {
       resolveUnresolvedWikilinks(this.db, note.path, id);
     }
 
-    // Dispatch async hooks post-commit. Never blocks the caller.
     this.hooks.dispatch("updated", note, this);
 
     return note;
@@ -89,8 +84,6 @@ export class SqliteStore implements Store {
     const oldTitle = pathTitle(oldPath);
     const newTitle = pathTitle(newPath);
 
-    // Find notes whose content contains a likely wikilink to the old path
-    // Search for both the full old path and just the old basename
     const candidates = this.db.prepare(`
       SELECT id, content FROM notes
       WHERE content LIKE ? OR content LIKE ?
@@ -99,14 +92,11 @@ export class SqliteStore implements Store {
     for (const row of candidates) {
       let updated = row.content;
 
-      // Replace [[OldPath...]] with [[NewPath...]] (preserving aliases and anchors)
       updated = updated.replace(
         new RegExp(`\\[\\[${escapeRegex(oldPath)}([#|\\]])`, "g"),
         `[[${newPath}$1`,
       );
 
-      // Replace [[OldTitle...]] with [[NewTitle...]] (basename references)
-      // Only if old title !== new title and old title !== old path (avoid double-replace)
       if (oldTitle !== newTitle && oldTitle !== oldPath) {
         updated = updated.replace(
           new RegExp(`\\[\\[${escapeRegex(oldTitle)}([#|\\]])`, "g"),
@@ -115,118 +105,113 @@ export class SqliteStore implements Store {
       }
 
       if (updated !== row.content) {
-        // Call noteOps directly (not this.updateNote) to avoid recursive cascading.
-        // Only content changes here, so path normalization/cascading aren't needed.
         noteOps.updateNote(this.db, row.id, { content: updated });
         syncWikilinks(this.db, row.id, updated);
       }
     }
   }
 
-  deleteNote(id: string): void {
+  async deleteNote(id: string): Promise<void> {
     noteOps.deleteNote(this.db, id);
   }
 
-  queryNotes(opts: QueryOpts): Note[] {
+  async queryNotes(opts: QueryOpts): Promise<Note[]> {
     return noteOps.queryNotes(this.db, opts);
   }
 
-  searchNotes(query: string, opts?: { tags?: string[]; limit?: number }): Note[] {
+  async searchNotes(query: string, opts?: { tags?: string[]; limit?: number }): Promise<Note[]> {
     return noteOps.searchNotes(this.db, query, opts);
   }
 
   // ---- Tags ----
 
-  tagNote(noteId: string, tags: string[]): void {
+  async tagNote(noteId: string, tags: string[]): Promise<void> {
     noteOps.tagNote(this.db, noteId, tags);
   }
 
-  untagNote(noteId: string, tags: string[]): void {
+  async untagNote(noteId: string, tags: string[]): Promise<void> {
     noteOps.untagNote(this.db, noteId, tags);
   }
 
-  listTags(): { name: string; count: number }[] {
+  async listTags(): Promise<{ name: string; count: number }[]> {
     return noteOps.listTags(this.db);
   }
 
-  deleteTag(name: string): { deleted: boolean; notes_untagged: number } {
+  async deleteTag(name: string): Promise<{ deleted: boolean; notes_untagged: number }> {
     return noteOps.deleteTag(this.db, name);
   }
 
   // ---- Vault Stats ----
 
-  getVaultStats(opts?: { topTagsLimit?: number }) {
+  async getVaultStats(opts?: { topTagsLimit?: number }) {
     return noteOps.getVaultStats(this.db, opts);
   }
 
   // ---- Links ----
 
-  createLink(sourceId: string, targetId: string, relationship: string, metadata?: Record<string, unknown>): Link {
+  async createLink(sourceId: string, targetId: string, relationship: string, metadata?: Record<string, unknown>): Promise<Link> {
     return linkOps.createLink(this.db, sourceId, targetId, relationship, metadata);
   }
 
-  deleteLink(sourceId: string, targetId: string, relationship: string): void {
+  async deleteLink(sourceId: string, targetId: string, relationship: string): Promise<void> {
     linkOps.deleteLink(this.db, sourceId, targetId, relationship);
   }
 
-  getLinks(noteId: string, opts?: { direction?: "outbound" | "inbound" | "both" }): Link[] {
+  async getLinks(noteId: string, opts?: { direction?: "outbound" | "inbound" | "both" }): Promise<Link[]> {
     return linkOps.getLinks(this.db, noteId, opts);
   }
 
-  listLinks(opts?: { noteId?: string; direction?: "outbound" | "inbound" | "both"; relationship?: string }): Link[] {
+  async listLinks(opts?: { noteId?: string; direction?: "outbound" | "inbound" | "both"; relationship?: string }): Promise<Link[]> {
     return linkOps.listLinks(this.db, opts);
   }
 
   // ---- Bulk Operations ----
 
-  createNotes(inputs: noteOps.BulkNoteInput[]): Note[] {
+  async createNotes(inputs: noteOps.BulkNoteInput[]): Promise<Note[]> {
     const notes = noteOps.createNotes(this.db, inputs);
-    // Dispatch hooks for each created note — AFTER the bulk transaction
-    // commits inside noteOps.createNotes. Dispatch itself is async-safe
-    // (queueMicrotask), so the loop returns immediately.
     for (const note of notes) {
       this.hooks.dispatch("created", note, this);
     }
     return notes;
   }
 
-  batchTag(noteIds: string[], tags: string[]): number {
+  async batchTag(noteIds: string[], tags: string[]): Promise<number> {
     return noteOps.batchTag(this.db, noteIds, tags);
   }
 
-  batchUntag(noteIds: string[], tags: string[]): number {
+  async batchUntag(noteIds: string[], tags: string[]): Promise<number> {
     return noteOps.batchUntag(this.db, noteIds, tags);
   }
 
   // ---- Deeper Link Queries ----
 
-  traverseLinks(noteId: string, opts?: { max_depth?: number; relationship?: string }) {
+  async traverseLinks(noteId: string, opts?: { max_depth?: number; relationship?: string }) {
     return linkOps.traverseLinks(this.db, noteId, opts);
   }
 
-  findPath(sourceId: string, targetId: string, opts?: { max_depth?: number }) {
+  async findPath(sourceId: string, targetId: string, opts?: { max_depth?: number }) {
     return linkOps.findPath(this.db, sourceId, targetId, opts);
   }
 
   // ---- Tag Schemas ----
 
-  listTagSchemas() {
+  async listTagSchemas() {
     return tagSchemaOps.listTagSchemas(this.db);
   }
 
-  getTagSchema(tag: string) {
+  async getTagSchema(tag: string) {
     return tagSchemaOps.getTagSchema(this.db, tag);
   }
 
-  upsertTagSchema(tag: string, schema: { description?: string; fields?: Record<string, tagSchemaOps.TagFieldSchema> }) {
+  async upsertTagSchema(tag: string, schema: { description?: string; fields?: Record<string, tagSchemaOps.TagFieldSchema> }) {
     return tagSchemaOps.upsertTagSchema(this.db, tag, schema);
   }
 
-  deleteTagSchema(tag: string) {
+  async deleteTagSchema(tag: string) {
     return tagSchemaOps.deleteTagSchema(this.db, tag);
   }
 
-  getTagSchemaMap() {
+  async getTagSchemaMap() {
     return tagSchemaOps.getTagSchemaMap(this.db);
   }
 
@@ -236,7 +221,7 @@ export class SqliteStore implements Store {
    * Create a note without triggering wikilink sync.
    * Use this during bulk imports, then call syncAllWikilinks() after.
    */
-  createNoteRaw(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Note {
+  async createNoteRaw(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Promise<Note> {
     return noteOps.createNote(this.db, content, opts);
   }
 
@@ -244,7 +229,7 @@ export class SqliteStore implements Store {
    * Sync wikilinks for all notes in the vault.
    * Efficient for bulk imports — call once after importing all notes.
    */
-  syncAllWikilinks(): { synced: number; totalAdded: number; totalRemoved: number } {
+  async syncAllWikilinks(): Promise<{ synced: number; totalAdded: number; totalRemoved: number }> {
     const allNotes = noteOps.queryNotes(this.db, { limit: 1000000 });
     let synced = 0;
     let totalAdded = 0;
@@ -265,7 +250,7 @@ export class SqliteStore implements Store {
 
   // ---- Attachments ----
 
-  addAttachment(noteId: string, filePath: string, mimeType: string, metadata?: Record<string, unknown>): Attachment {
+  async addAttachment(noteId: string, filePath: string, mimeType: string, metadata?: Record<string, unknown>): Promise<Attachment> {
     const id = noteOps.generateId();
     const now = new Date().toISOString();
     const metadataJson = metadata ? JSON.stringify(metadata) : "{}";
@@ -276,7 +261,7 @@ export class SqliteStore implements Store {
     return { id, noteId, path: filePath, mimeType, metadata, createdAt: now };
   }
 
-  getAttachments(noteId: string): Attachment[] {
+  async getAttachments(noteId: string): Promise<Attachment[]> {
     const rows = this.db.prepare(
       "SELECT * FROM attachments WHERE note_id = ? ORDER BY created_at",
     ).all(noteId) as { id: string; note_id: string; path: string; mime_type: string; metadata: string | null; created_at: string }[];
@@ -297,6 +282,11 @@ export class SqliteStore implements Store {
     });
   }
 }
+
+/** @deprecated Renamed to `BunSqliteStore` to make the runtime split explicit. Kept as an alias for backward compatibility. */
+export const SqliteStore = BunSqliteStore;
+/** @deprecated Renamed to `BunSqliteStore`. */
+export type SqliteStore = BunSqliteStore;
 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -94,47 +94,47 @@ export interface HydratedLink extends Link {
 
 export interface Store {
   // Notes
-  createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Note;
-  getNote(id: string): Note | null;
-  getNoteByPath(path: string): Note | null;
-  getNotes(ids: string[]): Note[];
-  updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; skipUpdatedAt?: boolean }): Note;
-  deleteNote(id: string): void;
-  queryNotes(opts: QueryOpts): Note[];
-  searchNotes(query: string, opts?: { tags?: string[]; limit?: number }): Note[];
+  createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Promise<Note>;
+  getNote(id: string): Promise<Note | null>;
+  getNoteByPath(path: string): Promise<Note | null>;
+  getNotes(ids: string[]): Promise<Note[]>;
+  updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; skipUpdatedAt?: boolean }): Promise<Note>;
+  deleteNote(id: string): Promise<void>;
+  queryNotes(opts: QueryOpts): Promise<Note[]>;
+  searchNotes(query: string, opts?: { tags?: string[]; limit?: number }): Promise<Note[]>;
 
   // Tags
-  tagNote(noteId: string, tags: string[]): void;
-  untagNote(noteId: string, tags: string[]): void;
-  listTags(): { name: string; count: number }[];
-  deleteTag(name: string): { deleted: boolean; notes_untagged: number };
+  tagNote(noteId: string, tags: string[]): Promise<void>;
+  untagNote(noteId: string, tags: string[]): Promise<void>;
+  listTags(): Promise<{ name: string; count: number }[]>;
+  deleteTag(name: string): Promise<{ deleted: boolean; notes_untagged: number }>;
 
   // Vault stats (aggregate, read-only)
-  getVaultStats(opts?: { topTagsLimit?: number }): VaultStats;
+  getVaultStats(opts?: { topTagsLimit?: number }): Promise<VaultStats>;
 
   // Links
-  createLink(sourceId: string, targetId: string, relationship: string, metadata?: Record<string, unknown>): Link;
-  deleteLink(sourceId: string, targetId: string, relationship: string): void;
-  getLinks(noteId: string, opts?: { direction?: "outbound" | "inbound" | "both" }): Link[];
-  listLinks(opts?: { noteId?: string; direction?: "outbound" | "inbound" | "both"; relationship?: string }): Link[];
+  createLink(sourceId: string, targetId: string, relationship: string, metadata?: Record<string, unknown>): Promise<Link>;
+  deleteLink(sourceId: string, targetId: string, relationship: string): Promise<void>;
+  getLinks(noteId: string, opts?: { direction?: "outbound" | "inbound" | "both" }): Promise<Link[]>;
+  listLinks(opts?: { noteId?: string; direction?: "outbound" | "inbound" | "both"; relationship?: string }): Promise<Link[]>;
 
   // Bulk operations
-  createNotes(inputs: { content: string; id?: string; path?: string; tags?: string[] }[]): Note[];
-  batchTag(noteIds: string[], tags: string[]): number;
-  batchUntag(noteIds: string[], tags: string[]): number;
+  createNotes(inputs: { content: string; id?: string; path?: string; tags?: string[] }[]): Promise<Note[]>;
+  batchTag(noteIds: string[], tags: string[]): Promise<number>;
+  batchUntag(noteIds: string[], tags: string[]): Promise<number>;
 
   // Deeper link queries
-  traverseLinks(noteId: string, opts?: { max_depth?: number; relationship?: string }): { noteId: string; depth: number; relationship: string; direction: "outbound" | "inbound" }[];
-  findPath(sourceId: string, targetId: string, opts?: { max_depth?: number }): { path: string[]; relationships: string[] } | null;
+  traverseLinks(noteId: string, opts?: { max_depth?: number; relationship?: string }): Promise<{ noteId: string; depth: number; relationship: string; direction: "outbound" | "inbound" }[]>;
+  findPath(sourceId: string, targetId: string, opts?: { max_depth?: number }): Promise<{ path: string[]; relationships: string[] } | null>;
 
   // Tag schemas
-  listTagSchemas(): { tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }[];
-  getTagSchema(tag: string): { tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> } | null;
-  upsertTagSchema(tag: string, schema: { description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }): { tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> };
-  deleteTagSchema(tag: string): boolean;
-  getTagSchemaMap(): Record<string, { description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }>;
+  listTagSchemas(): Promise<{ tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }[]>;
+  getTagSchema(tag: string): Promise<{ tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> } | null>;
+  upsertTagSchema(tag: string, schema: { description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }): Promise<{ tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }>;
+  deleteTagSchema(tag: string): Promise<boolean>;
+  getTagSchemaMap(): Promise<Record<string, { description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[] }> }>>;
 
   // Attachments
-  addAttachment(noteId: string, path: string, mimeType: string, metadata?: Record<string, unknown>): Attachment;
-  getAttachments(noteId: string): Attachment[];
+  addAttachment(noteId: string, path: string, mimeType: string, metadata?: Record<string, unknown>): Promise<Attachment>;
+  getAttachments(noteId: string): Promise<Attachment[]>;
 }

--- a/core/src/wikilinks.test.ts
+++ b/core/src/wikilinks.test.ts
@@ -110,28 +110,28 @@ More text
 // Resolution
 // ---------------------------------------------------------------------------
 
-describe("resolveWikilink", () => {
-  it("resolves exact path match", () => {
-    store.createNote("Target note", { path: "My Note" });
+describe("resolveWikilink", async () => {
+  it("resolves exact path match", async () => {
+    await store.createNote("Target note", { path: "My Note" });
     const id = resolveWikilink(db, "My Note");
     expect(id).toBeTruthy();
   });
 
-  it("resolves case-insensitively", () => {
-    const note = store.createNote("Target", { path: "My Note" });
+  it("resolves case-insensitively", async () => {
+    const note = await store.createNote("Target", { path: "My Note" });
     const id = resolveWikilink(db, "my note");
     expect(id).toBe(note.id);
   });
 
-  it("resolves basename match", () => {
-    const note = store.createNote("Deep note", { path: "Projects/Parachute/README" });
+  it("resolves basename match", async () => {
+    const note = await store.createNote("Deep note", { path: "Projects/Parachute/README" });
     const id = resolveWikilink(db, "README");
     expect(id).toBe(note.id);
   });
 
-  it("returns null for ambiguous basename", () => {
-    store.createNote("A", { path: "Folder1/README" });
-    store.createNote("B", { path: "Folder2/README" });
+  it("returns null for ambiguous basename", async () => {
+    await store.createNote("A", { path: "Folder1/README" });
+    await store.createNote("B", { path: "Folder2/README" });
     const id = resolveWikilink(db, "README");
     expect(id).toBeNull();
   });
@@ -146,21 +146,21 @@ describe("resolveWikilink", () => {
 // Sync
 // ---------------------------------------------------------------------------
 
-describe("syncWikilinks", () => {
-  it("creates links for resolved wikilinks", () => {
-    const target = store.createNote("Target", { path: "Target Note" });
-    const source = store.createNote("See [[Target Note]]");
+describe("syncWikilinks", async () => {
+  it("creates links for resolved wikilinks", async () => {
+    const target = await store.createNote("Target", { path: "Target Note" });
+    const source = await store.createNote("See [[Target Note]]");
 
-    const links = store.getLinks(source.id, { direction: "outbound" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links).toHaveLength(1);
     expect(links[0].targetId).toBe(target.id);
     expect(links[0].relationship).toBe("wikilink");
   });
 
-  it("tracks unresolved wikilinks", () => {
-    const source = store.createNote("See [[Missing Note]]");
+  it("tracks unresolved wikilinks", async () => {
+    const source = await store.createNote("See [[Missing Note]]");
 
-    const links = store.getLinks(source.id, { direction: "outbound" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links).toHaveLength(0);
 
     // Check unresolved table
@@ -171,85 +171,85 @@ describe("syncWikilinks", () => {
     expect(unresolved[0].target_path).toBe("Missing Note");
   });
 
-  it("resolves pending wikilinks when target note is created", () => {
-    const source = store.createNote("See [[Future Note]]");
+  it("resolves pending wikilinks when target note is created", async () => {
+    const source = await store.createNote("See [[Future Note]]");
 
     // No link yet
-    expect(store.getLinks(source.id, { direction: "outbound" })).toHaveLength(0);
+    expect(await store.getLinks(source.id, { direction: "outbound" })).toHaveLength(0);
 
     // Create the target note
-    const target = store.createNote("I exist now", { path: "Future Note" });
+    const target = await store.createNote("I exist now", { path: "Future Note" });
 
     // Link should now exist
-    const links = store.getLinks(source.id, { direction: "outbound" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links).toHaveLength(1);
     expect(links[0].targetId).toBe(target.id);
   });
 
-  it("removes links when wikilinks are removed from content", () => {
-    const target = store.createNote("Target", { path: "Target" });
-    const source = store.createNote("See [[Target]]");
+  it("removes links when wikilinks are removed from content", async () => {
+    const target = await store.createNote("Target", { path: "Target" });
+    const source = await store.createNote("See [[Target]]");
 
-    expect(store.getLinks(source.id, { direction: "outbound" })).toHaveLength(1);
+    expect(await store.getLinks(source.id, { direction: "outbound" })).toHaveLength(1);
 
     // Update content to remove the wikilink
-    store.updateNote(source.id, { content: "No more links here." });
+    await store.updateNote(source.id, { content: "No more links here." });
 
-    expect(store.getLinks(source.id, { direction: "outbound" })).toHaveLength(0);
+    expect(await store.getLinks(source.id, { direction: "outbound" })).toHaveLength(0);
   });
 
-  it("adds new links when wikilinks are added to content", () => {
-    const a = store.createNote("A", { path: "Note A" });
-    const b = store.createNote("B", { path: "Note B" });
-    const source = store.createNote("See [[Note A]]");
+  it("adds new links when wikilinks are added to content", async () => {
+    const a = await store.createNote("A", { path: "Note A" });
+    const b = await store.createNote("B", { path: "Note B" });
+    const source = await store.createNote("See [[Note A]]");
 
-    expect(store.getLinks(source.id, { direction: "outbound" })).toHaveLength(1);
+    expect(await store.getLinks(source.id, { direction: "outbound" })).toHaveLength(1);
 
     // Update to add another link
-    store.updateNote(source.id, { content: "See [[Note A]] and [[Note B]]" });
+    await store.updateNote(source.id, { content: "See [[Note A]] and [[Note B]]" });
 
-    const links = store.getLinks(source.id, { direction: "outbound" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links).toHaveLength(2);
   });
 
-  it("does not create self-links", () => {
-    const note = store.createNote("I link to [[Myself]]", { path: "Myself" });
-    const links = store.getLinks(note.id, { direction: "outbound" });
+  it("does not create self-links", async () => {
+    const note = await store.createNote("I link to [[Myself]]", { path: "Myself" });
+    const links = await store.getLinks(note.id, { direction: "outbound" });
     expect(links.filter((l) => l.relationship === "wikilink")).toHaveLength(0);
   });
 
-  it("deduplicates multiple mentions of same target", () => {
-    const target = store.createNote("Target", { path: "Target" });
-    const source = store.createNote("See [[Target]] and again [[Target]]");
+  it("deduplicates multiple mentions of same target", async () => {
+    const target = await store.createNote("Target", { path: "Target" });
+    const source = await store.createNote("See [[Target]] and again [[Target]]");
 
-    const links = store.getLinks(source.id, { direction: "outbound" })
+    const links = (await store.getLinks(source.id, { direction: "outbound" }))
       .filter((l) => l.relationship === "wikilink");
     expect(links).toHaveLength(1);
   });
 
-  it("preserves non-wikilink links", () => {
-    const a = store.createNote("A", { id: "a", path: "Note A" });
-    const b = store.createNote("B", { id: "b", path: "Note B" });
+  it("preserves non-wikilink links", async () => {
+    const a = await store.createNote("A", { id: "a", path: "Note A" });
+    const b = await store.createNote("B", { id: "b", path: "Note B" });
 
     // Manual semantic link
-    store.createLink("a", "b", "related-to");
+    await store.createLink("a", "b", "related-to");
 
     // Create note with wikilink to B
-    const source = store.createNote("See [[Note B]]", { id: "source" });
+    const source = await store.createNote("See [[Note B]]", { id: "source" });
 
     // Update content to remove wikilink
-    store.updateNote("source", { content: "No links" });
+    await store.updateNote("source", { content: "No links" });
 
     // Semantic link between a and b should still exist
-    const links = store.getLinks("a", { direction: "outbound" });
+    const links = await store.getLinks("a", { direction: "outbound" });
     expect(links.some((l) => l.relationship === "related-to")).toBe(true);
   });
 
-  it("stores display text and anchor in link metadata", () => {
-    const target = store.createNote("Target", { path: "Target" });
-    const source = store.createNote("See [[Target#Introduction|intro]]");
+  it("stores display text and anchor in link metadata", async () => {
+    const target = await store.createNote("Target", { path: "Target" });
+    const source = await store.createNote("See [[Target#Introduction|intro]]");
 
-    const links = store.getLinks(source.id, { direction: "outbound" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links).toHaveLength(1);
     expect(links[0].metadata?.display).toBe("intro");
     expect(links[0].metadata?.anchor).toBe("Introduction");
@@ -260,17 +260,17 @@ describe("syncWikilinks", () => {
 // Integration with path changes
 // ---------------------------------------------------------------------------
 
-describe("path-based resolution", () => {
-  it("resolves pending links when a note gets a path", () => {
-    const source = store.createNote("See [[Named Note]]");
-    expect(store.getLinks(source.id, { direction: "outbound" })).toHaveLength(0);
+describe("path-based resolution", async () => {
+  it("resolves pending links when a note gets a path", async () => {
+    const source = await store.createNote("See [[Named Note]]");
+    expect(await store.getLinks(source.id, { direction: "outbound" })).toHaveLength(0);
 
     // Create a note without a path, then give it one
-    const target = store.createNote("Unnamed");
-    store.updateNote(target.id, { path: "Named Note" });
+    const target = await store.createNote("Unnamed");
+    await store.updateNote(target.id, { path: "Named Note" });
 
     // The pending link should be resolved
-    const links = store.getLinks(source.id, { direction: "outbound" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links).toHaveLength(1);
     expect(links[0].targetId).toBe(target.id);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -930,7 +930,7 @@ async function cmdImport(args: string[]) {
 
   for (const note of notes) {
     // Skip if a note with this path already exists
-    const existing = store.getNoteByPath(note.path);
+    const existing = await store.getNoteByPath(note.path);
     if (existing) {
       skipped++;
       continue;
@@ -939,7 +939,7 @@ async function cmdImport(args: string[]) {
     // Build metadata from frontmatter (excluding tags, already extracted)
     const metadata = Object.keys(note.frontmatter).length > 0 ? note.frontmatter : undefined;
 
-    store.createNoteRaw(note.content, {
+    await store.createNoteRaw(note.content, {
       path: note.path,
       tags: note.tags.length > 0 ? note.tags : undefined,
       metadata: metadata as Record<string, unknown>,
@@ -952,7 +952,7 @@ async function cmdImport(args: string[]) {
   if (skipped > 0) console.log(`Skipped ${skipped} notes (path already exists)`);
 
   if (imported > 0) {
-    const linkResult = store.syncAllWikilinks();
+    const linkResult = await store.syncAllWikilinks();
     console.log(`Resolved ${linkResult.totalAdded} wikilinks across ${linkResult.synced} notes.`);
   }
 }
@@ -992,7 +992,7 @@ async function cmdExport(args: string[]) {
   const { getVaultStore } = await import("./vault-store.ts");
 
   const store = getVaultStore(vaultName);
-  const notes = store.queryNotes({ limit: 100000, sort: "asc" });
+  const notes = await store.queryNotes({ limit: 100000, sort: "asc" });
 
   console.log(`Exporting ${notes.length} notes from vault "${vaultName}" to ${fullPath}`);
   mkdir(fullPath, { recursive: true });

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -95,7 +95,7 @@ async function handleMcp(
       };
     }
     try {
-      const result = tool.execute((args ?? {}) as Record<string, unknown>);
+      const result = await tool.execute((args ?? {}) as Record<string, unknown>);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -66,7 +66,7 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
       name: coreTool.name,
       description,
       inputSchema,
-      execute: (params) => {
+      execute: async (params) => {
         const vaultName = (params.vault as string) ?? defaultVault;
         const config = readVaultConfig(vaultName);
         if (!config) {
@@ -76,7 +76,7 @@ export function generateUnifiedMcpTools(): McpToolDef[] {
         const vaultTools = generateMcpTools(store);
         const tool = vaultTools.find((t) => t.name === coreTool.name)!;
         const { vault: _, ...rest } = params;
-        return tool.execute(rest);
+        return await tool.execute(rest);
       },
     };
   });
@@ -129,7 +129,7 @@ function overrideVaultInfo(tools: McpToolDef[], defaultVault: string): void {
   const vaultInfo = tools.find((t) => t.name === "vault-info");
   if (!vaultInfo) return;
 
-  vaultInfo.execute = (params) => {
+  vaultInfo.execute = async (params) => {
     const vaultName = (params.vault as string) ?? defaultVault;
     const config = readVaultConfig(vaultName);
     if (!config) throw new Error(`Vault "${vaultName}" not found`);
@@ -147,7 +147,7 @@ function overrideVaultInfo(tools: McpToolDef[], defaultVault: string): void {
 
     if (params.include_stats) {
       const store = getVaultStore(vaultName);
-      result.stats = store.getVaultStats();
+      result.stats = await store.getVaultStats();
     }
 
     return result;

--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -57,18 +57,18 @@ function makeStore(notes: Record<string, { content: string; tags?: string[]; met
   } as any;
 }
 
-describe("handleViewNote", () => {
-  it("returns 404 for non-existent note", () => {
+describe("handleViewNote", async () => {
+  it("returns 404 for non-existent note", async () => {
     const store = makeStore({});
-    const resp = handleViewNote(store, "missing");
+    const resp = await handleViewNote(store, "missing");
     expect(resp.status).toBe(404);
   });
 
-  it("returns 404 for note without publish tag (unauthenticated)", () => {
+  it("returns 404 for note without publish tag (unauthenticated)", async () => {
     const store = makeStore({
       "n1": { content: "hello", tags: ["other"] },
     });
-    const resp = handleViewNote(store, "n1");
+    const resp = await handleViewNote(store, "n1");
     expect(resp.status).toBe(404);
   });
 
@@ -76,7 +76,7 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n1": { content: "# Hello\n\nWorld", tags: ["publish"], path: "Blog/My Post.md" },
     });
-    const resp = handleViewNote(store, "n1");
+    const resp = await handleViewNote(store, "n1");
     expect(resp.status).toBe(200);
     expect(resp.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
 
@@ -90,7 +90,7 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n2": { content: "Content here", metadata: { published: true } },
     });
-    const resp = handleViewNote(store, "n2");
+    const resp = await handleViewNote(store, "n2");
     expect(resp.status).toBe(200);
     const html = await resp.text();
     expect(html).toContain("<p>Content here</p>");
@@ -103,7 +103,7 @@ describe("handleViewNote", () => {
         tags: ["publish"],
       },
     });
-    const resp = handleViewNote(store, "n3");
+    const resp = await handleViewNote(store, "n3");
     const html = await resp.text();
     expect(html).toContain("<strong>bold</strong>");
     expect(html).toContain("<em>italic</em>");
@@ -117,7 +117,7 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n4": { content: "<script>alert('xss')</script>", tags: ["publish"] },
     });
-    const resp = handleViewNote(store, "n4");
+    const resp = await handleViewNote(store, "n4");
     const html = await resp.text();
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
@@ -127,7 +127,7 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n6": { content: "[click me](javascript:alert(1))", tags: ["publish"] },
     });
-    const resp = handleViewNote(store, "n6");
+    const resp = await handleViewNote(store, "n6");
     const html = await resp.text();
     expect(html).not.toContain("javascript:");
     expect(html).toContain("click me");
@@ -138,7 +138,7 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n7": { content: "[click](data:text/html;base64,PHNjcmlwdD4=)", tags: ["publish"] },
     });
-    const resp = handleViewNote(store, "n7");
+    const resp = await handleViewNote(store, "n7");
     const html = await resp.text();
     expect(html).not.toContain("data:");
     expect(html).toContain("click");
@@ -148,7 +148,7 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n8": { content: "[site](https://example.com) and [mail](mailto:a@b.com)", tags: ["publish"] },
     });
-    const resp = handleViewNote(store, "n8");
+    const resp = await handleViewNote(store, "n8");
     const html = await resp.text();
     expect(html).toContain('href="https://example.com"');
     expect(html).toContain('href="mailto:a@b.com"');
@@ -158,17 +158,17 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n5": { content: "test", tags: ["publish"] },
     });
-    const resp = handleViewNote(store, "n5");
+    const resp = await handleViewNote(store, "n5");
     const html = await resp.text();
     expect(html).toContain("prefers-color-scheme: dark");
   });
 
   // CSP header
-  it("includes Content-Security-Policy header", () => {
+  it("includes Content-Security-Policy header", async () => {
     const store = makeStore({
       "n1": { content: "test", tags: ["publish"] },
     });
-    const resp = handleViewNote(store, "n1");
+    const resp = await handleViewNote(store, "n1");
     const csp = resp.headers.get("Content-Security-Policy");
     expect(csp).toContain("script-src 'none'");
     expect(csp).toContain("default-src 'self'");
@@ -179,17 +179,17 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "private": { content: "secret stuff", tags: ["internal"] },
     });
-    const resp = handleViewNote(store, "private", { authenticated: true });
+    const resp = await handleViewNote(store, "private", { authenticated: true });
     expect(resp.status).toBe(200);
     const html = await resp.text();
     expect(html).toContain("<p>secret stuff</p>");
   });
 
-  it("returns 404 for unpublished note when not authenticated", () => {
+  it("returns 404 for unpublished note when not authenticated", async () => {
     const store = makeStore({
       "private": { content: "secret stuff", tags: ["internal"] },
     });
-    const resp = handleViewNote(store, "private");
+    const resp = await handleViewNote(store, "private");
     expect(resp.status).toBe(404);
   });
 
@@ -198,17 +198,17 @@ describe("handleViewNote", () => {
     const store = makeStore({
       "n1": { content: "public content", tags: ["public"] },
     });
-    const resp = handleViewNote(store, "n1", { publishedTag: "public" });
+    const resp = await handleViewNote(store, "n1", { publishedTag: "public" });
     expect(resp.status).toBe(200);
     const html = await resp.text();
     expect(html).toContain("<p>public content</p>");
   });
 
-  it("rejects note with default tag when custom tag is configured", () => {
+  it("rejects note with default tag when custom tag is configured", async () => {
     const store = makeStore({
       "n1": { content: "content", tags: ["publish"] },
     });
-    const resp = handleViewNote(store, "n1", { publishedTag: "public" });
+    const resp = await handleViewNote(store, "n1", { publishedTag: "public" });
     expect(resp.status).toBe(404);
   });
 });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -69,14 +69,14 @@ function parseIncludeMetadata(url: URL): boolean | string[] | undefined {
 /**
  * Resolve a note by ID or path. Tries ID first, then case-insensitive path.
  */
-function resolveNote(store: Store, idOrPath: string): Note | null {
-  const byId = store.getNote(idOrPath);
+async function resolveNote(store: Store, idOrPath: string): Promise<Note | null> {
+  const byId = await store.getNote(idOrPath);
   if (byId) return byId;
-  return store.getNoteByPath(idOrPath);
+  return await store.getNoteByPath(idOrPath);
 }
 
-function requireNote(store: Store, idOrPath: string): Note {
-  const note = resolveNote(store, idOrPath);
+async function requireNote(store: Store, idOrPath: string): Promise<Note> {
+  const note = await resolveNote(store, idOrPath);
   if (!note) throw new NotFoundError(`Note not found: "${idOrPath}"`);
   return note;
 }
@@ -110,7 +110,7 @@ export async function handleNotes(
 
       // Single note by id/path
       if (id) {
-        const note = resolveNote(store, id);
+        const note = await resolveNote(store, id);
         if (!note) return json({ error: "Note not found", id }, 404);
         const includeContent = parseBool(parseQuery(url, "include_content"), true);
         let result: any = includeContent ? { ...note } : toNoteIndex(note);
@@ -119,7 +119,7 @@ export async function handleNotes(
           result.links = linkOps.getLinksHydrated(db, note.id);
         }
         if (parseBool(parseQuery(url, "include_attachments"), false)) {
-          result.attachments = store.getAttachments(note.id);
+          result.attachments = await store.getAttachments(note.id);
         }
         return json(result);
       }
@@ -128,7 +128,7 @@ export async function handleNotes(
       if (search) {
         const searchTags = parseQueryList(url, "tag");
         const limit = parseInt10(parseQuery(url, "limit")) ?? 50;
-        const results = store.searchNotes(search, { tags: searchTags, limit });
+        const results = await store.searchNotes(search, { tags: searchTags, limit });
         const includeContent = parseBool(parseQuery(url, "include_content"), false);
         const inclMeta = parseIncludeMetadata(url);
         let output = includeContent ? results : results.map(toNoteIndex);
@@ -140,7 +140,7 @@ export async function handleNotes(
 
       // Structured query
       const tags = parseQueryList(url, "tag");
-      let results: Note[] = store.queryNotes({
+      let results: Note[] = await store.queryNotes({
         tags,
         tagMatch: (parseQuery(url, "tag_match") as "all" | "any") ?? (tags && tags.length > 1 ? "any" : undefined),
         excludeTags: parseQueryList(url, "exclude_tag"),
@@ -157,7 +157,7 @@ export async function handleNotes(
       // Near-scope filter (graph neighborhood)
       const nearNoteId = parseQuery(url, "near[note_id]");
       if (nearNoteId) {
-        const anchor = resolveNote(store, nearNoteId);
+        const anchor = await resolveNote(store, nearNoteId);
         if (!anchor) return json({ error: "Anchor note not found", note_id: nearNoteId }, 404);
         const depth = Math.min(parseInt10(parseQuery(url, "near[depth]")) ?? 2, 5);
         const relationship = parseQuery(url, "near[relationship]") ?? undefined;
@@ -194,12 +194,14 @@ export async function handleNotes(
       }
 
       if (includeLinks || includeAttachments) {
-        return json(output.map((n: any) => {
-          const enriched = { ...n };
+        const enrichedOut: any[] = [];
+        for (const n of output) {
+          const enriched: any = { ...n };
           if (includeLinks) enriched.links = linkOps.getLinksHydrated(db, n.id);
-          if (includeAttachments) enriched.attachments = store.getAttachments(n.id);
-          return enriched;
-        }));
+          if (includeAttachments) enriched.attachments = await store.getAttachments(n.id);
+          enrichedOut.push(enriched);
+        }
+        return json(enrichedOut);
       }
 
       return json(output);
@@ -212,7 +214,7 @@ export async function handleNotes(
 
       const created: Note[] = [];
       for (const item of items) {
-        const note = store.createNote(item.content ?? "", {
+        const note = await store.createNote(item.content ?? "", {
           id: item.id,
           path: item.path,
           tags: item.tags,
@@ -223,18 +225,18 @@ export async function handleNotes(
         // Create explicit links
         if (item.links) {
           for (const link of item.links as { target: string; relationship: string }[]) {
-            const target = resolveNote(store, link.target);
-            if (target) store.createLink(note.id, target.id, link.relationship);
+            const target = await resolveNote(store, link.target);
+            if (target) await store.createLink(note.id, target.id, link.relationship);
           }
         }
 
-        created.push(store.getNote(note.id) ?? note);
+        created.push((await store.getNote(note.id)) ?? note);
       }
 
       // Apply tag schema defaults
       for (const note of created) {
         if (note.tags?.length) {
-          applySchemaDefaults(store, db, [note.id], note.tags);
+          await applySchemaDefaults(store, db, [note.id], note.tags);
         }
       }
 
@@ -254,16 +256,16 @@ export async function handleNotes(
   // Attachments sub-routes (keep as-is — Daily needs them)
   if (sub === "/attachments") {
     if (method === "POST") {
-      const note = resolveNote(store, idOrPath);
+      const note = await resolveNote(store, idOrPath);
       if (!note) return json({ error: "Not found" }, 404);
       const body = await req.json() as { path: string; mimeType: string };
       if (!body.path || !body.mimeType) return json({ error: "path and mimeType are required" }, 400);
-      return json(store.addAttachment(note.id, body.path, body.mimeType), 201);
+      return json(await store.addAttachment(note.id, body.path, body.mimeType), 201);
     }
     if (method === "GET") {
-      const note = resolveNote(store, idOrPath);
+      const note = await resolveNote(store, idOrPath);
       if (!note) return json({ error: "Not found" }, 404);
-      return json(store.getAttachments(note.id));
+      return json(await store.getAttachments(note.id));
     }
     return json({ error: "Method not allowed" }, 405);
   }
@@ -272,7 +274,7 @@ export async function handleNotes(
 
   // GET /notes/:idOrPath — single note
   if (method === "GET") {
-    const note = resolveNote(store, idOrPath);
+    const note = await resolveNote(store, idOrPath);
     if (!note) return json({ error: "Not found" }, 404);
     const includeContent = parseBool(parseQuery(url, "include_content"), true);
     let result: any = includeContent ? { ...note } : toNoteIndex(note);
@@ -281,7 +283,7 @@ export async function handleNotes(
       result.links = linkOps.getLinksHydrated(db, note.id);
     }
     if (parseBool(parseQuery(url, "include_attachments"), false)) {
-      result.attachments = store.getAttachments(note.id);
+      result.attachments = await store.getAttachments(note.id);
     }
     return json(result);
   }
@@ -289,7 +291,7 @@ export async function handleNotes(
   // PATCH /notes/:idOrPath — update (content, path, metadata, tags, links)
   if (method === "PATCH") {
     try {
-      const note = resolveNote(store, idOrPath);
+      const note = await resolveNote(store, idOrPath);
       if (!note) throw new NotFoundError(`Note not found: "${idOrPath}"`);
       const body = await req.json() as any;
 
@@ -298,9 +300,9 @@ export async function handleNotes(
       let contentOverride = body.content as string | undefined;
       if (linksRemove) {
         for (const link of linksRemove) {
-          const target = resolveNote(store, link.target);
+          const target = await resolveNote(store, link.target);
           if (target) {
-            store.deleteLink(note.id, target.id, link.relationship);
+            await store.deleteLink(note.id, target.id, link.relationship);
             if (link.relationship === "wikilink" && target.path) {
               const current = contentOverride ?? note.content;
               const cleaned = removeWikilinkBrackets(current, target.path);
@@ -323,27 +325,27 @@ export async function handleNotes(
       }
 
       if (Object.keys(updates).length > 0) {
-        store.updateNote(note.id, updates);
+        await store.updateNote(note.id, updates);
       }
 
       // Tags
       if (body.tags?.add?.length) {
-        store.tagNote(note.id, body.tags.add);
-        applySchemaDefaults(store, db, [note.id], body.tags.add);
+        await store.tagNote(note.id, body.tags.add);
+        await applySchemaDefaults(store, db, [note.id], body.tags.add);
       }
       if (body.tags?.remove?.length) {
-        store.untagNote(note.id, body.tags.remove);
+        await store.untagNote(note.id, body.tags.remove);
       }
 
       // Add links
       if (body.links?.add) {
         for (const link of body.links.add as { target: string; relationship: string; metadata?: Record<string, unknown> }[]) {
-          const target = resolveNote(store, link.target);
-          if (target) store.createLink(note.id, target.id, link.relationship, link.metadata);
+          const target = await resolveNote(store, link.target);
+          if (target) await store.createLink(note.id, target.id, link.relationship, link.metadata);
         }
       }
 
-      return json(store.getNote(note.id));
+      return json(await store.getNote(note.id));
     } catch (e: any) {
       if (e instanceof NotFoundError) return json({ error: e.message }, 404);
       throw e;
@@ -352,9 +354,9 @@ export async function handleNotes(
 
   // DELETE /notes/:idOrPath — admin only (enforced at server level)
   if (method === "DELETE") {
-    const note = resolveNote(store, idOrPath);
+    const note = await resolveNote(store, idOrPath);
     if (!note) return json({ error: "Not found" }, 404);
-    store.deleteNote(note.id);
+    await store.deleteNote(note.id);
     return json({ deleted: true, id: note.id });
   }
 
@@ -367,16 +369,15 @@ export async function handleNotes(
 
 export async function handleTags(req: Request, store: Store, subpath = ""): Promise<Response> {
   const url = new URL(req.url);
-  const db = (store as any).db;
 
   // GET /tags — list all, or get single tag detail
   if (req.method === "GET" && subpath === "") {
     const singleTag = parseQuery(url, "tag");
 
     if (singleTag) {
-      const allTags = store.listTags();
+      const allTags = await store.listTags();
       const found = allTags.find((t) => t.name === singleTag);
-      const schema = store.getTagSchema(singleTag);
+      const schema = await store.getTagSchema(singleTag);
       return json({
         name: singleTag,
         count: found?.count ?? 0,
@@ -385,9 +386,9 @@ export async function handleTags(req: Request, store: Store, subpath = ""): Prom
       });
     }
 
-    const tags = store.listTags();
+    const tags = await store.listTags();
     if (parseBool(parseQuery(url, "include_schema"), false)) {
-      const schemas = store.getTagSchemaMap();
+      const schemas = await store.getTagSchemaMap();
       return json(tags.map((t) => ({
         ...t,
         description: schemas[t.name]?.description ?? null,
@@ -404,9 +405,9 @@ export async function handleTags(req: Request, store: Store, subpath = ""): Prom
 
   // GET /tags/:name — single tag detail
   if (req.method === "GET") {
-    const allTags = store.listTags();
+    const allTags = await store.listTags();
     const found = allTags.find((t) => t.name === tagName);
-    const schema = store.getTagSchema(tagName);
+    const schema = await store.getTagSchema(tagName);
     return json({
       name: tagName,
       count: found?.count ?? 0,
@@ -418,9 +419,9 @@ export async function handleTags(req: Request, store: Store, subpath = ""): Prom
   // PUT /tags/:name — upsert tag schema (description + fields)
   if (req.method === "PUT") {
     const body = await req.json() as { description?: string; fields?: Record<string, unknown> };
-    const existing = store.getTagSchema(tagName);
+    const existing = await store.getTagSchema(tagName);
     const mergedFields = { ...existing?.fields, ...(body.fields as any) };
-    const schema = store.upsertTagSchema(tagName, {
+    const schema = await store.upsertTagSchema(tagName, {
       description: body.description ?? existing?.description,
       fields: Object.keys(mergedFields).length > 0 ? mergedFields : undefined,
     });
@@ -429,8 +430,8 @@ export async function handleTags(req: Request, store: Store, subpath = ""): Prom
 
   // DELETE /tags/:name — delete tag + schema from all notes
   if (req.method === "DELETE") {
-    store.deleteTagSchema(tagName);
-    return json(store.deleteTag(tagName));
+    await store.deleteTagSchema(tagName);
+    return json(await store.deleteTag(tagName));
   }
 
   return json({ error: "Method not allowed" }, 405);
@@ -440,7 +441,7 @@ export async function handleTags(req: Request, store: Store, subpath = ""): Prom
 // Find-path — GET /api/find-path?source=...&target=...
 // ---------------------------------------------------------------------------
 
-export function handleFindPath(req: Request, store: Store): Response {
+export async function handleFindPath(req: Request, store: Store): Promise<Response> {
   if (req.method !== "GET") return json({ error: "Method not allowed" }, 405);
 
   const url = new URL(req.url);
@@ -450,9 +451,9 @@ export function handleFindPath(req: Request, store: Store): Response {
 
   const db = (store as any).db;
   try {
-    const sourceNote = resolveNote(store, source);
+    const sourceNote = await resolveNote(store, source);
     if (!sourceNote) return json({ error: `Note not found: "${source}"` }, 404);
-    const targetNote = resolveNote(store, target);
+    const targetNote = await resolveNote(store, target);
     if (!targetNote) return json({ error: `Note not found: "${target}"` }, 404);
     const maxDepth = Math.min(parseInt10(parseQuery(url, "max_depth")) ?? 5, 10);
 
@@ -482,7 +483,7 @@ export async function handleVault(
       description: vaultConfig.description ?? null,
     };
     if (parseBool(parseQuery(url, "include_stats"), false)) {
-      result.stats = store.getVaultStats();
+      result.stats = await store.getVaultStats();
     }
     return json(result);
   }
@@ -611,13 +612,13 @@ function isNotePublished(note: { tags?: string[]; metadata?: unknown }, publishe
  * GET /view/:idOrPath — serve a note as clean HTML.
  * Supports ID or path resolution.
  */
-export function handleViewNote(
+export async function handleViewNote(
   store: Store,
   idOrPath: string,
   options: { authenticated?: boolean; publishedTag?: string } = {},
-): Response {
+): Promise<Response> {
   const { authenticated = false, publishedTag = "publish" } = options;
-  const note = resolveNote(store, idOrPath);
+  const note = await resolveNote(store, idOrPath);
   if (!note) {
     return new Response("Not Found", { status: 404, headers: { "Content-Type": "text/plain" } });
   }
@@ -773,7 +774,7 @@ export async function handleStorage(req: Request, path: string, vault: string): 
 // Tag schema defaults — same logic as core/src/mcp.ts applySchemaDefaults
 // ---------------------------------------------------------------------------
 
-function applySchemaDefaults(store: Store, db: any, noteIds: string[], tags: string[]): void {
+async function applySchemaDefaults(store: Store, db: any, noteIds: string[], tags: string[]): Promise<void> {
   const schemas = tagSchemaOps.getTagSchemaMap(db);
   if (Object.keys(schemas).length === 0) return;
 
@@ -790,7 +791,7 @@ function applySchemaDefaults(store: Store, db: any, noteIds: string[], tags: str
   if (Object.keys(defaults).length === 0) return;
 
   for (const noteId of noteIds) {
-    const note = store.getNote(noteId);
+    const note = await store.getNote(noteId);
     if (!note) continue;
     const existing = (note.metadata as Record<string, unknown>) ?? {};
     const missing: Record<string, unknown> = {};
@@ -798,7 +799,7 @@ function applySchemaDefaults(store: Store, db: any, noteIds: string[], tags: str
       if (!(field in existing)) missing[field] = value;
     }
     if (Object.keys(missing).length === 0) continue;
-    store.updateNote(noteId, {
+    await store.updateNote(noteId, {
       metadata: { ...existing, ...missing },
       skipUpdatedAt: true,
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,11 +76,11 @@ for (const vaultName of listVaults()) {
   const vaultConfig = readVaultConfig(vaultName);
   if (vaultConfig?.tag_schemas && Object.keys(vaultConfig.tag_schemas).length > 0) {
     const store = getVaultStore(vaultName);
-    const existingTags = new Set(store.listTagSchemas().map((s) => s.tag));
+    const existingTags = new Set((await store.listTagSchemas()).map((s) => s.tag));
     let migrated = 0;
     for (const [tag, schema] of Object.entries(vaultConfig.tag_schemas)) {
       if (!existingTags.has(tag)) {
-        store.upsertTagSchema(tag, schema);
+        await store.upsertTagSchema(tag, schema);
         migrated++;
       }
     }
@@ -397,7 +397,7 @@ async function route(req: Request, path: string, clientIp?: string): Promise<Res
     if (req.method !== "GET") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
-    const stats = store.getVaultStats();
+    const stats = await store.getVaultStats();
     return Response.json({
       name: vaultName,
       description: vaultConfig.description,

--- a/src/triggers.test.ts
+++ b/src/triggers.test.ts
@@ -97,13 +97,13 @@ describe("buildPredicate", () => {
   });
 });
 
-describe("registerTriggers — dispatch modes", () => {
+describe("registerTriggers — dispatch modes", async () => {
   let webhookServer: ReturnType<typeof Bun.serve>;
   let webhookPort: number;
   let lastRequest: { method: string; url: string; headers: Headers; body: unknown; formData?: FormData } | null = null;
   let webhookHandler: (req: Request) => Response | Promise<Response>;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     webhookHandler = () => Response.json({});
     webhookServer = Bun.serve({
       hostname: "127.0.0.1",
@@ -224,7 +224,7 @@ describe("registerTriggers — dispatch modes", () => {
     expect((file as File).name).toBe("recording.wav");
 
     // Verify note content was updated
-    const updated = store.getNote("n2");
+    const updated = await store.getNote("n2");
     expect(updated?.content).toBe("transcribed content");
 
     // Cleanup
@@ -272,12 +272,12 @@ describe("registerTriggers — dispatch modes", () => {
     expect(body.input).toBe("Hello world");
 
     // Verify attachment was created
-    const attachments = store.getAttachments("n3");
+    const attachments = await store.getAttachments("n3");
     expect(attachments.length).toBe(1);
     expect(attachments[0].mimeType).toBe("audio/ogg");
 
     // Verify metadata includes provider info
-    const updated = store.getNote("n3");
+    const updated = await store.getNote("n3");
     const meta = updated?.metadata as Record<string, unknown>;
     expect(meta.tts_provider).toBe("kokoro");
     expect(meta.tts_voice).toBe("af_heart");
@@ -307,7 +307,7 @@ describe("registerTriggers — dispatch modes", () => {
     await hooks.dispatch("created", note, store);
     await new Promise(r => setTimeout(r, 50));
 
-    const updated = store.getNote("n4");
+    const updated = await store.getNote("n4");
     const meta = updated?.metadata as Record<string, unknown>;
     expect(meta.skip_test_skipped_reason).toBe("no audio attachment found");
   });
@@ -330,7 +330,7 @@ describe("registerTriggers — dispatch modes", () => {
     await hooks.dispatch("created", note, store);
     await new Promise(r => setTimeout(r, 50));
 
-    const updated = store.getNote("n5");
+    const updated = await store.getNote("n5");
     const meta = updated?.metadata as Record<string, unknown>;
     expect(meta.empty_test_skipped_reason).toBe("note has no content to synthesize");
   });

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -313,7 +313,7 @@ export function registerTriggers(
 
         // Phase 1: claim
         try {
-          store.updateNote(note.id, {
+          await store.updateNote(note.id, {
             metadata: { ...existingMeta, [pendingKey]: pendingAt },
             skipUpdatedAt: true,
           });
@@ -324,7 +324,7 @@ export function registerTriggers(
 
         // Fire the webhook using the configured send mode
         let webhookResult: WebhookResponse;
-        const attachments = store.getAttachments(note.id);
+        const attachments = await store.getAttachments(note.id);
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), timeout);
         try {
@@ -358,7 +358,7 @@ export function registerTriggers(
         // trigger an infinite webhook loop on every update.
         if (webhookResult.skipped_reason) {
           try {
-            store.updateNote(note.id, {
+            await store.updateNote(note.id, {
               metadata: {
                 ...existingMeta,
                 [pendingKey]: undefined,
@@ -378,16 +378,16 @@ export function registerTriggers(
           // Add attachments first
           if (webhookResult.attachments?.length) {
             for (const att of webhookResult.attachments) {
-              store.addAttachment(note.id, att.path, att.mimeType, att.meta);
+              await store.addAttachment(note.id, att.path, att.mimeType, att.meta);
             }
           }
 
           // Read fresh metadata to avoid clobbering concurrent edits
-          const fresh = store.getNote(note.id);
+          const fresh = await store.getNote(note.id);
           const freshMeta = (fresh?.metadata as Record<string, unknown> | undefined) ?? existingMeta;
           const { [pendingKey]: _drop, ...restMeta } = freshMeta;
 
-          store.updateNote(note.id, {
+          await store.updateNote(note.id, {
             ...(webhookResult.content !== undefined ? { content: webhookResult.content } : {}),
             metadata: {
               ...restMeta,

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -29,39 +29,39 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("BunStore", () => {
-  test("creates and retrieves a note", () => {
-    const note = store.createNote("Hello world");
+describe("BunStore", async () => {
+  test("creates and retrieves a note", async () => {
+    const note = await store.createNote("Hello world");
     expect(note.id).toBeTruthy();
     expect(note.content).toBe("Hello world");
 
-    const fetched = store.getNote(note.id);
+    const fetched = await store.getNote(note.id);
     expect(fetched).not.toBeNull();
     expect(fetched!.content).toBe("Hello world");
   });
 
-  test("creates note with tags", () => {
-    const note = store.createNote("Tagged note", { tags: ["daily", "pinned"] });
+  test("creates note with tags", async () => {
+    const note = await store.createNote("Tagged note", { tags: ["daily", "pinned"] });
     expect(note.tags).toContain("daily");
     expect(note.tags).toContain("pinned");
   });
 
-  test("creates note with path", () => {
-    const note = store.createNote("Doc note", { path: "blog/first-post" });
+  test("creates note with path", async () => {
+    const note = await store.createNote("Doc note", { path: "blog/first-post" });
     expect(note.path).toBe("blog/first-post");
   });
 
-  test("updates a note", () => {
-    const note = store.createNote("Original");
-    const updated = store.updateNote(note.id, { content: "Updated" });
+  test("updates a note", async () => {
+    const note = await store.createNote("Original");
+    const updated = await store.updateNote(note.id, { content: "Updated" });
     expect(updated.content).toBe("Updated");
     expect(updated.updatedAt).toBeTruthy();
   });
 
-  test("user updates bump updatedAt", () => {
-    const note = store.createNote("Original");
+  test("user updates bump updatedAt", async () => {
+    const note = await store.createNote("Original");
     expect(note.updatedAt).toBeUndefined();
-    const updated = store.updateNote(note.id, { content: "Edited by user" });
+    const updated = await store.updateNote(note.id, { content: "Edited by user" });
     expect(updated.updatedAt).toBeTruthy();
   });
 
@@ -69,15 +69,15 @@ describe("BunStore", () => {
     // Hook writes (e.g., the reader-audio hook's metadata markers) must not
     // count as user activity. See issue #44 — hook writes were bumping
     // updatedAt and wrecking Daily's reader sort.
-    const note = store.createNote("Content");
+    const note = await store.createNote("Content");
     expect(note.updatedAt).toBeUndefined();
 
     // Fresh note: a machine write must not set updatedAt.
-    store.updateNote(note.id, {
+    await store.updateNote(note.id, {
       metadata: { audio_pending_at: "2026-04-09T10:00:00.000Z" },
       skipUpdatedAt: true,
     });
-    let fetched = store.getNote(note.id)!;
+    let fetched = await store.getNote(note.id)!;
     expect(fetched.updatedAt).toBeUndefined();
     expect((fetched.metadata as { audio_pending_at?: string } | undefined)?.audio_pending_at).toBe(
       "2026-04-09T10:00:00.000Z",
@@ -85,152 +85,152 @@ describe("BunStore", () => {
 
     // Now a real user edit bumps it.
     await new Promise((r) => setTimeout(r, 5));
-    store.updateNote(note.id, { content: "User edit" });
-    fetched = store.getNote(note.id)!;
+    await store.updateNote(note.id, { content: "User edit" });
+    fetched = await store.getNote(note.id)!;
     const userTs = fetched.updatedAt;
     expect(userTs).toBeTruthy();
 
     // A subsequent machine write must not overwrite the user's timestamp.
     await new Promise((r) => setTimeout(r, 5));
-    store.updateNote(note.id, {
+    await store.updateNote(note.id, {
       metadata: {
         ...(fetched.metadata as Record<string, unknown>),
         audio_rendered_at: "2026-04-09T10:05:00.000Z",
       },
       skipUpdatedAt: true,
     });
-    fetched = store.getNote(note.id)!;
+    fetched = await store.getNote(note.id)!;
     expect(fetched.updatedAt).toBe(userTs!);
     expect((fetched.metadata as { audio_rendered_at?: string } | undefined)?.audio_rendered_at).toBe(
       "2026-04-09T10:05:00.000Z",
     );
   });
 
-  test("deletes a note", () => {
-    const note = store.createNote("To delete");
-    store.deleteNote(note.id);
-    expect(store.getNote(note.id)).toBeNull();
+  test("deletes a note", async () => {
+    const note = await store.createNote("To delete");
+    await store.deleteNote(note.id);
+    expect(await store.getNote(note.id)).toBeNull();
   });
 
-  test("queries notes by tag", () => {
-    store.createNote("A", { tags: ["daily"] });
-    store.createNote("B", { tags: ["doc"] });
-    store.createNote("C", { tags: ["daily", "pinned"] });
+  test("queries notes by tag", async () => {
+    await store.createNote("A", { tags: ["daily"] });
+    await store.createNote("B", { tags: ["doc"] });
+    await store.createNote("C", { tags: ["daily", "pinned"] });
 
-    const daily = store.queryNotes({ tags: ["daily"] });
+    const daily = await store.queryNotes({ tags: ["daily"] });
     expect(daily.length).toBe(2);
   });
 
-  test("queries with exclude tags", () => {
-    store.createNote("A", { tags: ["daily"] });
-    store.createNote("B", { tags: ["daily", "archived"] });
+  test("queries with exclude tags", async () => {
+    await store.createNote("A", { tags: ["daily"] });
+    await store.createNote("B", { tags: ["daily", "archived"] });
 
-    const active = store.queryNotes({ tags: ["daily"], excludeTags: ["archived"] });
+    const active = await store.queryNotes({ tags: ["daily"], excludeTags: ["archived"] });
     expect(active.length).toBe(1);
     expect(active[0].content).toBe("A");
   });
 
-  test("full-text search", () => {
-    store.createNote("The quick brown fox");
-    store.createNote("A lazy dog");
+  test("full-text search", async () => {
+    await store.createNote("The quick brown fox");
+    await store.createNote("A lazy dog");
 
-    const results = store.searchNotes("fox");
+    const results = await store.searchNotes("fox");
     expect(results.length).toBe(1);
     expect(results[0].content).toContain("fox");
   });
 
-  test("tags and untags notes", () => {
-    const note = store.createNote("Taggable");
-    store.tagNote(note.id, ["important"]);
-    let fetched = store.getNote(note.id)!;
+  test("tags and untags notes", async () => {
+    const note = await store.createNote("Taggable");
+    await store.tagNote(note.id, ["important"]);
+    let fetched = await store.getNote(note.id)!;
     expect(fetched.tags).toContain("important");
 
-    store.untagNote(note.id, ["important"]);
-    fetched = store.getNote(note.id)!;
+    await store.untagNote(note.id, ["important"]);
+    fetched = await store.getNote(note.id)!;
     expect(fetched.tags).not.toContain("important");
   });
 
-  test("lists tags with counts", () => {
-    store.createNote("A", { tags: ["daily"] });
-    store.createNote("B", { tags: ["daily"] });
-    store.createNote("C", { tags: ["doc"] });
+  test("lists tags with counts", async () => {
+    await store.createNote("A", { tags: ["daily"] });
+    await store.createNote("B", { tags: ["daily"] });
+    await store.createNote("C", { tags: ["doc"] });
 
-    const tags = store.listTags();
+    const tags = await store.listTags();
     const daily = tags.find((t) => t.name === "daily");
     expect(daily?.count).toBe(2);
     const doc = tags.find((t) => t.name === "doc");
     expect(doc?.count).toBe(1);
   });
 
-  test("creates and queries links", () => {
-    const a = store.createNote("Note A");
-    const b = store.createNote("Note B");
+  test("creates and queries links", async () => {
+    const a = await store.createNote("Note A");
+    const b = await store.createNote("Note B");
 
-    const link = store.createLink(a.id, b.id, "related-to");
+    const link = await store.createLink(a.id, b.id, "related-to");
     expect(link.sourceId).toBe(a.id);
     expect(link.targetId).toBe(b.id);
     expect(link.relationship).toBe("related-to");
 
-    const outbound = store.getLinks(a.id, { direction: "outbound" });
+    const outbound = await store.getLinks(a.id, { direction: "outbound" });
     expect(outbound.length).toBe(1);
 
-    const inbound = store.getLinks(b.id, { direction: "inbound" });
+    const inbound = await store.getLinks(b.id, { direction: "inbound" });
     expect(inbound.length).toBe(1);
 
-    store.deleteLink(a.id, b.id, "related-to");
-    expect(store.getLinks(a.id).length).toBe(0);
+    await store.deleteLink(a.id, b.id, "related-to");
+    expect((await store.getLinks(a.id)).length).toBe(0);
   });
 
-  test("attachments", () => {
-    const note = store.createNote("With attachment");
-    const att = store.addAttachment(note.id, "/path/to/file.png", "image/png");
+  test("attachments", async () => {
+    const note = await store.createNote("With attachment");
+    const att = await store.addAttachment(note.id, "/path/to/file.png", "image/png");
     expect(att.noteId).toBe(note.id);
 
-    const atts = store.getAttachments(note.id);
+    const atts = await store.getAttachments(note.id);
     expect(atts.length).toBe(1);
     expect(atts[0].mimeType).toBe("image/png");
   });
 
-  test("starts with no tags", () => {
-    const tags = store.listTags();
+  test("starts with no tags", async () => {
+    const tags = await store.listTags();
     expect(tags.length).toBe(0);
   });
 
-  test("gets note by path", () => {
-    store.createNote("README content", { path: "Projects/Parachute/README" });
-    const note = store.getNoteByPath("Projects/Parachute/README");
+  test("gets note by path", async () => {
+    await store.createNote("README content", { path: "Projects/Parachute/README" });
+    const note = await store.getNoteByPath("Projects/Parachute/README");
     expect(note).not.toBeNull();
     expect(note!.content).toBe("README content");
     expect(note!.path).toBe("Projects/Parachute/README");
   });
 
-  test("gets multiple notes by IDs", () => {
-    const a = store.createNote("A");
-    const b = store.createNote("B");
-    const c = store.createNote("C");
+  test("gets multiple notes by IDs", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    const c = await store.createNote("C");
 
-    const fetched = store.getNotes([a.id, c.id]);
+    const fetched = await store.getNotes([a.id, c.id]);
     expect(fetched.length).toBe(2);
     expect(fetched.map((n) => n.content)).toContain("A");
     expect(fetched.map((n) => n.content)).toContain("C");
   });
 
-  test("queries by path prefix", () => {
-    store.createNote("Root README", { path: "README" });
-    store.createNote("Project README", { path: "Projects/Parachute/README" });
-    store.createNote("Project Notes", { path: "Projects/Parachute/Notes" });
-    store.createNote("Other", { path: "Other/Stuff" });
+  test("queries by path prefix", async () => {
+    await store.createNote("Root README", { path: "README" });
+    await store.createNote("Project README", { path: "Projects/Parachute/README" });
+    await store.createNote("Project Notes", { path: "Projects/Parachute/Notes" });
+    await store.createNote("Other", { path: "Other/Stuff" });
 
-    const results = store.queryNotes({ pathPrefix: "Projects/Parachute" });
+    const results = await store.queryNotes({ pathPrefix: "Projects/Parachute" });
     expect(results.length).toBe(2);
     expect(results.map((n) => n.path)).toContain("Projects/Parachute/README");
     expect(results.map((n) => n.path)).toContain("Projects/Parachute/Notes");
   });
 });
 
-describe("metadata", () => {
-  test("creates note with metadata", () => {
-    const note = store.createNote("Meeting notes", {
+describe("metadata", async () => {
+  test("creates note with metadata", async () => {
+    const note = await store.createNote("Meeting notes", {
       path: "Meetings/standup",
       metadata: { status: "draft", priority: "high", attendees: ["alice", "bob"] },
     });
@@ -240,35 +240,35 @@ describe("metadata", () => {
     expect(note.metadata!.attendees).toEqual(["alice", "bob"]);
   });
 
-  test("updates note metadata", () => {
-    const note = store.createNote("Doc", { metadata: { status: "draft" } });
-    const updated = store.updateNote(note.id, { metadata: { status: "published", version: 2 } });
+  test("updates note metadata", async () => {
+    const note = await store.createNote("Doc", { metadata: { status: "draft" } });
+    const updated = await store.updateNote(note.id, { metadata: { status: "published", version: 2 } });
     expect(updated.metadata!.status).toBe("published");
     expect(updated.metadata!.version).toBe(2);
   });
 
-  test("queries notes by metadata", () => {
-    store.createNote("Draft 1", { metadata: { status: "draft" } });
-    store.createNote("Draft 2", { metadata: { status: "draft" } });
-    store.createNote("Published", { metadata: { status: "published" } });
+  test("queries notes by metadata", async () => {
+    await store.createNote("Draft 1", { metadata: { status: "draft" } });
+    await store.createNote("Draft 2", { metadata: { status: "draft" } });
+    await store.createNote("Published", { metadata: { status: "published" } });
 
-    const drafts = store.queryNotes({ metadata: { status: "draft" } });
+    const drafts = await store.queryNotes({ metadata: { status: "draft" } });
     expect(drafts.length).toBe(2);
 
-    const published = store.queryNotes({ metadata: { status: "published" } });
+    const published = await store.queryNotes({ metadata: { status: "published" } });
     expect(published.length).toBe(1);
     expect(published[0].content).toBe("Published");
   });
 
-  test("notes without metadata return undefined metadata", () => {
-    const note = store.createNote("Plain note");
+  test("notes without metadata return undefined metadata", async () => {
+    const note = await store.createNote("Plain note");
     expect(note.metadata).toBeUndefined();
   });
 
-  test("creates link with metadata", () => {
-    const a = store.createNote("A");
-    const b = store.createNote("B");
-    const link = store.createLink(a.id, b.id, "related-to", {
+  test("creates link with metadata", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    const link = await store.createLink(a.id, b.id, "related-to", {
       confidence: 0.9,
       context: "mentioned in meeting",
     });
@@ -277,10 +277,10 @@ describe("metadata", () => {
     expect(link.metadata!.context).toBe("mentioned in meeting");
   });
 
-  test("hydrated links include note metadata", () => {
-    const a = store.createNote("A", { metadata: { type: "project" } });
-    const b = store.createNote("B", { metadata: { type: "task" } });
-    store.createLink(a.id, b.id, "contains");
+  test("hydrated links include note metadata", async () => {
+    const a = await store.createNote("A", { metadata: { type: "project" } });
+    const b = await store.createNote("B", { metadata: { type: "task" } });
+    await store.createLink(a.id, b.id, "contains");
 
     const links = getLinksHydrated(db, a.id);
     expect(links[0].sourceNote?.metadata?.type).toBe("project");
@@ -288,9 +288,9 @@ describe("metadata", () => {
   });
 });
 
-describe("bulk operations", () => {
-  test("creates multiple notes at once", () => {
-    const notes = store.createNotes([
+describe("bulk operations", async () => {
+  test("creates multiple notes at once", async () => {
+    const notes = await store.createNotes([
       { content: "Note 1", tags: ["daily"] },
       { content: "Note 2", tags: ["doc"] },
       { content: "Note 3" },
@@ -300,8 +300,8 @@ describe("bulk operations", () => {
     expect(notes[1].tags).toContain("doc");
   });
 
-  test("createNotes accepts per-note metadata and created_at (mixed batch)", () => {
-    const notes = store.createNotes([
+  test("createNotes accepts per-note metadata and created_at (mixed batch)", async () => {
+    const notes = await store.createNotes([
       { content: "Plain", tags: ["daily"] },
       {
         content: "With metadata",
@@ -331,7 +331,7 @@ describe("bulk operations", () => {
     expect(notes[2].metadata?.source).toBe("tana-import");
   });
 
-  test("createNotes preserves per-note metadata isolation across many notes", () => {
+  test("createNotes preserves per-note metadata isolation across many notes", async () => {
     const inputs = Array.from({ length: 5 }, (_, i) => ({
       content: `Day ${i}`,
       path: `Journal/2024-06-${String(i + 1).padStart(2, "0")}`,
@@ -343,7 +343,7 @@ describe("bulk operations", () => {
       },
       created_at: `2024-06-${String(i + 1).padStart(2, "0")}T12:00:00.000Z`,
     }));
-    const notes = store.createNotes(inputs);
+    const notes = await store.createNotes(inputs);
     expect(notes.length).toBe(5);
     for (let i = 0; i < 5; i++) {
       expect(notes[i].path).toBe(`Journal/2024-06-${String(i + 1).padStart(2, "0")}`);
@@ -354,9 +354,9 @@ describe("bulk operations", () => {
     }
   });
 
-  test("createNotes is backwards compatible — omitted metadata/created_at use defaults", () => {
+  test("createNotes is backwards compatible — omitted metadata/created_at use defaults", async () => {
     const before = new Date().toISOString();
-    const notes = store.createNotes([
+    const notes = await store.createNotes([
       { content: "Just content" },
       { content: "Content + tags", tags: ["x"] },
     ]);
@@ -368,89 +368,89 @@ describe("bulk operations", () => {
     expect(notes[0].createdAt <= after).toBe(true);
   });
 
-  test("batch tags multiple notes", () => {
-    const a = store.createNote("A");
-    const b = store.createNote("B");
-    const c = store.createNote("C");
+  test("batch tags multiple notes", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    const c = await store.createNote("C");
 
-    store.batchTag([a.id, b.id, c.id], ["important", "review"]);
+    await store.batchTag([a.id, b.id, c.id], ["important", "review"]);
 
-    expect(store.getNote(a.id)!.tags).toContain("important");
-    expect(store.getNote(b.id)!.tags).toContain("review");
-    expect(store.getNote(c.id)!.tags).toContain("important");
+    expect((await store.getNote(a.id))!.tags).toContain("important");
+    expect((await store.getNote(b.id))!.tags).toContain("review");
+    expect((await store.getNote(c.id))!.tags).toContain("important");
   });
 
-  test("batch untags multiple notes", () => {
-    const a = store.createNote("A", { tags: ["daily", "pinned"] });
-    const b = store.createNote("B", { tags: ["daily", "pinned"] });
+  test("batch untags multiple notes", async () => {
+    const a = await store.createNote("A", { tags: ["daily", "pinned"] });
+    const b = await store.createNote("B", { tags: ["daily", "pinned"] });
 
-    store.batchUntag([a.id, b.id], ["pinned"]);
+    await store.batchUntag([a.id, b.id], ["pinned"]);
 
-    expect(store.getNote(a.id)!.tags).toContain("daily");
-    expect(store.getNote(a.id)!.tags).not.toContain("pinned");
-    expect(store.getNote(b.id)!.tags).not.toContain("pinned");
+    expect((await store.getNote(a.id))!.tags).toContain("daily");
+    expect((await store.getNote(a.id))!.tags).not.toContain("pinned");
+    expect((await store.getNote(b.id))!.tags).not.toContain("pinned");
   });
 });
 
-describe("deeper link queries", () => {
-  test("traverses links multi-hop", () => {
-    const a = store.createNote("A");
-    const b = store.createNote("B");
-    const c = store.createNote("C");
-    const d = store.createNote("D");
+describe("deeper link queries", async () => {
+  test("traverses links multi-hop", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    const c = await store.createNote("C");
+    const d = await store.createNote("D");
 
-    store.createLink(a.id, b.id, "related-to");
-    store.createLink(b.id, c.id, "related-to");
-    store.createLink(c.id, d.id, "related-to");
+    await store.createLink(a.id, b.id, "related-to");
+    await store.createLink(b.id, c.id, "related-to");
+    await store.createLink(c.id, d.id, "related-to");
 
     // 1 hop from A: should find B
-    const hop1 = store.traverseLinks(a.id, { max_depth: 1 });
+    const hop1 = await store.traverseLinks(a.id, { max_depth: 1 });
     expect(hop1.length).toBe(1);
     expect(hop1[0].noteId).toBe(b.id);
 
     // 2 hops from A: should find B and C
-    const hop2 = store.traverseLinks(a.id, { max_depth: 2 });
+    const hop2 = await store.traverseLinks(a.id, { max_depth: 2 });
     expect(hop2.length).toBe(2);
     const ids2 = hop2.map((n) => n.noteId);
     expect(ids2).toContain(b.id);
     expect(ids2).toContain(c.id);
 
     // 3 hops from A: should find B, C, and D
-    const hop3 = store.traverseLinks(a.id, { max_depth: 3 });
+    const hop3 = await store.traverseLinks(a.id, { max_depth: 3 });
     expect(hop3.length).toBe(3);
   });
 
-  test("traverses with relationship filter", () => {
-    const a = store.createNote("A");
-    const b = store.createNote("B");
-    const c = store.createNote("C");
+  test("traverses with relationship filter", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    const c = await store.createNote("C");
 
-    store.createLink(a.id, b.id, "mentions");
-    store.createLink(a.id, c.id, "related-to");
+    await store.createLink(a.id, b.id, "mentions");
+    await store.createLink(a.id, c.id, "related-to");
 
-    const mentions = store.traverseLinks(a.id, { max_depth: 1, relationship: "mentions" });
+    const mentions = await store.traverseLinks(a.id, { max_depth: 1, relationship: "mentions" });
     expect(mentions.length).toBe(1);
     expect(mentions[0].noteId).toBe(b.id);
   });
 
-  test("finds path between notes", () => {
-    const a = store.createNote("A");
-    const b = store.createNote("B");
-    const c = store.createNote("C");
+  test("finds path between notes", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    const c = await store.createNote("C");
 
-    store.createLink(a.id, b.id, "related-to");
-    store.createLink(b.id, c.id, "mentions");
+    await store.createLink(a.id, b.id, "related-to");
+    await store.createLink(b.id, c.id, "mentions");
 
-    const result = store.findPath(a.id, c.id);
+    const result = await store.findPath(a.id, c.id);
     expect(result).not.toBeNull();
     expect(result!.path).toEqual([a.id, b.id, c.id]);
     expect(result!.relationships).toEqual(["related-to", "mentions"]);
   });
 
-  test("get-links returns hydrated note summaries", () => {
-    const a = store.createNote("Note A", { path: "a", tags: ["important"] });
-    const b = store.createNote("Note B", { path: "b" });
-    store.createLink(a.id, b.id, "related-to");
+  test("get-links returns hydrated note summaries", async () => {
+    const a = await store.createNote("Note A", { path: "a", tags: ["important"] });
+    const b = await store.createNote("Note B", { path: "b" });
+    await store.createLink(a.id, b.id, "related-to");
 
     const result = getLinksHydrated(db, a.id);
     expect(result.length).toBe(1);
@@ -459,17 +459,17 @@ describe("deeper link queries", () => {
     expect(result[0].sourceNote?.tags).toContain("important");
   });
 
-  test("returns null when no path exists", () => {
-    const a = store.createNote("A");
-    const b = store.createNote("B");
+  test("returns null when no path exists", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
     // No link between them
 
-    const result = store.findPath(a.id, b.id);
+    const result = await store.findPath(a.id, b.id);
     expect(result).toBeNull();
   });
 });
 
-describe("MCP tools", () => {
+describe("MCP tools", async () => {
   test("generates all 9 core tools", () => {
     const tools = generateMcpTools(store);
     expect(tools.length).toBe(9);
@@ -486,29 +486,29 @@ describe("MCP tools", () => {
     expect(names).toContain("vault-info");
   });
 
-  test("query-notes by id works", () => {
+  test("query-notes by id works", async () => {
     const tools = generateMcpTools(store);
-    const note = store.createNote("By ID", { path: "test/note" });
+    const note = await store.createNote("By ID", { path: "test/note" });
 
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ id: note.id }) as any;
+    const result = await query.execute({ id: note.id }) as any;
     expect(result.content).toBe("By ID");
     expect(result.path).toBe("test/note");
   });
 
-  test("query-notes by path works", () => {
+  test("query-notes by path works", async () => {
     const tools = generateMcpTools(store);
-    store.createNote("By Path", { path: "Projects/README" });
+    await store.createNote("By Path", { path: "Projects/README" });
 
     const query = tools.find((t) => t.name === "query-notes")!;
-    const result = query.execute({ id: "Projects/README" }) as any;
+    const result = await query.execute({ id: "Projects/README" }) as any;
     expect(result.content).toBe("By Path");
   });
 
-  test("create-note tool works via execute", () => {
+  test("create-note tool works via execute", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
-    const result = createNote.execute({ content: "MCP note", tags: ["daily"] }) as any;
+    const result = await createNote.execute({ content: "MCP note", tags: ["daily"] }) as any;
     expect(result.content).toBe("MCP note");
     expect(result.tags).toContain("daily");
   });
@@ -522,7 +522,7 @@ describe("MCP tools", () => {
   });
 });
 
-describe("unified MCP wrapper", () => {
+describe("unified MCP wrapper", async () => {
   test("vault-info routes through vault param", async () => {
     const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
     const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
@@ -538,14 +538,14 @@ describe("unified MCP wrapper", () => {
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
-    vaultStore.createNote("alpha", { tags: ["x", "y"] });
-    vaultStore.createNote("beta", { tags: ["x"] });
+    await vaultStore.createNote("alpha", { tags: ["x", "y"] });
+    await vaultStore.createNote("beta", { tags: ["x"] });
 
     const tools = generateUnifiedMcpTools();
     const vaultInfo = tools.find((t) => t.name === "vault-info");
     expect(vaultInfo).toBeTruthy();
 
-    const result = vaultInfo!.execute({ vault: vaultName, include_stats: true }) as any;
+    const result = await vaultInfo!.execute({ vault: vaultName, include_stats: true }) as any;
     expect(result.name).toBe(vaultName);
     expect(result.description).toBe("Test vault");
     expect(result.stats.totalNotes).toBe(2);
@@ -568,8 +568,8 @@ describe("unified MCP wrapper", () => {
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
-    vaultStore.createNote("A", { tags: ["person"] });
-    vaultStore.upsertTagSchema("person", {
+    await vaultStore.createNote("A", { tags: ["person"] });
+    await vaultStore.upsertTagSchema("person", {
       description: "A person",
       fields: { name: { type: "string", description: "Full name" } },
     });
@@ -578,7 +578,7 @@ describe("unified MCP wrapper", () => {
 
     // list-tags with tag param for single tag detail
     const listTags = tools.find((t) => t.name === "list-tags")!;
-    const detail = listTags.execute({ vault: vaultName, tag: "person" }) as any;
+    const detail = await listTags.execute({ vault: vaultName, tag: "person" }) as any;
     expect(detail.name).toBe("person");
     expect(detail.count).toBe(1);
     expect(detail.description).toBe("A person");
@@ -601,7 +601,7 @@ describe("unified MCP wrapper", () => {
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
-    vaultStore.upsertTagSchema("person", {
+    await vaultStore.upsertTagSchema("person", {
       description: "A person",
       fields: {
         first_appeared: { type: "string", description: "When" },
@@ -614,7 +614,7 @@ describe("unified MCP wrapper", () => {
     const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
     // Create a note tagged person with no metadata — defaults auto-populated
-    const result = createNote.execute({
+    const result = await createNote.execute({
       vault: vaultName,
       content: "Alice",
       tags: ["person"],
@@ -622,18 +622,18 @@ describe("unified MCP wrapper", () => {
     expect(result.content).toBe("Alice");
 
     // Verify defaults were written
-    const fresh = queryNotes.execute({ vault: vaultName, id: result.id }) as any;
+    const fresh = await queryNotes.execute({ vault: vaultName, id: result.id }) as any;
     expect(fresh.metadata.first_appeared).toBe("");
     expect(fresh.metadata.relationship).toBe("");
 
     // Create with explicit metadata — preserved
-    const result2 = createNote.execute({
+    const result2 = await createNote.execute({
       vault: vaultName,
       content: "Bob",
       tags: ["person"],
       metadata: { first_appeared: "2024-01", relationship: "friend" },
     }) as any;
-    const fresh2 = queryNotes.execute({ vault: vaultName, id: result2.id }) as any;
+    const fresh2 = await queryNotes.execute({ vault: vaultName, id: result2.id }) as any;
     expect(fresh2.metadata.first_appeared).toBe("2024-01");
     expect(fresh2.metadata.relationship).toBe("friend");
 
@@ -654,14 +654,14 @@ describe("unified MCP wrapper", () => {
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
-    vaultStore.upsertTagSchema("person", {
+    await vaultStore.upsertTagSchema("person", {
       description: "A person",
       fields: {
         first_appeared: { type: "string", description: "When" },
         relationship: { type: "string", description: "How" },
       },
     });
-    vaultStore.upsertTagSchema("project", {
+    await vaultStore.upsertTagSchema("project", {
       description: "A project",
       fields: {
         status: { type: "string", enum: ["active", "completed", "abandoned"], description: "Status" },
@@ -675,35 +675,35 @@ describe("unified MCP wrapper", () => {
     const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
     // Create a note, then add #person tag via update-note
-    const note = createNote.execute({ vault: vaultName, content: "Alice" }) as any;
-    updateNote.execute({ vault: vaultName, id: note.id, tags: { add: ["person"] } });
-    const after = queryNotes.execute({ vault: vaultName, id: note.id }) as any;
+    const note = await createNote.execute({ vault: vaultName, content: "Alice" }) as any;
+    await updateNote.execute({ vault: vaultName, id: note.id, tags: { add: ["person"] } });
+    const after = await queryNotes.execute({ vault: vaultName, id: note.id }) as any;
     expect(after.metadata.first_appeared).toBe("");
     expect(after.metadata.relationship).toBe("");
 
     // Tag note that already has partial metadata — only missing fields populated
-    const note2 = createNote.execute({
+    const note2 = await createNote.execute({
       vault: vaultName,
       content: "Bob",
       metadata: { first_appeared: "2023-11" },
     }) as any;
-    updateNote.execute({ vault: vaultName, id: note2.id, tags: { add: ["person"] } });
-    const after2 = queryNotes.execute({ vault: vaultName, id: note2.id }) as any;
+    await updateNote.execute({ vault: vaultName, id: note2.id, tags: { add: ["person"] } });
+    const after2 = await queryNotes.execute({ vault: vaultName, id: note2.id }) as any;
     expect(after2.metadata.first_appeared).toBe("2023-11"); // preserved
     expect(after2.metadata.relationship).toBe(""); // added
 
     // Tag with #project — enum defaults to first value, boolean to false, integer to 0
-    const note4 = createNote.execute({ vault: vaultName, content: "My Project" }) as any;
-    updateNote.execute({ vault: vaultName, id: note4.id, tags: { add: ["project"] } });
-    const after4 = queryNotes.execute({ vault: vaultName, id: note4.id }) as any;
+    const note4 = await createNote.execute({ vault: vaultName, content: "My Project" }) as any;
+    await updateNote.execute({ vault: vaultName, id: note4.id, tags: { add: ["project"] } });
+    const after4 = await queryNotes.execute({ vault: vaultName, id: note4.id }) as any;
     expect(after4.metadata.status).toBe("active");
     expect(after4.metadata.active).toBe(false);
     expect(after4.metadata.priority).toBe(0);
 
     // Multiple schema tags at once — all defaults merged
-    const note5 = createNote.execute({ vault: vaultName, content: "Multi" }) as any;
-    updateNote.execute({ vault: vaultName, id: note5.id, tags: { add: ["person", "project"] } });
-    const after5 = queryNotes.execute({ vault: vaultName, id: note5.id }) as any;
+    const note5 = await createNote.execute({ vault: vaultName, content: "Multi" }) as any;
+    await updateNote.execute({ vault: vaultName, id: note5.id, tags: { add: ["person", "project"] } });
+    const after5 = await queryNotes.execute({ vault: vaultName, id: note5.id }) as any;
     expect(after5.metadata.first_appeared).toBe("");
     expect(after5.metadata.relationship).toBe("");
     expect(after5.metadata.status).toBe("active");
@@ -726,7 +726,7 @@ describe("unified MCP wrapper", () => {
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
-    vaultStore.upsertTagSchema("person", {
+    await vaultStore.upsertTagSchema("person", {
       description: "A person",
       fields: { name: { type: "string" } },
     });
@@ -736,10 +736,10 @@ describe("unified MCP wrapper", () => {
     const updateNote = tools.find((t) => t.name === "update-note")!;
     const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
-    const note = createNote.execute({ vault: vaultName, content: "Test" }) as any;
+    const note = await createNote.execute({ vault: vaultName, content: "Test" }) as any;
     const originalUpdatedAt = note.updatedAt;
-    updateNote.execute({ vault: vaultName, id: note.id, tags: { add: ["person"] } });
-    const after = queryNotes.execute({ vault: vaultName, id: note.id }) as any;
+    await updateNote.execute({ vault: vaultName, id: note.id, tags: { add: ["person"] } });
+    const after = await queryNotes.execute({ vault: vaultName, id: note.id }) as any;
     expect(after.updatedAt).toBe(originalUpdatedAt);
     expect(after.metadata.name).toBe("");
 
@@ -807,10 +807,10 @@ function mkReq(method: string, path: string, body?: unknown): Request {
   return new Request(`${BASE}${path}`, init);
 }
 
-describe("HTTP /notes", () => {
+describe("HTTP /notes", async () => {
   test("GET /notes defaults to lean index (no content field)", async () => {
-    store.createNote("one content", { path: "a", tags: ["t"] });
-    store.createNote("two content", { path: "b", tags: ["t"] });
+    await store.createNote("one content", { path: "a", tags: ["t"] });
+    await store.createNote("two content", { path: "b", tags: ["t"] });
     const res = await handleNotes(mkReq("GET", "/notes"), store, "");
     const body = await res.json() as any[];
     expect(body).toHaveLength(2);
@@ -820,22 +820,22 @@ describe("HTTP /notes", () => {
   });
 
   test("GET /notes?include_content=true returns full notes", async () => {
-    store.createNote("full body", { path: "a" });
+    await store.createNote("full body", { path: "a" });
     const res = await handleNotes(mkReq("GET", "/notes?include_content=true"), store, "");
     const body = await res.json() as any[];
     expect(body[0].content).toBe("full body");
   });
 
   test("GET /notes?search=fox full-text search", async () => {
-    store.createNote("The quick brown fox");
-    store.createNote("A lazy dog");
+    await store.createNote("The quick brown fox");
+    await store.createNote("A lazy dog");
     const res = await handleNotes(mkReq("GET", "/notes?search=fox"), store, "");
     const body = await res.json() as any[];
     expect(body).toHaveLength(1);
   });
 
   test("GET /notes?search=fox&include_metadata=false strips metadata from search results", async () => {
-    store.createNote("The quick brown fox", { metadata: { summary: "animal" } });
+    await store.createNote("The quick brown fox", { metadata: { summary: "animal" } });
     const res = await handleNotes(mkReq("GET", "/notes?search=fox&include_metadata=false"), store, "");
     const body = await res.json() as any[];
     expect(body).toHaveLength(1);
@@ -843,14 +843,14 @@ describe("HTTP /notes", () => {
   });
 
   test("GET /notes/:id defaults to full content", async () => {
-    const n = store.createNote("hello", { id: "x" });
+    const n = await store.createNote("hello", { id: "x" });
     const res = await handleNotes(mkReq("GET", "/notes/x"), store, "/x");
     const body = await res.json() as any;
     expect(body.content).toBe("hello");
   });
 
   test("GET /notes/:id?include_content=false returns lean shape", async () => {
-    store.createNote("hello", { id: "x" });
+    await store.createNote("hello", { id: "x" });
     const res = await handleNotes(mkReq("GET", "/notes/x?include_content=false"), store, "/x");
     const body = await res.json() as any;
     expect(body).not.toHaveProperty("content");
@@ -859,8 +859,8 @@ describe("HTTP /notes", () => {
   });
 
   test("GET /notes?include_metadata=false strips metadata from list", async () => {
-    store.createNote("a", { tags: ["m"], metadata: { summary: "hello", status: "ok" } });
-    store.createNote("b", { tags: ["m"], metadata: { summary: "world" } });
+    await store.createNote("a", { tags: ["m"], metadata: { summary: "hello", status: "ok" } });
+    await store.createNote("b", { tags: ["m"], metadata: { summary: "world" } });
     const res = await handleNotes(mkReq("GET", "/notes?tag=m&include_metadata=false"), store, "");
     const body = await res.json() as any[];
     expect(body).toHaveLength(2);
@@ -870,7 +870,7 @@ describe("HTTP /notes", () => {
   });
 
   test("GET /notes?include_metadata=summary,status returns only those fields", async () => {
-    store.createNote("a", { tags: ["mf"], metadata: { summary: "hello", status: "ok", extra: true } });
+    await store.createNote("a", { tags: ["mf"], metadata: { summary: "hello", status: "ok", extra: true } });
     const res = await handleNotes(mkReq("GET", "/notes?tag=mf&include_metadata=summary,status"), store, "");
     const body = await res.json() as any[];
     expect(body).toHaveLength(1);
@@ -878,7 +878,7 @@ describe("HTTP /notes", () => {
   });
 
   test("GET /notes/:id?include_metadata=false strips metadata from single note", async () => {
-    store.createNote("hello", { id: "xm", metadata: { summary: "s" } });
+    await store.createNote("hello", { id: "xm", metadata: { summary: "s" } });
     const res = await handleNotes(mkReq("GET", "/notes/xm?include_metadata=false"), store, "/xm");
     const body = await res.json() as any;
     expect(body.metadata).toBeUndefined();
@@ -886,7 +886,7 @@ describe("HTTP /notes", () => {
   });
 
   test("GET /notes/:id?include_metadata=summary returns only specified fields", async () => {
-    store.createNote("hello", { id: "xm2", metadata: { summary: "s", status: "draft" } });
+    await store.createNote("hello", { id: "xm2", metadata: { summary: "s", status: "draft" } });
     const res = await handleNotes(mkReq("GET", "/notes/xm2?include_metadata=summary"), store, "/xm2");
     const body = await res.json() as any;
     expect(body.metadata).toEqual({ summary: "s" });
@@ -903,7 +903,7 @@ describe("HTTP /notes", () => {
   });
 
   test("POST /notes/:id/attachments accepts mimeType (camelCase) in body", async () => {
-    const n = store.createNote("x", { id: "x" });
+    const n = await store.createNote("x", { id: "x" });
     const res = await handleNotes(
       mkReq("POST", "/notes/x/attachments", { path: "files/a.png", mimeType: "image/png" }),
       store,
@@ -915,13 +915,13 @@ describe("HTTP /notes", () => {
   });
 });
 
-describe("HTTP GET /notes?format=graph", () => {
+describe("HTTP GET /notes?format=graph", async () => {
   test("returns nodes and edges for linked notes", async () => {
-    const a = store.createNote("A", { id: "a", path: "People/Alice", tags: ["person"] });
-    const b = store.createNote("B", { id: "b", path: "People/Bob", tags: ["person"] });
-    const c = store.createNote("C", { id: "c", path: "Projects/X" });
-    store.createLink("a", "b", "knows");
-    store.createLink("a", "c", "works-on");
+    const a = await store.createNote("A", { id: "a", path: "People/Alice", tags: ["person"] });
+    const b = await store.createNote("B", { id: "b", path: "People/Bob", tags: ["person"] });
+    const c = await store.createNote("C", { id: "c", path: "Projects/X" });
+    await store.createLink("a", "b", "knows");
+    await store.createLink("a", "c", "works-on");
 
     const res = await handleNotes(
       mkReq("GET", "/notes?format=graph&include_links=true"),
@@ -941,9 +941,9 @@ describe("HTTP GET /notes?format=graph", () => {
   });
 
   test("returns empty edges when include_links is not set", async () => {
-    store.createNote("A", { id: "a" });
-    store.createNote("B", { id: "b" });
-    store.createLink("a", "b", "ref");
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "ref");
 
     const res = await handleNotes(
       mkReq("GET", "/notes?format=graph"),
@@ -956,12 +956,12 @@ describe("HTTP GET /notes?format=graph", () => {
   });
 
   test("composes with near param for subgraph", async () => {
-    const a = store.createNote("A", { id: "a", path: "People/Mickey" });
-    const b = store.createNote("B", { id: "b" });
-    const c = store.createNote("C", { id: "c" });
-    const d = store.createNote("D", { id: "d" }); // not connected
-    store.createLink("a", "b", "knows");
-    store.createLink("b", "c", "knows");
+    const a = await store.createNote("A", { id: "a", path: "People/Mickey" });
+    const b = await store.createNote("B", { id: "b" });
+    const c = await store.createNote("C", { id: "c" });
+    const d = await store.createNote("D", { id: "d" }); // not connected
+    await store.createLink("a", "b", "knows");
+    await store.createLink("b", "c", "knows");
 
     const res = await handleNotes(
       mkReq("GET", "/notes?format=graph&include_links=true&near[note_id]=People/Mickey&near[depth]=2"),
@@ -976,11 +976,11 @@ describe("HTTP GET /notes?format=graph", () => {
   });
 
   test("near with depth=1 limits subgraph", async () => {
-    const a = store.createNote("A", { id: "a" });
-    const b = store.createNote("B", { id: "b" });
-    const c = store.createNote("C", { id: "c" });
-    store.createLink("a", "b", "ref");
-    store.createLink("b", "c", "ref");
+    const a = await store.createNote("A", { id: "a" });
+    const b = await store.createNote("B", { id: "b" });
+    const c = await store.createNote("C", { id: "c" });
+    await store.createLink("a", "b", "ref");
+    await store.createLink("b", "c", "ref");
 
     const res = await handleNotes(
       mkReq("GET", "/notes?format=graph&include_links=true&near[note_id]=a&near[depth]=1"),
@@ -995,9 +995,9 @@ describe("HTTP GET /notes?format=graph", () => {
   });
 });
 
-describe("HTTP PATCH /notes/:idOrPath (update)", () => {
+describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
   test("PATCH updates content and merges metadata", async () => {
-    const note = store.createNote("original", { id: "x", metadata: { a: 1 } });
+    const note = await store.createNote("original", { id: "x", metadata: { a: 1 } });
     const res = await handleNotes(
       mkReq("PATCH", "/notes/x", { content: "updated", metadata: { b: 2 } }),
       store,
@@ -1009,7 +1009,7 @@ describe("HTTP PATCH /notes/:idOrPath (update)", () => {
   });
 
   test("PATCH adds/removes tags", async () => {
-    store.createNote("x", { id: "x", tags: ["old"] });
+    await store.createNote("x", { id: "x", tags: ["old"] });
     const res = await handleNotes(
       mkReq("PATCH", "/notes/x", { tags: { add: ["new"], remove: ["old"] } }),
       store,
@@ -1021,15 +1021,15 @@ describe("HTTP PATCH /notes/:idOrPath (update)", () => {
   });
 
   test("PATCH adds/removes links", async () => {
-    store.createNote("a", { id: "a" });
-    store.createNote("b", { id: "b" });
+    await store.createNote("a", { id: "a" });
+    await store.createNote("b", { id: "b" });
     const res = await handleNotes(
       mkReq("PATCH", "/notes/a", { links: { add: [{ target: "b", relationship: "mentions" }] } }),
       store,
       "/a",
     );
     expect(res.status).toBe(200);
-    const links = store.getLinks("a", { direction: "outbound" });
+    const links = await store.getLinks("a", { direction: "outbound" });
     expect(links).toHaveLength(1);
 
     // Remove
@@ -1038,11 +1038,11 @@ describe("HTTP PATCH /notes/:idOrPath (update)", () => {
       store,
       "/a",
     );
-    expect(store.getLinks("a", { direction: "outbound" })).toHaveLength(0);
+    expect(await store.getLinks("a", { direction: "outbound" })).toHaveLength(0);
   });
 
   test("PATCH resolves note by path", async () => {
-    store.createNote("x", { path: "Projects/README" });
+    await store.createNote("x", { path: "Projects/README" });
     const res = await handleNotes(
       mkReq("PATCH", `/notes/${encodeURIComponent("Projects/README")}`, { content: "updated" }),
       store,
@@ -1053,7 +1053,7 @@ describe("HTTP PATCH /notes/:idOrPath (update)", () => {
   });
 
   test("DELETE resolves note by path", async () => {
-    store.createNote("x", { path: "Temp/note" });
+    await store.createNote("x", { path: "Temp/note" });
     const res = await handleNotes(
       mkReq("DELETE", `/notes/${encodeURIComponent("Temp/note")}`),
       store,
@@ -1061,14 +1061,14 @@ describe("HTTP PATCH /notes/:idOrPath (update)", () => {
     );
     const body = await res.json() as any;
     expect(body.deleted).toBe(true);
-    expect(store.getNoteByPath("Temp/note")).toBeNull();
+    expect(await store.getNoteByPath("Temp/note")).toBeNull();
   });
 });
 
-describe("HTTP /tags", () => {
+describe("HTTP /tags", async () => {
   test("GET /tags lists all tags", async () => {
-    store.createNote("A", { tags: ["daily"] });
-    store.createNote("B", { tags: ["daily", "pinned"] });
+    await store.createNote("A", { tags: ["daily"] });
+    await store.createNote("B", { tags: ["daily", "pinned"] });
     const res = await handleTags(mkReq("GET", "/tags"), store);
     const body = await res.json() as any[];
     const daily = body.find((t: any) => t.name === "daily");
@@ -1076,8 +1076,8 @@ describe("HTTP /tags", () => {
   });
 
   test("GET /tags?tag=name returns single tag detail with schema", async () => {
-    store.createNote("A", { tags: ["person"] });
-    store.upsertTagSchema("person", { description: "A person", fields: { name: { type: "string" } } });
+    await store.createNote("A", { tags: ["person"] });
+    await store.upsertTagSchema("person", { description: "A person", fields: { name: { type: "string" } } });
     const res = await handleTags(mkReq("GET", "/tags?tag=person"), store);
     const body = await res.json() as any;
     expect(body.name).toBe("person");
@@ -1098,43 +1098,43 @@ describe("HTTP /tags", () => {
   });
 
   test("DELETE /tags/:name removes tag and schema", async () => {
-    store.createNote("A", { tags: ["doomed"] });
-    store.upsertTagSchema("doomed", { description: "will be deleted" });
+    await store.createNote("A", { tags: ["doomed"] });
+    await store.upsertTagSchema("doomed", { description: "will be deleted" });
     const res = await handleTags(mkReq("DELETE", "/tags/doomed"), store, "/doomed");
     const body = await res.json() as any;
     expect(body.deleted).toBe(true);
-    expect(store.listTags().some((t) => t.name === "doomed")).toBe(false);
+    expect((await store.listTags()).some((t) => t.name === "doomed")).toBe(false);
   });
 });
 
-describe("HTTP /find-path", () => {
+describe("HTTP /find-path", async () => {
   test("finds path between two notes", async () => {
-    store.createNote("a", { id: "a" });
-    store.createNote("b", { id: "b" });
-    store.createNote("c", { id: "c" });
-    store.createLink("a", "b", "mentions");
-    store.createLink("b", "c", "related-to");
-    const res = handleFindPath(mkReq("GET", "/find-path?source=a&target=c"), store);
+    await store.createNote("a", { id: "a" });
+    await store.createNote("b", { id: "b" });
+    await store.createNote("c", { id: "c" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("b", "c", "related-to");
+    const res = await handleFindPath(mkReq("GET", "/find-path?source=a&target=c"), store);
     const body = await res.json() as any;
     expect(body.path).toEqual(["a", "b", "c"]);
     expect(body.relationships).toEqual(["mentions", "related-to"]);
   });
 
   test("returns null when no path exists", async () => {
-    store.createNote("a", { id: "a" });
-    store.createNote("b", { id: "b" });
-    const res = handleFindPath(mkReq("GET", "/find-path?source=a&target=b"), store);
+    await store.createNote("a", { id: "a" });
+    await store.createNote("b", { id: "b" });
+    const res = await handleFindPath(mkReq("GET", "/find-path?source=a&target=b"), store);
     const body = await res.json() as any;
     expect(body).toBeNull();
   });
 
   test("requires source and target params", async () => {
-    const res = handleFindPath(mkReq("GET", "/find-path?source=a"), store);
+    const res = await handleFindPath(mkReq("GET", "/find-path?source=a"), store);
     expect(res.status).toBe(400);
   });
 });
 
-describe("stateless MCP transport", () => {
+describe("stateless MCP transport", async () => {
   test("tools/call works without prior initialize handshake", async () => {
     const { handleUnifiedMcp } = await import("./mcp-http.ts");
     const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
@@ -1149,7 +1149,7 @@ describe("stateless MCP transport", () => {
     writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
-    vaultStore.createNote("test note", { tags: ["daily"] });
+    await vaultStore.createNote("test note", { tags: ["daily"] });
 
     // Direct tools/call — no initialize, no session header
     const req = new Request("http://localhost:1940/mcp", {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -77,7 +77,7 @@ describe("BunStore", async () => {
       metadata: { audio_pending_at: "2026-04-09T10:00:00.000Z" },
       skipUpdatedAt: true,
     });
-    let fetched = await store.getNote(note.id)!;
+    let fetched = (await store.getNote(note.id))!;
     expect(fetched.updatedAt).toBeUndefined();
     expect((fetched.metadata as { audio_pending_at?: string } | undefined)?.audio_pending_at).toBe(
       "2026-04-09T10:00:00.000Z",
@@ -86,7 +86,7 @@ describe("BunStore", async () => {
     // Now a real user edit bumps it.
     await new Promise((r) => setTimeout(r, 5));
     await store.updateNote(note.id, { content: "User edit" });
-    fetched = await store.getNote(note.id)!;
+    fetched = (await store.getNote(note.id))!;
     const userTs = fetched.updatedAt;
     expect(userTs).toBeTruthy();
 
@@ -99,7 +99,7 @@ describe("BunStore", async () => {
       },
       skipUpdatedAt: true,
     });
-    fetched = await store.getNote(note.id)!;
+    fetched = (await store.getNote(note.id))!;
     expect(fetched.updatedAt).toBe(userTs!);
     expect((fetched.metadata as { audio_rendered_at?: string } | undefined)?.audio_rendered_at).toBe(
       "2026-04-09T10:05:00.000Z",
@@ -142,11 +142,11 @@ describe("BunStore", async () => {
   test("tags and untags notes", async () => {
     const note = await store.createNote("Taggable");
     await store.tagNote(note.id, ["important"]);
-    let fetched = await store.getNote(note.id)!;
+    let fetched = (await store.getNote(note.id))!;
     expect(fetched.tags).toContain("important");
 
     await store.untagNote(note.id, ["important"]);
-    fetched = await store.getNote(note.id)!;
+    fetched = (await store.getNote(note.id))!;
     expect(fetched.tags).not.toContain("important");
   });
 


### PR DESCRIPTION
## Summary
- Converts the `Store` interface from sync to async — every method now returns `Promise<T>`. Internal ops (`noteOps`, `linkOps`, `tagSchemaOps`) stay sync on the raw `bun:sqlite` Database; only the public Store boundary is wrapped.
- Renames `SqliteStore` → `BunSqliteStore`. Keeps `SqliteStore` as a `@deprecated` alias (both value and type) for compat.
- Unblocks a future Cloudflare Durable Objects SQLite backend whose storage API is async-only.

## Scope
- `core/src/types.ts` — Store interface signatures now `Promise<T>`.
- `core/src/store.ts` — class renamed, every method `async`, wraps the unchanged sync internal ops. `cascadeRename` kept sync.
- `core/src/hooks.ts` — one `await` added around `store.getNote` inside the semaphore.
- `core/src/mcp.ts`, `src/mcp-tools.ts`, `src/mcp-http.ts`, `src/routes.ts`, `src/server.ts`, `src/triggers.ts`, `src/cli.ts` — await production callers; `handleFindPath` / `handleViewNote` / `resolveNote` / `applySchemaDefaults` now async.
- Tests swept (8 files) + non-null assertions restored.

## Test plan
- [x] `bun test`: 387 pass / 3 skip (pre-existing) / 0 fail
- [x] `bun run tsc --noEmit`: no new type errors (net -7 vs. main for test-file null-errors)
- [x] Smoke test against `BunSqliteStore` in-process — create/get/stats/alias all work
- [x] Independent self-review via nested reviewer agent — verdict: ship

## Follow-ups (not in this PR)
- `DoSqliteStore` Cloudflare backend (separate PR once this lands).