### PR TITLE
feat(core): BlobStore abstraction — FS + R2 backends

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -11,7 +11,10 @@
     "./sql-db": "./src/sql-db.ts",
     "./schema": "./src/schema.ts",
     "./mcp": "./src/mcp.ts",
-    "./hooks": "./src/hooks.ts"
+    "./hooks": "./src/hooks.ts",
+    "./blob-store": "./src/blob-store.ts",
+    "./blob-fs": "./src/blob-fs.ts",
+    "./blob-r2": "./src/blob-r2.ts"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "*"

--- a/core/package.json
+++ b/core/package.json
@@ -3,5 +3,22 @@
   "version": "0.1.0",
   "description": "Parachute Vault core — schema, store, graph operations, MCP tools",
   "type": "module",
-  "private": true
+  "private": true,
+  "exports": {
+    ".": "./src/store.ts",
+    "./do": "./src/store-do.ts",
+    "./types": "./src/types.ts",
+    "./sql-db": "./src/sql-db.ts",
+    "./schema": "./src/schema.ts",
+    "./mcp": "./src/mcp.ts",
+    "./hooks": "./src/hooks.ts"
+  },
+  "peerDependencies": {
+    "@cloudflare/workers-types": "*"
+  },
+  "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+      "optional": true
+    }
+  }
 }

--- a/core/src/attachments.ts
+++ b/core/src/attachments.ts
@@ -1,0 +1,56 @@
+/**
+ * Attachment DB ops — shared by `BunSqliteStore` and `DoSqliteStore`.
+ * Runs against the `SqlDb` abstraction so it's portable across runtimes.
+ * The `path` column is a `BlobStore` key, not a filesystem path.
+ */
+
+import type { SqlDb } from "./sql-db.js";
+import type { Attachment } from "./types.js";
+import { generateId } from "./notes.js";
+
+interface AttachmentRow {
+  id: string;
+  note_id: string;
+  path: string;
+  mime_type: string;
+  metadata: string | null;
+  created_at: string;
+}
+
+export function addAttachment(
+  db: SqlDb,
+  noteId: string,
+  path: string,
+  mimeType: string,
+  metadata?: Record<string, unknown>,
+): Attachment {
+  const id = generateId();
+  const now = new Date().toISOString();
+  const metadataJson = metadata ? JSON.stringify(metadata) : "{}";
+  db.prepare(
+    "INSERT INTO attachments (id, note_id, path, mime_type, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(id, noteId, path, mimeType, metadataJson, now);
+
+  return { id, noteId, path, mimeType, metadata, createdAt: now };
+}
+
+export function getAttachments(db: SqlDb, noteId: string): Attachment[] {
+  const rows = db.prepare(
+    "SELECT * FROM attachments WHERE note_id = ? ORDER BY created_at",
+  ).all<AttachmentRow>(noteId);
+
+  return rows.map((r) => {
+    let metadata: Record<string, unknown> | undefined;
+    if (r.metadata && r.metadata !== "{}") {
+      try { metadata = JSON.parse(r.metadata); } catch {}
+    }
+    return {
+      id: r.id,
+      noteId: r.note_id,
+      path: r.path,
+      mimeType: r.mime_type,
+      metadata,
+      createdAt: r.created_at,
+    };
+  });
+}

--- a/core/src/blob-fs.test.ts
+++ b/core/src/blob-fs.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { FsBlobStore } from "./blob-fs.js";
+
+let root: string;
+let store: FsBlobStore;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "pv-blob-fs-"));
+  store = new FsBlobStore(root);
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) { out.set(c, offset); offset += c.byteLength; }
+  return out;
+}
+
+describe("FsBlobStore", () => {
+  it("round-trips bytes via nested key", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    await store.put("2026-04-14/audio.wav", bytes);
+
+    const got = await store.get("2026-04-14/audio.wav");
+    expect(got).not.toBeNull();
+    expect(got!.size).toBe(5);
+    const drained = await drain(got!.body);
+    expect(Array.from(drained)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("get returns null for missing keys", async () => {
+    expect(await store.get("missing/file.bin")).toBeNull();
+  });
+
+  it("delete removes the file; subsequent delete is a no-op", async () => {
+    await store.put("x/y.bin", new Uint8Array([9]));
+    await store.delete("x/y.bin");
+    expect(await store.get("x/y.bin")).toBeNull();
+    // Deleting again must not throw.
+    await store.delete("x/y.bin");
+  });
+
+  it("accepts ArrayBuffer and Blob inputs", async () => {
+    const ab = new Uint8Array([7, 8]).buffer;
+    await store.put("ab.bin", ab);
+    const blob = new Blob([new Uint8Array([9])]);
+    await store.put("blob.bin", blob);
+
+    const a = await store.get("ab.bin");
+    const b = await store.get("blob.bin");
+    expect(Array.from(await drain(a!.body))).toEqual([7, 8]);
+    expect(Array.from(await drain(b!.body))).toEqual([9]);
+  });
+
+  it("rejects keys that escape the root via '..'", async () => {
+    expect(store.put("../outside.bin", new Uint8Array([1]))).rejects.toThrow(/escapes root/);
+    expect(store.get("../outside.bin")).rejects.toThrow(/escapes root/);
+    expect(store.delete("../../outside.bin")).rejects.toThrow(/escapes root/);
+  });
+
+  it("rejects empty and null-byte keys", async () => {
+    expect(store.put("", new Uint8Array([1]))).rejects.toThrow(/Invalid blob key/);
+    expect(store.put("a\0b", new Uint8Array([1]))).rejects.toThrow(/Invalid blob key/);
+  });
+
+  it("creates intermediate directories as needed", async () => {
+    await store.put("deep/nested/path/thing.bin", new Uint8Array([1]));
+    expect(existsSync(join(root, "deep", "nested", "path", "thing.bin"))).toBe(true);
+  });
+});

--- a/core/src/blob-fs.ts
+++ b/core/src/blob-fs.ts
@@ -1,0 +1,63 @@
+/**
+ * Filesystem-backed `BlobStore`.
+ *
+ * Self-hosted deployments use this with the vault's assets directory as the
+ * root. Keys are relative, forward-slash paths like `2026-03-31/audio.wav`.
+ * A normalize-and-prefix-check guards against `..` escape.
+ */
+
+import { existsSync, mkdirSync, statSync, unlinkSync, readFileSync } from "fs";
+import { dirname, join, normalize, sep } from "path";
+import type { BlobStore, BlobObject, BlobPutOptions } from "./blob-store.js";
+
+export class FsBlobStore implements BlobStore {
+  constructor(public readonly rootDir: string) {}
+
+  async put(key: string, data: ArrayBuffer | Uint8Array | Blob, _opts?: BlobPutOptions): Promise<void> {
+    const abs = this.resolve(key);
+    mkdirSync(dirname(abs), { recursive: true });
+    const bytes = await toUint8Array(data);
+    await Bun.write(abs, bytes);
+  }
+
+  async get(key: string): Promise<BlobObject | null> {
+    const abs = this.resolve(key);
+    if (!existsSync(abs)) return null;
+    const size = statSync(abs).size;
+    // Bun.file().stream() would be nicer, but the bytes we already read are
+    // cheap to re-stream and keeps this dependency-free of Bun's File type.
+    const buf = readFileSync(abs);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(buf));
+        controller.close();
+      },
+    });
+    return { body: stream, size };
+  }
+
+  async delete(key: string): Promise<void> {
+    const abs = this.resolve(key);
+    if (existsSync(abs)) unlinkSync(abs);
+  }
+
+  /** Resolve a key to an absolute path, rejecting anything that escapes `rootDir`. */
+  private resolve(key: string): string {
+    if (!key || key.includes("\0")) {
+      throw new Error(`Invalid blob key: ${JSON.stringify(key)}`);
+    }
+    const root = normalize(this.rootDir);
+    const abs = normalize(join(root, key));
+    const rootWithSep = root.endsWith(sep) ? root : root + sep;
+    if (abs !== root && !abs.startsWith(rootWithSep)) {
+      throw new Error(`Blob key escapes root: ${JSON.stringify(key)}`);
+    }
+    return abs;
+  }
+}
+
+async function toUint8Array(data: ArrayBuffer | Uint8Array | Blob): Promise<Uint8Array> {
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  return new Uint8Array(await data.arrayBuffer());
+}

--- a/core/src/blob-r2.test.ts
+++ b/core/src/blob-r2.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { R2BlobStore, type R2BucketLike, type R2ObjectBody, type R2PutOptions } from "./blob-r2.js";
+
+class MockR2Bucket implements R2BucketLike {
+  readonly store = new Map<string, { bytes: Uint8Array; contentType?: string }>();
+
+  async put(key: string, value: ArrayBuffer | Uint8Array | Blob | ReadableStream, options?: R2PutOptions): Promise<unknown> {
+    const bytes = value instanceof Uint8Array ? value
+      : value instanceof ArrayBuffer ? new Uint8Array(value)
+      : value instanceof Blob ? new Uint8Array(await value.arrayBuffer())
+      : await drainToBytes(value as ReadableStream<Uint8Array>);
+    this.store.set(key, { bytes, contentType: options?.httpMetadata?.contentType });
+    return undefined;
+  }
+
+  async get(key: string): Promise<R2ObjectBody | null> {
+    const v = this.store.get(key);
+    if (!v) return null;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) { controller.enqueue(v.bytes); controller.close(); },
+    });
+    return {
+      body,
+      size: v.bytes.byteLength,
+      httpMetadata: v.contentType ? { contentType: v.contentType } : undefined,
+    };
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+async function drainToBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) { out.set(c, offset); offset += c.byteLength; }
+  return out;
+}
+
+let bucket: MockR2Bucket;
+
+beforeEach(() => {
+  bucket = new MockR2Bucket();
+});
+
+describe("R2BlobStore", () => {
+  it("round-trips bytes with mimeType", async () => {
+    const store = new R2BlobStore(bucket, "vault-abc");
+    await store.put("2026-04-14/a.wav", new Uint8Array([1, 2, 3]), { mimeType: "audio/wav" });
+
+    expect(bucket.store.has("vault-abc/2026-04-14/a.wav")).toBe(true);
+    const got = await store.get("2026-04-14/a.wav");
+    expect(got).not.toBeNull();
+    expect(got!.size).toBe(3);
+    expect(got!.mimeType).toBe("audio/wav");
+  });
+
+  it("returns null for missing keys", async () => {
+    const store = new R2BlobStore(bucket, "v1");
+    expect(await store.get("nope")).toBeNull();
+  });
+
+  it("delete removes the object", async () => {
+    const store = new R2BlobStore(bucket, "v1");
+    await store.put("x.bin", new Uint8Array([9]));
+    await store.delete("x.bin");
+    expect(await store.get("x.bin")).toBeNull();
+  });
+
+  it("works without a prefix", async () => {
+    const store = new R2BlobStore(bucket, "");
+    await store.put("a/b.bin", new Uint8Array([5]));
+    expect(bucket.store.has("a/b.bin")).toBe(true);
+  });
+
+  it("normalizes slashes between prefix and key", async () => {
+    const store = new R2BlobStore(bucket, "v1/");
+    await store.put("/a/b.bin", new Uint8Array([5]));
+    expect(bucket.store.has("v1/a/b.bin")).toBe(true);
+  });
+
+  it("rejects empty keys", async () => {
+    const store = new R2BlobStore(bucket, "v1");
+    expect(store.put("", new Uint8Array([1]))).rejects.toThrow(/non-empty/);
+  });
+});

--- a/core/src/blob-r2.ts
+++ b/core/src/blob-r2.ts
@@ -1,0 +1,71 @@
+/**
+ * Cloudflare R2–backed `BlobStore`.
+ *
+ * Import only from Workers code. Avoids a hard dependency on
+ * `@cloudflare/workers-types` by using a minimal structural interface for
+ * the bucket surface we use. A real `R2Bucket` binding satisfies it
+ * structurally.
+ *
+ * The `prefix` is prepended to every key with a `/` separator so one R2
+ * bucket can host many vaults (`<vault-id>/<date>/<file>`).
+ */
+
+import type { BlobStore, BlobObject, BlobPutOptions } from "./blob-store.js";
+
+// ---------------------------------------------------------------------------
+// Minimal structural types — shaped to match the bits of R2 we use.
+// ---------------------------------------------------------------------------
+
+export interface R2PutOptions {
+  httpMetadata?: { contentType?: string };
+}
+
+export interface R2ObjectBody {
+  readonly body: ReadableStream<Uint8Array>;
+  readonly size: number;
+  readonly httpMetadata?: { contentType?: string };
+}
+
+export interface R2BucketLike {
+  put(key: string, value: ArrayBuffer | Uint8Array | Blob | ReadableStream, options?: R2PutOptions): Promise<unknown>;
+  get(key: string): Promise<R2ObjectBody | null>;
+  delete(key: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export class R2BlobStore implements BlobStore {
+  /**
+   * @param bucket  An R2 bucket binding (from `env.<BINDING>`), or any object
+   *                that satisfies `R2BucketLike`.
+   * @param prefix  Optional key prefix. Joined with the user-supplied key via
+   *                `/`. Empty string = no prefix.
+   */
+  constructor(private readonly bucket: R2BucketLike, private readonly prefix: string = "") {}
+
+  async put(key: string, data: ArrayBuffer | Uint8Array | Blob, opts?: BlobPutOptions): Promise<void> {
+    await this.bucket.put(this.fullKey(key), data, opts?.mimeType ? { httpMetadata: { contentType: opts.mimeType } } : undefined);
+  }
+
+  async get(key: string): Promise<BlobObject | null> {
+    const obj = await this.bucket.get(this.fullKey(key));
+    if (!obj) return null;
+    return {
+      body: obj.body,
+      size: obj.size,
+      mimeType: obj.httpMetadata?.contentType,
+    };
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.bucket.delete(this.fullKey(key));
+  }
+
+  private fullKey(key: string): string {
+    if (!key) throw new Error("Blob key must be non-empty");
+    if (!this.prefix) return key;
+    return `${this.prefix.replace(/\/+$/, "")}/${key.replace(/^\/+/, "")}`;
+  }
+}

--- a/core/src/blob-store.ts
+++ b/core/src/blob-store.ts
@@ -1,0 +1,27 @@
+/**
+ * Runtime-portable blob (binary payload) storage.
+ *
+ * Attachment *metadata* lives in the SQLite `attachments` table; the actual
+ * bytes live here. Self-hosted deployments back this with the filesystem
+ * (`FsBlobStore`); Cloudflare Workers deployments back it with R2
+ * (`R2BlobStore`). The SQLite row's `path` column is the `key` passed to
+ * these methods — it is an opaque, forward-slash-separated string, never an
+ * absolute filesystem path.
+ */
+
+export interface BlobPutOptions {
+  mimeType?: string;
+}
+
+export interface BlobObject {
+  /** Readable stream of the blob's bytes. Consumer is responsible for draining. */
+  body: ReadableStream<Uint8Array>;
+  mimeType?: string;
+  size?: number;
+}
+
+export interface BlobStore {
+  put(key: string, data: ArrayBuffer | Uint8Array | Blob, opts?: BlobPutOptions): Promise<void>;
+  get(key: string): Promise<BlobObject | null>;
+  delete(key: string): Promise<void>;
+}

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -433,6 +433,24 @@ describe("attachments", async () => {
     const attachments = await store.getAttachments(note.id);
     expect(attachments).toHaveLength(0);
   });
+
+  it("blob I/O throws when no BlobStore is wired", async () => {
+    expect(store.putBlob("k", new Uint8Array([1]))).rejects.toThrow(/BlobStore/);
+    expect(store.getBlob("k")).rejects.toThrow(/BlobStore/);
+    expect(store.deleteBlob("k")).rejects.toThrow(/BlobStore/);
+  });
+
+  it("blob I/O propagates BlobStore rejections (not swallowed)", async () => {
+    const db2 = new Database(":memory:");
+    const blobStore = {
+      async put() { throw new Error("put failed"); },
+      async get() { return null; },
+      async delete() { throw new Error("delete failed"); },
+    };
+    const s = new SqliteStore(db2, { blobStore });
+    expect(s.putBlob("k", new Uint8Array([1]))).rejects.toThrow(/put failed/);
+    expect(s.deleteBlob("k")).rejects.toThrow(/delete failed/);
+  });
 });
 
 // ---- MCP Tools ----

--- a/core/src/links.ts
+++ b/core/src/links.ts
@@ -1,9 +1,9 @@
-import { Database } from "bun:sqlite";
+import type { SqlDb } from "./sql-db.js";
 import type { Link, NoteSummary, HydratedLink } from "./types.js";
 import { getNoteTags } from "./notes.js";
 
 export function createLink(
-  db: Database,
+  db: SqlDb,
   sourceId: string,
   targetId: string,
   relationship: string,
@@ -24,7 +24,7 @@ export function createLink(
 }
 
 export function deleteLink(
-  db: Database,
+  db: SqlDb,
   sourceId: string,
   targetId: string,
   relationship: string,
@@ -35,7 +35,7 @@ export function deleteLink(
 }
 
 export function getLinks(
-  db: Database,
+  db: SqlDb,
   noteId: string,
   opts?: { direction?: "outbound" | "inbound" | "both" },
 ): Link[] {
@@ -53,7 +53,7 @@ export function getLinks(
  * should pair the result with `getNote` / `getNotes`.
  */
 export function listLinks(
-  db: Database,
+  db: SqlDb,
   opts?: {
     noteId?: string;
     direction?: "outbound" | "inbound" | "both";
@@ -103,7 +103,7 @@ function parseMetadata(raw: string | null): Record<string, unknown> | undefined 
   try { return JSON.parse(raw); } catch { return undefined; }
 }
 
-function getNoteSummary(db: Database, noteId: string): NoteSummary | undefined {
+function getNoteSummary(db: SqlDb, noteId: string): NoteSummary | undefined {
   const row = db.prepare(
     "SELECT id, path, metadata, created_at, updated_at FROM notes WHERE id = ?",
   ).get(noteId) as SummaryRow | undefined;
@@ -118,7 +118,7 @@ function getNoteSummary(db: Database, noteId: string): NoteSummary | undefined {
   };
 }
 
-function getNoteSummaries(db: Database, noteIds: string[]): Map<string, NoteSummary> {
+function getNoteSummaries(db: SqlDb, noteIds: string[]): Map<string, NoteSummary> {
   const map = new Map<string, NoteSummary>();
   if (noteIds.length === 0) return map;
   const placeholders = noteIds.map(() => "?").join(", ");
@@ -143,7 +143,7 @@ function getNoteSummaries(db: Database, noteIds: string[]): Map<string, NoteSumm
  * Always includes note path/tags. Optionally includes content.
  */
 export function getLinksHydrated(
-  db: Database,
+  db: SqlDb,
   noteId: string,
   opts?: { direction?: "outbound" | "inbound" | "both"; include_content?: boolean },
 ): HydratedLink[] {
@@ -180,7 +180,7 @@ export interface TraversalNode {
  * Returns all reachable notes with their depth and how they were reached.
  */
 export function traverseLinks(
-  db: Database,
+  db: SqlDb,
   noteId: string,
   opts?: { max_depth?: number; relationship?: string },
 ): TraversalNode[] {
@@ -264,7 +264,7 @@ export function traverseLinks(
  * Returns the sequence of note IDs from source to target, or null if no path exists.
  */
 export function findPath(
-  db: Database,
+  db: SqlDb,
   sourceId: string,
   targetId: string,
   opts?: { max_depth?: number },

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1,4 +1,4 @@
-import { Database } from "bun:sqlite";
+import type { SqlDb } from "./sql-db.js";
 import type { Store, Note } from "./types.js";
 import * as noteOps from "./notes.js";
 import { filterMetadata } from "./notes.js";
@@ -20,7 +20,7 @@ export interface McpToolDef {
  * Resolve a note identifier — tries ID first, then case-insensitive path match.
  * Works everywhere a note reference is accepted.
  */
-function resolveNote(db: Database, idOrPath: string): Note | null {
+function resolveNote(db: SqlDb, idOrPath: string): Note | null {
   // Try ID match first (fast, indexed)
   const byId = noteOps.getNote(db, idOrPath);
   if (byId) return byId;
@@ -28,7 +28,7 @@ function resolveNote(db: Database, idOrPath: string): Note | null {
   return noteOps.getNoteByPath(db, idOrPath);
 }
 
-function requireNote(db: Database, idOrPath: string): Note {
+function requireNote(db: SqlDb, idOrPath: string): Note {
   const note = resolveNote(db, idOrPath);
   if (!note) throw new Error(`Note not found: "${idOrPath}"`);
   return note;
@@ -62,7 +62,7 @@ function removeWikilinkBrackets(content: string, targetPath: string): string {
  * Generate the 9 consolidated MCP tools for a vault.
  */
 export function generateMcpTools(store: Store): McpToolDef[] {
-  const db: Database = (store as any).db;
+  const db: SqlDb = (store as any).sqlDb;
 
   return [
 
@@ -619,7 +619,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
 // Tag schema effects — auto-populate defaults when tags are applied
 // ---------------------------------------------------------------------------
 
-async function applySchemaDefaults(store: Store, db: Database, noteIds: string[], tags: string[]): Promise<void> {
+async function applySchemaDefaults(store: Store, db: SqlDb, noteIds: string[], tags: string[]): Promise<void> {
   const schemas = tagSchemaOps.getTagSchemaMap(db);
   if (Object.keys(schemas).length === 0) return;
 

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -1,4 +1,4 @@
-import { Database } from "bun:sqlite";
+import type { SqlDb } from "./sql-db.js";
 import type { Note, NoteIndex, QueryOpts, VaultStats } from "./types.js";
 import { normalizePath } from "./paths.js";
 
@@ -21,7 +21,7 @@ export function generateId(): string {
 }
 
 export function createNote(
-  db: Database,
+  db: SqlDb,
   content: string,
   opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string },
 ): Note {
@@ -41,7 +41,7 @@ export function createNote(
   return getNote(db, id)!;
 }
 
-export function getNote(db: Database, id: string): Note | null {
+export function getNote(db: SqlDb, id: string): Note | null {
   const row = db.prepare("SELECT * FROM notes WHERE id = ?").get(id) as NoteRow | undefined;
   if (!row) return null;
 
@@ -50,7 +50,7 @@ export function getNote(db: Database, id: string): Note | null {
   return note;
 }
 
-export function getNoteByPath(db: Database, path: string): Note | null {
+export function getNoteByPath(db: SqlDb, path: string): Note | null {
   const row = db.prepare("SELECT * FROM notes WHERE path = ?").get(path) as NoteRow | undefined;
   if (!row) return null;
 
@@ -59,7 +59,7 @@ export function getNoteByPath(db: Database, path: string): Note | null {
   return note;
 }
 
-export function getNotes(db: Database, ids: string[]): Note[] {
+export function getNotes(db: SqlDb, ids: string[]): Note[] {
   if (ids.length === 0) return [];
   const placeholders = ids.map(() => "?").join(", ");
   const rows = db.prepare(
@@ -73,7 +73,7 @@ export function getNotes(db: Database, ids: string[]): Note[] {
 }
 
 export function updateNote(
-  db: Database,
+  db: SqlDb,
   id: string,
   updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean },
 ): Note {
@@ -115,11 +115,11 @@ export function updateNote(
   return getNote(db, id)!;
 }
 
-export function deleteNote(db: Database, id: string): void {
+export function deleteNote(db: SqlDb, id: string): void {
   db.prepare("DELETE FROM notes WHERE id = ?").run(id);
 }
 
-export function queryNotes(db: Database, opts: QueryOpts): Note[] {
+export function queryNotes(db: SqlDb, opts: QueryOpts): Note[] {
   const conditions: string[] = [];
   const params: unknown[] = [];
   const joins: string[] = [];
@@ -202,7 +202,7 @@ export function queryNotes(db: Database, opts: QueryOpts): Note[] {
 }
 
 export function searchNotes(
-  db: Database,
+  db: SqlDb,
   query: string,
   opts?: { tags?: string[]; limit?: number },
 ): Note[] {
@@ -249,7 +249,7 @@ export function searchNotes(
 
 // ---- Tag Operations ----
 
-export function tagNote(db: Database, noteId: string, tags: string[]): void {
+export function tagNote(db: SqlDb, noteId: string, tags: string[]): void {
   const insertTag = db.prepare("INSERT OR IGNORE INTO tags (name) VALUES (?)");
   const insertNoteTag = db.prepare("INSERT OR IGNORE INTO note_tags (note_id, tag_name) VALUES (?, ?)");
 
@@ -259,21 +259,21 @@ export function tagNote(db: Database, noteId: string, tags: string[]): void {
   }
 }
 
-export function untagNote(db: Database, noteId: string, tags: string[]): void {
+export function untagNote(db: SqlDb, noteId: string, tags: string[]): void {
   const stmt = db.prepare("DELETE FROM note_tags WHERE note_id = ? AND tag_name = ?");
   for (const tag of tags) {
     stmt.run(noteId, tag);
   }
 }
 
-export function getNoteTags(db: Database, noteId: string): string[] {
+export function getNoteTags(db: SqlDb, noteId: string): string[] {
   const rows = db.prepare(
     "SELECT tag_name FROM note_tags WHERE note_id = ? ORDER BY tag_name",
   ).all(noteId) as { tag_name: string }[];
   return rows.map((r) => r.tag_name);
 }
 
-export function listTags(db: Database): { name: string; count: number }[] {
+export function listTags(db: SqlDb): { name: string; count: number }[] {
   const rows = db.prepare(`
     SELECT t.name, COUNT(nt.note_id) as count
     FROM tags t
@@ -284,7 +284,7 @@ export function listTags(db: Database): { name: string; count: number }[] {
   return rows;
 }
 
-export function deleteTag(db: Database, name: string): { deleted: boolean; notes_untagged: number } {
+export function deleteTag(db: SqlDb, name: string): { deleted: boolean; notes_untagged: number } {
   const exists = db.prepare("SELECT 1 FROM tags WHERE name = ?").get(name);
   if (!exists) return { deleted: false, notes_untagged: 0 };
 
@@ -362,7 +362,7 @@ export function filterMetadata(obj: any, includeMetadata: boolean | string[] | u
  * Safe to call on large vaults. Read-only.
  */
 export function getVaultStats(
-  db: Database,
+  db: SqlDb,
   opts?: { topTagsLimit?: number },
 ): VaultStats {
   const topTagsLimit = opts?.topTagsLimit ?? 20;
@@ -422,11 +422,9 @@ export interface BulkNoteInput {
   created_at?: string;
 }
 
-export function createNotes(db: Database, inputs: BulkNoteInput[]): Note[] {
-  const results: Note[] = [];
-
-  db.exec("BEGIN");
-  try {
+export function createNotes(db: SqlDb, inputs: BulkNoteInput[]): Note[] {
+  return db.transaction(() => {
+    const results: Note[] = [];
     for (const input of inputs) {
       results.push(
         createNote(db, input.content, {
@@ -438,22 +436,15 @@ export function createNotes(db: Database, inputs: BulkNoteInput[]): Note[] {
         }),
       );
     }
-    db.exec("COMMIT");
-  } catch (err) {
-    db.exec("ROLLBACK");
-    throw err;
-  }
-
-  return results;
+    return results;
+  });
 }
 
-export function batchTag(db: Database, noteIds: string[], tags: string[]): number {
-  const insertTag = db.prepare("INSERT OR IGNORE INTO tags (name) VALUES (?)");
-  const insertNoteTag = db.prepare("INSERT OR IGNORE INTO note_tags (note_id, tag_name) VALUES (?, ?)");
-  let count = 0;
-
-  db.exec("BEGIN");
-  try {
+export function batchTag(db: SqlDb, noteIds: string[], tags: string[]): number {
+  return db.transaction(() => {
+    const insertTag = db.prepare("INSERT OR IGNORE INTO tags (name) VALUES (?)");
+    const insertNoteTag = db.prepare("INSERT OR IGNORE INTO note_tags (note_id, tag_name) VALUES (?, ?)");
+    let count = 0;
     for (const tag of tags) {
       insertTag.run(tag);
     }
@@ -463,34 +454,22 @@ export function batchTag(db: Database, noteIds: string[], tags: string[]): numbe
         count++;
       }
     }
-    db.exec("COMMIT");
-  } catch (err) {
-    db.exec("ROLLBACK");
-    throw err;
-  }
-
-  return count;
+    return count;
+  });
 }
 
-export function batchUntag(db: Database, noteIds: string[], tags: string[]): number {
-  const stmt = db.prepare("DELETE FROM note_tags WHERE note_id = ? AND tag_name = ?");
-  let count = 0;
-
-  db.exec("BEGIN");
-  try {
+export function batchUntag(db: SqlDb, noteIds: string[], tags: string[]): number {
+  return db.transaction(() => {
+    const stmt = db.prepare("DELETE FROM note_tags WHERE note_id = ? AND tag_name = ?");
+    let count = 0;
     for (const noteId of noteIds) {
       for (const tag of tags) {
         stmt.run(noteId, tag);
         count++;
       }
     }
-    db.exec("COMMIT");
-  } catch (err) {
-    db.exec("ROLLBACK");
-    throw err;
-  }
-
-  return count;
+    return count;
+  });
 }
 
 // ---- Internal ----

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -1,4 +1,4 @@
-import { Database } from "bun:sqlite";
+import type { SqlDb } from "./sql-db.js";
 import { normalizePath } from "./paths.js";
 
 export const SCHEMA_VERSION = 8;
@@ -126,7 +126,7 @@ CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_id);
 /**
  * Initialize database schema. Idempotent — safe to call on every startup.
  */
-export function initSchema(db: Database): void {
+export function initSchema(db: SqlDb): void {
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA foreign_keys = ON");
 
@@ -163,7 +163,7 @@ export function initSchema(db: Database): void {
   );
 }
 
-function hasColumn(db: Database, table: string, column: string): boolean {
+function hasColumn(db: SqlDb, table: string, column: string): boolean {
   const rows = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
   return rows.some((r) => r.name === column);
 }
@@ -171,7 +171,7 @@ function hasColumn(db: Database, table: string, column: string): boolean {
 /**
  * Migrate v3 → v4: add metadata JSON columns to notes and links.
  */
-function migrateToV4(db: Database): void {
+function migrateToV4(db: SqlDb): void {
   if (hasTable(db, "notes") && !hasColumn(db, "notes", "metadata")) {
     db.exec("ALTER TABLE notes ADD COLUMN metadata TEXT DEFAULT '{}'");
   }
@@ -186,7 +186,7 @@ function migrateToV4(db: Database): void {
 /**
  * Migrate v4 → v5: add UNIQUE constraint on path, normalize existing paths.
  */
-function migrateToV5(db: Database): void {
+function migrateToV5(db: SqlDb): void {
   if (!hasTable(db, "notes")) return;
 
   // Check if the unique index already exists
@@ -230,7 +230,7 @@ function migrateToV5(db: Database): void {
  * The table is already in SCHEMA_SQL so it's created for new vaults.
  * This migration handles existing vaults that were created before v6.
  */
-function migrateToV6(db: Database): void {
+function migrateToV6(db: SqlDb): void {
   // SCHEMA_SQL already creates the table via CREATE TABLE IF NOT EXISTS,
   // so this is a no-op for new vaults. For existing vaults where SCHEMA_SQL
   // ran above, the table now exists. Nothing extra needed here — the
@@ -243,18 +243,18 @@ function migrateToV6(db: Database): void {
  * The table is already in SCHEMA_SQL so it's created for new vaults.
  * This migration handles existing vaults that were created before v7.
  */
-function migrateToV7(db: Database): void {
+function migrateToV7(db: SqlDb): void {
   // SCHEMA_SQL already creates the table via CREATE TABLE IF NOT EXISTS,
   // so this is a no-op for new vaults. For existing vaults where SCHEMA_SQL
   // ran above, the table now exists. Nothing extra needed here.
 }
 
-function migrateToV8(db: Database): void {
+function migrateToV8(db: SqlDb): void {
   // SCHEMA_SQL already creates oauth_clients and oauth_codes via
   // CREATE TABLE IF NOT EXISTS. Nothing extra needed here.
 }
 
-function hasTable(db: Database, name: string): boolean {
+function hasTable(db: SqlDb, name: string): boolean {
   const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(name);
   return !!row;
 }
@@ -262,7 +262,7 @@ function hasTable(db: Database, name: string): boolean {
 /**
  * Migrate from v2 (things/thing_tags/edges/tools) to v3 (notes/note_tags/links).
  */
-function migrateFromV2(db: Database): void {
+function migrateFromV2(db: SqlDb): void {
   const alreadyMigrated = hasTable(db, "notes");
   if (alreadyMigrated) return;
 

--- a/core/src/sql-db.ts
+++ b/core/src/sql-db.ts
@@ -1,0 +1,174 @@
+/**
+ * Minimal SQL database adapter interface.
+ *
+ * Both `bun:sqlite` (self-hosted, used by `BunSqliteStore`) and Cloudflare
+ * Durable Objects SQLite (`ctx.storage.sql`, used by `DoSqliteStore`) expose
+ * synchronous prepare/exec surfaces. This interface captures the subset our
+ * ops helpers (`notes.ts`, `links.ts`, `wikilinks.ts`, `schema.ts`,
+ * `tag-schemas.ts`) actually use, so the same helpers work on both runtimes.
+ *
+ * Conventions:
+ * - Methods are synchronous. The async seam lives at the `Store` boundary.
+ * - `exec` accepts multi-statement SQL (schema init, `BEGIN`/`COMMIT`).
+ *   Implementations may split on `;` if the underlying driver only accepts
+ *   one statement at a time.
+ * - `transaction(fn)` runs `fn` inside a transaction. Use this instead of
+ *   bare `BEGIN`/`COMMIT`/`ROLLBACK` — DO's storage has no bare statement
+ *   form for those.
+ */
+
+import { Database as BunDatabase } from "bun:sqlite";
+
+// ---------------------------------------------------------------------------
+// Interfaces
+// ---------------------------------------------------------------------------
+
+export interface SqlRunResult {
+  changes: number;
+  lastInsertRowid: number | bigint;
+}
+
+export interface SqlStatement {
+  get<T = unknown>(...params: unknown[]): T | undefined;
+  all<T = unknown>(...params: unknown[]): T[];
+  run(...params: unknown[]): SqlRunResult;
+}
+
+export interface SqlDb {
+  prepare(sql: string): SqlStatement;
+  exec(sql: string): void;
+  transaction<T>(fn: () => T): T;
+}
+
+class BunSqlStatement implements SqlStatement {
+  constructor(private readonly stmt: ReturnType<BunDatabase["prepare"]>) {}
+
+  get<T = unknown>(...params: unknown[]): T | undefined {
+    return (this.stmt.get(...(params as [])) as T | null) ?? undefined;
+  }
+
+  all<T = unknown>(...params: unknown[]): T[] {
+    return this.stmt.all(...(params as [])) as T[];
+  }
+
+  run(...params: unknown[]): SqlRunResult {
+    const r = this.stmt.run(...(params as []));
+    return { changes: r.changes, lastInsertRowid: r.lastInsertRowid };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-statement SQL splitter
+//
+// Drivers like Durable Objects' `ctx.storage.sql.exec` accept only one
+// statement per call. Our schema SQL contains trigger bodies with `BEGIN ...
+// END;` blocks, so a naive split on `;` would break them apart. This splitter
+// tracks `BEGIN`/`END` depth and quoted strings/line comments to produce a
+// clean list of top-level statements.
+// ---------------------------------------------------------------------------
+
+export function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let current = "";
+  let i = 0;
+  let beginDepth = 0;
+
+  while (i < sql.length) {
+    const ch = sql[i];
+    const rest = sql.slice(i);
+
+    // Line comment
+    if (ch === "-" && sql[i + 1] === "-") {
+      const nl = sql.indexOf("\n", i);
+      if (nl === -1) break;
+      i = nl + 1;
+      current += "\n";
+      continue;
+    }
+
+    // String literal
+    if (ch === "'") {
+      const end = findStringEnd(sql, i);
+      current += sql.slice(i, end + 1);
+      i = end + 1;
+      continue;
+    }
+
+    // Keyword detection (case-insensitive, word-bounded)
+    const beginMatch = /^BEGIN\b/i.exec(rest);
+    if (beginMatch && isWordBoundaryBefore(sql, i)) {
+      beginDepth++;
+      current += beginMatch[0];
+      i += beginMatch[0].length;
+      continue;
+    }
+    const endMatch = /^END\b/i.exec(rest);
+    if (endMatch && isWordBoundaryBefore(sql, i) && beginDepth > 0) {
+      beginDepth--;
+      current += endMatch[0];
+      i += endMatch[0].length;
+      continue;
+    }
+
+    if (ch === ";" && beginDepth === 0) {
+      const trimmed = current.trim();
+      if (trimmed) statements.push(trimmed);
+      current = "";
+      i++;
+      continue;
+    }
+
+    current += ch;
+    i++;
+  }
+
+  const trimmed = current.trim();
+  if (trimmed) statements.push(trimmed);
+  return statements;
+}
+
+function findStringEnd(sql: string, start: number): number {
+  let i = start + 1;
+  while (i < sql.length) {
+    if (sql[i] === "'") {
+      // Escaped quote: ''
+      if (sql[i + 1] === "'") { i += 2; continue; }
+      return i;
+    }
+    i++;
+  }
+  return sql.length - 1;
+}
+
+function isWordBoundaryBefore(sql: string, i: number): boolean {
+  if (i === 0) return true;
+  return !/[A-Za-z0-9_]/.test(sql[i - 1] ?? "");
+}
+
+// ---------------------------------------------------------------------------
+// Bun SQLite adapter — wraps `bun:sqlite`'s `Database`
+// ---------------------------------------------------------------------------
+
+export class BunSqliteAdapter implements SqlDb {
+  constructor(public readonly db: BunDatabase) {}
+
+  prepare(sql: string): SqlStatement {
+    return new BunSqlStatement(this.db.prepare(sql));
+  }
+
+  exec(sql: string): void {
+    this.db.exec(sql);
+  }
+
+  transaction<T>(fn: () => T): T {
+    this.db.exec("BEGIN");
+    try {
+      const result = fn();
+      this.db.exec("COMMIT");
+      return result;
+    } catch (err) {
+      this.db.exec("ROLLBACK");
+      throw err;
+    }
+  }
+}

--- a/core/src/sql-db.ts
+++ b/core/src/sql-db.ts
@@ -65,6 +65,9 @@ class BunSqlStatement implements SqlStatement {
 // END;` blocks, so a naive split on `;` would break them apart. This splitter
 // tracks `BEGIN`/`END` depth and quoted strings/line comments to produce a
 // clean list of top-level statements.
+//
+// Intentionally does NOT handle `/* block comments */` — our schema doesn't
+// use them. Add that if we ever introduce schema SQL that does.
 // ---------------------------------------------------------------------------
 
 export function splitSqlStatements(sql: string): string[] {

--- a/core/src/store-do.test.ts
+++ b/core/src/store-do.test.ts
@@ -1,0 +1,197 @@
+/**
+ * DoSqliteStore tests — exercised via a mock `DoDurableObjectStorage`
+ * backed by bun:sqlite.
+ *
+ * The point of these tests isn't to retest the SQL (the `BunSqliteStore`
+ * suite already covers every ops helper). It's to prove:
+ *
+ *   1. `DoSqliteAdapter` correctly maps the DO-style surface
+ *      (`storage.sql.exec(query, ...bindings)` returning a cursor) onto
+ *      the `SqlDb` contract the ops helpers consume.
+ *   2. `DoSqliteStore` wires hooks, wikilink sync, schema init, and the
+ *      statement-level behaviours the same way `BunSqliteStore` does.
+ *   3. Multi-statement SQL (schema init, including FTS triggers with
+ *      `BEGIN ... END;` blocks) is split cleanly.
+ *   4. Attachments throw rather than silently misbehave.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { DoSqliteStore, type DoDurableObjectStorage, type DoSqlStorage, type DoSqlCursor } from "./store-do.js";
+import { splitSqlStatements } from "./sql-db.js";
+
+// ---------------------------------------------------------------------------
+// Mock DO storage — delegates to an in-memory bun:sqlite Database, but
+// only uses the DO-shaped surface (exec + cursor + transactionSync). This
+// ensures the adapter would behave identically on real DO storage.
+// ---------------------------------------------------------------------------
+
+function mockStorage(db: Database): DoDurableObjectStorage {
+  const sql: DoSqlStorage = {
+    exec<T>(query: string, ...bindings: unknown[]): DoSqlCursor<T> {
+      const stmt = db.prepare(query);
+      // Detect data-modifying statements — bun:sqlite only gives us `.run()`
+      // with `changes`, and `.all()` for reads. We route by SQL keyword.
+      const isSelect = /^\s*(SELECT|PRAGMA|WITH)\b/i.test(query);
+
+      if (isSelect) {
+        const rows = stmt.all(...(bindings as [])) as T[];
+        return { toArray: () => rows, rowsWritten: 0 };
+      }
+
+      const result = stmt.run(...(bindings as []));
+      return { toArray: () => [] as T[], rowsWritten: result.changes };
+    },
+  };
+
+  return {
+    sql,
+    transactionSync<T>(closure: () => T): T {
+      db.exec("BEGIN");
+      try {
+        const r = closure();
+        db.exec("COMMIT");
+        return r;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}
+
+let store: DoSqliteStore;
+
+beforeEach(() => {
+  const db = new Database(":memory:");
+  store = new DoSqliteStore(mockStorage(db));
+});
+
+// ---------------------------------------------------------------------------
+// Splitter
+// ---------------------------------------------------------------------------
+
+describe("splitSqlStatements", () => {
+  it("splits top-level statements on ;", () => {
+    const stmts = splitSqlStatements("CREATE TABLE a (x INT); CREATE TABLE b (y INT);");
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain("CREATE TABLE a");
+    expect(stmts[1]).toContain("CREATE TABLE b");
+  });
+
+  it("keeps BEGIN ... END; trigger bodies intact", () => {
+    const sql = `
+      CREATE TRIGGER t AFTER INSERT ON notes BEGIN
+        INSERT INTO notes_fts(rowid, content) VALUES (new.rowid, new.content);
+      END;
+      CREATE INDEX i ON notes(created_at);
+    `;
+    const stmts = splitSqlStatements(sql);
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toMatch(/CREATE TRIGGER/);
+    expect(stmts[0]).toMatch(/END$/);
+    expect(stmts[1]).toMatch(/CREATE INDEX/);
+  });
+
+  it("ignores semicolons inside string literals", () => {
+    const stmts = splitSqlStatements("INSERT INTO t VALUES ('a;b'); SELECT 1;");
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain("'a;b'");
+  });
+
+  it("ignores line comments", () => {
+    const stmts = splitSqlStatements(`
+      -- a comment ;
+      SELECT 1;
+    `);
+    expect(stmts).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store wiring
+// ---------------------------------------------------------------------------
+
+describe("DoSqliteStore", () => {
+  it("initialises schema (no PRAGMA errors, FTS triggers land)", async () => {
+    // If initSchema failed on multi-statement or PRAGMA, construction would
+    // have thrown in beforeEach.
+    const stats = await store.getVaultStats();
+    expect(stats.totalNotes).toBe(0);
+  });
+
+  it("creates, retrieves, and deletes a note", async () => {
+    const n = await store.createNote("hello from DO", { path: "Hello" });
+    expect(n.id).toBeTruthy();
+    expect(n.path).toBe("Hello");
+
+    const fetched = await store.getNote(n.id);
+    expect(fetched?.content).toBe("hello from DO");
+
+    const byPath = await store.getNoteByPath("Hello");
+    expect(byPath?.id).toBe(n.id);
+
+    await store.deleteNote(n.id);
+    expect(await store.getNote(n.id)).toBeNull();
+  });
+
+  it("tags and queries by tag", async () => {
+    const n = await store.createNote("tagged", { tags: ["x", "y"] });
+    const byTag = await store.queryNotes({ tags: ["x"] });
+    expect(byTag.map((r) => r.id)).toContain(n.id);
+
+    await store.untagNote(n.id, ["x"]);
+    const after = await store.queryNotes({ tags: ["x"] });
+    expect(after.map((r) => r.id)).not.toContain(n.id);
+  });
+
+  it("runs bulk createNotes inside transactionSync", async () => {
+    const notes = await store.createNotes([
+      { content: "one" },
+      { content: "two" },
+      { content: "three" },
+    ]);
+    expect(notes).toHaveLength(3);
+    const all = await store.queryNotes({});
+    expect(all).toHaveLength(3);
+  });
+
+  it("creates and queries links", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    await store.createLink(a.id, b.id, "relates-to");
+    const links = await store.getLinks(a.id, { direction: "outbound" });
+    expect(links).toHaveLength(1);
+    expect(links[0]!.targetId).toBe(b.id);
+  });
+
+  it("syncs wikilinks on note create (cross-note link)", async () => {
+    const target = await store.createNote("target body", { path: "Target" });
+    const source = await store.createNote("see [[Target]]", { path: "Source" });
+    const links = await store.getLinks(source.id, { direction: "outbound" });
+    expect(links.some((l) => l.targetId === target.id && l.relationship === "wikilink")).toBe(true);
+  });
+
+  it("runs FTS search after inserting via DO adapter", async () => {
+    await store.createNote("the quick brown fox");
+    await store.createNote("a slow blue whale");
+    const hits = await store.searchNotes("brown");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.content).toContain("brown");
+  });
+
+  it("upserts and reads tag schemas", async () => {
+    await store.upsertTagSchema("project", {
+      description: "Active projects",
+      fields: { name: { type: "string" } },
+    });
+    const s = await store.getTagSchema("project");
+    expect(s?.description).toBe("Active projects");
+    expect(s?.fields?.name?.type).toBe("string");
+  });
+
+  it("throws on attachment methods (not yet supported)", async () => {
+    expect(store.addAttachment("n", "/tmp/x", "image/png")).rejects.toThrow(/attachments/);
+    expect(store.getAttachments("n")).rejects.toThrow(/attachments/);
+  });
+});

--- a/core/src/store-do.test.ts
+++ b/core/src/store-do.test.ts
@@ -190,8 +190,63 @@ describe("DoSqliteStore", () => {
     expect(s?.fields?.name?.type).toBe("string");
   });
 
-  it("throws on attachment methods (not yet supported)", async () => {
-    expect(store.addAttachment("n", "/tmp/x", "image/png")).rejects.toThrow(/attachments/);
-    expect(store.getAttachments("n")).rejects.toThrow(/attachments/);
+  it("creates and reads attachment metadata (DB-only)", async () => {
+    const n = await store.createNote("with attachment");
+    const att = await store.addAttachment(n.id, "2026-04-14/audio.wav", "audio/wav", { duration: 12 });
+    expect(att.path).toBe("2026-04-14/audio.wav");
+    expect(att.mimeType).toBe("audio/wav");
+
+    const atts = await store.getAttachments(n.id);
+    expect(atts).toHaveLength(1);
+    expect(atts[0]!.metadata).toEqual({ duration: 12 });
+  });
+
+  it("throws on blob I/O when no BlobStore is wired", async () => {
+    expect(store.putBlob("k", new Uint8Array([1]))).rejects.toThrow(/BlobStore/);
+    expect(store.getBlob("k")).rejects.toThrow(/BlobStore/);
+    expect(store.deleteBlob("k")).rejects.toThrow(/BlobStore/);
+  });
+
+  it("routes blob I/O through the provided BlobStore", async () => {
+    const db = new (await import("bun:sqlite")).Database(":memory:");
+    const mem = new Map<string, { bytes: Uint8Array; mimeType?: string }>();
+    const blobStore = {
+      async put(key: string, data: Uint8Array | ArrayBuffer | Blob, opts?: { mimeType?: string }) {
+        const bytes = data instanceof Uint8Array ? data
+          : data instanceof ArrayBuffer ? new Uint8Array(data)
+          : new Uint8Array(await (data as Blob).arrayBuffer());
+        mem.set(key, { bytes, mimeType: opts?.mimeType });
+      },
+      async get(key: string) {
+        const v = mem.get(key);
+        if (!v) return null;
+        return {
+          body: new ReadableStream<Uint8Array>({ start(c) { c.enqueue(v.bytes); c.close(); } }),
+          mimeType: v.mimeType,
+          size: v.bytes.byteLength,
+        };
+      },
+      async delete(key: string) { mem.delete(key); },
+    };
+    const s = new DoSqliteStore(mockStorage(db), { blobStore });
+    await s.putBlob("a/b.bin", new Uint8Array([1, 2, 3]), { mimeType: "application/octet-stream" });
+    const got = await s.getBlob("a/b.bin");
+    expect(got).not.toBeNull();
+    expect(got!.size).toBe(3);
+    expect(got!.mimeType).toBe("application/octet-stream");
+    await s.deleteBlob("a/b.bin");
+    expect(await s.getBlob("a/b.bin")).toBeNull();
+  });
+
+  it("propagates BlobStore.put/delete rejections (not swallowed by async wrapper)", async () => {
+    const db = new (await import("bun:sqlite")).Database(":memory:");
+    const blobStore = {
+      async put() { throw new Error("put failed"); },
+      async get() { return null; },
+      async delete() { throw new Error("delete failed"); },
+    };
+    const s = new DoSqliteStore(mockStorage(db), { blobStore });
+    expect(s.putBlob("k", new Uint8Array([1]))).rejects.toThrow(/put failed/);
+    expect(s.deleteBlob("k")).rejects.toThrow(/delete failed/);
   });
 });

--- a/core/src/store-do.ts
+++ b/core/src/store-do.ts
@@ -67,6 +67,12 @@ class DoSqlStatement implements SqlStatement {
     const cursor = this.sql.exec(this.query, ...params);
     // Force execution by materializing (DO cursors are lazy).
     cursor.toArray();
+    // `rowsWritten` is best-effort and not identical to bun:sqlite's
+    // `.changes` — on DO it can include rows written by triggers. Today
+    // only `deleteTagSchema` inspects `.changes` (`> 0`), which is fine
+    // either way. Don't count on exact row counts downstream.
+    // `lastInsertRowid` is always 0 because every table in our schema
+    // uses a TEXT PRIMARY KEY; nothing in core reads it.
     return { changes: cursor.rowsWritten, lastInsertRowid: 0 };
   }
 }

--- a/core/src/store-do.ts
+++ b/core/src/store-do.ts
@@ -23,6 +23,8 @@ import * as tagSchemaOps from "./tag-schemas.js";
 import { syncWikilinks, resolveUnresolvedWikilinks } from "./wikilinks.js";
 import { pathTitle } from "./paths.js";
 import { HookRegistry } from "./hooks.js";
+import * as attachmentOps from "./attachments.js";
+import type { BlobStore } from "./blob-store.js";
 
 // ---------------------------------------------------------------------------
 // Minimal structural types for the DO storage surface we use.
@@ -110,11 +112,13 @@ export class DoSqliteAdapter implements SqlDb {
 export class DoSqliteStore implements Store {
   public readonly hooks: HookRegistry;
   public readonly sqlDb: SqlDb;
+  public readonly blobStore?: BlobStore;
 
-  constructor(storage: DoDurableObjectStorage, opts?: { hooks?: HookRegistry }) {
+  constructor(storage: DoDurableObjectStorage, opts?: { hooks?: HookRegistry; blobStore?: BlobStore }) {
     this.sqlDb = new DoSqliteAdapter(storage);
     initSchema(this.sqlDb);
     this.hooks = opts?.hooks ?? new HookRegistry();
+    this.blobStore = opts?.blobStore;
   }
 
   // ---- Notes ----
@@ -297,15 +301,32 @@ export class DoSqliteStore implements Store {
   }
 
   // ---- Attachments ----
-  // R2 integration is tracked in a follow-up PR. Self-hosted filesystem
-  // attachments are not portable to Workers, so these throw for now.
 
-  async addAttachment(_noteId: string, _filePath: string, _mimeType: string, _metadata?: Record<string, unknown>): Promise<Attachment> {
-    throw new Error("attachments are not yet supported on DoSqliteStore");
+  async addAttachment(noteId: string, filePath: string, mimeType: string, metadata?: Record<string, unknown>): Promise<Attachment> {
+    return attachmentOps.addAttachment(this.sqlDb, noteId, filePath, mimeType, metadata);
   }
 
-  async getAttachments(_noteId: string): Promise<Attachment[]> {
-    throw new Error("attachments are not yet supported on DoSqliteStore");
+  async getAttachments(noteId: string): Promise<Attachment[]> {
+    return attachmentOps.getAttachments(this.sqlDb, noteId);
+  }
+
+  // ---- Blob I/O ----
+
+  async putBlob(key: string, data: ArrayBuffer | Uint8Array | Blob, opts?: { mimeType?: string }): Promise<void> {
+    await this.requireBlobStore().put(key, data, opts);
+  }
+
+  async getBlob(key: string) {
+    return this.requireBlobStore().get(key);
+  }
+
+  async deleteBlob(key: string): Promise<void> {
+    await this.requireBlobStore().delete(key);
+  }
+
+  private requireBlobStore(): BlobStore {
+    if (!this.blobStore) throw new Error("DoSqliteStore was constructed without a BlobStore");
+    return this.blobStore;
   }
 }
 

--- a/core/src/store-do.ts
+++ b/core/src/store-do.ts
@@ -1,5 +1,21 @@
-import { Database } from "bun:sqlite";
+/**
+ * Cloudflare Durable Objects SQLite-backed `Store` implementation.
+ *
+ * Consumes `ctx.storage.sql` (and `ctx.storage.transactionSync`) via a
+ * minimal adapter, so all of the ops helpers in `notes.ts`, `links.ts`,
+ * `wikilinks.ts`, `schema.ts`, and `tag-schemas.ts` run unchanged on both
+ * bun:sqlite and DO SQLite.
+ *
+ * Import this file from Workers code only — it has no `bun:sqlite` runtime
+ * dependency. Self-hosted code paths should import `./store.js` instead.
+ *
+ * Attachments are not yet supported on this store; the methods throw. R2
+ * integration is tracked separately.
+ */
+
 import type { Store, Note, Link, Attachment, QueryOpts } from "./types.js";
+import type { SqlDb, SqlStatement, SqlRunResult } from "./sql-db.js";
+import { splitSqlStatements } from "./sql-db.js";
 import { initSchema } from "./schema.js";
 import * as noteOps from "./notes.js";
 import * as linkOps from "./links.js";
@@ -7,21 +23,90 @@ import * as tagSchemaOps from "./tag-schemas.js";
 import { syncWikilinks, resolveUnresolvedWikilinks } from "./wikilinks.js";
 import { pathTitle } from "./paths.js";
 import { HookRegistry } from "./hooks.js";
-import { BunSqliteAdapter, type SqlDb } from "./sql-db.js";
 
-/**
- * bun:sqlite-backed Store implementation. Internally everything is
- * synchronous; the public Store API is async so the same interface
- * can back an async runtime (e.g. Cloudflare Durable Objects SQLite).
- */
-export class BunSqliteStore implements Store {
+// ---------------------------------------------------------------------------
+// Minimal structural types for the DO storage surface we use.
+//
+// We deliberately avoid depending on `@cloudflare/workers-types` at compile
+// time so the package ships without pulling that type graph into self-hosted
+// builds. Callers that have the real types can pass `ctx.storage` directly —
+// it structurally satisfies this interface.
+// ---------------------------------------------------------------------------
+
+export interface DoSqlCursor<T = Record<string, unknown>> {
+  toArray(): T[];
+  readonly rowsWritten: number;
+}
+
+export interface DoSqlStorage {
+  exec<T = Record<string, unknown>>(query: string, ...bindings: unknown[]): DoSqlCursor<T>;
+}
+
+export interface DoDurableObjectStorage {
+  readonly sql: DoSqlStorage;
+  transactionSync<T>(closure: () => T): T;
+}
+
+// ---------------------------------------------------------------------------
+// DoSqliteAdapter — wraps `ctx.storage` into the shared `SqlDb` interface.
+// ---------------------------------------------------------------------------
+
+class DoSqlStatement implements SqlStatement {
+  constructor(private readonly sql: DoSqlStorage, private readonly query: string) {}
+
+  get<T = unknown>(...params: unknown[]): T | undefined {
+    const rows = this.sql.exec<T>(this.query, ...params).toArray();
+    return rows.length > 0 ? rows[0] : undefined;
+  }
+
+  all<T = unknown>(...params: unknown[]): T[] {
+    return this.sql.exec<T>(this.query, ...params).toArray();
+  }
+
+  run(...params: unknown[]): SqlRunResult {
+    const cursor = this.sql.exec(this.query, ...params);
+    // Force execution by materializing (DO cursors are lazy).
+    cursor.toArray();
+    return { changes: cursor.rowsWritten, lastInsertRowid: 0 };
+  }
+}
+
+export class DoSqliteAdapter implements SqlDb {
+  constructor(public readonly storage: DoDurableObjectStorage) {}
+
+  prepare(sql: string): SqlStatement {
+    return new DoSqlStatement(this.storage.sql, sql);
+  }
+
+  /**
+   * Execute one or more statements. Multi-statement SQL is split by
+   * `splitSqlStatements` since DO's `sql.exec` only accepts a single
+   * statement per call. `PRAGMA` statements are skipped — DO SQLite doesn't
+   * support them and the WAL/foreign-keys pragmas our schema uses aren't
+   * meaningful on DO storage (which is already transactional).
+   */
+  exec(sql: string): void {
+    for (const stmt of splitSqlStatements(sql)) {
+      if (/^\s*PRAGMA\b/i.test(stmt)) continue;
+      this.storage.sql.exec(stmt);
+    }
+  }
+
+  transaction<T>(fn: () => T): T {
+    return this.storage.transactionSync(fn);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DoSqliteStore
+// ---------------------------------------------------------------------------
+
+export class DoSqliteStore implements Store {
   public readonly hooks: HookRegistry;
-  /** Adapter that satisfies the shared `SqlDb` contract. Used internally and
-   *  by external code that wants to call the ops helpers directly. */
   public readonly sqlDb: SqlDb;
 
-  constructor(public readonly db: Database, opts?: { hooks?: HookRegistry }) {
-    this.sqlDb = new BunSqliteAdapter(db);
+  constructor(storage: DoDurableObjectStorage, opts?: { hooks?: HookRegistry }) {
+    this.sqlDb = new DoSqliteAdapter(storage);
     initSchema(this.sqlDb);
     this.hooks = opts?.hooks ?? new HookRegistry();
   }
@@ -30,17 +115,9 @@ export class BunSqliteStore implements Store {
 
   async createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Promise<Note> {
     const note = noteOps.createNote(this.sqlDb, content, opts);
-
-    if (content) {
-      syncWikilinks(this.sqlDb, note.id, content);
-    }
-
-    if (note.path) {
-      resolveUnresolvedWikilinks(this.sqlDb, note.path, note.id);
-    }
-
+    if (content) syncWikilinks(this.sqlDb, note.id, content);
+    if (note.path) resolveUnresolvedWikilinks(this.sqlDb, note.path, note.id);
     this.hooks.dispatch("created", note, this);
-
     return note;
   }
 
@@ -77,14 +154,9 @@ export class BunSqliteStore implements Store {
     }
 
     this.hooks.dispatch("updated", note, this);
-
     return note;
   }
 
-  /**
-   * When a note is renamed, update [[wikilinks]] in other notes that referenced the old path.
-   * Matches both full path and basename references.
-   */
   private cascadeRename(oldPath: string, newPath: string): void {
     const oldTitle = pathTitle(oldPath);
     const newTitle = pathTitle(newPath);
@@ -92,7 +164,7 @@ export class BunSqliteStore implements Store {
     const candidates = this.sqlDb.prepare(`
       SELECT id, content FROM notes
       WHERE content LIKE ? OR content LIKE ?
-    `).all(`%[[${oldPath}%`, `%[[${oldTitle}%`) as { id: string; content: string }[];
+    `).all<{ id: string; content: string }>(`%[[${oldPath}%`, `%[[${oldTitle}%`);
 
     for (const row of candidates) {
       let updated = row.content;
@@ -170,13 +242,11 @@ export class BunSqliteStore implements Store {
     return linkOps.listLinks(this.sqlDb, opts);
   }
 
-  // ---- Bulk Operations ----
+  // ---- Bulk ----
 
   async createNotes(inputs: noteOps.BulkNoteInput[]): Promise<Note[]> {
     const notes = noteOps.createNotes(this.sqlDb, inputs);
-    for (const note of notes) {
-      this.hooks.dispatch("created", note, this);
-    }
+    for (const note of notes) this.hooks.dispatch("created", note, this);
     return notes;
   }
 
@@ -188,7 +258,7 @@ export class BunSqliteStore implements Store {
     return noteOps.batchUntag(this.sqlDb, noteIds, tags);
   }
 
-  // ---- Deeper Link Queries ----
+  // ---- Graph ----
 
   async traverseLinks(noteId: string, opts?: { max_depth?: number; relationship?: string }) {
     return linkOps.traverseLinks(this.sqlDb, noteId, opts);
@@ -220,78 +290,18 @@ export class BunSqliteStore implements Store {
     return tagSchemaOps.getTagSchemaMap(this.sqlDb);
   }
 
-  // ---- Batch Wikilink Sync ----
-
-  /**
-   * Create a note without triggering wikilink sync.
-   * Use this during bulk imports, then call syncAllWikilinks() after.
-   */
-  async createNoteRaw(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Promise<Note> {
-    return noteOps.createNote(this.sqlDb, content, opts);
-  }
-
-  /**
-   * Sync wikilinks for all notes in the vault.
-   * Efficient for bulk imports — call once after importing all notes.
-   */
-  async syncAllWikilinks(): Promise<{ synced: number; totalAdded: number; totalRemoved: number }> {
-    const allNotes = noteOps.queryNotes(this.sqlDb, { limit: 1000000 });
-    let synced = 0;
-    let totalAdded = 0;
-    let totalRemoved = 0;
-
-    for (const note of allNotes) {
-      if (!note.content) continue;
-      const result = syncWikilinks(this.sqlDb, note.id, note.content);
-      if (result.added > 0 || result.removed > 0) {
-        synced++;
-        totalAdded += result.added;
-        totalRemoved += result.removed;
-      }
-    }
-
-    return { synced, totalAdded, totalRemoved };
-  }
-
   // ---- Attachments ----
+  // R2 integration is tracked in a follow-up PR. Self-hosted filesystem
+  // attachments are not portable to Workers, so these throw for now.
 
-  async addAttachment(noteId: string, filePath: string, mimeType: string, metadata?: Record<string, unknown>): Promise<Attachment> {
-    const id = noteOps.generateId();
-    const now = new Date().toISOString();
-    const metadataJson = metadata ? JSON.stringify(metadata) : "{}";
-    this.sqlDb.prepare(
-      "INSERT INTO attachments (id, note_id, path, mime_type, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-    ).run(id, noteId, filePath, mimeType, metadataJson, now);
-
-    return { id, noteId, path: filePath, mimeType, metadata, createdAt: now };
+  async addAttachment(_noteId: string, _filePath: string, _mimeType: string, _metadata?: Record<string, unknown>): Promise<Attachment> {
+    throw new Error("attachments are not yet supported on DoSqliteStore");
   }
 
-  async getAttachments(noteId: string): Promise<Attachment[]> {
-    const rows = this.sqlDb.prepare(
-      "SELECT * FROM attachments WHERE note_id = ? ORDER BY created_at",
-    ).all(noteId) as { id: string; note_id: string; path: string; mime_type: string; metadata: string | null; created_at: string }[];
-
-    return rows.map((r) => {
-      let metadata: Record<string, unknown> | undefined;
-      if (r.metadata && r.metadata !== "{}") {
-        try { metadata = JSON.parse(r.metadata); } catch {}
-      }
-      return {
-        id: r.id,
-        noteId: r.note_id,
-        path: r.path,
-        mimeType: r.mime_type,
-        metadata,
-        createdAt: r.created_at,
-      };
-    });
+  async getAttachments(_noteId: string): Promise<Attachment[]> {
+    throw new Error("attachments are not yet supported on DoSqliteStore");
   }
 }
-
-/** @deprecated Renamed to `BunSqliteStore` to make the runtime split explicit. Kept as an alias for backward compatibility. */
-export const SqliteStore = BunSqliteStore;
-/** @deprecated Renamed to `BunSqliteStore`. */
-export type SqliteStore = BunSqliteStore;
 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -8,6 +8,8 @@ import { syncWikilinks, resolveUnresolvedWikilinks } from "./wikilinks.js";
 import { pathTitle } from "./paths.js";
 import { HookRegistry } from "./hooks.js";
 import { BunSqliteAdapter, type SqlDb } from "./sql-db.js";
+import * as attachmentOps from "./attachments.js";
+import type { BlobStore } from "./blob-store.js";
 
 /**
  * bun:sqlite-backed Store implementation. Internally everything is
@@ -19,11 +21,13 @@ export class BunSqliteStore implements Store {
   /** Adapter that satisfies the shared `SqlDb` contract. Used internally and
    *  by external code that wants to call the ops helpers directly. */
   public readonly sqlDb: SqlDb;
+  public readonly blobStore?: BlobStore;
 
-  constructor(public readonly db: Database, opts?: { hooks?: HookRegistry }) {
+  constructor(public readonly db: Database, opts?: { hooks?: HookRegistry; blobStore?: BlobStore }) {
     this.sqlDb = new BunSqliteAdapter(db);
     initSchema(this.sqlDb);
     this.hooks = opts?.hooks ?? new HookRegistry();
+    this.blobStore = opts?.blobStore;
   }
 
   // ---- Notes ----
@@ -256,35 +260,30 @@ export class BunSqliteStore implements Store {
   // ---- Attachments ----
 
   async addAttachment(noteId: string, filePath: string, mimeType: string, metadata?: Record<string, unknown>): Promise<Attachment> {
-    const id = noteOps.generateId();
-    const now = new Date().toISOString();
-    const metadataJson = metadata ? JSON.stringify(metadata) : "{}";
-    this.sqlDb.prepare(
-      "INSERT INTO attachments (id, note_id, path, mime_type, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-    ).run(id, noteId, filePath, mimeType, metadataJson, now);
-
-    return { id, noteId, path: filePath, mimeType, metadata, createdAt: now };
+    return attachmentOps.addAttachment(this.sqlDb, noteId, filePath, mimeType, metadata);
   }
 
   async getAttachments(noteId: string): Promise<Attachment[]> {
-    const rows = this.sqlDb.prepare(
-      "SELECT * FROM attachments WHERE note_id = ? ORDER BY created_at",
-    ).all(noteId) as { id: string; note_id: string; path: string; mime_type: string; metadata: string | null; created_at: string }[];
+    return attachmentOps.getAttachments(this.sqlDb, noteId);
+  }
 
-    return rows.map((r) => {
-      let metadata: Record<string, unknown> | undefined;
-      if (r.metadata && r.metadata !== "{}") {
-        try { metadata = JSON.parse(r.metadata); } catch {}
-      }
-      return {
-        id: r.id,
-        noteId: r.note_id,
-        path: r.path,
-        mimeType: r.mime_type,
-        metadata,
-        createdAt: r.created_at,
-      };
-    });
+  // ---- Blob I/O ----
+
+  async putBlob(key: string, data: ArrayBuffer | Uint8Array | Blob, opts?: { mimeType?: string }): Promise<void> {
+    await this.requireBlobStore().put(key, data, opts);
+  }
+
+  async getBlob(key: string) {
+    return this.requireBlobStore().get(key);
+  }
+
+  async deleteBlob(key: string): Promise<void> {
+    await this.requireBlobStore().delete(key);
+  }
+
+  private requireBlobStore(): BlobStore {
+    if (!this.blobStore) throw new Error("BunSqliteStore was constructed without a BlobStore");
+    return this.blobStore;
   }
 }
 

--- a/core/src/tag-schemas.ts
+++ b/core/src/tag-schemas.ts
@@ -6,7 +6,7 @@
  * and soft warnings on create/tag operations.
  */
 
-import { Database } from "bun:sqlite";
+import type { SqlDb } from "./sql-db.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -36,19 +36,19 @@ interface TagSchemaRow {
 // ---------------------------------------------------------------------------
 
 /** List all tag schemas. */
-export function listTagSchemas(db: Database): TagSchema[] {
+export function listTagSchemas(db: SqlDb): TagSchema[] {
   const rows = db.prepare("SELECT * FROM tag_schemas ORDER BY tag_name").all() as TagSchemaRow[];
   return rows.map(rowToSchema);
 }
 
 /** Get a single tag's schema, or null if none defined. */
-export function getTagSchema(db: Database, tag: string): TagSchema | null {
+export function getTagSchema(db: SqlDb, tag: string): TagSchema | null {
   const row = db.prepare("SELECT * FROM tag_schemas WHERE tag_name = ?").get(tag) as TagSchemaRow | undefined;
   return row ? rowToSchema(row) : null;
 }
 
 /** Get all schemas as a lookup map (tag → schema). Used by schema effects. */
-export function getTagSchemaMap(db: Database): Record<string, { description?: string; fields?: Record<string, TagFieldSchema> }> {
+export function getTagSchemaMap(db: SqlDb): Record<string, { description?: string; fields?: Record<string, TagFieldSchema> }> {
   const schemas = listTagSchemas(db);
   const map: Record<string, { description?: string; fields?: Record<string, TagFieldSchema> }> = {};
   for (const s of schemas) {
@@ -62,7 +62,7 @@ export function getTagSchemaMap(db: Database): Record<string, { description?: st
  * Ensures the tag exists in the tags table first.
  */
 export function upsertTagSchema(
-  db: Database,
+  db: SqlDb,
   tag: string,
   schema: { description?: string; fields?: Record<string, TagFieldSchema> },
 ): TagSchema {
@@ -82,7 +82,7 @@ export function upsertTagSchema(
 }
 
 /** Delete a tag's schema. Returns true if a schema was deleted. */
-export function deleteTagSchema(db: Database, tag: string): boolean {
+export function deleteTagSchema(db: SqlDb, tag: string): boolean {
   const result = db.prepare("DELETE FROM tag_schemas WHERE tag_name = ?").run(tag);
   return result.changes > 0;
 }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -137,4 +137,11 @@ export interface Store {
   // Attachments
   addAttachment(noteId: string, path: string, mimeType: string, metadata?: Record<string, unknown>): Promise<Attachment>;
   getAttachments(noteId: string): Promise<Attachment[]>;
+
+  // Blob (binary payload) I/O. Throws if the store was constructed without a
+  // BlobStore. Key format is opaque to the interface — callers (e.g. the
+  // /storage route) decide the naming scheme.
+  putBlob(key: string, data: ArrayBuffer | Uint8Array | Blob, opts?: { mimeType?: string }): Promise<void>;
+  getBlob(key: string): Promise<{ body: ReadableStream<Uint8Array>; mimeType?: string; size?: number } | null>;
+  deleteBlob(key: string): Promise<void>;
 }

--- a/core/src/wikilinks.test.ts
+++ b/core/src/wikilinks.test.ts
@@ -113,31 +113,31 @@ More text
 describe("resolveWikilink", async () => {
   it("resolves exact path match", async () => {
     await store.createNote("Target note", { path: "My Note" });
-    const id = resolveWikilink(db, "My Note");
+    const id = resolveWikilink(store.sqlDb, "My Note");
     expect(id).toBeTruthy();
   });
 
   it("resolves case-insensitively", async () => {
     const note = await store.createNote("Target", { path: "My Note" });
-    const id = resolveWikilink(db, "my note");
+    const id = resolveWikilink(store.sqlDb, "my note");
     expect(id).toBe(note.id);
   });
 
   it("resolves basename match", async () => {
     const note = await store.createNote("Deep note", { path: "Projects/Parachute/README" });
-    const id = resolveWikilink(db, "README");
+    const id = resolveWikilink(store.sqlDb, "README");
     expect(id).toBe(note.id);
   });
 
   it("returns null for ambiguous basename", async () => {
     await store.createNote("A", { path: "Folder1/README" });
     await store.createNote("B", { path: "Folder2/README" });
-    const id = resolveWikilink(db, "README");
+    const id = resolveWikilink(store.sqlDb, "README");
     expect(id).toBeNull();
   });
 
   it("returns null for unresolvable target", () => {
-    const id = resolveWikilink(db, "Nonexistent Note");
+    const id = resolveWikilink(store.sqlDb, "Nonexistent Note");
     expect(id).toBeNull();
   });
 });

--- a/core/src/wikilinks.ts
+++ b/core/src/wikilinks.ts
@@ -1,4 +1,4 @@
-import { Database } from "bun:sqlite";
+import type { SqlDb } from "./sql-db.js";
 import * as linkOps from "./links.js";
 
 // ---------------------------------------------------------------------------
@@ -115,7 +115,7 @@ function stripCode(content: string): string {
  *    (e.g., "README" matches "Projects/Parachute/README")
  *    Only if there's exactly one match (ambiguous = unresolved)
  */
-export function resolveWikilink(db: Database, target: string): string | null {
+export function resolveWikilink(db: SqlDb, target: string): string | null {
   // 1. Exact match (case-insensitive)
   const exact = db.prepare(
     "SELECT id FROM notes WHERE path = ? COLLATE NOCASE",
@@ -151,7 +151,7 @@ export interface WikilinkResolution {
 /**
  * Resolve a wikilink target with full detail — single match, ambiguous, or unresolved.
  */
-export function resolveWikilinkDetailed(db: Database, target: string): WikilinkResolution {
+export function resolveWikilinkDetailed(db: SqlDb, target: string): WikilinkResolution {
   // 1. Exact match (case-insensitive)
   const exact = db.prepare(
     "SELECT id, path FROM notes WHERE path = ? COLLATE NOCASE",
@@ -195,7 +195,7 @@ export interface UnresolvedWikilink {
 /**
  * List unresolved wikilinks across the vault.
  */
-export function listUnresolvedWikilinks(db: Database, limit = 50): { unresolved: UnresolvedWikilink[]; count: number } {
+export function listUnresolvedWikilinks(db: SqlDb, limit = 50): { unresolved: UnresolvedWikilink[]; count: number } {
   let total: number;
   let rows: { source_id: string; target_path: string }[];
   try {
@@ -240,7 +240,7 @@ const WIKILINK_REL = "wikilink";
  * Returns counts of changes made.
  */
 export function syncWikilinks(
-  db: Database,
+  db: SqlDb,
   noteId: string,
   content: string,
 ): { added: number; removed: number; unresolved: string[] } {
@@ -320,7 +320,7 @@ export function syncWikilinks(
  * Ensure the unresolved_wikilinks table exists.
  * Called lazily — only when we actually have unresolved links.
  */
-export function ensureUnresolvedTable(db: Database): void {
+export function ensureUnresolvedTable(db: SqlDb): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS unresolved_wikilinks (
       source_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
@@ -334,7 +334,7 @@ export function ensureUnresolvedTable(db: Database): void {
  * Update unresolved wikilinks for a note.
  */
 function syncUnresolvedWikilinks(
-  db: Database,
+  db: SqlDb,
   noteId: string,
   unresolvedPaths: string[],
 ): void {
@@ -367,7 +367,7 @@ function syncUnresolvedWikilinks(
  * Returns the number of links resolved.
  */
 export function resolveUnresolvedWikilinks(
-  db: Database,
+  db: SqlDb,
   notePath: string,
   noteId: string,
 ): number {

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -6,6 +6,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import crypto from "node:crypto";
 import { initSchema } from "../core/src/schema.ts";
+import { BunSqliteAdapter } from "../core/src/sql-db.ts";
 import { generateToken, createToken, resolveToken } from "./token-store.ts";
 import {
   handleProtectedResource,
@@ -21,7 +22,7 @@ let db: Database;
 
 beforeEach(() => {
   db = new Database(":memory:");
-  initSchema(db);
+  initSchema(new BunSqliteAdapter(db));
 });
 
 afterEach(() => {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -99,7 +99,7 @@ export async function handleNotes(
 ): Promise<Response> {
   const url = new URL(req.url);
   const method = req.method;
-  const db = (store as any).db;
+  const db = (store as any).sqlDb;
 
   // ---- Collection routes (no ID in path) ----
   if (subpath === "") {
@@ -449,7 +449,7 @@ export async function handleFindPath(req: Request, store: Store): Promise<Respon
   const target = parseQuery(url, "target");
   if (!source || !target) return json({ error: "source and target parameters are required" }, 400);
 
-  const db = (store as any).db;
+  const db = (store as any).sqlDb;
   try {
     const sourceNote = await resolveNote(store, source);
     if (!sourceNote) return json({ error: `Note not found: "${source}"` }, 404);
@@ -510,7 +510,7 @@ export function handleUnresolvedWikilinks(req: Request, store: Store): Response 
   const url = new URL(req.url);
   const limitStr = url.searchParams.get("limit");
   const limit = limitStr ? parseInt(limitStr, 10) : 50;
-  const db = (store as any).db;
+  const db = (store as any).sqlDb;
   return Response.json(listUnresolvedWikilinks(db, limit));
 }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -16,8 +16,7 @@ import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
 import { toNoteIndex, filterMetadata } from "../core/src/notes.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
-import { join, extname, normalize } from "path";
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
+import { join, extname } from "path";
 import { vaultDir } from "./config.ts";
 
 // ---------------------------------------------------------------------------
@@ -710,9 +709,7 @@ const MIME_TYPES: Record<string, string> = {
   ".webp": "image/webp",
 };
 
-export async function handleStorage(req: Request, path: string, vault: string): Promise<Response> {
-  const assets = assetsDir(vault);
-
+export async function handleStorage(req: Request, path: string, store: Store): Promise<Response> {
   if (req.method === "POST" && path === "/upload") {
     const form = await req.formData();
     const file = form.get("file");
@@ -728,43 +725,36 @@ export async function handleStorage(req: Request, path: string, vault: string): 
     }
 
     const date = new Date().toISOString().split("T")[0];
-    const dir = join(assets, date);
-    mkdirSync(dir, { recursive: true });
-
     const filename = `${Date.now()}-${crypto.randomUUID()}${ext}`;
-    const filePath = join(dir, filename);
-    const buffer = Buffer.from(await file.arrayBuffer());
-    writeFileSync(filePath, buffer);
-
-    const relativePath = `${date}/${filename}`;
+    const key = `${date}/${filename}`;
     const mimeType = MIME_TYPES[ext] ?? "application/octet-stream";
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    await store.putBlob(key, bytes, { mimeType });
 
-    return json({ path: relativePath, size: buffer.length, mimeType }, 201);
+    return json({ path: key, size: bytes.byteLength, mimeType }, 201);
   }
 
   const fileMatch = path.match(/^\/([^/]+)\/(.+)$/);
   if (req.method === "GET" && fileMatch) {
-    const reqPath = `${fileMatch[1]}/${fileMatch[2]}`;
-    const filePath = normalize(join(assets, reqPath));
-
-    if (!filePath.startsWith(normalize(assets))) {
-      return json({ error: "Invalid path" }, 403);
+    const key = `${fileMatch[1]}/${fileMatch[2]}`;
+    let obj;
+    try {
+      obj = await store.getBlob(key);
+    } catch (err: any) {
+      // FsBlobStore throws on `..` escape; surface as 403.
+      if (err?.message?.includes("escapes root") || err?.message?.includes("Invalid blob key")) {
+        return json({ error: "Invalid path" }, 403);
+      }
+      throw err;
     }
-    if (!existsSync(filePath)) {
-      return json({ error: "Not found" }, 404);
-    }
+    if (!obj) return json({ error: "Not found" }, 404);
 
-    const stat = statSync(filePath);
-    const ext = extname(filePath).toLowerCase();
-    const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
-    const fileBuffer = readFileSync(filePath);
+    const ext = extname(key).toLowerCase();
+    const contentType = obj.mimeType ?? MIME_TYPES[ext] ?? "application/octet-stream";
+    const headers: Record<string, string> = { "Content-Type": contentType };
+    if (obj.size !== undefined) headers["Content-Length"] = String(obj.size);
 
-    return new Response(fileBuffer, {
-      headers: {
-        "Content-Type": contentType,
-        "Content-Length": String(stat.size),
-      },
-    });
+    return new Response(obj.body, { headers });
   }
 
   return json({ error: "Not found" }, 404);

--- a/src/server.ts
+++ b/src/server.ts
@@ -316,7 +316,7 @@ async function route(req: Request, path: string, clientIp?: string): Promise<Res
       writeVaultConfig(vaultConfig);
     });
     if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store);
-    if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), defaultVault);
+    if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), store);
     if (apiPath === "/health") return Response.json({ status: "ok", vault: defaultVault });
   }
 
@@ -440,7 +440,7 @@ async function route(req: Request, path: string, clientIp?: string): Promise<Res
     return handleUnresolvedWikilinks(req, store);
   }
   if (apiPath.startsWith("/storage")) {
-    return handleStorage(req, apiPath.slice(8), vaultName);
+    return handleStorage(req, apiPath.slice(8), store);
   }
   if (apiPath === "/health") {
     return Response.json({ status: "ok", vault: vaultName });

--- a/src/token-store.test.ts
+++ b/src/token-store.test.ts
@@ -6,6 +6,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { initSchema } from "../core/src/schema.ts";
+import { BunSqliteAdapter } from "../core/src/sql-db.ts";
 import {
   generateToken,
   createToken,
@@ -18,7 +19,7 @@ let db: Database;
 
 beforeEach(() => {
   db = new Database(":memory:");
-  initSchema(db);
+  initSchema(new BunSqliteAdapter(db));
 });
 
 afterEach(() => {

--- a/src/vault-store.ts
+++ b/src/vault-store.ts
@@ -7,7 +7,9 @@
 
 import { SqliteStore } from "../core/src/store.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
+import { FsBlobStore } from "../core/src/blob-fs.ts";
 import { openVaultDb } from "./db.ts";
+import { assetsDir } from "./routes.ts";
 
 export { SqliteStore as BunStore };
 export { defaultHookRegistry };
@@ -26,7 +28,10 @@ export function getVaultStore(name: string): SqliteStore {
     const db = openVaultDb(name);
     // Share the process-wide hook registry so features can register
     // handlers once at startup and have them fire for every vault.
-    store = new SqliteStore(db, { hooks: defaultHookRegistry });
+    store = new SqliteStore(db, {
+      hooks: defaultHookRegistry,
+      blobStore: new FsBlobStore(assetsDir(name)),
+    });
     stores.set(name, store);
     storeToVault.set(store, name);
   }

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -282,7 +282,7 @@ describe("metadata", async () => {
     const b = await store.createNote("B", { metadata: { type: "task" } });
     await store.createLink(a.id, b.id, "contains");
 
-    const links = getLinksHydrated(db, a.id);
+    const links = getLinksHydrated(store.sqlDb, a.id);
     expect(links[0].sourceNote?.metadata?.type).toBe("project");
     expect(links[0].targetNote?.metadata?.type).toBe("task");
   });
@@ -452,7 +452,7 @@ describe("deeper link queries", async () => {
     const b = await store.createNote("Note B", { path: "b" });
     await store.createLink(a.id, b.id, "related-to");
 
-    const result = getLinksHydrated(db, a.id);
+    const result = getLinksHydrated(store.sqlDb, a.id);
     expect(result.length).toBe(1);
     expect(result[0].targetNote?.path).toBe("b");
     expect(result[0].sourceNote?.path).toBe("a");


### PR DESCRIPTION
## Summary
- Extracts a runtime-portable `BlobStore` interface; `FsBlobStore` for self-hosted Bun, `R2BlobStore` for Cloudflare Workers/DO.
- `DoSqliteStore.addAttachment`/`getAttachments` now work end-to-end (previously threw). Shared `attachments.ts` ops keep both stores identical on the metadata side.
- `handleStorage` now uses `store.putBlob`/`getBlob`; the filesystem path + traversal check move into `FsBlobStore`. Workers bundles stay free of `@cloudflare/workers-types` via structural R2 types + subpath export.

## What changed
- `core/src/blob-store.ts` — interface (`put`/`get`/`delete`, opaque string key)
- `core/src/blob-fs.ts` — filesystem impl; normalize+prefix path-traversal guard; null-byte/empty-key rejection
- `core/src/blob-r2.ts` — R2 impl; structural `R2BucketLike` avoids hard workers-types dep; prefix+key join normalizes slashes
- `core/src/attachments.ts` — shared DB ops used by both stores
- `core/src/store.ts` + `core/src/store-do.ts` — optional `blobStore` constructor opt; delegate attachments; `putBlob`/`getBlob`/`deleteBlob` methods
- `src/routes.ts` — `handleStorage(req, path, store)`; traversal errors surfaced as 403
- `src/vault-store.ts` — wires `FsBlobStore(assetsDir(name))` for self-hosted
- `core/package.json` — adds `./blob-store`, `./blob-fs`, `./blob-r2` subpath exports

## Self-review catch
An initial draft missed `await` on `store.putBlob`/`deleteBlob` → rejections would have become unhandled and uploads would 201 even on traversal/disk errors. Fixed, and regression tests now cover the rejection-propagation path for both store classes.

## Test plan
- [x] `bun test core/src/ src/` → 418 pass (up from 400)
- [x] New coverage: FsBlobStore round-trip + traversal, R2BlobStore prefix handling, DoSqliteStore attachment metadata, rejection propagation on both stores
- [x] `bunx tsc --noEmit` → no new errors (245 pre-existing, unchanged by this PR)
- [ ] Manual smoke: self-hosted `/api/storage/upload` + download still works (Daily still exercises this path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)