### PR TITLE
feat: optimistic concurrency on update-note

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -673,10 +673,14 @@ describe("MCP tools", async () => {
   });
 
   it("update-note is atomic under concurrent if_updated_at — exactly one winner", async () => {
-    // Reproduces the TOCTOU scenario: two callers read the same updated_at
-    // and fire updates in parallel. Exactly one must commit; the other must
-    // get a ConflictError. Both seeing success would silently destroy one
-    // write, which is precisely what if_updated_at exists to prevent.
+    // Fires two updates with the same if_updated_at via `Promise.allSettled`.
+    // bun:sqlite is synchronous, so these interleave at JS microtask
+    // boundaries rather than in true parallel — but that's the production
+    // concurrency model (one node, event-loop scheduling). The guarantee
+    // comes from the atomic conditional UPDATE in notes.ts: exactly one of
+    // the two statements can match `AND updated_at IS ?`. Without that
+    // atomicity both would commit and silently destroy one write — the
+    // scenario if_updated_at exists to prevent.
     const note = await store.createNote("seed");
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -575,6 +575,103 @@ describe("MCP tools", async () => {
     expect(result.content).toBe("Updated");
   });
 
+  it("update-note accepts if_updated_at when it matches current updated_at", async () => {
+    const note = await store.createNote("First");
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const first = await updateNote.execute({ id: note.id, content: "Second" }) as any;
+    expect(first.content).toBe("Second");
+    expect(first.updatedAt).toBeTruthy();
+
+    const second = await updateNote.execute({
+      id: note.id,
+      content: "Third",
+      if_updated_at: first.updatedAt,
+    }) as any;
+    expect(second.content).toBe("Third");
+  });
+
+  it("update-note rejects if_updated_at mismatch with conflict error", async () => {
+    const note = await store.createNote("First");
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const after = await updateNote.execute({ id: note.id, content: "Second" }) as any;
+
+    // Simulate a stale client that has the pre-update timestamp (or something else).
+    const staleTimestamp = "2020-01-01T00:00:00.000Z";
+    expect(staleTimestamp).not.toBe(after.updatedAt);
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: note.id,
+        content: "Third",
+        if_updated_at: staleTimestamp,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    expect(err.code).toBe("CONFLICT");
+    expect(err.note_id).toBe(note.id);
+    expect(err.current_updated_at).toBe(after.updatedAt);
+    expect(err.expected_updated_at).toBe(staleTimestamp);
+
+    // Note unchanged
+    expect((await store.getNote(note.id))!.content).toBe("Second");
+  });
+
+  it("update-note if_updated_at conflicts for a never-updated note when caller expects a value", async () => {
+    const note = await store.createNote("First");
+    expect(note.updatedAt).toBeUndefined();
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: note.id,
+        content: "Second",
+        if_updated_at: "2020-01-01T00:00:00.000Z",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    expect(err.code).toBe("CONFLICT");
+    expect(err.current_updated_at).toBeUndefined();
+  });
+
+  it("update-note batch aborts on first conflict without touching subsequent items", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // Bump a's updated_at so any stale if_updated_at conflicts.
+    const bumped = await updateNote.execute({ id: "a", content: "A bumped" }) as any;
+    expect(bumped.updatedAt).toBeTruthy();
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        notes: [
+          { id: "a", content: "A new", if_updated_at: "2020-01-01T00:00:00.000Z" },
+          { id: "b", content: "B new" },
+        ],
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("CONFLICT");
+
+    // a was not modified by this call; b was not touched.
+    expect((await store.getNote("a"))!.content).toBe("A bumped");
+    expect((await store.getNote("b"))!.content).toBe("B");
+  });
+
   it("query-notes single note by id", async () => {
     const note = await store.createNote("Hello", { path: "test/note" });
     const tools = generateMcpTools(store);

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -641,7 +641,7 @@ describe("MCP tools", async () => {
     }
     expect(err).toBeTruthy();
     expect(err.code).toBe("CONFLICT");
-    expect(err.current_updated_at).toBeUndefined();
+    expect(err.current_updated_at).toBeNull();
   });
 
   it("update-note batch aborts on first conflict without touching subsequent items", async () => {
@@ -670,6 +670,72 @@ describe("MCP tools", async () => {
     // a was not modified by this call; b was not touched.
     expect((await store.getNote("a"))!.content).toBe("A bumped");
     expect((await store.getNote("b"))!.content).toBe("B");
+  });
+
+  it("update-note is atomic under concurrent if_updated_at — exactly one winner", async () => {
+    // Reproduces the TOCTOU scenario: two callers read the same updated_at
+    // and fire updates in parallel. Exactly one must commit; the other must
+    // get a ConflictError. Both seeing success would silently destroy one
+    // write, which is precisely what if_updated_at exists to prevent.
+    const note = await store.createNote("seed");
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // Establish a known updated_at the two callers both read.
+    const seed = await updateNote.execute({ id: note.id, content: "seed-v1" }) as any;
+    expect(seed.updatedAt).toBeTruthy();
+
+    const results = await Promise.allSettled([
+      updateNote.execute({ id: note.id, content: "racer-A", if_updated_at: seed.updatedAt }),
+      updateNote.execute({ id: note.id, content: "racer-B", if_updated_at: seed.updatedAt }),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const err = (rejected[0] as PromiseRejectedResult).reason as any;
+    expect(err?.code).toBe("CONFLICT");
+
+    // The winner's content is what ended up persisted.
+    const winner = (fulfilled[0] as PromiseFulfilledResult<any>).value;
+    const persisted = await store.getNote(note.id);
+    expect(persisted!.content).toBe(winner.content);
+    expect(["racer-A", "racer-B"]).toContain(persisted!.content);
+  });
+
+  it("update-note with links.remove rolls back link deletion when if_updated_at conflicts", async () => {
+    await store.createNote("Target", { id: "target", path: "People/Alice" });
+    const source = await store.createNote("See [[People/Alice]] for details", {
+      id: "source",
+    });
+    await store.createLink("source", "target", "wikilink");
+
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // Bump so a stale if_updated_at conflicts; and capture state after bump.
+    await updateNote.execute({ id: "source", content: "See [[People/Alice]] for details" });
+    const preConflictLinks = await store.getLinks("source", { direction: "outbound" });
+    expect(preConflictLinks).toHaveLength(1);
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: "source",
+        links: { remove: [{ target: "target", relationship: "wikilink" }] },
+        if_updated_at: "2020-01-01T00:00:00.000Z",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("CONFLICT");
+
+    // The link must still exist — if it had been removed before the
+    // conflict check, this would be 0.
+    const postConflictLinks = await store.getLinks("source", { direction: "outbound" });
+    expect(postConflictLinks).toHaveLength(1);
+    expect((await store.getNote("source"))!.content).toBe("See [[People/Alice]] for details");
   });
 
   it("query-notes single note by id", async () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -305,7 +305,8 @@ Defaults: include_content=true for single note, false for lists. include_links=f
 - \`tags: { add: ["x"], remove: ["y"] }\` — add/remove tags
 - \`links: { add: [{ target, relationship }], remove: [{ target, relationship }] }\` — add/remove links
 - When removing a wikilink-type link, \`[[brackets]]\` are also removed from content.
-- For batch: pass a \`notes\` array, each with an \`id\` field.`,
+- For batch: pass a \`notes\` array, each with an \`id\` field.
+- Optimistic concurrency: pass \`if_updated_at\` with the \`updated_at\` value you last read. The update is rejected with a conflict error if the note has changed since. Re-read the note, reconcile, and retry.`,
       inputSchema: {
         type: "object",
         properties: {
@@ -314,6 +315,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
           path: { type: "string", description: "New path" },
           metadata: { type: "object", description: "Metadata to merge (keys are merged, not replaced wholesale)" },
           created_at: { type: "string", description: "New created_at timestamp" },
+          if_updated_at: { type: "string", description: "Optimistic concurrency check: the updated_at value you last read. Rejects with a conflict error if the note has been modified since." },
           tags: {
             type: "object",
             properties: {
@@ -361,6 +363,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
                 path: { type: "string" },
                 metadata: { type: "object" },
                 created_at: { type: "string" },
+                if_updated_at: { type: "string" },
                 tags: { type: "object" },
                 links: { type: "object" },
               },
@@ -377,6 +380,12 @@ Defaults: include_content=true for single note, false for lists. include_links=f
         const updated: Note[] = [];
         for (const item of items) {
           const note = requireNote(db, item.id as string);
+
+          // --- Optimistic concurrency check ---
+          if (item.if_updated_at !== undefined && note.updatedAt !== item.if_updated_at) {
+            throw new ConflictError(note.id, note.updatedAt, item.if_updated_at as string);
+          }
+
           let contentOverride = item.content as string | undefined;
 
           // --- Remove links (before content update, so bracket removal applies) ---
@@ -670,5 +679,26 @@ function normalizeTags(tag: unknown): string[] | undefined {
   if (!tag) return undefined;
   if (Array.isArray(tag)) return tag;
   return [tag as string];
+}
+
+// ---------------------------------------------------------------------------
+// Conflict error — thrown when optimistic concurrency check fails
+// ---------------------------------------------------------------------------
+
+export class ConflictError extends Error {
+  code = "CONFLICT" as const;
+  note_id: string;
+  current_updated_at: string | undefined;
+  expected_updated_at: string;
+
+  constructor(noteId: string, current: string | undefined, expected: string) {
+    super(
+      `conflict: note "${noteId}" has been modified (current updated_at=${current ?? "null"}, expected=${expected})`,
+    );
+    this.name = "ConflictError";
+    this.note_id = noteId;
+    this.current_updated_at = current;
+    this.expected_updated_at = expected;
+  }
 }
 

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -363,7 +363,7 @@ Defaults: include_content=true for single note, false for lists. include_links=f
                 path: { type: "string" },
                 metadata: { type: "object" },
                 created_at: { type: "string" },
-                if_updated_at: { type: "string" },
+                if_updated_at: { type: "string", description: "Optimistic concurrency check for this item; rejects with a conflict error if the note has been modified since." },
                 tags: { type: "object" },
                 links: { type: "object" },
               },
@@ -381,33 +381,29 @@ Defaults: include_content=true for single note, false for lists. include_links=f
         for (const item of items) {
           const note = requireNote(db, item.id as string);
 
-          // --- Optimistic concurrency check ---
-          if (item.if_updated_at !== undefined && note.updatedAt !== item.if_updated_at) {
-            throw new ConflictError(note.id, note.updatedAt, item.if_updated_at as string);
-          }
-
+          // --- Plan bracket cleanup for wikilink removals (no DB writes yet) ---
+          // We compute the cleaned content so we can do the core UPDATE first
+          // (with if_updated_at atomically) before any link deletions. If the
+          // UPDATE fails on a conflict, nothing has been mutated.
           let contentOverride = item.content as string | undefined;
-
-          // --- Remove links (before content update, so bracket removal applies) ---
           const linksRemove = (item.links as any)?.remove as { target: string; relationship: string }[] | undefined;
+          const resolvedLinksToRemove: { targetId: string; relationship: string }[] = [];
           if (linksRemove) {
             for (const link of linksRemove) {
               const target = resolveNote(db, link.target);
-              if (target) {
-                await store.deleteLink(note.id, target.id, link.relationship);
-                // Remove [[brackets]] from content if this was a wikilink
-                if (link.relationship === "wikilink" && target.path) {
-                  const currentContent = contentOverride ?? note.content;
-                  const cleaned = removeWikilinkBrackets(currentContent, target.path);
-                  if (cleaned !== currentContent) {
-                    contentOverride = cleaned;
-                  }
+              if (!target) continue;
+              resolvedLinksToRemove.push({ targetId: target.id, relationship: link.relationship });
+              if (link.relationship === "wikilink" && target.path) {
+                const currentContent = contentOverride ?? note.content;
+                const cleaned = removeWikilinkBrackets(currentContent, target.path);
+                if (cleaned !== currentContent) {
+                  contentOverride = cleaned;
                 }
               }
             }
           }
 
-          // --- Core update (content, path, metadata, created_at) ---
+          // --- Core update (content, path, metadata, created_at + concurrency check) ---
           const updates: any = {};
           if (contentOverride !== undefined) updates.content = contentOverride;
           if (item.path !== undefined) updates.path = item.path;
@@ -417,12 +413,22 @@ Defaults: include_content=true for single note, false for lists. include_links=f
             updates.metadata = { ...existing, ...(item.metadata as Record<string, unknown>) };
           }
           if (item.created_at !== undefined) updates.created_at = item.created_at;
+          if (item.if_updated_at !== undefined) updates.if_updated_at = item.if_updated_at as string;
 
           let result: Note;
           if (Object.keys(updates).length > 0) {
+            // store.updateNote routes through noteOps.updateNote, which runs
+            // the UPDATE (with optional `AND updated_at IS ?`) atomically and
+            // throws ConflictError on mismatch. No mutations have happened
+            // yet, so a throw here leaves the note untouched.
             result = await store.updateNote(note.id, updates);
           } else {
             result = note;
+          }
+
+          // --- Remove links (after core UPDATE so a conflict leaves them intact) ---
+          for (const { targetId, relationship } of resolvedLinksToRemove) {
+            await store.deleteLink(note.id, targetId, relationship);
           }
 
           // --- Tags ---
@@ -681,24 +687,7 @@ function normalizeTags(tag: unknown): string[] | undefined {
   return [tag as string];
 }
 
-// ---------------------------------------------------------------------------
-// Conflict error — thrown when optimistic concurrency check fails
-// ---------------------------------------------------------------------------
-
-export class ConflictError extends Error {
-  code = "CONFLICT" as const;
-  note_id: string;
-  current_updated_at: string | undefined;
-  expected_updated_at: string;
-
-  constructor(noteId: string, current: string | undefined, expected: string) {
-    super(
-      `conflict: note "${noteId}" has been modified (current updated_at=${current ?? "null"}, expected=${expected})`,
-    );
-    this.name = "ConflictError";
-    this.note_id = noteId;
-    this.current_updated_at = current;
-    this.expected_updated_at = expected;
-  }
-}
+// Re-exported for backward compat; defined in notes.ts alongside the
+// conditional-UPDATE implementation that raises it.
+export { ConflictError } from "./notes.js";
 

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -72,10 +72,45 @@ export function getNotes(db: Database, ids: string[]): Note[] {
   });
 }
 
+/**
+ * Thrown by `updateNote` when an `if_updated_at` precondition does not match
+ * the note's current `updated_at`. The SELECT+check+UPDATE happens as one
+ * atomic conditional UPDATE so two concurrent callers cannot both pass the
+ * check and both commit.
+ */
+export class ConflictError extends Error {
+  code = "CONFLICT" as const;
+  note_id: string;
+  current_updated_at: string | null;
+  expected_updated_at: string;
+
+  constructor(noteId: string, current: string | null, expected: string) {
+    super(
+      `conflict: note "${noteId}" has been modified (current updated_at=${current ?? "null"}, expected=${expected})`,
+    );
+    this.name = "ConflictError";
+    this.note_id = noteId;
+    this.current_updated_at = current;
+    this.expected_updated_at = expected;
+  }
+}
+
 export function updateNote(
   db: Database,
   id: string,
-  updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean },
+  updates: {
+    content?: string;
+    path?: string;
+    metadata?: Record<string, unknown>;
+    created_at?: string;
+    skipUpdatedAt?: boolean;
+    /**
+     * Optimistic concurrency token. When provided, the UPDATE runs with an
+     * additional `AND updated_at IS ?` clause; if no row is affected and the
+     * note still exists, a `ConflictError` is thrown.
+     */
+    if_updated_at?: string;
+  },
 ): Note {
   const sets: string[] = [];
   const values: unknown[] = [];
@@ -83,8 +118,17 @@ export function updateNote(
   // Hooks and other machine-level writers pass `skipUpdatedAt: true` so
   // their metadata markers don't look like user activity. See issue #44.
   if (!updates.skipUpdatedAt) {
+    let now = new Date().toISOString();
+    // OC contract: the new updated_at must be strictly greater than the
+    // caller's if_updated_at so a subsequent OC reader can distinguish
+    // pre- from post-update state. Without this, two writes landing in the
+    // same wall-clock millisecond would produce identical timestamps and
+    // let a second OC writer see the first writer's work as "unchanged."
+    if (updates.if_updated_at !== undefined && now <= updates.if_updated_at) {
+      now = new Date(new Date(updates.if_updated_at).getTime() + 1).toISOString();
+    }
     sets.push("updated_at = ?");
-    values.push(new Date().toISOString());
+    values.push(now);
   }
 
   if (updates.content !== undefined) {
@@ -104,15 +148,45 @@ export function updateNote(
     values.push(updates.created_at);
   }
 
-  // No-op: skipUpdatedAt with no other fields. Avoid generating invalid SQL.
+  // No-op: no SET fields. If a caller still passed `if_updated_at`, we need
+  // to validate the precondition; a conditional UPDATE that sets updated_at
+  // to itself does exactly that atomically without changing any data.
   if (sets.length === 0) {
+    if (updates.if_updated_at !== undefined) {
+      const probe = db.prepare(
+        "UPDATE notes SET updated_at = updated_at WHERE id = ? AND updated_at IS ?",
+      ).run(id, updates.if_updated_at);
+      if (probe.changes === 0) {
+        throwConflictOrMissing(db, id, updates.if_updated_at);
+      }
+    }
     return getNote(db, id)!;
   }
 
   values.push(id);
-  db.prepare(`UPDATE notes SET ${sets.join(", ")} WHERE id = ?`).run(...values);
+  let sql = `UPDATE notes SET ${sets.join(", ")} WHERE id = ?`;
+  if (updates.if_updated_at !== undefined) {
+    sql += " AND updated_at IS ?";
+    values.push(updates.if_updated_at);
+  }
+
+  const res = db.prepare(sql).run(...values);
+
+  if (updates.if_updated_at !== undefined && res.changes === 0) {
+    throwConflictOrMissing(db, id, updates.if_updated_at);
+  }
 
   return getNote(db, id)!;
+}
+
+function throwConflictOrMissing(db: Database, id: string, expected: string): never {
+  const row = db.prepare("SELECT updated_at FROM notes WHERE id = ?").get(id) as
+    | { updated_at: string | null }
+    | undefined;
+  if (!row) {
+    throw new Error(`Note not found: "${id}"`);
+  }
+  throw new ConflictError(id, row.updated_at, expected);
 }
 
 export function deleteNote(db: Database, id: string): void {

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -124,6 +124,8 @@ export function updateNote(
     // pre- from post-update state. Without this, two writes landing in the
     // same wall-clock millisecond would produce identical timestamps and
     // let a second OC writer see the first writer's work as "unchanged."
+    // Comparison is lexicographic on ISO 8601 strings — valid because
+    // `.toISOString()` always emits fixed-width UTC (`...Z`).
     if (updates.if_updated_at !== undefined && now <= updates.if_updated_at) {
       now = new Date(new Date(updates.if_updated_at).getTime() + 1).toISOString();
     }
@@ -148,9 +150,11 @@ export function updateNote(
     values.push(updates.created_at);
   }
 
-  // No-op: no SET fields. If a caller still passed `if_updated_at`, we need
-  // to validate the precondition; a conditional UPDATE that sets updated_at
-  // to itself does exactly that atomically without changing any data.
+  // No-op: no SET fields. If a caller still passed `if_updated_at`, we
+  // need to validate the precondition; a conditional UPDATE that sets
+  // updated_at to itself does exactly that atomically — even a no-net-
+  // change UPDATE takes the write lock in WAL mode, so it still serializes
+  // with other writers and `.changes` reflects whether the WHERE matched.
   if (sets.length === 0) {
     if (updates.if_updated_at !== undefined) {
       const probe = db.prepare(

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -51,7 +51,17 @@ export class BunSqliteStore implements Store {
     return noteOps.getNotes(this.db, ids);
   }
 
-  async updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean }): Promise<Note> {
+  async updateNote(
+    id: string,
+    updates: {
+      content?: string;
+      path?: string;
+      metadata?: Record<string, unknown>;
+      created_at?: string;
+      skipUpdatedAt?: boolean;
+      if_updated_at?: string;
+    },
+  ): Promise<Note> {
     let oldPath: string | undefined;
     if (updates.path !== undefined) {
       const existing = noteOps.getNote(this.db, id);

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -98,7 +98,7 @@ export interface Store {
   getNote(id: string): Promise<Note | null>;
   getNoteByPath(path: string): Promise<Note | null>;
   getNotes(ids: string[]): Promise<Note[]>;
-  updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; skipUpdatedAt?: boolean }): Promise<Note>;
+  updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean; if_updated_at?: string }): Promise<Note>;
   deleteNote(id: string): Promise<void>;
   queryNotes(opts: QueryOpts): Promise<Note[]>;
   searchNotes(query: string, opts?: { tags?: string[]; limit?: number }): Promise<Note[]>;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -295,38 +295,26 @@ export async function handleNotes(
       if (!note) throw new NotFoundError(`Note not found: "${idOrPath}"`);
       const body = await req.json() as any;
 
-      // Optimistic concurrency check
-      if (body.if_updated_at !== undefined && note.updatedAt !== body.if_updated_at) {
-        return json(
-          {
-            error: "conflict",
-            message: `note "${note.id}" has been modified since if_updated_at`,
-            note_id: note.id,
-            current_updated_at: note.updatedAt ?? null,
-            expected_updated_at: body.if_updated_at,
-          },
-          409,
-        );
-      }
-
-      // Remove links first (before content update for bracket removal)
-      const linksRemove = body.links?.remove as { target: string; relationship: string }[] | undefined;
+      // --- Plan bracket cleanup for wikilink removals (no DB writes yet) ---
+      // The actual link deletions happen only after the core UPDATE succeeds,
+      // so a conflict leaves the note untouched.
       let contentOverride = body.content as string | undefined;
+      const linksRemove = body.links?.remove as { target: string; relationship: string }[] | undefined;
+      const resolvedLinksToRemove: { targetId: string; relationship: string }[] = [];
       if (linksRemove) {
         for (const link of linksRemove) {
           const target = await resolveNote(store, link.target);
-          if (target) {
-            await store.deleteLink(note.id, target.id, link.relationship);
-            if (link.relationship === "wikilink" && target.path) {
-              const current = contentOverride ?? note.content;
-              const cleaned = removeWikilinkBrackets(current, target.path);
-              if (cleaned !== current) contentOverride = cleaned;
-            }
+          if (!target) continue;
+          resolvedLinksToRemove.push({ targetId: target.id, relationship: link.relationship });
+          if (link.relationship === "wikilink" && target.path) {
+            const current = contentOverride ?? note.content;
+            const cleaned = removeWikilinkBrackets(current, target.path);
+            if (cleaned !== current) contentOverride = cleaned;
           }
         }
       }
 
-      // Core update
+      // --- Core update (runs the if_updated_at check atomically) ---
       const updates: any = {};
       if (contentOverride !== undefined) updates.content = contentOverride;
       if (body.path !== undefined) updates.path = body.path;
@@ -337,9 +325,17 @@ export async function handleNotes(
       if (body.created_at !== undefined || body.createdAt !== undefined) {
         updates.created_at = body.created_at ?? body.createdAt;
       }
+      if (body.if_updated_at !== undefined) {
+        updates.if_updated_at = body.if_updated_at;
+      }
 
       if (Object.keys(updates).length > 0) {
         await store.updateNote(note.id, updates);
+      }
+
+      // --- Remove links (after core UPDATE; conflict would have thrown already) ---
+      for (const { targetId, relationship } of resolvedLinksToRemove) {
+        await store.deleteLink(note.id, targetId, relationship);
       }
 
       // Tags
@@ -362,6 +358,18 @@ export async function handleNotes(
       return json(await store.getNote(note.id));
     } catch (e: any) {
       if (e instanceof NotFoundError) return json({ error: e.message }, 404);
+      if (e && e.code === "CONFLICT") {
+        return json(
+          {
+            error: "conflict",
+            message: e.message,
+            note_id: e.note_id,
+            current_updated_at: e.current_updated_at ?? null,
+            expected_updated_at: e.expected_updated_at,
+          },
+          409,
+        );
+      }
       throw e;
     }
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -295,6 +295,20 @@ export async function handleNotes(
       if (!note) throw new NotFoundError(`Note not found: "${idOrPath}"`);
       const body = await req.json() as any;
 
+      // Optimistic concurrency check
+      if (body.if_updated_at !== undefined && note.updatedAt !== body.if_updated_at) {
+        return json(
+          {
+            error: "conflict",
+            message: `note "${note.id}" has been modified since if_updated_at`,
+            note_id: note.id,
+            current_updated_at: note.updatedAt ?? null,
+            expected_updated_at: body.if_updated_at,
+          },
+          409,
+        );
+      }
+
       // Remove links first (before content update for bracket removal)
       const linksRemove = body.links?.remove as { target: string; relationship: string }[] | undefined;
       let contentOverride = body.content as string | undefined;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -358,6 +358,9 @@ export async function handleNotes(
       return json(await store.getNote(note.id));
     } catch (e: any) {
       if (e instanceof NotFoundError) return json({ error: e.message }, 404);
+      // Duck-type on `code` rather than `instanceof ConflictError`: this
+      // error originates in the core package and survives any future
+      // bundling / module-boundary split more robustly than a prototype check.
       if (e && e.code === "CONFLICT") {
         return json(
           {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1052,6 +1052,51 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect(body.content).toBe("updated");
   });
 
+  test("PATCH with matching if_updated_at succeeds", async () => {
+    const note = await store.createNote("first", { id: "x" });
+    // First bump — sets updated_at
+    const first = await handleNotes(
+      mkReq("PATCH", "/notes/x", { content: "second" }),
+      store,
+      "/x",
+    );
+    const firstBody = await first.json() as any;
+    expect(firstBody.updatedAt).toBeTruthy();
+
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", { content: "third", if_updated_at: firstBody.updatedAt }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.content).toBe("third");
+  });
+
+  test("PATCH with stale if_updated_at returns 409 and does not modify note", async () => {
+    await store.createNote("first", { id: "x" });
+    await handleNotes(mkReq("PATCH", "/notes/x", { content: "second" }), store, "/x");
+    const current = await store.getNote("x");
+
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", {
+        content: "third",
+        if_updated_at: "2020-01-01T00:00:00.000Z",
+      }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json() as any;
+    expect(body.error).toBe("conflict");
+    expect(body.note_id).toBe("x");
+    expect(body.current_updated_at).toBe(current!.updatedAt);
+    expect(body.expected_updated_at).toBe("2020-01-01T00:00:00.000Z");
+
+    // Unchanged
+    expect((await store.getNote("x"))!.content).toBe("second");
+  });
+
   test("DELETE resolves note by path", async () => {
     await store.createNote("x", { path: "Temp/note" });
     const res = await handleNotes(


### PR DESCRIPTION
## Summary

- Add optional `if_updated_at` parameter to the `update-note` MCP tool and the `PATCH /notes/:idOrPath` HTTP route.
- When supplied and it doesn't match the note's current `updated_at`, the update is rejected: MCP throws `ConflictError` (code `CONFLICT`), HTTP returns 409 `{ error: "conflict", ... }`.
- Batch mode fails fast on the first conflict — items later in the array aren't touched.

This is the first of three features from the [memory architecture decision](https://github.com/ParachuteComputer/parachute-vault/issues) (canon + link expansion). Smallest, unblocks safe multi-writer flows (canon-curator agents + Aaron editing simultaneously, etc.).

Design notes:
- The check compares strings exactly. If the client passes `if_updated_at` and the note has `updatedAt: undefined` (never updated), they mismatch — so a client that passes this parameter is asserting a specific observed state.
- `ConflictError` is exported from `core/src/mcp.ts` so downstream consumers can distinguish it from other errors if they want.

## Test plan

- [x] `bun test` — 393 pass / 3 skip / 0 fail (added 4 MCP-layer tests + 2 HTTP-layer tests)
- [x] Unit: matching `if_updated_at` succeeds; mismatched rejects with current/expected; never-updated note with caller expecting a value conflicts; batch aborts on first conflict without touching later items.
- [x] HTTP: matching succeeds (200); stale returns 409 with `{ error: "conflict", note_id, current_updated_at, expected_updated_at }` and leaves the note unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)