### PR TITLE
feat: link expansion on query-notes

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -938,3 +938,232 @@ describe("MCP tools", async () => {
     expect(fresh.metadata.status).toBe("active");
   });
 });
+
+// ---- query-notes link expansion ----
+
+describe("query-notes link expansion", async () => {
+  it("expands a single [[wikilink]] inline in full mode by default", async () => {
+    await store.createNote("# Who I Am\nI teach Taiji.", { path: "Statements/Who" });
+    await store.createNote(
+      "Canon:\nSee [[Statements/Who]] for identity.",
+      { path: "Canon" },
+    );
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({
+      id: "Canon",
+      expand_links: true,
+    }) as any;
+
+    expect(result.content).toContain('<expanded path="Statements/Who" mode="full">');
+    expect(result.content).toContain("I teach Taiji.");
+    expect(result.content).toContain("</expanded>");
+  });
+
+  it("summary mode inlines only metadata.summary, not full content", async () => {
+    await store.createNote(
+      "# Long canonical statement\n\n(Many paragraphs of detail follow...)",
+      { path: "Statements/Philosophy", metadata: { summary: "Unforced / wu wei." } },
+    );
+    await store.createNote("Overview: [[Statements/Philosophy]]", { path: "Index" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({
+      id: "Index",
+      expand_links: true,
+      expand_mode: "summary",
+    }) as any;
+
+    expect(result.content).toContain('mode="summary"');
+    expect(result.content).toContain("Unforced / wu wei.");
+    expect(result.content).not.toContain("Many paragraphs of detail");
+  });
+
+  it("deduplicates: a linked note expanded once, subsequent references marked", async () => {
+    await store.createNote("target body", { path: "Target" });
+    await store.createNote(
+      "First [[Target]], then [[Target]] again.",
+      { path: "Source" },
+    );
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({
+      id: "Source",
+      expand_links: true,
+    }) as any;
+
+    // Exactly one <expanded> block.
+    const openCount = (result.content.match(/<expanded /g) ?? []).length;
+    expect(openCount).toBe(1);
+    expect(result.content).toContain("(expanded above)");
+  });
+
+  it("cycle guard: A→B→A does not expand A inside B", async () => {
+    await store.createNote("A body with [[B]] reference.", { path: "A" });
+    await store.createNote("B body with [[A]] reference.", { path: "B" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({
+      id: "A",
+      expand_links: true,
+      expand_depth: 3,
+    }) as any;
+
+    // A appears as the container but should only be expanded once (in the top-level note).
+    // B is expanded inside A; inside B, the [[A]] reference should NOT re-expand A.
+    const expandedOpens = (result.content.match(/<expanded path="(A|B)" mode="full">/g) ?? []).length;
+    expect(expandedOpens).toBe(1); // only B is expanded; A is the top note, never re-expanded
+    expect(result.content).toContain("(expanded above)"); // B's reference to A becomes the marker
+  });
+
+  it("expand_depth=1 (default) expands top-level wikilinks but not nested ones", async () => {
+    await store.createNote("leaf content", { path: "Leaf" });
+    await store.createNote("middle body with [[Leaf]] inside", { path: "Middle" });
+    await store.createNote("root references [[Middle]]", { path: "Root" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({ id: "Root", expand_links: true }) as any;
+
+    expect(result.content).toContain('<expanded path="Middle"');
+    // Middle's content is inlined, including its raw [[Leaf]] reference — but Leaf is NOT expanded.
+    expect(result.content).toContain("[[Leaf]]");
+    expect(result.content).not.toContain('<expanded path="Leaf"');
+  });
+
+  it("expand_depth=2 recurses one additional level", async () => {
+    await store.createNote("leaf content", { path: "Leaf" });
+    await store.createNote("middle [[Leaf]] inside", { path: "Middle" });
+    await store.createNote("root references [[Middle]]", { path: "Root" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({
+      id: "Root",
+      expand_links: true,
+      expand_depth: 2,
+    }) as any;
+
+    expect(result.content).toContain('<expanded path="Middle"');
+    expect(result.content).toContain('<expanded path="Leaf"');
+    expect(result.content).toContain("leaf content");
+  });
+
+  it("expand_depth is clamped to MAX_EXPAND_DEPTH (3)", async () => {
+    await store.createNote("level-4", { path: "L4" });
+    await store.createNote("level-3 [[L4]]", { path: "L3" });
+    await store.createNote("level-2 [[L3]]", { path: "L2" });
+    await store.createNote("level-1 [[L2]]", { path: "L1" });
+    await store.createNote("root [[L1]]", { path: "Root" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    // Request depth=99 — should clamp to 3, so L4 is NOT expanded.
+    const result = await query.execute({
+      id: "Root",
+      expand_links: true,
+      expand_depth: 99,
+    }) as any;
+
+    expect(result.content).toContain('<expanded path="L1"');
+    expect(result.content).toContain('<expanded path="L2"');
+    expect(result.content).toContain('<expanded path="L3"');
+    expect(result.content).not.toContain('<expanded path="L4"');
+    expect(result.content).toContain("[[L4]]"); // raw, beyond clamp
+  });
+
+  it("leaves unresolved [[wikilinks]] unchanged", async () => {
+    await store.createNote("root mentions [[DoesNotExist]]", { path: "Root" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({ id: "Root", expand_links: true }) as any;
+    expect(result.content).toBe("root mentions [[DoesNotExist]]");
+  });
+
+  it("expand_links: false (default) leaves content untouched", async () => {
+    await store.createNote("target body", { path: "Target" });
+    await store.createNote("before [[Target]] after", { path: "Source" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({ id: "Source" }) as any;
+    expect(result.content).toBe("before [[Target]] after");
+    expect(result.content).not.toContain("<expanded");
+  });
+
+  it("list queries expand per-note and dedup across the result", async () => {
+    await store.createNote("shared body", { path: "Shared" });
+    await store.createNote(
+      "first note references [[Shared]]",
+      { path: "A", tags: ["list-test"] },
+    );
+    await store.createNote(
+      "second note also references [[Shared]]",
+      { path: "B", tags: ["list-test"] },
+    );
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({
+      tag: ["list-test"],
+      include_content: true,
+      expand_links: true,
+      sort: "asc",
+    }) as any[];
+
+    expect(result).toHaveLength(2);
+    const expandedBlocks = result
+      .map((n) => (n.content.match(/<expanded /g) ?? []).length)
+      .reduce((a, b) => a + b, 0);
+    expect(expandedBlocks).toBe(1); // shared note expanded exactly once total
+    const withMarker = result.find((n) => n.content.includes("(expanded above)"));
+    expect(withMarker).toBeTruthy();
+  });
+
+  it("self-reference does not expand (note can't inline itself)", async () => {
+    await store.createNote("I reference [[Self]] in my own body.", { path: "Self" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({ id: "Self", expand_links: true }) as any;
+    expect(result.content).not.toContain("<expanded");
+    expect(result.content).toContain("(expanded above)");
+  });
+
+  it("handles [[Target|alias]] and [[Target#anchor]] wikilink forms", async () => {
+    await store.createNote("target body", { path: "Target" });
+    await store.createNote(
+      "See [[Target|the target]] or [[Target#section]].",
+      { path: "Source" },
+    );
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({ id: "Source", expand_links: true }) as any;
+    // Both references resolve to same target — first expands, second marked.
+    const openCount = (result.content.match(/<expanded /g) ?? []).length;
+    expect(openCount).toBe(1);
+    expect(result.content).toContain("(expanded above)");
+  });
+
+  it("expand_mode=summary with no metadata.summary renders empty body inline", async () => {
+    await store.createNote("unsummarized body", { path: "Plain" });
+    await store.createNote("see [[Plain]]", { path: "Src" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({
+      id: "Src",
+      expand_links: true,
+      expand_mode: "summary",
+    }) as any;
+    expect(result.content).toContain('mode="summary"');
+    // Summary is empty — we still get the block but with nothing between delimiters.
+    expect(result.content).not.toContain("unsummarized body");
+  });
+});

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -1151,6 +1151,66 @@ describe("query-notes link expansion", async () => {
     expect(result.content).toContain("(expanded above)");
   });
 
+  it("does not expand wikilinks inside fenced code blocks", async () => {
+    await store.createNote("target body", { path: "Target" });
+    await store.createNote(
+      "Example code:\n```\n[[Target]]\n```\nAnd a real link: [[Target]].",
+      { path: "Src" },
+    );
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({ id: "Src", expand_links: true }) as any;
+
+    // The fenced [[Target]] stays verbatim; the real one gets expanded exactly once.
+    const expandedOpens = (result.content.match(/<expanded /g) ?? []).length;
+    expect(expandedOpens).toBe(1);
+    expect(result.content).toContain("```\n[[Target]]\n```");
+  });
+
+  it("does not expand wikilinks inside inline code", async () => {
+    await store.createNote("target body", { path: "Target" });
+    await store.createNote(
+      "Pass `[[Target]]` to render a link. A real one: [[Target]].",
+      { path: "Src" },
+    );
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({ id: "Src", expand_links: true }) as any;
+    const expandedOpens = (result.content.match(/<expanded /g) ?? []).length;
+    expect(expandedOpens).toBe(1);
+    expect(result.content).toContain("`[[Target]]`");
+  });
+
+  it("expand_depth=0 is a no-op (no expansion performed)", async () => {
+    await store.createNote("target body", { path: "Target" });
+    await store.createNote("see [[Target]]", { path: "Src" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const result = await query.execute({
+      id: "Src",
+      expand_links: true,
+      expand_depth: 0,
+    }) as any;
+    expect(result.content).toBe("see [[Target]]");
+  });
+
+  it("expand_links=true is a silent no-op when include_content=false", async () => {
+    await store.createNote("target body", { path: "Target" });
+    await store.createNote("see [[Target]]", { path: "Src", tags: ["silent"] });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    // List mode defaults to include_content=false; expansion has nothing to
+    // operate on, so the result is the standard lean/index shape.
+    const result = await query.execute({ tag: ["silent"], expand_links: true }) as any[];
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBeUndefined();
+    expect(result[0].preview).toBeTruthy();
+  });
+
   it("expand_mode=summary with no metadata.summary renders empty body inline", async () => {
     await store.createNote("unsummarized body", { path: "Plain" });
     await store.createNote("see [[Plain]]", { path: "Src" });

--- a/core/src/expand.ts
+++ b/core/src/expand.ts
@@ -1,0 +1,101 @@
+/**
+ * Inline expansion of [[wikilinks]] in note content.
+ *
+ * Used by `query-notes` when `expand_links=true`. Replaces wikilink matches
+ * with delimited blocks containing the linked note's content (full mode) or
+ * metadata summary (summary mode). Deduplicates across the query and guards
+ * against cycles via a shared `expanded` set.
+ */
+
+import { Database } from "bun:sqlite";
+import type { Note } from "./types.js";
+import * as noteOps from "./notes.js";
+import { resolveWikilink } from "./wikilinks.js";
+
+export type ExpandMode = "full" | "summary";
+
+export const DEFAULT_EXPAND_DEPTH = 1;
+export const MAX_EXPAND_DEPTH = 3;
+
+export interface ExpandContext {
+  db: Database;
+  mode: ExpandMode;
+  /** Note IDs already expanded in this query. Shared across all expansions. */
+  expanded: Set<string>;
+}
+
+/** Matches wikilinks the same way the parser does — but retains positions. */
+const WIKILINK_RE = /(!?)\[\[([^\[\]\n]+?)\]\]/g;
+
+/**
+ * Expand wikilinks in `content` up to `remainingDepth` levels deep. Returns
+ * content with `<expanded>` blocks replacing each wikilink occurrence.
+ *
+ * `remainingDepth` counts down: when it reaches 0, no further expansion
+ * happens. A call with remainingDepth=1 expands top-level wikilinks only;
+ * wikilinks inside those expansions are left as-is.
+ */
+export function expandContent(
+  content: string,
+  ctx: ExpandContext,
+  remainingDepth: number,
+): string {
+  if (remainingDepth <= 0) return content;
+
+  return content.replace(WIKILINK_RE, (match, _bang: string, inner: string) => {
+    const target = parseTarget(inner);
+    if (!target) return match;
+
+    const noteId = resolveWikilink(ctx.db, target);
+    if (!noteId) return match; // unresolved or ambiguous — leave as-is
+
+    if (ctx.expanded.has(noteId)) {
+      return `${match} (expanded above)`;
+    }
+    ctx.expanded.add(noteId);
+
+    const note = noteOps.getNote(ctx.db, noteId);
+    if (!note) return match; // shouldn't happen, but be safe
+
+    if (ctx.mode === "summary") {
+      return renderSummary(note);
+    }
+
+    // Full mode — expand nested wikilinks one less level deep.
+    const nested = expandContent(note.content, ctx, remainingDepth - 1);
+    return renderFull(note, nested);
+  });
+}
+
+function parseTarget(inner: string): string | null {
+  // Strip display alias: "target|display" → "target"
+  const pipeIdx = inner.indexOf("|");
+  let targetPart = pipeIdx === -1 ? inner : inner.slice(0, pipeIdx);
+  // Strip anchor/block-ref: "target#heading" → "target"
+  const hashIdx = targetPart.indexOf("#");
+  if (hashIdx !== -1) targetPart = targetPart.slice(0, hashIdx);
+  const target = targetPart.trim();
+  return target || null;
+}
+
+function renderFull(note: Note, content: string): string {
+  const pathAttr = escapeAttr(note.path ?? note.id);
+  return `<expanded path="${pathAttr}" mode="full">\n${content}\n</expanded>`;
+}
+
+function renderSummary(note: Note): string {
+  const pathAttr = escapeAttr(note.path ?? note.id);
+  const summary = summaryText(note);
+  return `<expanded path="${pathAttr}" mode="summary">\n${summary}\n</expanded>`;
+}
+
+function summaryText(note: Note): string {
+  const meta = note.metadata as Record<string, unknown> | undefined;
+  const s = meta?.summary;
+  if (typeof s === "string" && s.trim()) return s.trim();
+  return "";
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}

--- a/core/src/expand.ts
+++ b/core/src/expand.ts
@@ -24,7 +24,12 @@ export interface ExpandContext {
   expanded: Set<string>;
 }
 
-/** Matches wikilinks the same way the parser does — but retains positions. */
+/**
+ * Matches wikilinks the same way the parser does — but retains positions.
+ * Embeds (`![[...]]`) are treated as regular links here; the `!` is discarded
+ * in the expansion output. If embed-specific rendering is needed later,
+ * inspect the first capture group.
+ */
 const WIKILINK_RE = /(!?)\[\[([^\[\]\n]+?)\]\]/g;
 
 /**
@@ -34,6 +39,10 @@ const WIKILINK_RE = /(!?)\[\[([^\[\]\n]+?)\]\]/g;
  * `remainingDepth` counts down: when it reaches 0, no further expansion
  * happens. A call with remainingDepth=1 expands top-level wikilinks only;
  * wikilinks inside those expansions are left as-is.
+ *
+ * Wikilinks inside fenced or inline code blocks are left untouched — mirrors
+ * the behavior of `parseWikilinks` in `wikilinks.ts` so the link graph and
+ * the expansion view stay consistent.
  */
 export function expandContent(
   content: string,
@@ -42,7 +51,11 @@ export function expandContent(
 ): string {
   if (remainingDepth <= 0) return content;
 
-  return content.replace(WIKILINK_RE, (match, _bang: string, inner: string) => {
+  const codeSkip = codeRanges(content);
+
+  return content.replace(WIKILINK_RE, (match, _bang: string, inner: string, offset: number) => {
+    if (inCodeRange(offset, codeSkip)) return match;
+
     const target = parseTarget(inner);
     if (!target) return match;
 
@@ -58,6 +71,7 @@ export function expandContent(
     if (!note) return match; // shouldn't happen, but be safe
 
     if (ctx.mode === "summary") {
+      // Summary mode doesn't recurse: depth > 1 has no additional effect.
       return renderSummary(note);
     }
 
@@ -65,6 +79,27 @@ export function expandContent(
     const nested = expandContent(note.content, ctx, remainingDepth - 1);
     return renderFull(note, nested);
   });
+}
+
+function codeRanges(content: string): [number, number][] {
+  const ranges: [number, number][] = [];
+  const fenced = /```[\s\S]*?```/g;
+  let m: RegExpExecArray | null;
+  while ((m = fenced.exec(content)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  const inline = /`[^`\n]+`/g;
+  while ((m = inline.exec(content)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
+}
+
+function inCodeRange(pos: number, ranges: [number, number][]): boolean {
+  for (const [start, end] of ranges) {
+    if (pos >= start && pos < end) return true;
+  }
+  return false;
 }
 
 function parseTarget(inner: string): string | null {
@@ -97,5 +132,9 @@ function summaryText(note: Note): string {
 }
 
 function escapeAttr(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -4,6 +4,13 @@ import * as noteOps from "./notes.js";
 import { filterMetadata } from "./notes.js";
 import * as linkOps from "./links.js";
 import * as tagSchemaOps from "./tag-schemas.js";
+import {
+  expandContent,
+  DEFAULT_EXPAND_DEPTH,
+  MAX_EXPAND_DEPTH,
+  type ExpandContext,
+  type ExpandMode,
+} from "./expand.js";
 
 export interface McpToolDef {
   name: string;
@@ -78,7 +85,9 @@ export function generateMcpTools(store: Store): McpToolDef[] {
 - **Graph neighborhood**: pass \`near\` to scope results to notes within N hops of an anchor note
 - **No filters**: returns all notes (paginated)
 
-Defaults: include_content=true for single note, false for lists. include_links=false. tag_match="any".`,
+Defaults: include_content=true for single note, false for lists. include_links=false. tag_match="any".
+
+Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returned content. Tune with \`expand_depth\` (1–3, default 1) and \`expand_mode\` ("full" inlines full content, "summary" inlines only metadata.summary). Expansions are deduplicated across the query and cycle-guarded.`,
       inputSchema: {
         type: "object",
         properties: {
@@ -121,9 +130,26 @@ Defaults: include_content=true for single note, false for lists. include_links=f
           },
           include_links: { type: "boolean", description: "Include inbound + outbound links per note (default: false)" },
           include_attachments: { type: "boolean", description: "Include attachment records (default: false)" },
+          expand_links: { type: "boolean", description: "Inline [[wikilinks]] in returned content (default: false). Requires content to be returned." },
+          expand_depth: { type: "number", description: "Recursion depth for link expansion (default 1, max 3)." },
+          expand_mode: { type: "string", enum: ["full", "summary"], description: "Expansion rendering: 'full' inlines the linked note's content, 'summary' inlines only metadata.summary. Default: 'full'." },
         },
       },
       execute: async (params) => {
+        // --- Link expansion config (shared across single + list paths) ---
+        const expandLinks = params.expand_links === true;
+        const expandMode = (params.expand_mode as ExpandMode) ?? "full";
+        const expandDepth = Math.max(
+          0,
+          Math.min(
+            (params.expand_depth as number | undefined) ?? DEFAULT_EXPAND_DEPTH,
+            MAX_EXPAND_DEPTH,
+          ),
+        );
+        const expandCtx: ExpandContext | null = expandLinks
+          ? { db, mode: expandMode, expanded: new Set() }
+          : null;
+
         // --- Single note by ID/path ---
         if (params.id) {
           const note = resolveNote(db, params.id as string);
@@ -131,6 +157,11 @@ Defaults: include_content=true for single note, false for lists. include_links=f
           const includeContent = params.include_content !== false; // default true for single
           let result: any = includeContent ? { ...note } : noteOps.toNoteIndex(note);
           result = filterMetadata(result, params.include_metadata as boolean | string[] | undefined);
+          if (expandCtx && includeContent && typeof result.content === "string") {
+            // Mark the top-level note as already expanded so it can't recursively inline itself.
+            expandCtx.expanded.add(note.id);
+            result.content = expandContent(result.content, expandCtx, expandDepth);
+          }
           if (params.include_links) {
             result.links = linkOps.getLinksHydrated(db, note.id);
           }
@@ -189,7 +220,18 @@ Defaults: include_content=true for single note, false for lists. include_links=f
         // --- Format output ---
         const includeContent = params.include_content === true; // default false for list
         const includeMetadata = params.include_metadata as boolean | string[] | undefined;
-        let output = includeContent ? results : results.map(noteOps.toNoteIndex);
+        let output: any[] = includeContent ? results.map((n) => ({ ...n })) : results.map(noteOps.toNoteIndex);
+
+        // --- Expand wikilinks inline (only meaningful when content is present) ---
+        if (expandCtx && includeContent) {
+          // Mark all top-level notes as already expanded so they can't inline each other.
+          for (const n of output) expandCtx.expanded.add(n.id);
+          for (const n of output) {
+            if (typeof n.content === "string") {
+              n.content = expandContent(n.content, expandCtx, expandDepth);
+            }
+          }
+        }
 
         // --- Apply metadata filtering ---
         if (includeMetadata !== undefined && includeMetadata !== true) {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -130,8 +130,8 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           },
           include_links: { type: "boolean", description: "Include inbound + outbound links per note (default: false)" },
           include_attachments: { type: "boolean", description: "Include attachment records (default: false)" },
-          expand_links: { type: "boolean", description: "Inline [[wikilinks]] in returned content (default: false). Requires content to be returned." },
-          expand_depth: { type: "number", description: "Recursion depth for link expansion (default 1, max 3)." },
+          expand_links: { type: "boolean", description: "Inline [[wikilinks]] in returned content (default: false). Has no effect if content is not included (e.g., default list mode with include_content=false); wikilinks inside fenced or inline code are not expanded." },
+          expand_depth: { type: "number", description: "Recursion depth for link expansion (default 1, max 3). Only meaningful in 'full' mode — 'summary' mode does not recurse." },
           expand_mode: { type: "string", enum: ["full", "summary"], description: "Expansion rendering: 'full' inlines the linked note's content, 'summary' inlines only metadata.summary. Default: 'full'." },
         },
       },
@@ -156,12 +156,12 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           if (!note) return { error: "Note not found", id: params.id };
           const includeContent = params.include_content !== false; // default true for single
           let result: any = includeContent ? { ...note } : noteOps.toNoteIndex(note);
-          result = filterMetadata(result, params.include_metadata as boolean | string[] | undefined);
           if (expandCtx && includeContent && typeof result.content === "string") {
             // Mark the top-level note as already expanded so it can't recursively inline itself.
             expandCtx.expanded.add(note.id);
             result.content = expandContent(result.content, expandCtx, expandDepth);
           }
+          result = filterMetadata(result, params.include_metadata as boolean | string[] | undefined);
           if (params.include_links) {
             result.links = linkOps.getLinksHydrated(db, note.id);
           }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -16,6 +16,13 @@ import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
 import { toNoteIndex, filterMetadata } from "../core/src/notes.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
+import {
+  expandContent,
+  DEFAULT_EXPAND_DEPTH,
+  MAX_EXPAND_DEPTH,
+  type ExpandContext,
+  type ExpandMode,
+} from "../core/src/expand.ts";
 import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { vaultDir } from "./config.ts";
@@ -63,6 +70,27 @@ function parseIncludeMetadata(url: URL): boolean | string[] | undefined {
   const fields = val.split(",").map((s) => s.trim()).filter(Boolean);
   if (fields.length === 0) return undefined; // empty string → treat as default (all)
   return fields;
+}
+
+/**
+ * Parse expand_links/expand_depth/expand_mode from query params, returning
+ * an (ExpandContext, depth) pair if expansion is requested, else null.
+ */
+function parseExpandParams(
+  url: URL,
+  db: any,
+): { ctx: ExpandContext; depth: number } | null {
+  if (!parseBool(parseQuery(url, "expand_links"), false)) return null;
+  const modeRaw = parseQuery(url, "expand_mode");
+  const mode: ExpandMode = modeRaw === "summary" ? "summary" : "full";
+  const depth = Math.max(
+    0,
+    Math.min(
+      parseInt10(parseQuery(url, "expand_depth")) ?? DEFAULT_EXPAND_DEPTH,
+      MAX_EXPAND_DEPTH,
+    ),
+  );
+  return { ctx: { db, mode, expanded: new Set() }, depth };
 }
 
 
@@ -114,6 +142,11 @@ export async function handleNotes(
         if (!note) return json({ error: "Note not found", id }, 404);
         const includeContent = parseBool(parseQuery(url, "include_content"), true);
         let result: any = includeContent ? { ...note } : toNoteIndex(note);
+        const expand = parseExpandParams(url, db);
+        if (expand && includeContent && typeof result.content === "string") {
+          expand.ctx.expanded.add(note.id);
+          result.content = expandContent(result.content, expand.ctx, expand.depth);
+        }
         result = filterMetadata(result, parseIncludeMetadata(url));
         if (parseBool(parseQuery(url, "include_links"), false)) {
           result.links = linkOps.getLinksHydrated(db, note.id);
@@ -131,7 +164,16 @@ export async function handleNotes(
         const results = await store.searchNotes(search, { tags: searchTags, limit });
         const includeContent = parseBool(parseQuery(url, "include_content"), false);
         const inclMeta = parseIncludeMetadata(url);
-        let output = includeContent ? results : results.map(toNoteIndex);
+        let output: any[] = includeContent ? results.map((n) => ({ ...n })) : results.map(toNoteIndex);
+        const expand = parseExpandParams(url, db);
+        if (expand && includeContent) {
+          for (const n of output) expand.ctx.expanded.add(n.id);
+          for (const n of output) {
+            if (typeof n.content === "string") {
+              n.content = expandContent(n.content, expand.ctx, expand.depth);
+            }
+          }
+        }
         if (inclMeta !== undefined && inclMeta !== true) {
           output = output.map((n: any) => filterMetadata(n, inclMeta));
         }
@@ -170,7 +212,16 @@ export async function handleNotes(
       const includeLinks = parseBool(parseQuery(url, "include_links"), false);
       const includeAttachments = parseBool(parseQuery(url, "include_attachments"), false);
       const inclMeta = parseIncludeMetadata(url);
-      let output: any[] = includeContent ? results : results.map(toNoteIndex);
+      let output: any[] = includeContent ? results.map((n) => ({ ...n })) : results.map(toNoteIndex);
+      const expand = parseExpandParams(url, db);
+      if (expand && includeContent) {
+        for (const n of output) expand.ctx.expanded.add(n.id);
+        for (const n of output) {
+          if (typeof n.content === "string") {
+            n.content = expandContent(n.content, expand.ctx, expand.depth);
+          }
+        }
+      }
       if (inclMeta !== undefined && inclMeta !== true) {
         output = output.map((n: any) => filterMetadata(n, inclMeta));
       }
@@ -278,6 +329,11 @@ export async function handleNotes(
     if (!note) return json({ error: "Not found" }, 404);
     const includeContent = parseBool(parseQuery(url, "include_content"), true);
     let result: any = includeContent ? { ...note } : toNoteIndex(note);
+    const expand = parseExpandParams(url, db);
+    if (expand && includeContent && typeof result.content === "string") {
+      expand.ctx.expanded.add(note.id);
+      result.content = expandContent(result.content, expand.ctx, expand.depth);
+    }
     result = filterMetadata(result, parseIncludeMetadata(url));
     if (parseBool(parseQuery(url, "include_links"), false)) {
       result.links = linkOps.getLinksHydrated(db, note.id);

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -892,6 +892,55 @@ describe("HTTP /notes", async () => {
     expect(body.metadata).toEqual({ summary: "s" });
   });
 
+  test("GET /notes/:id?expand_links=true inlines wikilink content", async () => {
+    await store.createNote("target body", { path: "Target" });
+    await store.createNote("see [[Target]]", { id: "src", path: "Src" });
+    const res = await handleNotes(
+      mkReq("GET", "/notes/src?expand_links=true"),
+      store,
+      "/src",
+    );
+    const body = await res.json() as any;
+    expect(body.content).toContain('<expanded path="Target" mode="full">');
+    expect(body.content).toContain("target body");
+  });
+
+  test("GET /notes/:id?expand_links=true&expand_mode=summary inlines metadata.summary only", async () => {
+    await store.createNote("long body", {
+      path: "T",
+      metadata: { summary: "short" },
+    });
+    await store.createNote("see [[T]]", { id: "sx", path: "Sx" });
+    const res = await handleNotes(
+      mkReq("GET", "/notes/sx?expand_links=true&expand_mode=summary"),
+      store,
+      "/sx",
+    );
+    const body = await res.json() as any;
+    expect(body.content).toContain('mode="summary"');
+    expect(body.content).toContain("short");
+    expect(body.content).not.toContain("long body");
+  });
+
+  test("GET /notes?tag=&include_content=true&expand_links=true expands per-note with cross-note dedup", async () => {
+    await store.createNote("shared body", { path: "Shared" });
+    await store.createNote("first [[Shared]]", { path: "A", tags: ["el"] });
+    await store.createNote("second [[Shared]]", { path: "B", tags: ["el"] });
+    const res = await handleNotes(
+      mkReq("GET", "/notes?tag=el&include_content=true&expand_links=true&sort=asc"),
+      store,
+      "",
+    );
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(2);
+    const expandedBlocks = body
+      .map((n: any) => (n.content.match(/<expanded /g) ?? []).length)
+      .reduce((a: number, b: number) => a + b, 0);
+    expect(expandedBlocks).toBe(1);
+    const withMarker = body.find((n: any) => n.content.includes("(expanded above)"));
+    expect(withMarker).toBeTruthy();
+  });
+
   test("POST /notes accepts createdAt (camelCase) in body", async () => {
     const res = await handleNotes(
       mkReq("POST", "/notes", { content: "hi", createdAt: "2025-01-01T00:00:00.000Z" }),


### PR DESCRIPTION
## Summary

- Adds inline `[[wikilink]]` expansion to the `query-notes` MCP tool and the `GET /notes` HTTP routes (single-note, search, and structured list paths).
- New params: `expand_links` (bool, default false), `expand_depth` (clamped 0–3, default 1), `expand_mode` (`"full"` | `"summary"`, default `"full"`).
- Full mode inlines the linked note's content inside `<expanded path="..." mode="full">...</expanded>` delimiters; summary mode inlines `metadata.summary` (or empty) inside `<expanded path="..." mode="summary">...</expanded>`.
- Deduplication + cycle guard: each linked note is expanded at most once per query; subsequent references become marker text ``[[...]] (expanded above)``. Top-level notes are pre-seeded into the `expanded` set so they can't inline themselves or each other.
- Wikilinks inside fenced / inline code blocks are not expanded — matches `parseWikilinks` behaviour so the link graph and the expansion view stay consistent.
- Unresolved / ambiguous targets are left as-is.

This is the second of three features from the [memory architecture decision](https://github.com/ParachuteComputer/parachute-vault/issues) (depends on nothing; can land after #103). Unlocks `Uni/Canon`-style view notes: a small note of wikilinks that, queried with `expand_links=true`, returns the whole orienting bundle in a single call — and summary mode keeps the cost low for dynamic-view collections.

Core logic lives in the new `core/src/expand.ts` module, keeping `mcp.ts` and `routes.ts` thin.

### Reviewer pass

Self-reviewed via the `reviewer` subagent; findings applied in commit 2 (`fix(expand): …`):

- Skip wikilinks inside fenced / inline code blocks (previously expanded them, inconsistent with the parser).
- `escapeAttr` now also escapes `<` / `>`.
- Align filter/expand ordering across MCP single-note, MCP list, and all HTTP paths.
- Schema descriptions call out the silent no-op when `include_content=false` and the depth-has-no-effect behaviour in summary mode.

## Test plan

- [x] `bun test` — 407 pass / 3 skip / 0 fail (17 new tests: 14 MCP-layer, 3 HTTP-layer)
- [x] Unit: full-mode expand of one wikilink; summary-mode inlines only `metadata.summary`; dedup of repeated same-target wikilinks; cycle guard A→B→A; depth=1 default prevents nested expansion; depth=2 recurses one more level; depth=99 clamps to 3; unresolved links unchanged; `expand_links=false` is the default and leaves content untouched; list queries share the dedup set across notes; self-reference does not expand; alias / anchor wikilink forms handled; code blocks (fenced + inline) skipped; `expand_depth=0` is a no-op; `expand_links=true` with `include_content=false` silently no-ops.
- [x] HTTP: `GET /notes/:id?expand_links=true` inlines full content; `expand_mode=summary` inlines only summary; list `GET /notes?tag=&include_content=true&expand_links=true` does cross-note dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)