### PR TITLE
feat(cli): uninstall, doctor, url commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1095,7 +1095,11 @@ async function cmdDoctor() {
 
 function cmdUrl() {
   // Intentionally minimal — scripts parse this, so print only the URL.
-  const port = readGlobalConfig().port || DEFAULT_PORT;
+  // Load .env first so PORT overrides in the env file take precedence over
+  // config.yaml, matching the behavior of `status` and `restart`.
+  loadEnvFile();
+  const envPort = process.env.PORT ? Number(process.env.PORT) : undefined;
+  const port = envPort ?? readGlobalConfig().port ?? DEFAULT_PORT;
   console.log(`http://127.0.0.1:${port}`);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,10 +40,17 @@ import {
   ERR_PATH,
 } from "./config.ts";
 import type { VaultConfig } from "./config.ts";
+import { VAULTS_DIR } from "./config.ts";
 import { installAgent, uninstallAgent, isAgentLoaded, restartAgent } from "./launchd.ts";
-import { installSystemdService, restartSystemdService, isSystemdAvailable, isServiceActive } from "./systemd.ts";
+import { installSystemdService, uninstallSystemdService, restartSystemdService, isSystemdAvailable, isServiceActive } from "./systemd.ts";
 import { checkHealth, waitForHealthy, tailFile } from "./health.ts";
 import type { HealthResult } from "./health.ts";
+import {
+  WRAPPER_PATH,
+  SERVER_PATH_FILE,
+  readServerPathPointer,
+  removeDaemonWrapper,
+} from "./daemon.ts";
 import { confirm, ask, askPassword, choose } from "./prompt.ts";
 import { generateToken, createToken, listTokens, revokeToken, migrateVaultKeys } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
@@ -130,6 +137,15 @@ switch (command) {
     break;
   case "restart":
     await cmdRestart();
+    break;
+  case "uninstall":
+    await cmdUninstall(cmdArgs);
+    break;
+  case "doctor":
+    await cmdDoctor();
+    break;
+  case "url":
+    cmdUrl();
     break;
   case "import":
     await cmdImport(cmdArgs);
@@ -903,6 +919,177 @@ function printErrLogTail(n: number) {
 }
 
 // ---------------------------------------------------------------------------
+// Uninstall / Doctor / URL
+// ---------------------------------------------------------------------------
+
+async function cmdUninstall(argsList: string[]) {
+  const wipe = argsList.includes("--wipe");
+  const skipPrompts = argsList.includes("--yes") || argsList.includes("-y");
+
+  console.log("Parachute Vault uninstall\n");
+  console.log("This removes the daemon registration and wrapper script.");
+  if (wipe) {
+    console.log("`--wipe` will ALSO remove vaults (SQLite DBs) and .env.\n");
+  } else {
+    console.log("User data (~/.parachute/vaults, ~/.parachute/.env) is left alone.\n");
+  }
+
+  if (!skipPrompts) {
+    const ok = await confirm("Proceed?");
+    if (!ok) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  // 1. Stop and remove the daemon registration.
+  if (process.platform === "darwin") {
+    console.log("Removing launchd agent...");
+    await uninstallAgent();
+  } else if (isSystemdAvailable()) {
+    console.log("Removing systemd service...");
+    await uninstallSystemdService();
+  } else {
+    console.log("No daemon manager on this platform — skipping service removal.");
+  }
+
+  // 2. Remove wrapper + pointer file (shared across platforms).
+  console.log("Removing wrapper and server-path pointer...");
+  await removeDaemonWrapper();
+
+  // 3. Optionally wipe user data. Double-confirm so nobody loses a vault
+  // by muscle-memory — this is the one genuinely destructive path.
+  if (wipe) {
+    const vaultsExist = existsSync(VAULTS_DIR);
+    const envExists = existsSync(ENV_PATH);
+    if (!vaultsExist && !envExists) {
+      console.log("No user data to remove.");
+    } else {
+      console.log("\nUser data that would be removed:");
+      if (vaultsExist) console.log(`  ${VAULTS_DIR} (SQLite vaults)`);
+      if (envExists) console.log(`  ${ENV_PATH} (.env config + secrets)`);
+
+      let doWipe = skipPrompts;
+      if (!skipPrompts) {
+        doWipe = await confirm("Delete this data? (cannot be undone)");
+      }
+      if (doWipe) {
+        if (vaultsExist) rmSync(VAULTS_DIR, { recursive: true, force: true });
+        if (envExists) rmSync(ENV_PATH, { force: true });
+        console.log("User data removed.");
+      } else {
+        console.log("Kept user data.");
+      }
+    }
+  }
+
+  console.log("\nDone. To reinstall: `parachute vault init`.");
+}
+
+interface DoctorCheck {
+  name: string;
+  status: "pass" | "warn" | "fail";
+  detail?: string;
+  fix?: string;
+}
+
+async function cmdDoctor() {
+  const checks: DoctorCheck[] = [];
+
+  // Pointer file. The stale-path failure mode shows up here first.
+  if (!existsSync(SERVER_PATH_FILE)) {
+    checks.push({
+      name: "server-path pointer",
+      status: "fail",
+      detail: `missing: ${SERVER_PATH_FILE}`,
+      fix: "Run `parachute vault init` to create it.",
+    });
+  } else {
+    const pointed = readServerPathPointer();
+    if (!pointed) {
+      checks.push({
+        name: "server-path pointer",
+        status: "fail",
+        detail: `empty: ${SERVER_PATH_FILE}`,
+        fix: "Run `parachute vault init` to rewrite it.",
+      });
+    } else if (!existsSync(pointed)) {
+      checks.push({
+        name: "server.ts at pointer target",
+        status: "fail",
+        detail: `points to ${pointed}, which does not exist`,
+        fix: "Run `parachute vault init` from the current repo location.",
+      });
+    } else {
+      checks.push({
+        name: "server-path pointer",
+        status: "pass",
+        detail: `→ ${pointed}`,
+      });
+    }
+  }
+
+  // Wrapper script. Independent of the pointer — a missing wrapper means
+  // launchd/systemd has nothing to exec.
+  if (!existsSync(WRAPPER_PATH)) {
+    checks.push({
+      name: "wrapper script",
+      status: "fail",
+      detail: `missing: ${WRAPPER_PATH}`,
+      fix: "Run `parachute vault init`.",
+    });
+  } else {
+    checks.push({ name: "wrapper script", status: "pass", detail: WRAPPER_PATH });
+  }
+
+  // Daemon registration.
+  if (process.platform === "darwin") {
+    const loaded = await isAgentLoaded();
+    checks.push({
+      name: "launchd agent",
+      status: loaded ? "pass" : "warn",
+      detail: loaded ? "loaded" : "not loaded",
+      fix: loaded ? undefined : "Run `parachute vault init` or `parachute vault restart`.",
+    });
+  } else if (isSystemdAvailable()) {
+    const active = await isServiceActive();
+    checks.push({
+      name: "systemd service",
+      status: active ? "pass" : "warn",
+      detail: active ? "active" : "not active",
+      fix: active ? undefined : "Run `parachute vault init` or `parachute vault restart`.",
+    });
+  }
+
+  // Render.
+  const icons = { pass: " ✓", warn: " !", fail: " ✗" } as const;
+  console.log("Parachute Vault — doctor\n");
+  for (const c of checks) {
+    const icon = icons[c.status];
+    console.log(`  ${icon} ${c.name}${c.detail ? `  (${c.detail})` : ""}`);
+    if (c.fix) console.log(`       fix: ${c.fix}`);
+  }
+
+  const hasFailure = checks.some((c) => c.status === "fail");
+  const hasWarn = checks.some((c) => c.status === "warn");
+  console.log();
+  if (hasFailure) {
+    console.log("doctor: problems found (exit 1). See `parachute vault status` for runtime details.");
+    process.exit(1);
+  } else if (hasWarn) {
+    console.log("doctor: warnings only. `parachute vault status` has live runtime detail.");
+  } else {
+    console.log("doctor: all checks passed. For live runtime state: `parachute vault status`.");
+  }
+}
+
+function cmdUrl() {
+  // Intentionally minimal — scripts parse this, so print only the URL.
+  const port = readGlobalConfig().port || DEFAULT_PORT;
+  console.log(`http://127.0.0.1:${port}`);
+}
+
+// ---------------------------------------------------------------------------
 // Import / Export
 // ---------------------------------------------------------------------------
 
@@ -1151,8 +1338,11 @@ function usage() {
 Parachute Vault — self-hosted knowledge graph
 
 Setup:
-  parachute vault init                     Set up everything (one command)
+  parachute vault init                     Set up everything (one command, idempotent)
   parachute vault status                   Check what's running
+  parachute vault doctor                   Diagnose install/config issues
+  parachute vault uninstall [--wipe]       Remove daemon; --wipe also removes vaults + .env
+  parachute vault url                      Print the local server URL (for scripts)
 
 Vaults:
   parachute vault create <name>            Create a new vault

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -957,8 +957,15 @@ async function cmdUninstall(argsList: string[]) {
   console.log("Removing wrapper and server-path pointer...");
   await removeDaemonWrapper();
 
-  // 3. Optionally wipe user data. Double-confirm so nobody loses a vault
-  // by muscle-memory — this is the one genuinely destructive path.
+  // 3. Clear the MCP entry in ~/.claude.json so Claude Code doesn't keep
+  // retrying a dead server every session. If ~/.claude.json doesn't exist
+  // or has no matching entry, this is a silent no-op.
+  console.log("Removing MCP entry from ~/.claude.json...");
+  removeMcpConfig();
+
+  // 4. Optionally wipe user data. The second confirm below defaults to
+  // NO so a distracted Enter-presser can't lose their vault. `--yes`
+  // explicitly opts into the destructive path for scripted uninstalls.
   if (wipe) {
     const vaultsExist = existsSync(VAULTS_DIR);
     const envExists = existsSync(ENV_PATH);
@@ -969,9 +976,12 @@ async function cmdUninstall(argsList: string[]) {
       if (vaultsExist) console.log(`  ${VAULTS_DIR} (SQLite vaults)`);
       if (envExists) console.log(`  ${ENV_PATH} (.env config + secrets)`);
 
+      // Default to NO on the wipe confirm — this is the "don't lose a
+      // vault to muscle memory" guard. `--yes` is an explicit opt-in to
+      // the whole destructive path.
       let doWipe = skipPrompts;
       if (!skipPrompts) {
-        doWipe = await confirm("Delete this data? (cannot be undone)");
+        doWipe = await confirm("Delete this data? (cannot be undone)", false);
       }
       if (doWipe) {
         if (vaultsExist) rmSync(VAULTS_DIR, { recursive: true, force: true });
@@ -1341,7 +1351,9 @@ Setup:
   parachute vault init                     Set up everything (one command, idempotent)
   parachute vault status                   Check what's running
   parachute vault doctor                   Diagnose install/config issues
-  parachute vault uninstall [--wipe]       Remove daemon; --wipe also removes vaults + .env
+  parachute vault uninstall [--wipe] [--yes]
+                                           Remove daemon + MCP entry; --wipe also removes vaults + .env.
+                                           --yes skips prompts (DANGEROUS with --wipe: no confirmation).
   parachute vault url                      Print the local server URL (for scripts)
 
 Vaults:

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -79,6 +79,27 @@ describe("vault uninstall", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("--yes --wipe removes user data non-interactively", async () => {
+    // Scripted uninstall contract. --yes is an explicit opt-in to the
+    // destructive path — skipping the interactive guard is the whole
+    // point. We keep this behavior, but the help text warns.
+    // Note: this test exercises filesystem wipe only. It still invokes
+    // uninstallAgent(), which is safe because launchd.ts wraps each
+    // step in try/catch and we're on a tempdir that was never registered.
+    const vaultsDir = join(dir, "vaults");
+    const envFile = join(dir, ".env");
+    mkdirSync(vaultsDir, { recursive: true });
+    writeFileSync(join(vaultsDir, "marker"), "doomed");
+    writeFileSync(envFile, "PORT=1940\n");
+
+    const res = runCli(["uninstall", "--yes", "--wipe"], dir);
+    expect(res.exitCode).toBe(0);
+
+    const { existsSync } = await import("fs");
+    expect(existsSync(vaultsDir)).toBe(false);
+    expect(existsSync(envFile)).toBe(false);
+  });
+
   test("answering 'no' at the prompt does not touch daemon/filesystem", async () => {
     // Set up a fake install: wrapper + pointer in the temp PARACHUTE_HOME.
     const wrapper = join(dir, "start.sh");

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration tests for `parachute vault doctor` and `parachute vault url`.
+ *
+ * We spawn the CLI as a subprocess with `PARACHUTE_HOME` pointed at a
+ * fresh tempdir — so each test exercises the real code path (config +
+ * daemon path resolution + exit codes) against a known filesystem state.
+ * This catches wiring bugs that pure-function tests can't (e.g., a
+ * missing import or a broken switch case).
+ *
+ * We deliberately avoid asserting on daemon-manager check output — that
+ * depends on the host machine's live launchctl/systemd state and isn't
+ * part of the PR's contract.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from "fs";
+import { join, resolve } from "path";
+import { tmpdir } from "os";
+
+const CLI = resolve(import.meta.dir, "cli.ts");
+
+function runCli(args: string[], parachuteHome: string): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync({
+    cmd: ["bun", CLI, ...args],
+    env: { ...process.env, PARACHUTE_HOME: parachuteHome },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+describe("vault doctor", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vault-doctor-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("fails with a clear message when the pointer file is missing", () => {
+    const res = runCli(["doctor"], dir);
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toMatch(/server-path pointer/);
+    expect(res.stdout).toMatch(/missing/);
+    expect(res.stdout).toMatch(/parachute vault init/);
+  });
+
+  test("fails when the pointer targets a non-existent file (moved repo)", () => {
+    writeFileSync(join(dir, "server-path"), "/does/not/exist/server.ts\n");
+    writeFileSync(join(dir, "start.sh"), "#!/bin/bash\n");
+    const res = runCli(["doctor"], dir);
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toMatch(/points to/);
+    expect(res.stdout).toMatch(/repo location|init/i);
+  });
+
+  test("passes the pointer check when the target exists", () => {
+    // Use the CLI file itself as a stand-in existing target — it is
+    // guaranteed to exist since we just spawned bun with it.
+    writeFileSync(join(dir, "server-path"), CLI + "\n");
+    writeFileSync(join(dir, "start.sh"), "#!/bin/bash\n");
+    const res = runCli(["doctor"], dir);
+    expect(res.stdout).toMatch(/✓ server-path pointer/);
+    expect(res.stdout).toMatch(/✓ wrapper script/);
+  });
+});
+
+describe("vault uninstall", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vault-uninstall-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("answering 'no' at the prompt does not touch daemon/filesystem", async () => {
+    // Set up a fake install: wrapper + pointer in the temp PARACHUTE_HOME.
+    const wrapper = join(dir, "start.sh");
+    const pointer = join(dir, "server-path");
+    writeFileSync(wrapper, "#!/bin/bash\n");
+    writeFileSync(pointer, "/tmp/fake.ts\n");
+
+    const proc = Bun.spawn({
+      cmd: ["bun", CLI, "uninstall"],
+      env: { ...process.env, PARACHUTE_HOME: dir },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write("n\n");
+    await proc.stdin.end();
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toMatch(/Cancelled/);
+    // Files should still exist — the bail-out must happen before any
+    // destructive op.
+    const { existsSync } = await import("fs");
+    expect(existsSync(wrapper)).toBe(true);
+    expect(existsSync(pointer)).toBe(true);
+  });
+});
+
+describe("vault url", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vault-url-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("prints the default URL when no port is configured", () => {
+    const res = runCli(["url"], dir);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout.trim()).toBe("http://127.0.0.1:1940");
+  });
+
+  test("reflects a custom port from config.yaml", () => {
+    writeFileSync(join(dir, "config.yaml"), "port: 9999\n");
+    const res = runCli(["url"], dir);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout.trim()).toBe("http://127.0.0.1:9999");
+  });
+});


### PR DESCRIPTION
## Summary

PR 3 of the 3-PR observability series. Stacked on top of PR #106 (path-resilient start.sh + idempotent init) — review/merge #106 first, then rebase this on main. Three small commands round out the install/uninstall/diagnose story:

### \`parachute vault uninstall [--wipe] [--yes]\`

Stops the daemon, removes the launchd/systemd registration, deletes the shared \`start.sh\` + \`server-path\` pointer, and clears the \`parachute-vault\` MCP entry from \`~/.claude.json\` so Claude sessions stop retrying a dead server.

By default user data is preserved. \`--wipe\` removes SQLite vaults and \`.env\` after a second confirmation that defaults to **No** — a distracted Enter-presser keeps their data. \`--yes\` is a scripted bypass for both prompts; \`--yes --wipe\` is the silent total-destruction contract (documented and flagged in the help text).

### \`parachute vault doctor\`

Filesystem-level diagnostics for the stale-path failure mode that started this series. Checks:
- The server-path pointer exists, is non-empty, and points at a real file.
- The wrapper script exists.
- The daemon manager reports the agent as loaded/active (warn, not fail).

Each failing check prints a one-line \`fix:\` suggestion. Exits non-zero on any fail so CI can key off it. Runtime \`/health\` is deliberately not checked here — that's \`vault status\`'s job, which keeps the two commands focused.

```
Parachute Vault — doctor

   ✗ server-path pointer  (points to /old/path/src/server.ts, which does not exist)
       fix: Run \`parachute vault init\` from the current repo location.
   ✓ wrapper script  (/Users/you/.parachute/start.sh)
   ✓ launchd agent  (loaded)

doctor: problems found (exit 1). See \`parachute vault status\` for runtime details.
```

### \`parachute vault url\`

Prints \`http://127.0.0.1:<port>\` with nothing else on stdout. Enables \`curl "$(parachute vault url)/api/notes"\` and similar scripting.

### Self-review

Ran \`reviewer\` on the first commit. It flagged two real issues I fixed in a follow-up:

1. **Wipe confirm defaulted to Yes.** \`confirm("Delete this data?")\` — no second arg means \`defaultYes=true\`. Anyone hitting Enter twice at \`uninstall --wipe\` loses their vault. Now passes \`false\` explicitly, with a comment explaining why it's load-bearing.
2. **Uninstall wasn't clearing the MCP entry in \`~/.claude.json\`.** Wired in the existing \`removeMcpConfig()\` helper.

Also added an integration test for the \`--yes --wipe\` contract to verify it actually does wipe (given the above change, there's a real risk of flipping the default the other way by mistake).

A unit test for the "default-N regression" path was attempted but Bun's \`readline/promises\` doesn't reliably deliver two sequential answers through a piped stdin — the subprocess hangs on the second prompt. Left the guard to code review + the inline comment.

## Test plan

- [x] \`bun test\` — 431 pass / 3 skip / 0 fail.
- [x] 7 new integration tests for \`doctor\`/\`url\`/\`uninstall\` via subprocess with \`PARACHUTE_HOME\` pointing at tempdirs — exercises the full argv → switch → config → filesystem path.
- [x] \`--yes --wipe\` test confirms VAULTS_DIR and .env are removed.
- [x] Live smoke: \`bun src/cli.ts doctor\` against my own machine correctly detects the missing pointer file (that's the expected state pre-merge of PR #106) and exits 1.
- [x] Live smoke: \`bun src/cli.ts url\` prints \`http://127.0.0.1:1940\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)