### PR TITLE
fix(cli): uninstall --wipe clears config.yaml + logs; --yes --wipe prints audit line

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,7 @@ import {
   ENV_PATH,
   LOG_PATH,
   ERR_PATH,
+  GLOBAL_CONFIG_PATH,
 } from "./config.ts";
 import type { VaultConfig } from "./config.ts";
 import { VAULTS_DIR } from "./config.ts";
@@ -929,9 +930,20 @@ async function cmdUninstall(argsList: string[]) {
   console.log("Parachute Vault uninstall\n");
   console.log("This removes the daemon registration and wrapper script.");
   if (wipe) {
-    console.log("`--wipe` will ALSO remove vaults (SQLite DBs) and .env.\n");
+    console.log("`--wipe` will ALSO remove vaults, .env, config.yaml, and daemon logs.\n");
   } else {
     console.log("User data (~/.parachute/vaults, ~/.parachute/.env) is left alone.\n");
+  }
+
+  // Scripted `--yes --wipe` bypasses both interactive confirms. That's the
+  // intended contract for unattended uninstalls, but it should not be
+  // silent — print a single audit line so logs show when a destructive
+  // wipe ran and which paths it targeted. Non-interactive callers won't
+  // miss this; interactive users already see the prompts.
+  if (skipPrompts && wipe) {
+    const ts = new Date().toISOString();
+    const targets = [VAULTS_DIR, ENV_PATH, GLOBAL_CONFIG_PATH, LOG_PATH, ERR_PATH].join(", ");
+    console.log(`[${ts}] scripted destructive wipe: ${targets}`);
   }
 
   if (!skipPrompts) {
@@ -967,14 +979,25 @@ async function cmdUninstall(argsList: string[]) {
   // NO so a distracted Enter-presser can't lose their vault. `--yes`
   // explicitly opts into the destructive path for scripted uninstalls.
   if (wipe) {
+    // Inventory what's actually on disk. Paths that don't exist are a
+    // silent no-op on removal, but we also skip listing them so the
+    // "would be removed" summary doesn't lie to the user.
     const vaultsExist = existsSync(VAULTS_DIR);
     const envExists = existsSync(ENV_PATH);
-    if (!vaultsExist && !envExists) {
+    const configExists = existsSync(GLOBAL_CONFIG_PATH);
+    const logExists = existsSync(LOG_PATH);
+    const errExists = existsSync(ERR_PATH);
+
+    const anyExist = vaultsExist || envExists || configExists || logExists || errExists;
+    if (!anyExist) {
       console.log("No user data to remove.");
     } else {
       console.log("\nUser data that would be removed:");
       if (vaultsExist) console.log(`  ${VAULTS_DIR} (SQLite vaults)`);
       if (envExists) console.log(`  ${ENV_PATH} (.env config + secrets)`);
+      if (configExists) console.log(`  ${GLOBAL_CONFIG_PATH} (global config)`);
+      if (logExists) console.log(`  ${LOG_PATH} (daemon log)`);
+      if (errExists) console.log(`  ${ERR_PATH} (daemon error log)`);
 
       // Default to NO on the wipe confirm — this is the "don't lose a
       // vault to muscle memory" guard. `--yes` is an explicit opt-in to
@@ -986,6 +1009,9 @@ async function cmdUninstall(argsList: string[]) {
       if (doWipe) {
         if (vaultsExist) rmSync(VAULTS_DIR, { recursive: true, force: true });
         if (envExists) rmSync(ENV_PATH, { force: true });
+        if (configExists) rmSync(GLOBAL_CONFIG_PATH, { force: true });
+        if (logExists) rmSync(LOG_PATH, { force: true });
+        if (errExists) rmSync(ERR_PATH, { force: true });
         console.log("User data removed.");
       } else {
         console.log("Kept user data.");
@@ -1356,7 +1382,8 @@ Setup:
   parachute vault status                   Check what's running
   parachute vault doctor                   Diagnose install/config issues
   parachute vault uninstall [--wipe] [--yes]
-                                           Remove daemon + MCP entry; --wipe also removes vaults + .env.
+                                           Remove daemon + MCP entry; --wipe also removes vaults, .env,
+                                           config.yaml, and daemon logs (vault.log, vault.err).
                                            --yes skips prompts (DANGEROUS with --wipe: no confirmation).
   parachute vault url                      Print the local server URL (for scripts)
 

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -100,6 +100,53 @@ describe("vault uninstall", () => {
     expect(existsSync(envFile)).toBe(false);
   });
 
+  test("--yes --wipe removes config.yaml and daemon logs alongside vaults + .env", async () => {
+    // Regression: the help text advertised "vaults + .env" but config.yaml,
+    // vault.log, and vault.err were being left behind. `uninstall --wipe`
+    // should fully reset ~/.parachute, or the next `init` picks up stale
+    // state (in particular a stale config.yaml port). Keep this test in
+    // sync with the path list in cmdUninstall and the usage help.
+    const vaultsDir = join(dir, "vaults");
+    const envFile = join(dir, ".env");
+    const configYaml = join(dir, "config.yaml");
+    const logFile = join(dir, "vault.log");
+    const errFile = join(dir, "vault.err");
+    mkdirSync(vaultsDir, { recursive: true });
+    writeFileSync(join(vaultsDir, "marker"), "doomed");
+    writeFileSync(envFile, "PORT=1940\n");
+    writeFileSync(configYaml, "port: 1940\n");
+    writeFileSync(logFile, "some log\n");
+    writeFileSync(errFile, "some err\n");
+
+    const res = runCli(["uninstall", "--yes", "--wipe"], dir);
+    expect(res.exitCode).toBe(0);
+
+    const { existsSync } = await import("fs");
+    expect(existsSync(vaultsDir)).toBe(false);
+    expect(existsSync(envFile)).toBe(false);
+    expect(existsSync(configYaml)).toBe(false);
+    expect(existsSync(logFile)).toBe(false);
+    expect(existsSync(errFile)).toBe(false);
+  });
+
+  test("--yes --wipe prints a destructive-wipe audit line before acting", async () => {
+    // `--yes --wipe` bypasses both interactive confirms. It must not be
+    // silent: a scripted uninstaller should leave one grep-able line in
+    // stdout documenting the destructive run (ISO timestamp + target paths).
+    writeFileSync(join(dir, ".env"), "PORT=1940\n");
+
+    const res = runCli(["uninstall", "--yes", "--wipe"], dir);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toMatch(/scripted destructive wipe/);
+    // ISO-8601 timestamp shape (year-month-dayTtime). Loose enough to
+    // avoid flaking on sub-second precision differences.
+    expect(res.stdout).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    // Targets should be enumerated by path.
+    expect(res.stdout).toMatch(/vaults/);
+    expect(res.stdout).toMatch(/\.env/);
+    expect(res.stdout).toMatch(/config\.yaml/);
+  });
+
   test("answering 'no' at the prompt does not touch daemon/filesystem", async () => {
     // Set up a fake install: wrapper + pointer in the temp PARACHUTE_HOME.
     const wrapper = join(dir, "start.sh");


### PR DESCRIPTION
## Summary
- `uninstall --wipe` advertised "vaults + .env" but left `config.yaml`, `vault.log`, and `vault.err` behind, so reinstalling could pick up a stale port and users saw old daemon errors tailed on the next run. It now fully resets `~/.parachute` (vaults, `.env`, `config.yaml`, `vault.log`, `vault.err`) and the "would be removed" summary + top-level help text are kept in sync.
- `uninstall --yes --wipe` is the scripted destructive path and already bypasses both interactive confirms — but it was doing so silently. It now prints one ISO-timestamped line to stdout naming the target paths before acting, so uninstaller logs show when a destructive run happened and what it touched.

## Test plan
- [x] `bun test src/doctor.test.ts` — 9 pass (2 new: expanded-wipe coverage + audit-line coverage)
- [x] Full suite: `bun test src/ core/src/` — 446 pass / 0 fail (was 444, +2 new tests)
- [ ] Manual smoke: `PARACHUTE_HOME=/tmp/pv-test parachute vault uninstall --yes --wipe` shows the audit line and leaves an empty directory

T-6 days to launch.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code