### PR TITLE
feat(cli): doctor — bun-on-PATH, MCP entry, port collision checks

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,7 @@ import {
   SERVER_PATH_FILE,
   readServerPathPointer,
   removeDaemonWrapper,
+  resolveServerPath,
 } from "./daemon.ts";
 import { confirm, ask, askPassword, choose } from "./prompt.ts";
 import { generateToken, createToken, listTokens, revokeToken, migrateVaultKeys } from "./token-store.ts";
@@ -1071,6 +1072,114 @@ async function cmdDoctor() {
     });
   }
 
+  // bun on PATH. Not strictly required for an already-installed vault
+  // (start.sh embeds an absolute bun path at init time), but missing `bun`
+  // is the #1 failure mode for first-time OSS users, so surface it clearly.
+  const bunOnPath = Bun.which("bun");
+  if (bunOnPath) {
+    checks.push({ name: "bun on PATH", status: "pass", detail: bunOnPath });
+  } else {
+    checks.push({
+      name: "bun on PATH",
+      status: "warn",
+      detail: "`bun` not resolvable via PATH",
+      fix: "Install Bun: curl -fsSL https://bun.sh/install | bash (then restart your shell).",
+    });
+  }
+
+  // MCP entry in ~/.claude.json. Split into three separate checks so the
+  // user can see exactly which condition fails: "entry present", "port
+  // matches vault", "daemon reachable over MCP URL". A common failure is
+  // "entry exists but port is stale" after the user changed PORT without
+  // re-running `mcp-install`.
+  const port = resolveVaultPort();
+  const mcpEntry = readMcpEntry();
+  if (!mcpEntry.found) {
+    checks.push({
+      name: "MCP entry in ~/.claude.json",
+      status: "warn",
+      detail: mcpEntry.reason,
+      fix: "Run `parachute vault mcp-install` to register the vault with Claude.",
+    });
+  } else {
+    checks.push({
+      name: "MCP entry in ~/.claude.json",
+      status: "pass",
+      detail: mcpEntry.url,
+    });
+
+    // Port match. Fall back to a warn if the URL has no parseable port
+    // (malformed entry) rather than a hard fail — we can still tell the
+    // user what we saw.
+    if (mcpEntry.port === port) {
+      checks.push({
+        name: "MCP URL port matches vault",
+        status: "pass",
+        detail: `port ${port}`,
+      });
+    } else {
+      checks.push({
+        name: "MCP URL port matches vault",
+        status: "warn",
+        detail: `MCP URL port ${mcpEntry.port ?? "(unparseable)"} ≠ vault port ${port}`,
+        fix: "Re-run `parachute vault mcp-install` to refresh the MCP URL.",
+      });
+    }
+
+    // Reachability probe. We do NOT require the daemon to be up for doctor
+    // to pass: a user who ran `vault status` already knows the daemon is
+    // off. This line is just a bonus telltale. Treat any HTTP response
+    // (even 401/404) as "reachable" — we're testing TCP+HTTP, not auth.
+    const reach = await probeMcpUrl(mcpEntry.url);
+    if (reach.ok) {
+      checks.push({
+        name: "MCP URL reachable",
+        status: "pass",
+        detail: reach.detail,
+      });
+    } else {
+      checks.push({
+        name: "MCP URL reachable",
+        status: "warn",
+        detail: reach.detail,
+        fix: "Start the daemon: `parachute vault restart` (or `init` if not yet installed).",
+      });
+    }
+  }
+
+  // Port collision. If something's holding the vault's configured port
+  // that ISN'T our daemon, the server will fail to bind on restart — a
+  // silent-until-crash-loop failure we want to catch at doctor time.
+  const collision = await checkPortCollision(port);
+  switch (collision.status) {
+    case "free":
+      checks.push({
+        name: `port ${port} availability`,
+        status: "pass",
+        detail: "no listener (ready to bind)",
+      });
+      break;
+    case "ours":
+      checks.push({
+        name: `port ${port} availability`,
+        status: "pass",
+        detail: `held by our daemon (pid ${collision.pids.join(", ")})`,
+      });
+      break;
+    case "foreign":
+      checks.push({
+        name: `port ${port} availability`,
+        status: "warn",
+        detail: `port in use by non-vault process: ${collision.detail}`,
+        fix: "Stop the conflicting process, or set a different PORT in ~/.parachute/.env and re-run `parachute vault init`.",
+      });
+      break;
+    case "unknown":
+      // Tool unavailable (no lsof / ss). Silent: we prefer a missing check
+      // over a spurious warning on minimal Linux images.
+      break;
+  }
+
   // Render.
   const icons = { pass: " ✓", warn: " !", fail: " ✗" } as const;
   console.log("Parachute Vault — doctor\n");
@@ -1095,12 +1204,204 @@ async function cmdDoctor() {
 
 function cmdUrl() {
   // Intentionally minimal — scripts parse this, so print only the URL.
-  // Load .env first so PORT overrides in the env file take precedence over
-  // config.yaml, matching the behavior of `status` and `restart`.
+  console.log(`http://127.0.0.1:${resolveVaultPort()}`);
+}
+
+/**
+ * Resolve the vault's port the way `status`, `restart`, `url`, and `doctor`
+ * all need to agree on: env override (~/.parachute/.env) wins, then
+ * config.yaml, then DEFAULT_PORT. Sources .env as a side effect so callers
+ * running this before any env read still see PORT.
+ */
+function resolveVaultPort(): number {
   loadEnvFile();
   const envPort = process.env.PORT ? Number(process.env.PORT) : undefined;
-  const port = envPort ?? readGlobalConfig().port ?? DEFAULT_PORT;
-  console.log(`http://127.0.0.1:${port}`);
+  return envPort ?? readGlobalConfig().port ?? DEFAULT_PORT;
+}
+
+// ---------------------------------------------------------------------------
+// Doctor helpers — MCP entry / port collision
+// ---------------------------------------------------------------------------
+
+type McpEntryLookup =
+  | { found: false; reason: string }
+  | { found: true; url: string; port: number | null };
+
+/**
+ * Read `~/.claude.json` and return the shape of the `parachute-vault` MCP
+ * entry if present. The entry is always an HTTP MCP pointing at the local
+ * daemon — `{ type: "http", url: "http://127.0.0.1:<port>/vaults/<name>/mcp" }`
+ * — so we parse the URL's port for the port-match check.
+ *
+ * Invariant: the check is NON-fatal. A missing ~/.claude.json is a warn,
+ * not a fail: plenty of users install the vault first and wire it to
+ * Claude later. We just make the "is it wired up?" state legible.
+ */
+function readMcpEntry(): McpEntryLookup {
+  const claudeJsonPath = resolve(homedir(), ".claude.json");
+  if (!existsSync(claudeJsonPath)) {
+    return { found: false, reason: `${claudeJsonPath} does not exist` };
+  }
+  let config: any;
+  try {
+    config = JSON.parse(readFileSync(claudeJsonPath, "utf-8"));
+  } catch (err: any) {
+    return {
+      found: false,
+      reason: `${claudeJsonPath} is not valid JSON: ${String(err?.message ?? err)}`,
+    };
+  }
+  const entry = config?.mcpServers?.["parachute-vault"];
+  if (!entry) {
+    return {
+      found: false,
+      reason: `no mcpServers["parachute-vault"] entry in ${claudeJsonPath}`,
+    };
+  }
+  // The entry is always a URL-bearing HTTP MCP. Non-URL shapes are
+  // unexpected (Claude Code would ignore them anyway) but we surface the
+  // raw shape so the user can see what's there.
+  const url = typeof entry.url === "string" ? entry.url : null;
+  if (!url) {
+    return {
+      found: false,
+      reason: `mcpServers["parachute-vault"] has no \`url\` field (got ${JSON.stringify(entry).slice(0, 80)})`,
+    };
+  }
+  let entryPort: number | null = null;
+  try {
+    const parsed = new URL(url);
+    entryPort = parsed.port ? Number(parsed.port) : null;
+  } catch {
+    entryPort = null;
+  }
+  return { found: true, url, port: entryPort };
+}
+
+/**
+ * HEAD-probe the MCP URL to tell "entry present but daemon unreachable"
+ * apart from "entry present and daemon happily responding." Any HTTP
+ * response — including auth failures — counts as reachable: the check is
+ * about TCP + HTTP liveness, not correctness of the user's token.
+ *
+ * 2s timeout keeps `doctor` snappy when the daemon is down.
+ */
+async function probeMcpUrl(url: string): Promise<{ ok: boolean; detail: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 2000);
+  try {
+    const resp = await fetch(url, { method: "HEAD", signal: controller.signal });
+    return { ok: true, detail: `HTTP ${resp.status}` };
+  } catch (err: any) {
+    const msg = String(err?.message ?? err);
+    if (
+      /ECONNREFUSED|ConnectionRefused|Unable to connect|refused/i.test(msg) ||
+      err?.code === "ECONNREFUSED"
+    ) {
+      return { ok: false, detail: `connection refused (daemon not running?)` };
+    }
+    if (err?.name === "AbortError" || /aborted|timeout/i.test(msg)) {
+      return { ok: false, detail: `timeout after 2000ms` };
+    }
+    return { ok: false, detail: msg };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+type PortCollision =
+  | { status: "free" }
+  | { status: "ours"; pids: number[] }
+  | { status: "foreign"; pids: number[]; detail: string }
+  | { status: "unknown" }; // no probe tool available
+
+/**
+ * Probe which process (if any) holds a TCP LISTEN socket on `port`.
+ *
+ * macOS: lsof is ubiquitous; we prefer it.
+ * Linux: lsof is common but not guaranteed. Fall back to `ss -tlnp`. If
+ *        neither exists, return "unknown" rather than a misleading "free."
+ *
+ * To decide whether the holder is "ours," we pull `ps -o command= -p <pid>`
+ * for each listening PID and look for a marker unique to our daemon —
+ * either the wrapper path or the pointer-file's server.ts path. This is
+ * heuristic but good enough to avoid warning when the vault is just
+ * running normally.
+ */
+async function checkPortCollision(port: number): Promise<PortCollision> {
+  const pids = await listListeningPids(port);
+  if (pids === null) return { status: "unknown" };
+  if (pids.length === 0) return { status: "free" };
+
+  // Build the set of path fragments that mark a process as ours. We check
+  // multiple signals because `doctor` may be running from a different
+  // PARACHUTE_HOME than the live daemon (tempdirs, Docker, developer
+  // machines): the wrapper path alone isn't enough. The pointer target and
+  // the currently-resolved server.ts path cover the common deployments.
+  const marks: string[] = [WRAPPER_PATH, resolveServerPath()];
+  const pointed = readServerPathPointer();
+  if (pointed) marks.push(pointed);
+
+  const descriptions: string[] = [];
+  let allOurs = true;
+  for (const pid of pids) {
+    const cmdline = await describeProcess(pid);
+    descriptions.push(`pid ${pid}: ${cmdline ?? "(unknown)"}`);
+    const mine = cmdline !== null && marks.some((m) => cmdline.includes(m));
+    if (!mine) allOurs = false;
+  }
+  if (allOurs) return { status: "ours", pids };
+  return { status: "foreign", pids, detail: descriptions.join("; ") };
+}
+
+/**
+ * Return PIDs holding a TCP LISTEN socket on `port`, or null if we can't
+ * tell (no probe tool). Empty array means no listener.
+ */
+async function listListeningPids(port: number): Promise<number[] | null> {
+  // Prefer lsof — same invocation works on macOS and Linux where present.
+  if (Bun.which("lsof")) {
+    try {
+      const r = await Bun.$`lsof -nP -iTCP:${port} -sTCP:LISTEN -Fp`.quiet().nothrow();
+      // lsof exits 1 with no output when nothing matches; that's "free," not
+      // an error. We distinguish by inspecting stdout rather than exitCode.
+      const out = r.stdout.toString();
+      const pids = [...out.matchAll(/^p(\d+)/gm)].map((m) => Number(m[1]));
+      return [...new Set(pids)];
+    } catch {
+      // Fall through to ss if lsof itself blew up unexpectedly.
+    }
+  }
+  if (Bun.which("ss")) {
+    try {
+      const r = await Bun.$`ss -tlnpH sport = :${port}`.quiet().nothrow();
+      const out = r.stdout.toString();
+      // `users:(("bun",pid=12345,fd=7))` — we pull every pid=NNNN.
+      const pids = [...out.matchAll(/pid=(\d+)/g)].map((m) => Number(m[1]));
+      if (pids.length > 0) return [...new Set(pids)];
+      // No users field but a listener row present? Treat as foreign with no
+      // attributable PID. Parsing the local address is overkill for a warn.
+      if (/LISTEN/.test(out)) return [-1];
+      return [];
+    } catch {}
+  }
+  return null;
+}
+
+/**
+ * Fetch a one-line description of a process by PID. Returns null if the
+ * PID is gone or ps is missing. Used only to classify a listener as ours
+ * vs foreign, so "good enough" beats "precisely parsed."
+ */
+async function describeProcess(pid: number): Promise<string | null> {
+  if (pid < 0) return null;
+  try {
+    const r = await Bun.$`ps -o command= -p ${pid}`.quiet().nothrow();
+    if (r.exitCode !== 0) return null;
+    return r.stdout.toString().trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -19,10 +19,20 @@ import { tmpdir } from "os";
 
 const CLI = resolve(import.meta.dir, "cli.ts");
 
-function runCli(args: string[], parachuteHome: string): { exitCode: number; stdout: string; stderr: string } {
+/**
+ * Run the CLI as a subprocess. `parachuteHome` is always passed as the
+ * isolated config dir; `extraEnv` is merged last so tests can override
+ * `HOME` (for the `~/.claude.json` MCP-entry checks) or unset `PATH`
+ * (for the bun-on-PATH check) without affecting unrelated tests.
+ */
+function runCli(
+  args: string[],
+  parachuteHome: string,
+  extraEnv: Record<string, string | undefined> = {},
+): { exitCode: number; stdout: string; stderr: string } {
   const proc = Bun.spawnSync({
     cmd: ["bun", CLI, ...args],
-    env: { ...process.env, PARACHUTE_HOME: parachuteHome },
+    env: { ...process.env, PARACHUTE_HOME: parachuteHome, ...extraEnv },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -31,6 +41,23 @@ function runCli(args: string[], parachuteHome: string): { exitCode: number; stdo
     stdout: new TextDecoder().decode(proc.stdout),
     stderr: new TextDecoder().decode(proc.stderr),
   };
+}
+
+/**
+ * Write a minimal ~/.claude.json with the given vault MCP URL. Returns the
+ * full path. Used by the MCP-entry-present tests.
+ */
+function writeClaudeJson(home: string, url: string): string {
+  const path = join(home, ".claude.json");
+  writeFileSync(
+    path,
+    JSON.stringify(
+      { mcpServers: { "parachute-vault": { type: "http", url } } },
+      null,
+      2,
+    ),
+  );
+  return path;
 }
 
 describe("vault doctor", () => {
@@ -67,6 +94,135 @@ describe("vault doctor", () => {
     const res = runCli(["doctor"], dir);
     expect(res.stdout).toMatch(/✓ server-path pointer/);
     expect(res.stdout).toMatch(/✓ wrapper script/);
+  });
+});
+
+/**
+ * Extended doctor checks: bun-on-PATH, MCP entry presence + port match +
+ * reachability, and port-collision detection. All tests use an isolated
+ * HOME (so the user's real ~/.claude.json isn't consulted) and an isolated
+ * PARACHUTE_HOME, so they're reproducible on any machine.
+ *
+ * We intentionally do NOT test the "held by our daemon" (ours) branch of
+ * the port-collision check: it requires running a process whose cmdline
+ * contains our server.ts path, and we have no hook to fake that without
+ * spawning the real server. The foreign branch exercises the collision
+ * detection path end-to-end, which is what actually matters for warning
+ * OSS users; the ours branch is covered by the unit-level fact that
+ * `describeProcess` runs `ps` against the PID lsof returns.
+ */
+describe("vault doctor — extended checks", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vault-doctor-ext-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reports bun on PATH when `bun` is resolvable", () => {
+    // The test harness itself runs under bun, so bun is guaranteed to be
+    // on PATH here. This confirms the happy path renders correctly.
+    const res = runCli(["doctor"], dir, { HOME: dir });
+    expect(res.stdout).toMatch(/✓ bun on PATH/);
+  });
+
+  test("warns when `bun` is not on PATH", () => {
+    // We need two things at once:
+    //   a) the child's PATH must NOT resolve `bun` (so the doctor check fails)
+    //   b) we still need to launch the child under bun (so the test runs)
+    // Solution: launch the child via bun's absolute path directly, and set
+    // its PATH to an empty tempdir. `Bun.spawnSync`'s cmd[0] with an
+    // absolute path bypasses PATH lookup entirely.
+    const bunAbs = process.execPath; // the bun executable running this test
+    const emptyPathDir = mkdtempSync(join(tmpdir(), "empty-path-"));
+    try {
+      const proc = Bun.spawnSync({
+        cmd: [bunAbs, CLI, "doctor"],
+        env: { ...process.env, PARACHUTE_HOME: dir, HOME: dir, PATH: emptyPathDir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = new TextDecoder().decode(proc.stdout);
+      expect(stdout).toMatch(/! bun on PATH/);
+      expect(stdout).toMatch(/not resolvable/);
+      expect(stdout).toMatch(/bun\.sh\/install/);
+    } finally {
+      rmSync(emptyPathDir, { recursive: true, force: true });
+    }
+  });
+
+  test("warns when ~/.claude.json has no parachute-vault MCP entry", () => {
+    // Isolated HOME with no ~/.claude.json at all — the most common
+    // pre-`mcp-install` state for new users.
+    const res = runCli(["doctor"], dir, { HOME: dir });
+    expect(res.stdout).toMatch(/! MCP entry in ~\/\.claude\.json/);
+    expect(res.stdout).toMatch(/does not exist|no mcpServers/);
+    expect(res.stdout).toMatch(/mcp-install/);
+  });
+
+  test("warns when ~/.claude.json exists but has no parachute-vault entry", () => {
+    writeFileSync(join(dir, ".claude.json"), JSON.stringify({ mcpServers: {} }));
+    const res = runCli(["doctor"], dir, { HOME: dir });
+    expect(res.stdout).toMatch(/! MCP entry in ~\/\.claude\.json/);
+    expect(res.stdout).toMatch(/no mcpServers\["parachute-vault"\] entry/);
+  });
+
+  test("passes MCP entry + port-match checks when URL points at the configured port", () => {
+    // Use a non-default port to prove we're actually reading config.yaml,
+    // not just matching against DEFAULT_PORT.
+    writeFileSync(join(dir, "config.yaml"), "port: 4321\n");
+    writeClaudeJson(dir, "http://127.0.0.1:4321/vaults/default/mcp");
+    const res = runCli(["doctor"], dir, { HOME: dir });
+    expect(res.stdout).toMatch(/✓ MCP entry in ~\/\.claude\.json/);
+    expect(res.stdout).toMatch(/✓ MCP URL port matches vault\s+\(port 4321\)/);
+    // Reachability will warn because nothing is bound to 4321 in the test
+    // env — this is the "entry present, port matches, daemon unreachable"
+    // state the handoff explicitly called out as useful to surface.
+    expect(res.stdout).toMatch(/! MCP URL reachable/);
+  });
+
+  test("warns when MCP URL port does not match the vault's configured port", () => {
+    writeFileSync(join(dir, "config.yaml"), "port: 4321\n");
+    writeClaudeJson(dir, "http://127.0.0.1:9999/vaults/default/mcp");
+    const res = runCli(["doctor"], dir, { HOME: dir });
+    expect(res.stdout).toMatch(/✓ MCP entry in ~\/\.claude\.json/);
+    expect(res.stdout).toMatch(/! MCP URL port matches vault/);
+    expect(res.stdout).toMatch(/MCP URL port 9999 ≠ vault port 4321/);
+  });
+
+  test("warns when the configured port is held by an unrelated process", async () => {
+    // Find a free port, bind to it with a plain Bun.serve that has nothing
+    // to do with our server.ts — so the collision check will classify it
+    // as foreign. Using port 0 gets the OS to pick; we then write that
+    // port into config.yaml and let doctor discover the clash.
+    const server = Bun.serve({ port: 0, fetch: () => new Response("other") });
+    try {
+      const port = server.port;
+      writeFileSync(join(dir, "config.yaml"), `port: ${port}\n`);
+      const res = runCli(["doctor"], dir, { HOME: dir });
+      // The rendered name includes the port number, so match loosely.
+      expect(res.stdout).toMatch(new RegExp(`! port ${port} availability`));
+      expect(res.stdout).toMatch(/port in use by non-vault process/);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("reports port as free when nothing is bound to it", () => {
+    // Hardcoded ports are a portability trap — e.g. OrbStack grabs 54321
+    // on macOS, which would spuriously trip the foreign branch. Instead,
+    // ask the OS for a free port (bind to 0, then release) and point
+    // doctor at that port. The race window between stop() and doctor's
+    // lsof is tiny; for the stability of this test we accept it as the
+    // best available cross-platform "free-ish port" signal.
+    const probe = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+    const port = probe.port;
+    probe.stop(true);
+    writeFileSync(join(dir, "config.yaml"), `port: ${port}\n`);
+    const res = runCli(["doctor"], dir, { HOME: dir });
+    expect(res.stdout).toMatch(new RegExp(`✓ port ${port} availability`));
+    expect(res.stdout).toMatch(/no listener \(ready to bind\)/);
   });
 });
 


### PR DESCRIPTION
## Summary

Extends `parachute vault doctor` with three new diagnostics that catch the most common first-time-user failure modes for OSS-launch users:

- **bun on PATH** — warn if `bun` isn't resolvable via `which bun`. The installed daemon's `start.sh` embeds an absolute bun path at init time, so a later PATH change doesn't break an already-installed vault — but missing bun pre-install is the #1 setup failure and doctor should say so clearly.
- **MCP entry in `~/.claude.json`** — three separate lines so users can distinguish *entry present* / *port matches vault* / *daemon reachable over MCP URL*. Any HTTP response (even 401) counts as reachable — the probe tests TCP + HTTP liveness, not auth correctness. Daemon-down is surfaced as a warn rather than a fail, so users see the full config state at a glance (\"entry present, port matches, daemon unreachable\" is the informative state the handoff called out).
- **port availability** — uses `lsof -nP -iTCP:<port> -sTCP:LISTEN` (macOS + most Linux) with an `ss -tlnp` fallback to detect whether something else holds the vault's configured port, and classifies the holder as *ours* vs *foreign* by matching `ps -o command=` against the wrapper path, pointer target, and currently-resolved server.ts. Silent (no spurious warning) on minimal Linux images that have neither tool.

Also factors the env→config.yaml→DEFAULT_PORT resolution shared by `status`, `url`, `restart`, and now `doctor` into a small `resolveVaultPort()` helper so they can't drift.

Sample output on a live-daemon machine with no MCP entry wired up:

```
Parachute Vault — doctor

   ✓ server-path pointer  (→ /…/src/server.ts)
   ✓ wrapper script  (/Users/u/.parachute/start.sh)
   ✓ launchd agent  (loaded)
   ✓ bun on PATH  (/Users/u/.bun/bin/bun)
   ! MCP entry in ~/.claude.json  (no mcpServers[\"parachute-vault\"] entry)
       fix: Run \`parachute vault mcp-install\`…
   ✓ port 1940 availability  (held by our daemon (pid 12468))
```

## Test plan

- [x] Full suite: `bun test src/ core/src/` → **452 pass / 0 fail** (pre-change baseline 444/0; +8 new tests in `src/doctor.test.ts`).
- [x] Manual: isolated PARACHUTE_HOME + HOME with no config — all three new checks render.
- [x] Manual: isolated HOME with a faked `~/.claude.json` at matching port — pass/pass/pass.
- [x] Manual: isolated HOME with mismatched port — `MCP URL port 9999 ≠ vault port 1940` warn surfaces; reachability warn surfaces.
- [x] Manual: other process binding the configured port (via `Bun.serve({ port: 0 })`) — `port in use by non-vault process` warn.
- [x] The \"held by our daemon\" branch is covered end-to-end by running against the live daemon during manual testing.

## Notes

Rebased off `origin/main` (9688efd), independent of PR #108. PR #108's uninstall-wipe changes and this doctor-extension touch different code paths; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)