### PR TITLE
MVP vault backup: local destination + launchd + status

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ parachute vault tokens revoke <token-id> --vault work         # revoke a token
 parachute vault config                     # show all options
 parachute vault config set KEY value       # set a config value
 parachute vault restart                    # apply changes
+
+# Backup
+parachute vault backup                         # one-shot backup to configured destinations
+parachute vault backup --schedule daily        # hourly | daily | weekly | manual (macOS)
+parachute vault backup status                  # schedule, last run, destinations, next run
 ```
 
 ## MCP tools (9)
@@ -163,6 +168,36 @@ triggers:
 5. Vault saves the audio as an attachment and sets `narrate_rendered_at` metadata
 
 Webhook servers (scribe, narrate) are stateless — they don't need vault's API key.
+
+### Backing up your vault
+
+Your vault is just SQLite DBs + a handful of YAML files under `~/.parachute/`. `parachute vault backup` snapshots everything into a single timestamped tarball, for a one-shot or a scheduled run.
+
+```bash
+parachute vault backup                         # one-shot — snapshot + ship to destinations
+parachute vault backup --schedule daily        # register a launchd agent (macOS)
+parachute vault backup --schedule manual       # stop scheduled backups
+parachute vault backup status                  # schedule, last run, destinations, next run
+```
+
+Configure destinations in `~/.parachute/config.yaml`:
+
+```yaml
+backup:
+  schedule: daily       # hourly | daily | weekly | manual
+  retention: 14         # keep the N most recent snapshots per destination
+  destinations:
+    - kind: local
+      path: ~/Library/Mobile Documents/com~apple~CloudDocs/parachute-backups
+```
+
+**What's in a snapshot**: atomic `VACUUM INTO` copies of every `vaults/<name>/vault.db`, your `config.yaml`, and each vault's `vault.yaml`, bundled as `parachute-backup-<timestamp>.tar.gz`. Safe under concurrent reads/writes — no need to stop the daemon.
+
+**Restore**: extract the tarball into a fresh `~/.parachute/` and run `parachute vault init` to re-register the daemon. The DBs and configs drop in place; you don't need any special restore command (for now — a dedicated `vault restore` is coming soon).
+
+Destination kinds shipping in this release: `local` (any filesystem path — including iCloud Drive, a mounted external disk, or an rsync/Syncthing-backed folder). `s3`, `rsync`, and `cloud` destinations are planned but not yet implemented.
+
+On Linux, scheduled runs via systemd timers are a follow-up; for now `parachute vault backup` works on Linux but you'll need to wire the cron yourself.
 
 ### View endpoint
 

--- a/README.md
+++ b/README.md
@@ -185,11 +185,26 @@ Configure destinations in `~/.parachute/config.yaml`:
 ```yaml
 backup:
   schedule: daily       # hourly | daily | weekly | manual
-  retention: 14         # keep the N most recent snapshots per destination
+  retention:
+    daily: 7            # last 7 daily snapshots
+    weekly: 4           # last-of-week for 4 weeks
+    monthly: 12         # last-of-month for 12 months
+    yearly: null        # last-of-year, unbounded (null = keep every year forever)
   destinations:
     - kind: local
       path: ~/Library/Mobile Documents/com~apple~CloudDocs/parachute-backups
 ```
+
+**Retention is tiered** (grandfather / father / son). After each run, the pruner keeps the union of four tiers:
+
+| Tier    | What it keeps                                          |
+|---------|--------------------------------------------------------|
+| daily   | The N most recent snapshots.                           |
+| weekly  | The last snapshot of each of the last N ISO weeks.     |
+| monthly | The last snapshot of each of the last N calendar months.|
+| yearly  | The last snapshot of each year — `null` means unbounded.|
+
+A snapshot that qualifies for multiple tiers is kept once. Set any tier to `0` to disable it; sparse data (days without a backup) just means some tiers contribute nothing that day. Bucketing uses your local timezone, so calendars line up with what you see, not UTC.
 
 **What's in a snapshot**: atomic `VACUUM INTO` copies of every `vaults/<name>/vault.db`, your `config.yaml`, and each vault's `vault.yaml`, bundled as `parachute-backup-<timestamp>.tar.gz`. Safe under concurrent reads/writes — no need to stop the daemon.
 

--- a/src/backup-launchd.test.ts
+++ b/src/backup-launchd.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Plist shape tests for the scheduled-backup launchd agent.
+ *
+ * These mirror `launchd.test.ts` in spirit — we don't actually register
+ * the plist with launchctl (that would mutate the developer's machine).
+ * We only verify:
+ *
+ *   1. The plist contains the bun path, the cli path, and the right
+ *      `vault backup` ProgramArguments.
+ *   2. Each schedule value produces the right scheduling key
+ *      (StartInterval vs StartCalendarInterval with Hour + Weekday).
+ *   3. The XML is superficially well-formed (opens and closes matching tags).
+ *
+ * The actual `installBackupAgent` / `uninstallBackupAgent` flow is tested
+ * indirectly via `cmdBackupSchedule` in higher-level CLI integration tests.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { generateBackupPlist, BACKUP_LABEL } from "./backup-launchd.ts";
+
+describe("generateBackupPlist", () => {
+  const basic = {
+    bunPath: "/Users/alice/.bun/bin/bun",
+    cliPath: "/Users/alice/repo/parachute-vault/src/cli.ts",
+  };
+
+  test("hourly → StartInterval 3600", () => {
+    const plist = generateBackupPlist({ ...basic, schedule: "hourly" });
+    expect(plist).toContain("<key>StartInterval</key>");
+    expect(plist).toContain("<integer>3600</integer>");
+    expect(plist).not.toContain("<key>StartCalendarInterval</key>");
+  });
+
+  test("daily → StartCalendarInterval with Hour=3 (no Weekday)", () => {
+    const plist = generateBackupPlist({ ...basic, schedule: "daily" });
+    expect(plist).toContain("<key>StartCalendarInterval</key>");
+    expect(plist).toContain("<key>Hour</key>");
+    expect(plist).toContain("<integer>3</integer>");
+    expect(plist).not.toContain("<key>Weekday</key>");
+  });
+
+  test("weekly → StartCalendarInterval with Hour=3, Weekday=0 (Sunday)", () => {
+    const plist = generateBackupPlist({ ...basic, schedule: "weekly" });
+    expect(plist).toContain("<key>StartCalendarInterval</key>");
+    expect(plist).toContain("<key>Hour</key>");
+    expect(plist).toContain("<key>Weekday</key>");
+    // The plist has both Hour=3 AND Weekday=0 — verify both by locating
+    // their surrounding keys.
+    const weekdayMatch = plist.match(/<key>Weekday<\/key>\s*<integer>(\d+)<\/integer>/);
+    expect(weekdayMatch).not.toBeNull();
+    expect(weekdayMatch![1]).toBe("0");
+  });
+
+  test("ProgramArguments runs `bun <cli.ts> vault backup`", () => {
+    const plist = generateBackupPlist({ ...basic, schedule: "daily" });
+    expect(plist).toContain(`<string>${basic.bunPath}</string>`);
+    expect(plist).toContain(`<string>${basic.cliPath}</string>`);
+    expect(plist).toContain("<string>vault</string>");
+    expect(plist).toContain("<string>backup</string>");
+  });
+
+  test("uses the backup-specific label, not the daemon label", () => {
+    const plist = generateBackupPlist({ ...basic, schedule: "daily" });
+    expect(plist).toContain(`<string>${BACKUP_LABEL}</string>`);
+    // Different from the daemon label. If somebody ever unified them, this
+    // test fires so the change is intentional.
+    expect(BACKUP_LABEL).toBe("computer.parachute.vault.backup");
+  });
+
+  test("RunAtLoad is false — we do not want a backup to fire on every login", () => {
+    // Opposite of the daemon (which has RunAtLoad=true to keep the server
+    // running at login). For the backup agent, running at login is user-
+    // hostile: it delays login and churns iCloud on every cold boot.
+    const plist = generateBackupPlist({ ...basic, schedule: "daily" });
+    expect(plist).toContain("<key>RunAtLoad</key>");
+    expect(plist).toMatch(/<key>RunAtLoad<\/key>\s*<false\/>/);
+  });
+
+  test("XML opens and closes plist dict", () => {
+    // Superficial well-formedness — catches stray typos in the template.
+    // A full XML validator would be overkill; matching open/close counts
+    // is sufficient for the single hand-rolled plist.
+    const plist = generateBackupPlist({ ...basic, schedule: "daily" });
+    expect(plist).toMatch(/<plist version="1\.0">/);
+    expect(plist).toMatch(/<\/plist>\s*$/);
+    const opens = (plist.match(/<dict>/g) ?? []).length;
+    const closes = (plist.match(/<\/dict>/g) ?? []).length;
+    expect(opens).toBe(closes);
+  });
+});

--- a/src/backup-launchd.ts
+++ b/src/backup-launchd.ts
@@ -1,0 +1,169 @@
+/**
+ * macOS launchd agent for the scheduled backup job.
+ *
+ * Parallels `launchd.ts` (which manages the vault daemon). Differences:
+ *
+ *   - StartInterval / StartCalendarInterval instead of KeepAlive — this is
+ *     a one-shot-on-a-schedule job, not a long-running daemon.
+ *   - Separate label + plist path so the two agents don't collide in
+ *     launchctl.
+ *   - The program executes `bun <cli.ts> vault backup` against the same
+ *     server-path pointer the daemon uses, which keeps "which bun, which
+ *     repo" in sync across both agents automatically.
+ *
+ * Linux systemd-timer variant is deliberately out-of-scope for the MVP; see
+ * the scoping note in the PR description.
+ */
+
+import { homedir } from "os";
+import { join } from "path";
+import { writeFile, unlink } from "fs/promises";
+import { existsSync } from "fs";
+import { $ } from "bun";
+import {
+  CONFIG_DIR,
+  LOG_PATH,
+  ERR_PATH,
+} from "./config.ts";
+import type { BackupSchedule } from "./config.ts";
+import { resolveServerPath } from "./daemon.ts";
+
+export const BACKUP_LABEL = "computer.parachute.vault.backup";
+export const BACKUP_PLIST_PATH = join(homedir(), "Library", "LaunchAgents", `${BACKUP_LABEL}.plist`);
+
+/**
+ * Resolve the CLI path the backup job should invoke. Sibling-to-server.ts
+ * — we reuse `resolveServerPath()`'s dirname-of-module approach so a move
+ * of the repo updates both the daemon and the backup agent on the next
+ * `parachute vault backup --schedule <f>` run.
+ */
+export function resolveCliPath(): string {
+  const serverPath = resolveServerPath(); // <repo>/src/server.ts
+  return serverPath.replace(/server\.ts$/, "cli.ts");
+}
+
+/**
+ * Build plist XML for a given schedule. Pure string builder for test-ability
+ * — `backup-launchd.test.ts` locks the schedule → plist shape contract.
+ */
+export function generateBackupPlist(opts: {
+  schedule: Exclude<BackupSchedule, "manual">;
+  bunPath: string;
+  cliPath: string;
+  label?: string;
+  logPath?: string;
+  errPath?: string;
+  workingDir?: string;
+}): string {
+  const label = opts.label ?? BACKUP_LABEL;
+  const logPath = opts.logPath ?? LOG_PATH;
+  const errPath = opts.errPath ?? ERR_PATH;
+  const workingDir = opts.workingDir ?? CONFIG_DIR;
+
+  const intervalXml = scheduleToPlistXml(opts.schedule);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${opts.bunPath}</string>
+    <string>${opts.cliPath}</string>
+    <string>vault</string>
+    <string>backup</string>
+  </array>
+${intervalXml}
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>${logPath}</string>
+  <key>StandardErrorPath</key>
+  <string>${errPath}</string>
+  <key>WorkingDirectory</key>
+  <string>${workingDir}</string>
+</dict>
+</plist>`;
+}
+
+/**
+ * Map a schedule string to the appropriate launchd key.
+ *
+ *   hourly → StartInterval 3600 (seconds)
+ *   daily  → StartCalendarInterval at 03:00 local
+ *   weekly → StartCalendarInterval at 03:00 Sunday
+ *
+ * Why 03:00: the classic "everybody's asleep, iCloud Drive isn't fighting
+ * the active user for bandwidth" slot. If the machine is asleep at that
+ * time, launchd fires the job on the next wake — so a laptop user who
+ * sleeps at midnight still gets their backup.
+ */
+function scheduleToPlistXml(schedule: "hourly" | "daily" | "weekly"): string {
+  if (schedule === "hourly") {
+    return `  <key>StartInterval</key>
+  <integer>3600</integer>`;
+  }
+  // daily + weekly: StartCalendarInterval dict.
+  const hour = 3;
+  const minute = 0;
+  const lines: string[] = [];
+  lines.push(`  <key>StartCalendarInterval</key>`);
+  lines.push(`  <dict>`);
+  lines.push(`    <key>Hour</key>`);
+  lines.push(`    <integer>${hour}</integer>`);
+  lines.push(`    <key>Minute</key>`);
+  lines.push(`    <integer>${minute}</integer>`);
+  if (schedule === "weekly") {
+    // 0 = Sunday per Apple's docs.
+    lines.push(`    <key>Weekday</key>`);
+    lines.push(`    <integer>0</integer>`);
+  }
+  lines.push(`  </dict>`);
+  return lines.join("\n");
+}
+
+/**
+ * Install (or re-install) the backup agent for the given schedule. Idempotent
+ * — same pattern as `installAgent()` in `launchd.ts`: unload first so a
+ * re-registration takes effect even if the prior plist is loaded.
+ *
+ * `schedule: "manual"` uninstalls the agent — no plist means no scheduled
+ * runs. This is what the spec asks for: `manual` is the off-switch.
+ */
+export async function installBackupAgent(schedule: BackupSchedule): Promise<void> {
+  if (process.platform !== "darwin") {
+    throw new Error("launchd backup agent is only available on macOS. systemd timer variant is a follow-up PR.");
+  }
+
+  if (schedule === "manual") {
+    await uninstallBackupAgent();
+    return;
+  }
+
+  const bunPath = Bun.which("bun") || join(homedir(), ".bun", "bin", "bun");
+  const cliPath = resolveCliPath();
+  const plist = generateBackupPlist({ schedule, bunPath, cliPath });
+  await writeFile(BACKUP_PLIST_PATH, plist);
+
+  // Bounce in the same pattern as the daemon agent.
+  try { await $`launchctl unload ${BACKUP_PLIST_PATH}`.quiet(); } catch {}
+  try { await $`launchctl load ${BACKUP_PLIST_PATH}`.quiet(); } catch {}
+}
+
+export async function uninstallBackupAgent(): Promise<void> {
+  try { await $`launchctl unload ${BACKUP_PLIST_PATH}`.quiet(); } catch {}
+  try {
+    if (existsSync(BACKUP_PLIST_PATH)) await unlink(BACKUP_PLIST_PATH);
+  } catch {}
+}
+
+export async function isBackupAgentLoaded(): Promise<boolean> {
+  try {
+    const result = await $`launchctl list ${BACKUP_LABEL}`.quiet();
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/backup.test.ts
+++ b/src/backup.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Integration tests for the backup module.
+ *
+ * Strategy mirrors `doctor.test.ts`: spin up an isolated `PARACHUTE_HOME`
+ * tempdir, populate it with fake vaults / DBs / config, run backup end-to-
+ * end, then unpack the resulting tarball and assert on contents. This
+ * exercises the full pipeline — SQLite VACUUM INTO, tar assembly, local
+ * destination copy, retention pruning — without requiring a live daemon.
+ *
+ * We also unit-test the pure helpers (filename round-tripping, retention
+ * ordering, tilde expansion) so regressions don't hide behind the
+ * integration harness.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+  readdirSync,
+} from "fs";
+import { join, resolve } from "path";
+import { tmpdir, homedir } from "os";
+import { Database } from "bun:sqlite";
+import { $ } from "bun";
+
+import {
+  backupFilename,
+  parseBackupFilename,
+  expandTilde,
+  stageSnapshot,
+  assembleTarball,
+  pruneRetention,
+  runBackup,
+  readLastBackup,
+  nextRunEstimate,
+  checkDestinationWritable,
+} from "./backup.ts";
+import type { BackupConfig } from "./config.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a small SQLite DB with one row, for snapshot-contents assertions. */
+function makeFakeDb(path: string, marker: string) {
+  mkdirSync(resolve(path, ".."), { recursive: true });
+  const db = new Database(path);
+  db.run("CREATE TABLE marker (v TEXT)");
+  db.run("INSERT INTO marker VALUES (?)", [marker]);
+  db.close();
+}
+
+/** Extract a tar.gz into a fresh tempdir and return that dir. */
+async function untar(tarball: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "untar-"));
+  await $`tar -xzf ${tarball} -C ${dir}`.quiet();
+  return dir;
+}
+
+/** Write a minimal vault.yaml so `listVaultsIn` picks up the vault. */
+function makeFakeVault(vaultsDir: string, name: string, marker: string) {
+  const dir = join(vaultsDir, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "vault.yaml"), `name: ${name}\ncreated_at: "2026-01-01T00:00:00.000Z"\napi_keys:\n`);
+  makeFakeDb(join(dir, "vault.db"), marker);
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("backup — pure helpers", () => {
+  test("backupFilename uses timestamp with colons replaced by hyphens", () => {
+    const ts = "2026-04-17T08:30:00.000Z";
+    expect(backupFilename(ts)).toBe("parachute-backup-2026-04-17T08-30-00.000Z.tar.gz");
+  });
+
+  test("parseBackupFilename round-trips with backupFilename", () => {
+    const ts = "2026-04-17T08-30-00.000Z";
+    const name = `parachute-backup-${ts}.tar.gz`;
+    expect(parseBackupFilename(name)).toEqual({ timestamp: ts });
+  });
+
+  test("parseBackupFilename returns null for unrelated files", () => {
+    expect(parseBackupFilename("something.tar.gz")).toBeNull();
+    expect(parseBackupFilename("parachute-backup.tar")).toBeNull(); // missing .gz
+    expect(parseBackupFilename("README.md")).toBeNull();
+  });
+
+  test("expandTilde expands leading ~/ but leaves absolute paths alone", () => {
+    expect(expandTilde("~/foo")).toBe(join(homedir(), "foo"));
+    expect(expandTilde("~")).toBe(homedir());
+    expect(expandTilde("/absolute/path")).toBe("/absolute/path");
+    expect(expandTilde("relative/path")).toBe("relative/path"); // not expanded — by design
+  });
+
+  test("nextRunEstimate returns null for manual, forward-moving Date otherwise", () => {
+    const base = new Date("2026-04-17T00:00:00Z");
+    expect(nextRunEstimate("manual", base)).toBeNull();
+    const daily = nextRunEstimate("daily", base)!;
+    expect(daily.getTime()).toBeGreaterThan(base.getTime());
+    // Weekly is strictly later than daily.
+    const weekly = nextRunEstimate("weekly", base)!;
+    expect(weekly.getTime()).toBeGreaterThan(daily.getTime());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retention pruning
+// ---------------------------------------------------------------------------
+
+describe("backup — retention pruning", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "backup-prune-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("keeps the N most recent by filename timestamp", () => {
+    // Create 5 backup files with monotonically later timestamps. The
+    // ISO-with-hyphens format sorts lexicographically, so we can rely on
+    // alphabetical ordering to match chronology.
+    const stamps = [
+      "2026-01-01T00-00-00.000Z",
+      "2026-02-01T00-00-00.000Z",
+      "2026-03-01T00-00-00.000Z",
+      "2026-04-01T00-00-00.000Z",
+      "2026-05-01T00-00-00.000Z",
+    ];
+    for (const s of stamps) {
+      writeFileSync(join(dir, `parachute-backup-${s}.tar.gz`), "x");
+    }
+    const pruned = pruneRetention(dir, 3);
+    expect(pruned).toBe(2);
+    const left = readdirSync(dir).sort();
+    expect(left).toEqual([
+      "parachute-backup-2026-03-01T00-00-00.000Z.tar.gz",
+      "parachute-backup-2026-04-01T00-00-00.000Z.tar.gz",
+      "parachute-backup-2026-05-01T00-00-00.000Z.tar.gz",
+    ]);
+  });
+
+  test("no-op when fewer files than retention", () => {
+    writeFileSync(join(dir, `parachute-backup-2026-01-01T00-00-00.000Z.tar.gz`), "x");
+    const pruned = pruneRetention(dir, 14);
+    expect(pruned).toBe(0);
+    expect(readdirSync(dir).length).toBe(1);
+  });
+
+  test("ignores non-backup files in the destination directory", () => {
+    // iCloud sometimes drops .DS_Store / .icloud placeholder files into a
+    // sync dir. Retention must only touch parachute-backup-*.tar.gz.
+    writeFileSync(join(dir, ".DS_Store"), "x");
+    writeFileSync(join(dir, "README.md"), "x");
+    writeFileSync(join(dir, "parachute-backup-2026-01-01T00-00-00.000Z.tar.gz"), "x");
+    writeFileSync(join(dir, "parachute-backup-2026-02-01T00-00-00.000Z.tar.gz"), "x");
+    const pruned = pruneRetention(dir, 1);
+    expect(pruned).toBe(1);
+    // The non-backup files are untouched.
+    expect(existsSync(join(dir, ".DS_Store"))).toBe(true);
+    expect(existsSync(join(dir, "README.md"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stageSnapshot — SQLite VACUUM INTO + config copy
+// ---------------------------------------------------------------------------
+
+describe("backup — stageSnapshot", () => {
+  let home: string;
+  beforeEach(() => { home = mkdtempSync(join(tmpdir(), "backup-stage-")); });
+  afterEach(() => { rmSync(home, { recursive: true, force: true }); });
+
+  test("snapshots top-level *.db files and mirrors vaults/", async () => {
+    // Top-level legacy-style DB.
+    makeFakeDb(join(home, "daily.db"), "top-level-marker");
+    // Per-vault DBs with yaml config.
+    const vaultsDir = join(home, "vaults");
+    makeFakeVault(vaultsDir, "default", "default-marker");
+    makeFakeVault(vaultsDir, "work", "work-marker");
+    // Global config.yaml.
+    writeFileSync(join(home, "config.yaml"), "port: 1940\n");
+
+    const stage = mkdtempSync(join(tmpdir(), "stage-"));
+    try {
+      const { stagingDir, contents } = await stageSnapshot({
+        configDir: home,
+        vaultsDir,
+        stagingDir: stage,
+      });
+      expect(stagingDir).toBe(stage);
+
+      // DB snapshots are at expected paths
+      expect(contents.dbSnapshots).toContain("config-daily.db");
+      expect(contents.dbSnapshots).toContain(join("vaults", "default", "vault.db"));
+      expect(contents.dbSnapshots).toContain(join("vaults", "work", "vault.db"));
+
+      // Config files are all there
+      expect(contents.configFiles).toContain("config.yaml");
+      expect(contents.configFiles).toContain(join("vaults", "default", "vault.yaml"));
+      expect(contents.configFiles).toContain(join("vaults", "work", "vault.yaml"));
+
+      // Snapshot preserves DB contents — open a snapshot and verify the
+      // marker row round-tripped (proves VACUUM INTO actually ran, not
+      // just a zero-byte file).
+      const defaultSnap = new Database(join(stage, "vaults", "default", "vault.db"), {
+        readonly: true,
+      });
+      const row = defaultSnap.query("SELECT v FROM marker").get() as { v: string };
+      expect(row.v).toBe("default-marker");
+      defaultSnap.close();
+    } finally {
+      rmSync(stage, { recursive: true, force: true });
+    }
+  });
+
+  test("empty parachute home: no DBs, no configs, no crash", async () => {
+    const stage = mkdtempSync(join(tmpdir(), "stage-empty-"));
+    try {
+      const { contents } = await stageSnapshot({
+        configDir: home,
+        vaultsDir: join(home, "vaults"),
+        stagingDir: stage,
+      });
+      expect(contents.dbSnapshots).toEqual([]);
+      expect(contents.configFiles).toEqual([]);
+    } finally {
+      rmSync(stage, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assembleTarball
+// ---------------------------------------------------------------------------
+
+describe("backup — assembleTarball", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "backup-tar-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("produces a readable .tar.gz containing the staging contents", async () => {
+    const stage = mkdtempSync(join(tmpdir(), "stage-tar-"));
+    try {
+      writeFileSync(join(stage, "hello.txt"), "hi");
+      mkdirSync(join(stage, "subdir"), { recursive: true });
+      writeFileSync(join(stage, "subdir", "nested.txt"), "nested");
+
+      const tarball = join(dir, "out.tar.gz");
+      await assembleTarball(stage, tarball);
+
+      expect(existsSync(tarball)).toBe(true);
+      const extracted = await untar(tarball);
+      try {
+        expect(readFileSync(join(extracted, "hello.txt"), "utf-8")).toBe("hi");
+        expect(readFileSync(join(extracted, "subdir", "nested.txt"), "utf-8")).toBe("nested");
+      } finally {
+        rmSync(extracted, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(stage, { recursive: true, force: true });
+    }
+  });
+
+  test("produces a valid empty tarball when staging dir is empty", async () => {
+    const stage = mkdtempSync(join(tmpdir(), "stage-empty-tar-"));
+    try {
+      const tarball = join(dir, "empty.tar.gz");
+      await assembleTarball(stage, tarball);
+      expect(existsSync(tarball)).toBe(true);
+      // tar still extracts cleanly — just produces an empty dir.
+      const extracted = await untar(tarball);
+      try {
+        expect(readdirSync(extracted).length).toBe(0);
+      } finally {
+        rmSync(extracted, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(stage, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runBackup — end-to-end
+// ---------------------------------------------------------------------------
+
+describe("backup — runBackup end-to-end", () => {
+  let home: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "backup-e2e-"));
+    destDir = mkdtempSync(join(tmpdir(), "backup-dest-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(destDir, { recursive: true, force: true });
+  });
+
+  test("writes a tarball with DB snapshots + configs to a local destination", async () => {
+    // Populate: one top-level DB, one vault, global config.
+    makeFakeDb(join(home, "daily.db"), "daily-marker");
+    const vaultsDir = join(home, "vaults");
+    makeFakeVault(vaultsDir, "default", "default-marker");
+    writeFileSync(join(home, "config.yaml"), "port: 1940\n");
+
+    const cfg: BackupConfig = {
+      schedule: "manual",
+      retention: 14,
+      destinations: [{ kind: "local", path: destDir }],
+    };
+
+    const now = "2026-04-17T08:30:00.000Z";
+    const result = await runBackup({
+      configDir: home,
+      vaultsDir,
+      backup: cfg,
+      now,
+    });
+
+    // Tarball landed at the destination with the expected filename.
+    const expectedName = backupFilename(now);
+    expect(result.destinations.length).toBe(1);
+    expect(result.destinations[0].writtenPath).toBe(join(destDir, expectedName));
+    expect(existsSync(join(destDir, expectedName))).toBe(true);
+
+    // Tarball contents include the vault DB + yaml + top-level DB + config.
+    const extracted = await untar(join(destDir, expectedName));
+    try {
+      expect(existsSync(join(extracted, "config.yaml"))).toBe(true);
+      expect(existsSync(join(extracted, "config-daily.db"))).toBe(true);
+      expect(existsSync(join(extracted, "vaults", "default", "vault.db"))).toBe(true);
+      expect(existsSync(join(extracted, "vaults", "default", "vault.yaml"))).toBe(true);
+
+      // Verify the snapshotted DB is readable and contains the marker row.
+      const snap = new Database(join(extracted, "vaults", "default", "vault.db"), {
+        readonly: true,
+      });
+      const row = snap.query("SELECT v FROM marker").get() as { v: string };
+      expect(row.v).toBe("default-marker");
+      snap.close();
+    } finally {
+      rmSync(extracted, { recursive: true, force: true });
+    }
+
+    // runBackup wrote a last-backup metadata file for `status`.
+    const last = readLastBackup(home);
+    expect(last).not.toBeNull();
+    expect(last!.timestamp).toBe(now);
+    expect(last!.destinations[0].path).toBe(join(destDir, expectedName));
+  });
+
+  test("retention pruning: 15 runs, retention=3 leaves 3 files on disk", async () => {
+    makeFakeDb(join(home, "daily.db"), "m");
+    const cfg: BackupConfig = {
+      schedule: "manual",
+      retention: 3,
+      destinations: [{ kind: "local", path: destDir }],
+    };
+
+    // Simulate 5 runs with monotonically increasing timestamps.
+    for (let i = 1; i <= 5; i++) {
+      const now = `2026-04-${String(i).padStart(2, "0")}T08:30:00.000Z`;
+      await runBackup({
+        configDir: home,
+        vaultsDir: join(home, "vaults"),
+        backup: cfg,
+        now,
+      });
+    }
+
+    // Only the 3 most recent remain.
+    const survivors = readdirSync(destDir).filter((n) => n.startsWith("parachute-backup-")).sort();
+    expect(survivors.length).toBe(3);
+    // The earliest (Apr 1, Apr 2) are gone; Apr 3/4/5 are kept.
+    expect(survivors[0]).toMatch(/2026-04-03T/);
+    expect(survivors[2]).toMatch(/2026-04-05T/);
+  });
+
+  test("per-destination failure doesn't abort other destinations", async () => {
+    makeFakeDb(join(home, "daily.db"), "m");
+    // Use an unwritable path alongside a working one. `/` is a classic
+    // unwritable-root target that mkdirSync(recursive: true) on a normal
+    // user account will reject with EACCES.
+    const cfg: BackupConfig = {
+      schedule: "manual",
+      retention: 14,
+      destinations: [
+        { kind: "local", path: "/this/path/should/definitely/not/exist/and/be/unwritable" },
+        { kind: "local", path: destDir },
+      ],
+    };
+    const result = await runBackup({
+      configDir: home,
+      vaultsDir: join(home, "vaults"),
+      backup: cfg,
+      now: "2026-04-17T08:30:00.000Z",
+    });
+
+    expect(result.destinations.length).toBe(2);
+    // Either the mkdirSync throws (expected) or it somehow succeeds. Assert
+    // only on the second destination's success — that's the contract:
+    // one bad destination must not poison the other.
+    const good = result.destinations[1];
+    expect(good.error).toBeUndefined();
+    expect(good.writtenPath).toBe(join(destDir, backupFilename("2026-04-17T08:30:00.000Z")));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkDestinationWritable
+// ---------------------------------------------------------------------------
+
+describe("backup — checkDestinationWritable", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "dest-writable-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("writable path: passes + creates missing directory", () => {
+    const sub = join(dir, "nested", "dest");
+    const res = checkDestinationWritable({ kind: "local", path: sub });
+    expect(res.ok).toBe(true);
+    expect(res.path).toBe(sub);
+    expect(existsSync(sub)).toBe(true);
+  });
+
+  test("unwritable path: fails with error detail", () => {
+    const res = checkDestinationWritable({
+      kind: "local",
+      path: "/nonexistent/and/root-only/destination",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration — `parachute vault backup` + `backup status`
+// ---------------------------------------------------------------------------
+
+describe("CLI — vault backup", () => {
+  const CLI = resolve(import.meta.dir, "cli.ts");
+
+  function runCli(
+    args: string[],
+    parachuteHome: string,
+  ): { exitCode: number; stdout: string; stderr: string } {
+    const proc = Bun.spawnSync({
+      cmd: ["bun", CLI, ...args],
+      env: { ...process.env, PARACHUTE_HOME: parachuteHome },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      exitCode: proc.exitCode ?? -1,
+      stdout: new TextDecoder().decode(proc.stdout),
+      stderr: new TextDecoder().decode(proc.stderr),
+    };
+  }
+
+  let home: string;
+  let destDir: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "cli-backup-"));
+    destDir = mkdtempSync(join(tmpdir(), "cli-backup-dest-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(destDir, { recursive: true, force: true });
+  });
+
+  test("exits non-zero with a clear message when no destinations are configured", () => {
+    writeFileSync(join(home, "config.yaml"), "port: 1940\n");
+    const res = runCli(["backup"], home);
+    expect(res.exitCode).not.toBe(0);
+    expect(res.stderr).toMatch(/No backup destinations configured/);
+  });
+
+  test("`vault backup` writes a tarball when a local destination is configured", async () => {
+    // Populate a minimal vault + config with a local destination.
+    writeFileSync(
+      join(home, "config.yaml"),
+      [
+        "port: 1940",
+        "default_vault: default",
+        "backup:",
+        "  schedule: manual",
+        "  retention: 14",
+        "  destinations:",
+        "    - kind: local",
+        `      path: ${destDir}`,
+      ].join("\n") + "\n",
+    );
+    // A minimal vault so stageSnapshot has a DB to snapshot.
+    makeFakeVault(join(home, "vaults"), "default", "cli-marker");
+
+    const res = runCli(["backup"], home);
+    expect(res.exitCode, res.stderr).toBe(0);
+    expect(res.stdout).toMatch(/Running backup/);
+    expect(res.stdout).toMatch(/local →/);
+
+    const tarballs = readdirSync(destDir).filter((n) => n.startsWith("parachute-backup-"));
+    expect(tarballs.length).toBe(1);
+
+    // Unpack and verify the vault DB + vault.yaml are in there.
+    const extracted = await untar(join(destDir, tarballs[0]));
+    try {
+      expect(existsSync(join(extracted, "vaults", "default", "vault.db"))).toBe(true);
+      expect(existsSync(join(extracted, "vaults", "default", "vault.yaml"))).toBe(true);
+      expect(existsSync(join(extracted, "config.yaml"))).toBe(true);
+    } finally {
+      rmSync(extracted, { recursive: true, force: true });
+    }
+  });
+
+  test("`vault backup status` prints schedule / destinations / last run", () => {
+    writeFileSync(
+      join(home, "config.yaml"),
+      [
+        "port: 1940",
+        "backup:",
+        "  schedule: daily",
+        "  retention: 7",
+        "  destinations:",
+        "    - kind: local",
+        `      path: ${destDir}`,
+      ].join("\n") + "\n",
+    );
+    const res = runCli(["backup", "status"], home);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toMatch(/Schedule:\s+daily/);
+    expect(res.stdout).toMatch(/Retention:\s+7/);
+    expect(res.stdout).toMatch(new RegExp(`local:\\s+${destDir.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}`));
+    // No backup has been run yet — assert on the "never" line.
+    expect(res.stdout).toMatch(/Last run:\s+\(never\)/);
+  });
+});

--- a/src/backup.test.ts
+++ b/src/backup.test.ts
@@ -34,12 +34,15 @@ import {
   stageSnapshot,
   assembleTarball,
   pruneRetention,
+  computeKeepSet,
+  listSnapshots,
+  tierTally,
   runBackup,
   readLastBackup,
   nextRunEstimate,
   checkDestinationWritable,
 } from "./backup.ts";
-import type { BackupConfig } from "./config.ts";
+import type { BackupConfig, RetentionPolicy } from "./config.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -110,43 +113,168 @@ describe("backup — pure helpers", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Retention pruning
+// Tiered retention pruning (grandfather / father / son)
 // ---------------------------------------------------------------------------
 
-describe("backup — retention pruning", () => {
+/**
+ * Touch a synthetic snapshot file with the given Date as its embedded
+ * timestamp. We produce a filename in the exact format runBackup would
+ * produce so the parse/bucket pipeline sees a realistic input.
+ */
+function makeSnapshot(dir: string, d: Date): string {
+  const name = backupFilename(d.toISOString());
+  writeFileSync(join(dir, name), "x");
+  return name;
+}
+
+/** Build a dense sequence of daily snapshots across a UTC date range. */
+function dailySnapshots(dir: string, startUtc: string, days: number): Date[] {
+  const start = new Date(startUtc);
+  const out: Date[] = [];
+  for (let i = 0; i < days; i++) {
+    const d = new Date(start.getTime() + i * 86400_000);
+    // Fix to 12:00 UTC so every timestamp lands in the middle of the day —
+    // avoids local-midnight edge cases in test assertions.
+    d.setUTCHours(12, 0, 0, 0);
+    makeSnapshot(dir, d);
+    out.push(d);
+  }
+  return out;
+}
+
+/** Full policy: helper so tests read naturally. */
+function policy(p: Partial<RetentionPolicy>): RetentionPolicy {
+  return { daily: 0, weekly: 0, monthly: 0, yearly: 0, ...p };
+}
+
+describe("backup — tiered retention pruning", () => {
   let dir: string;
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "backup-prune-")); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
-  test("keeps the N most recent by filename timestamp", () => {
-    // Create 5 backup files with monotonically later timestamps. The
-    // ISO-with-hyphens format sorts lexicographically, so we can rely on
-    // alphabetical ordering to match chronology.
-    const stamps = [
-      "2026-01-01T00-00-00.000Z",
-      "2026-02-01T00-00-00.000Z",
-      "2026-03-01T00-00-00.000Z",
-      "2026-04-01T00-00-00.000Z",
-      "2026-05-01T00-00-00.000Z",
-    ];
-    for (const s of stamps) {
-      writeFileSync(join(dir, `parachute-backup-${s}.tar.gz`), "x");
-    }
-    const pruned = pruneRetention(dir, 3);
-    expect(pruned).toBe(2);
-    const left = readdirSync(dir).sort();
-    expect(left).toEqual([
-      "parachute-backup-2026-03-01T00-00-00.000Z.tar.gz",
-      "parachute-backup-2026-04-01T00-00-00.000Z.tar.gz",
-      "parachute-backup-2026-05-01T00-00-00.000Z.tar.gz",
-    ]);
+  test("daily tier: keeps last N snapshots unconditionally", () => {
+    // 10 consecutive days, keep daily=3 — the 3 most recent survive.
+    dailySnapshots(dir, "2026-01-01T00:00:00Z", 10);
+    const pruned = pruneRetention(dir, policy({ daily: 3 }));
+    expect(pruned).toBe(7);
+    const left = readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).sort();
+    expect(left.length).toBe(3);
+    // Chronological order: last 3 days are Jan 8, 9, 10.
+    expect(left[0]).toMatch(/2026-01-08T/);
+    expect(left[2]).toMatch(/2026-01-10T/);
   });
 
-  test("no-op when fewer files than retention", () => {
-    writeFileSync(join(dir, `parachute-backup-2026-01-01T00-00-00.000Z.tar.gz`), "x");
-    const pruned = pruneRetention(dir, 14);
+  test("daily: 0 disables tier but other tiers still apply", () => {
+    dailySnapshots(dir, "2026-01-01T00:00:00Z", 30);
+    // Only the monthly tier: one snapshot from January kept (the last),
+    // everything else pruned.
+    pruneRetention(dir, policy({ monthly: 1 }));
+    const left = readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).sort();
+    expect(left.length).toBe(1);
+    expect(left[0]).toMatch(/2026-01-30T/);
+  });
+
+  test("weekly tier: one snapshot per ISO week, N most recent weeks", () => {
+    // 4 weeks of daily snapshots — 28 entries across 4 weeks plus overflow.
+    dailySnapshots(dir, "2026-01-05T00:00:00Z", 28); // Mon Jan 5 → Sun Feb 1
+    // Weekly=2 alone: keep last-of-week for the last 2 ISO weeks only.
+    pruneRetention(dir, policy({ weekly: 2 }));
+    const left = readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).sort();
+    // 2 survivors: the Sunday of each of the two most recent weeks.
+    expect(left.length).toBe(2);
+  });
+
+  test("monthly tier: last snapshot of each of N months", () => {
+    // One snapshot per day across 3 full months.
+    dailySnapshots(dir, "2026-01-01T00:00:00Z", 90);
+    pruneRetention(dir, policy({ monthly: 2 }));
+    const left = readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).sort();
+    expect(left.length).toBe(2);
+    // Last-of-Feb (Feb 28, 2026 — not leap year) and last-of-Mar (Mar 31).
+    expect(left[0]).toMatch(/2026-02-28T/);
+    expect(left[1]).toMatch(/2026-03-31T/);
+  });
+
+  test("yearly: null means unbounded — keeps last-of-year for every year in history", () => {
+    // One snapshot per year across 5 years. Every year survives because
+    // yearly is null.
+    for (const y of [2022, 2023, 2024, 2025, 2026]) {
+      makeSnapshot(dir, new Date(Date.UTC(y, 5, 15, 12, 0, 0)));
+    }
+    const pruned = pruneRetention(dir, policy({ yearly: null }));
     expect(pruned).toBe(0);
-    expect(readdirSync(dir).length).toBe(1);
+    const left = readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).sort();
+    expect(left.length).toBe(5);
+  });
+
+  test("sparse data: alternate-day snapshots across 3 years, full policy", () => {
+    // Build roughly 550 snapshots spread every other day across three years.
+    // The union tier selection should degrade gracefully across the gaps.
+    const entries: Date[] = [];
+    for (let y = 2024; y <= 2026; y++) {
+      for (let day = 0; day < 365; day += 2) {
+        const d = new Date(Date.UTC(y, 0, 1 + day, 12, 0, 0));
+        makeSnapshot(dir, d);
+        entries.push(d);
+      }
+    }
+    // The full default-shaped policy with unbounded yearly.
+    pruneRetention(dir, policy({ daily: 7, weekly: 4, monthly: 12, yearly: null }));
+    const left = readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).sort();
+
+    // Assertions — exact membership:
+    //  - daily: the last 7 entries in the ascending list.
+    //  - weekly: at most 4 weeks; each contributes one keeper.
+    //  - monthly: the 12 most recent calendar months with data.
+    //  - yearly (null): every year with data — 2024, 2025, 2026 → 3 keepers
+    //    (some of which overlap with the monthly/daily tiers; union dedupes).
+    // A loose but informative check: the keep count falls well under the
+    // full 550-ish and comfortably above the bare daily=7.
+    expect(left.length).toBeGreaterThanOrEqual(7);
+    // Union of tiers cannot exceed: 7 daily + 4 weekly + 12 monthly + 3 yearly
+    // = 26 at the absolute upper bound, minus overlap. We just bound it here.
+    expect(left.length).toBeLessThanOrEqual(26);
+
+    // At least one keeper per year — the yearly tier guarantees this.
+    const years = new Set(
+      left.map((n) => n.match(/parachute-backup-(\d{4})-/)?.[1]).filter(Boolean),
+    );
+    expect(years.has("2024")).toBe(true);
+    expect(years.has("2025")).toBe(true);
+    expect(years.has("2026")).toBe(true);
+
+    // The most recent snapshot is always kept (it's in the daily tier).
+    const mostRecent = backupFilename(entries[entries.length - 1].toISOString());
+    expect(left).toContain(mostRecent);
+  });
+
+  test("year-boundary overlap: Dec 31 vs Jan 1 land in different yearly buckets", () => {
+    // Snapshots on two consecutive days straddling the year boundary.
+    // The yearly tier should keep BOTH — one for each year.
+    makeSnapshot(dir, new Date(Date.UTC(2025, 11, 31, 12, 0, 0))); // Dec 31 2025
+    makeSnapshot(dir, new Date(Date.UTC(2026, 0, 1, 12, 0, 0))); // Jan 1 2026
+    pruneRetention(dir, policy({ yearly: null }));
+    const left = readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).sort();
+    expect(left.length).toBe(2);
+  });
+
+  test("end-of-week rollover: Sunday and Monday cross ISO-week boundary", () => {
+    // 2026-01-04 is Sun (ISO week 1), 2026-01-05 is Mon (ISO week 2).
+    // Weekly=2 should keep one from each week. Noon UTC → most timezones
+    // put both on the expected local calendar day.
+    const sun = new Date(Date.UTC(2026, 0, 4, 12, 0, 0));
+    const mon = new Date(Date.UTC(2026, 0, 5, 12, 0, 0));
+    makeSnapshot(dir, sun);
+    makeSnapshot(dir, mon);
+    const keep = computeKeepSet(listSnapshots(dir), policy({ weekly: 2 }));
+    expect(keep.size).toBe(2);
+  });
+
+  test("no-op when every snapshot is kept by some tier", () => {
+    dailySnapshots(dir, "2026-01-01T00:00:00Z", 5);
+    const pruned = pruneRetention(dir, policy({ daily: 7 }));
+    expect(pruned).toBe(0);
+    expect(readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).length).toBe(5);
   });
 
   test("ignores non-backup files in the destination directory", () => {
@@ -154,13 +282,49 @@ describe("backup — retention pruning", () => {
     // sync dir. Retention must only touch parachute-backup-*.tar.gz.
     writeFileSync(join(dir, ".DS_Store"), "x");
     writeFileSync(join(dir, "README.md"), "x");
-    writeFileSync(join(dir, "parachute-backup-2026-01-01T00-00-00.000Z.tar.gz"), "x");
-    writeFileSync(join(dir, "parachute-backup-2026-02-01T00-00-00.000Z.tar.gz"), "x");
-    const pruned = pruneRetention(dir, 1);
-    expect(pruned).toBe(1);
+    dailySnapshots(dir, "2026-01-01T00:00:00Z", 5);
+    pruneRetention(dir, policy({ daily: 1 }));
     // The non-backup files are untouched.
     expect(existsSync(join(dir, ".DS_Store"))).toBe(true);
     expect(existsSync(join(dir, "README.md"))).toBe(true);
+    // Only 1 backup file survives.
+    expect(readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).length).toBe(1);
+  });
+
+  test("all tiers 0 / null yearly=0: everything pruned", () => {
+    dailySnapshots(dir, "2026-01-01T00:00:00Z", 5);
+    const pruned = pruneRetention(dir, policy({}));
+    expect(pruned).toBe(5);
+    expect(readdirSync(dir).filter((n) => n.startsWith("parachute-backup-")).length).toBe(0);
+  });
+
+  test("a snapshot satisfying multiple tiers is kept once, not duplicated", () => {
+    // A single snapshot at year-end/month-end/week-end satisfies all four
+    // tiers. Deletion count is 0, on-disk count stays at 1.
+    makeSnapshot(dir, new Date(Date.UTC(2026, 11, 31, 12, 0, 0)));
+    const pruned = pruneRetention(dir, policy({ daily: 7, weekly: 4, monthly: 12, yearly: null }));
+    expect(pruned).toBe(0);
+    const left = readdirSync(dir).filter((n) => n.startsWith("parachute-backup-"));
+    expect(left.length).toBe(1);
+  });
+});
+
+describe("backup — tierTally", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "backup-tally-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("reports per-tier contribution counts for `backup status`", () => {
+    dailySnapshots(dir, "2026-01-01T00:00:00Z", 60);
+    const t = tierTally(dir, policy({ daily: 7, weekly: 4, monthly: 2, yearly: null }));
+    expect(t.total).toBe(60);
+    expect(t.daily).toBe(7);
+    // 60 daily snapshots span ~9 ISO weeks; cap at 4.
+    expect(t.weekly).toBe(4);
+    // 60 days straddles Jan + Feb + 1 day into March → monthly cap at 2.
+    expect(t.monthly).toBe(2);
+    // All 60 days are in 2026 → yearly is 1.
+    expect(t.yearly).toBe(1);
   });
 });
 
@@ -309,7 +473,7 @@ describe("backup — runBackup end-to-end", () => {
 
     const cfg: BackupConfig = {
       schedule: "manual",
-      retention: 14,
+      retention: { daily: 7, weekly: 4, monthly: 12, yearly: null },
       destinations: [{ kind: "local", path: destDir }],
     };
 
@@ -353,11 +517,13 @@ describe("backup — runBackup end-to-end", () => {
     expect(last!.destinations[0].path).toBe(join(destDir, expectedName));
   });
 
-  test("retention pruning: 15 runs, retention=3 leaves 3 files on disk", async () => {
+  test("retention pruning runs end-to-end: daily=3 leaves 3 most recent", async () => {
     makeFakeDb(join(home, "daily.db"), "m");
     const cfg: BackupConfig = {
       schedule: "manual",
-      retention: 3,
+      // Pure daily tier so this test stays focused on pipeline integration
+      // rather than tier bucketing (unit-tested above).
+      retention: { daily: 3, weekly: 0, monthly: 0, yearly: 0 },
       destinations: [{ kind: "local", path: destDir }],
     };
 
@@ -387,7 +553,7 @@ describe("backup — runBackup end-to-end", () => {
     // user account will reject with EACCES.
     const cfg: BackupConfig = {
       schedule: "manual",
-      retention: 14,
+      retention: { daily: 7, weekly: 4, monthly: 12, yearly: null },
       destinations: [
         { kind: "local", path: "/this/path/should/definitely/not/exist/and/be/unwritable" },
         { kind: "local", path: destDir },
@@ -488,7 +654,11 @@ describe("CLI — vault backup", () => {
         "default_vault: default",
         "backup:",
         "  schedule: manual",
-        "  retention: 14",
+        "  retention:",
+        "    daily: 7",
+        "    weekly: 4",
+        "    monthly: 12",
+        "    yearly: null",
         "  destinations:",
         "    - kind: local",
         `      path: ${destDir}`,
@@ -523,7 +693,11 @@ describe("CLI — vault backup", () => {
         "port: 1940",
         "backup:",
         "  schedule: daily",
-        "  retention: 7",
+        "  retention:",
+        "    daily: 7",
+        "    weekly: 4",
+        "    monthly: 12",
+        "    yearly: null",
         "  destinations:",
         "    - kind: local",
         `      path: ${destDir}`,
@@ -532,7 +706,8 @@ describe("CLI — vault backup", () => {
     const res = runCli(["backup", "status"], home);
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toMatch(/Schedule:\s+daily/);
-    expect(res.stdout).toMatch(/Retention:\s+7/);
+    // Tiered retention line: "7 daily / 4 weekly / 12 monthly / ∞ yearly"
+    expect(res.stdout).toMatch(/Retention:\s+7 daily \/ 4 weekly \/ 12 monthly \/ ∞ yearly/);
     expect(res.stdout).toMatch(new RegExp(`local:\\s+${destDir.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}`));
     // No backup has been run yet — assert on the "never" line.
     expect(res.stdout).toMatch(/Last run:\s+\(never\)/);

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,0 +1,484 @@
+/**
+ * Vault backup — atomic SQLite snapshots + tarball assembly + destination
+ * dispatch + retention pruning.
+ *
+ * The pipeline is intentionally split into small, composable stages so that
+ * later destinations (`s3`, `rsync`, `cloud`) can be plugged in without
+ * rewriting the snapshot/tarball/prune layers. A future encryption hook
+ * would slot between `assembleTarball` and `writeToDestinations`.
+ *
+ * Why `VACUUM INTO` instead of the SQLite Online Backup API: `VACUUM INTO`
+ * produces a defragmented copy of the database in a single atomic operation
+ * and is safe against concurrent readers and writers under WAL journaling
+ * mode — exactly our use case. It is a synchronous server-side SQLite
+ * primitive, so we don't need a separate backup thread or library. The only
+ * caveat is that it copies the whole DB; at vault sizes we care about
+ * (single-digit GB), that's faster than we'd save by doing an incremental
+ * backup, and simpler is better for MVP.
+ */
+
+import { homedir } from "os";
+import { join, basename, resolve } from "path";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, copyFileSync, statSync } from "fs";
+import { tmpdir } from "os";
+import { Database } from "bun:sqlite";
+import { $ } from "bun";
+import {
+  CONFIG_DIR,
+  VAULTS_DIR,
+  GLOBAL_CONFIG_PATH,
+  listVaults,
+  vaultDir,
+  vaultDbPath,
+  vaultConfigPath,
+  readGlobalConfig,
+  writeGlobalConfig,
+  defaultBackupConfig,
+} from "./config.ts";
+import type { BackupConfig, BackupDestination, BackupSchedule } from "./config.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface BackupResult {
+  /** Absolute path of the assembled tarball on disk (temp staging). */
+  tarballPath: string;
+  /** ISO8601 timestamp used in the tarball filename. */
+  timestamp: string;
+  /** Size of the tarball on disk, in bytes. */
+  bytes: number;
+  /** Per-destination outcome. One destination's failure does not stop others. */
+  destinations: DestinationResult[];
+  /** What the tarball contained — for verification in tests and `status`. */
+  contents: TarballContents;
+}
+
+export interface DestinationResult {
+  destination: BackupDestination;
+  /** Absolute path the tarball ended up at, or null on failure. */
+  writtenPath: string | null;
+  /** Number of old snapshots pruned after retention was applied. */
+  pruned: number;
+  /** Non-fatal error, if any. */
+  error?: string;
+}
+
+export interface TarballContents {
+  dbSnapshots: string[];  // filenames inside the tarball
+  configFiles: string[];  // filenames inside the tarball
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/** Expand a leading `~/` or bare `~` in a config path. No-op for absolute. */
+export function expandTilde(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+/**
+ * Build the backup filename for a given timestamp. Separated so tests can
+ * pass a frozen timestamp and assert the format.
+ */
+export function backupFilename(timestamp: string): string {
+  // ISO8601 has colons — not portable on filesystems (FAT/Windows mounts,
+  // some iCloud edge cases). Replace them with hyphens. The result still
+  // sorts lexicographically in chronological order.
+  const safe = timestamp.replace(/:/g, "-");
+  return `parachute-backup-${safe}.tar.gz`;
+}
+
+/** Inverse of `backupFilename` for parsing filenames during retention prune. */
+export function parseBackupFilename(name: string): { timestamp: string } | null {
+  const m = name.match(/^parachute-backup-(.+)\.tar\.gz$/);
+  if (!m) return null;
+  return { timestamp: m[1] };
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot stage — produces SQLite copies + config files in a staging dir
+// ---------------------------------------------------------------------------
+
+/**
+ * Take a `VACUUM INTO` snapshot of every `.db` file we can find in
+ * `CONFIG_DIR`:
+ *
+ *   1. Top-level `~/.parachute/*.db` — covers legacy pre-multi-vault installs
+ *      (e.g. `daily.db`) and any user-placed sidecar DBs. Hits include `.bak`
+ *      copies, which we intentionally skip since they're already static
+ *      snapshots that `cp` would duplicate faster than VACUUM.
+ *   2. Per-vault `vaults/<name>/vault.db` via `listVaults()`.
+ *
+ * Returns the staging directory so the next stage can tar it up.
+ */
+export async function stageSnapshot(opts?: {
+  /** Override config dir. Tests point this at a tempdir. */
+  configDir?: string;
+  /** Override vaults dir. Tests point this at a tempdir's vaults/. */
+  vaultsDir?: string;
+  /** Override staging dir. Tests pass a tempdir to inspect contents. */
+  stagingDir?: string;
+}): Promise<{ stagingDir: string; contents: TarballContents }> {
+  const configDir = opts?.configDir ?? CONFIG_DIR;
+  const vaultsDir = opts?.vaultsDir ?? VAULTS_DIR;
+  const stagingDir = opts?.stagingDir ?? mkdtempSync(join(tmpdir(), "parachute-backup-"));
+
+  const dbSnapshots: string[] = [];
+  const configFiles: string[] = [];
+
+  // 1. Top-level *.db files in CONFIG_DIR. Skip .bak and other non-live files.
+  if (existsSync(configDir)) {
+    for (const entry of readdirSync(configDir)) {
+      if (!entry.endsWith(".db")) continue;
+      const src = join(configDir, entry);
+      // Skip symlinks-to-dirs, subdirs, etc. A `.db` extension on a directory
+      // is exotic; `statSync` isolates us from it.
+      try {
+        const st = statSync(src);
+        if (!st.isFile()) continue;
+      } catch {
+        continue;
+      }
+      const destName = `config-${entry}`;
+      const dest = join(stagingDir, destName);
+      vacuumInto(src, dest);
+      dbSnapshots.push(destName);
+    }
+  }
+
+  // 2. Per-vault DBs. We mirror the vaults/<name>/ layout inside the tarball
+  // so a restore can drop the whole directory back in place without renaming.
+  // vault.yaml is included alongside vault.db for the same reason.
+  if (existsSync(vaultsDir)) {
+    const vaultNames = listVaultsIn(vaultsDir);
+    for (const name of vaultNames) {
+      const dbSrc = join(vaultsDir, name, "vault.db");
+      const cfgSrc = join(vaultsDir, name, "vault.yaml");
+
+      if (existsSync(dbSrc)) {
+        const mirrorDir = join(stagingDir, "vaults", name);
+        mkdirSync(mirrorDir, { recursive: true });
+        const dbDest = join(mirrorDir, "vault.db");
+        vacuumInto(dbSrc, dbDest);
+        dbSnapshots.push(join("vaults", name, "vault.db"));
+      }
+      if (existsSync(cfgSrc)) {
+        const mirrorDir = join(stagingDir, "vaults", name);
+        mkdirSync(mirrorDir, { recursive: true });
+        copyFileSync(cfgSrc, join(mirrorDir, "vault.yaml"));
+        configFiles.push(join("vaults", name, "vault.yaml"));
+      }
+    }
+  }
+
+  // 3. Global config.yaml — the heart of "restore my setup" for a new machine.
+  const globalCfgSrc = opts?.configDir ? join(opts.configDir, "config.yaml") : GLOBAL_CONFIG_PATH;
+  if (existsSync(globalCfgSrc)) {
+    copyFileSync(globalCfgSrc, join(stagingDir, "config.yaml"));
+    configFiles.push("config.yaml");
+  }
+
+  return { stagingDir, contents: { dbSnapshots, configFiles } };
+}
+
+/** Take a VACUUM INTO snapshot. Atomic against concurrent writers under WAL. */
+function vacuumInto(srcDbPath: string, destPath: string): void {
+  // VACUUM INTO requires the destination file NOT to exist — SQLite enforces
+  // this to avoid clobbering a live DB with a partial vacuum output. Staging
+  // dirs are fresh, so this should always hold; belt-and-braces guard below.
+  if (existsSync(destPath)) rmSync(destPath);
+  // readwrite=true is required — VACUUM INTO is considered a write by SQLite
+  // (it creates the output file), so read-only handles are rejected.
+  const db = new Database(srcDbPath, { readwrite: true });
+  try {
+    // Parameter binding: SQLite does NOT allow bound parameters for the
+    // VACUUM INTO target path, so we must splice it in. The path comes
+    // from our own staging tempdir — no user-controlled input — so
+    // string interpolation is safe. We still escape single quotes
+    // defensively in case a username contains one.
+    const escaped = destPath.replace(/'/g, "''");
+    db.run(`VACUUM INTO '${escaped}'`);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Small internal helper so tests can point us at a vaults dir that isn't
+ * the global VAULTS_DIR without plumbing the override through `listVaults()`.
+ */
+function listVaultsIn(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir).filter((entry) => {
+      const cfg = join(dir, entry, "vault.yaml");
+      return existsSync(cfg);
+    });
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tarball stage
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a staging directory into a gzip'd tarball at `outPath`. Uses `tar`
+ * from PATH — macOS and every Linux distro we target ships bsdtar or GNU
+ * tar. We could reimplement the tar format in pure TypeScript, but that's
+ * a maintenance tax for no user-visible benefit.
+ *
+ * The tar is rooted at the staging dir (via `-C`) so the archive contains
+ * `config.yaml`, `vaults/...`, and `config-*.db` at the top level rather
+ * than burying them under a random tempdir prefix.
+ */
+export async function assembleTarball(stagingDir: string, outPath: string): Promise<void> {
+  mkdirSync(resolve(outPath, ".."), { recursive: true });
+  const entries = readdirSync(stagingDir);
+  if (entries.length === 0) {
+    // `tar` on some platforms errors on an empty input list; we'd rather
+    // produce an empty-but-valid tarball. An empty staging dir means the
+    // user has no DBs yet — a legitimate state on a fresh install.
+    await $`tar -czf ${outPath} -C ${stagingDir} --files-from /dev/null`.quiet();
+    return;
+  }
+  await $`tar -czf ${outPath} -C ${stagingDir} ${entries}`.quiet();
+}
+
+// ---------------------------------------------------------------------------
+// Destination stage
+// ---------------------------------------------------------------------------
+
+/**
+ * Write the tarball to each configured destination. Per-destination errors
+ * are captured, not thrown — a dead S3 bucket shouldn't prevent the local
+ * iCloud copy from succeeding. Callers surface results.
+ */
+export async function writeToDestinations(
+  tarballPath: string,
+  destinations: BackupDestination[],
+  retention: number,
+): Promise<DestinationResult[]> {
+  const results: DestinationResult[] = [];
+  for (const dest of destinations) {
+    try {
+      const res = await writeToDestination(tarballPath, dest, retention);
+      results.push(res);
+    } catch (err: any) {
+      results.push({
+        destination: dest,
+        writtenPath: null,
+        pruned: 0,
+        error: String(err?.message ?? err),
+      });
+    }
+  }
+  return results;
+}
+
+async function writeToDestination(
+  tarballPath: string,
+  dest: BackupDestination,
+  retention: number,
+): Promise<DestinationResult> {
+  switch (dest.kind) {
+    case "local": {
+      const target = expandTilde(dest.path);
+      mkdirSync(target, { recursive: true });
+      const outName = basename(tarballPath);
+      const out = join(target, outName);
+      copyFileSync(tarballPath, out);
+      const pruned = pruneRetention(target, retention);
+      return { destination: dest, writtenPath: out, pruned };
+    }
+    // Exhaustiveness guard — if a future destination kind is added to the
+    // type union but not handled here, the compiler fails the build.
+    default: {
+      const _exhaustive: never = dest;
+      throw new Error(`Unsupported destination kind: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Retention: keep the N most recent `parachute-backup-*.tar.gz` files by
+ * filename timestamp (NOT file mtime — mtime is unreliable after move/sync,
+ * especially under iCloud which rewrites timestamps). Returns the count
+ * pruned.
+ */
+export function pruneRetention(dir: string, keep: number): number {
+  if (!existsSync(dir)) return 0;
+  const entries = readdirSync(dir).filter((n) => parseBackupFilename(n) !== null);
+  // Lexicographic sort works because our timestamp format is ISO8601 with
+  // colons replaced by hyphens — still left-padded and zero-aligned.
+  entries.sort();
+  const excess = entries.length - keep;
+  if (excess <= 0) return 0;
+  const doomed = entries.slice(0, excess);
+  for (const name of doomed) {
+    try {
+      rmSync(join(dir, name));
+    } catch {
+      // Prune failure is non-fatal; we'd rather keep making new backups
+      // than abort because one stale file is locked.
+    }
+  }
+  return doomed.length;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a single backup end-to-end: stage, tar, ship to destinations. This is
+ * what `parachute vault backup` and the launchd-scheduled job both invoke.
+ *
+ * The staging dir is cleaned up on exit; the tarball itself is kept (copied
+ * to each destination) and also left behind in the staging dir's parent —
+ * actually, no: we drop the staging dir entirely and rely on the
+ * destination-side copy as the durable artifact.
+ */
+export async function runBackup(opts?: {
+  configDir?: string;
+  vaultsDir?: string;
+  backup?: BackupConfig;
+  /** Freeze "now" for deterministic tests. ISO8601 string. */
+  now?: string;
+}): Promise<BackupResult> {
+  const backup = opts?.backup ?? readGlobalConfig().backup ?? defaultBackupConfig();
+  const timestamp = opts?.now ?? new Date().toISOString();
+
+  const { stagingDir, contents } = await stageSnapshot({
+    configDir: opts?.configDir,
+    vaultsDir: opts?.vaultsDir,
+  });
+
+  try {
+    const tarName = backupFilename(timestamp);
+    const tarballPath = join(stagingDir, "__out__", tarName);
+    await assembleTarball(stagingDir, tarballPath);
+    const bytes = statSync(tarballPath).size;
+
+    const results = await writeToDestinations(tarballPath, backup.destinations, backup.retention);
+
+    // Record last-backup metadata for `status`. Stored in a small JSON file
+    // inside CONFIG_DIR so it survives across daemons and doesn't require
+    // plumbing through config.yaml (which is hand-edited by users).
+    recordLastBackup({
+      timestamp,
+      bytes,
+      destinations: results.map((r) => ({
+        path: r.writtenPath,
+        error: r.error ?? null,
+      })),
+    }, opts?.configDir);
+
+    return { tarballPath, timestamp, bytes, destinations: results, contents };
+  } finally {
+    // The staging dir has the only copy of the tarball that isn't at a
+    // destination; destinations have already been written. Safe to clean.
+    try { rmSync(stagingDir, { recursive: true, force: true }); } catch {}
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Last-run metadata (for `status`)
+// ---------------------------------------------------------------------------
+
+export interface LastBackupMeta {
+  timestamp: string;
+  bytes: number;
+  destinations: Array<{ path: string | null; error: string | null }>;
+}
+
+export function lastBackupPath(configDir?: string): string {
+  return join(configDir ?? CONFIG_DIR, "backup-last.json");
+}
+
+function recordLastBackup(meta: LastBackupMeta, configDir?: string): void {
+  try {
+    mkdirSync(configDir ?? CONFIG_DIR, { recursive: true });
+    Bun.write(lastBackupPath(configDir), JSON.stringify(meta, null, 2) + "\n");
+  } catch {
+    // Non-fatal — losing last-run metadata is a UX regression, not a data loss.
+  }
+}
+
+export function readLastBackup(configDir?: string): LastBackupMeta | null {
+  const p = lastBackupPath(configDir);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(require("fs").readFileSync(p, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config ergonomics
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically update the `backup` section of global config. Creates the
+ * section with defaults if missing, then applies `patch`. Used by the
+ * `--schedule` flag and by tests.
+ */
+export function updateBackupConfig(patch: Partial<BackupConfig>): BackupConfig {
+  const cfg = readGlobalConfig();
+  const next: BackupConfig = { ...defaultBackupConfig(), ...(cfg.backup ?? {}), ...patch };
+  cfg.backup = next;
+  writeGlobalConfig(cfg);
+  return next;
+}
+
+/**
+ * Probe whether a destination is ready to receive a backup. For `local`,
+ * this is a mkdir + write-probe roundtrip. Used by `doctor` so users learn
+ * about an unwritable iCloud path BEFORE the scheduled run silently fails.
+ */
+export function checkDestinationWritable(dest: BackupDestination): {
+  ok: boolean;
+  path: string;
+  error?: string;
+} {
+  if (dest.kind !== "local") {
+    // Other destination kinds don't exist yet. When they do, each will
+    // implement its own writability probe (e.g., an S3 bucket HeadBucket).
+    return { ok: false, path: JSON.stringify(dest), error: "unsupported destination kind" };
+  }
+  const target = expandTilde(dest.path);
+  try {
+    mkdirSync(target, { recursive: true });
+    const probe = join(target, `.parachute-write-probe-${process.pid}`);
+    Bun.write(probe, "");
+    // Clean up the probe. Failure to remove it is not a writability failure
+    // — the directory is writable or the probe write above would have thrown.
+    try { rmSync(probe); } catch {}
+    return { ok: true, path: target };
+  } catch (err: any) {
+    return { ok: false, path: target, error: String(err?.message ?? err) };
+  }
+}
+
+/**
+ * Calendar-arithmetic "next run" estimate for `status`. This is deliberately
+ * approximate — launchd is our source of truth for actual firing — but it's
+ * what every cron-style UI shows and it's better than "unknown."
+ */
+export function nextRunEstimate(schedule: BackupSchedule, lastRun?: Date): Date | null {
+  if (schedule === "manual") return null;
+  const base = lastRun ?? new Date();
+  const next = new Date(base);
+  switch (schedule) {
+    case "hourly": next.setHours(next.getHours() + 1); break;
+    case "daily": next.setDate(next.getDate() + 1); break;
+    case "weekly": next.setDate(next.getDate() + 7); break;
+  }
+  return next;
+}

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -34,8 +34,9 @@ import {
   readGlobalConfig,
   writeGlobalConfig,
   defaultBackupConfig,
+  defaultRetentionPolicy,
 } from "./config.ts";
-import type { BackupConfig, BackupDestination, BackupSchedule } from "./config.ts";
+import type { BackupConfig, BackupDestination, BackupSchedule, RetentionPolicy } from "./config.ts";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -262,7 +263,7 @@ export async function assembleTarball(stagingDir: string, outPath: string): Prom
 export async function writeToDestinations(
   tarballPath: string,
   destinations: BackupDestination[],
-  retention: number,
+  retention: RetentionPolicy,
 ): Promise<DestinationResult[]> {
   const results: DestinationResult[] = [];
   for (const dest of destinations) {
@@ -284,7 +285,7 @@ export async function writeToDestinations(
 async function writeToDestination(
   tarballPath: string,
   dest: BackupDestination,
-  retention: number,
+  retention: RetentionPolicy,
 ): Promise<DestinationResult> {
   switch (dest.kind) {
     case "local": {
@@ -305,30 +306,244 @@ async function writeToDestination(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Tiered retention — grandfather / father / son
+// ---------------------------------------------------------------------------
+
 /**
- * Retention: keep the N most recent `parachute-backup-*.tar.gz` files by
- * filename timestamp (NOT file mtime — mtime is unreliable after move/sync,
- * especially under iCloud which rewrites timestamps). Returns the count
- * pruned.
+ * Parse a backup filename's timestamp component back into a Date. We wrote the
+ * timestamp as ISO-8601 with colons swapped for hyphens (for filesystem
+ * portability), so we have to swap back before handing to `new Date()`.
+ *
+ * The hyphen-for-colon swap is position-specific: the ISO-8601 date-time
+ * separator is `T`, after which there are three hyphens we introduced (HH-MM-SS)
+ * but also possibly real hyphens in the timezone offset (…+00:00 → +00-00).
+ * We undo every hyphen that appears AFTER the `T`, preserving the three
+ * leading hyphens in the YYYY-MM-DD portion.
  */
-export function pruneRetention(dir: string, keep: number): number {
+function timestampToDate(stamp: string): Date | null {
+  const tIdx = stamp.indexOf("T");
+  if (tIdx < 0) return null;
+  const head = stamp.slice(0, tIdx);
+  const tail = stamp.slice(tIdx).replace(/-/g, ":");
+  const iso = head + tail;
+  const d = new Date(iso);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+/**
+ * Bucket key for the daily tier: ISO calendar date in the local timezone
+ * (YYYY-MM-DD). We lean on `Intl.DateTimeFormat` with the system's default
+ * timezone because it handles DST transitions correctly, unlike hand-rolling
+ * with `getDate()` from a UTC Date that's been shifted by offset math.
+ */
+function localDateKey(d: Date): string {
+  // `en-CA` gives us ISO-like `YYYY-MM-DD` by default — a happy accident that
+  // saves us from assembling the pieces ourselves.
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
+function localYearKey(d: Date): string {
+  return new Intl.DateTimeFormat("en-CA", { year: "numeric" }).format(d);
+}
+
+function localYearMonthKey(d: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+  }).format(d);
+}
+
+/**
+ * ISO week bucket: (ISO week year, ISO week number). We compute both in the
+ * local timezone so "end-of-week rollover" aligns with what the user sees on
+ * their calendar. The ISO week year can differ from the calendar year at
+ * year boundaries (a Dec 31 Monday belongs to next year's week 1; a Jan 1
+ * Friday belongs to last year's week 53) — we handle that with the standard
+ * "week containing the year's first Thursday is week 1" rule.
+ */
+function isoWeekKey(d: Date): string {
+  // Pull out local-tz Y/M/D so week math stays aligned to the user's calendar
+  // instead of UTC.
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(d);
+  const yStr = parts.find((p) => p.type === "year")?.value ?? "1970";
+  const mStr = parts.find((p) => p.type === "month")?.value ?? "01";
+  const dStr = parts.find((p) => p.type === "day")?.value ?? "01";
+  const year = parseInt(yStr, 10);
+  const month = parseInt(mStr, 10);
+  const day = parseInt(dStr, 10);
+
+  // Work in a UTC Date that carries our local Y/M/D, so further arithmetic
+  // doesn't get perturbed by DST.
+  const target = new Date(Date.UTC(year, month - 1, day));
+  // Shift target to the Thursday of its week (ISO weeks are anchored there).
+  // getUTCDay(): 0=Sun, 1=Mon, …, 6=Sat. ISO wants Mon=1, so (day+6)%7 maps
+  // Sun→6, Mon→0, …, Sat→5, which is the "days since Monday."
+  const dayNum = (target.getUTCDay() + 6) % 7;
+  target.setUTCDate(target.getUTCDate() - dayNum + 3);
+  // Week 1 is the one containing Jan 4 (equivalently, the year's first Thursday).
+  const week1 = new Date(Date.UTC(target.getUTCFullYear(), 0, 4));
+  const week = 1 + Math.round(
+    ((target.getTime() - week1.getTime()) / 86400000 - 3 + ((week1.getUTCDay() + 6) % 7)) / 7,
+  );
+  const isoYear = target.getUTCFullYear();
+  // Pad week to 2 digits so string-sort matches chronological order.
+  return `${isoYear}-W${String(week).padStart(2, "0")}`;
+}
+
+export interface SnapshotEntry {
+  name: string;
+  timestamp: string;
+  date: Date;
+}
+
+/**
+ * Enumerate the `parachute-backup-*.tar.gz` files in a directory, parse each
+ * timestamp, and return them sorted ascending (oldest first) — the order we
+ * rely on for bucket-last-wins and for test determinism.
+ */
+export function listSnapshots(dir: string): SnapshotEntry[] {
+  if (!existsSync(dir)) return [];
+  const entries: SnapshotEntry[] = [];
+  for (const name of readdirSync(dir)) {
+    const parsed = parseBackupFilename(name);
+    if (!parsed) continue;
+    const d = timestampToDate(parsed.timestamp);
+    if (!d) continue;
+    entries.push({ name, timestamp: parsed.timestamp, date: d });
+  }
+  // Because our filename timestamps are lexicographically sortable, sorting
+  // by name and sorting by date yield the same order. We sort by timestamp
+  // string because it's cheaper and deterministic across clock skew.
+  entries.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  return entries;
+}
+
+/**
+ * Compute the subset of snapshots that the tiered policy keeps. Public for
+ * testability — `pruneRetention` is the mutating variant.
+ *
+ * Algorithm:
+ *   1. Group entries by bucket key for each tier (daily / weekly / monthly /
+ *      yearly). Since inputs are sorted ascending, the last entry overwriting
+ *      a given bucket key is the most-recent-in-bucket — exactly the one we
+ *      want to keep for that tier.
+ *   2. For weekly/monthly/yearly, take the N most recent bucket keys (or all
+ *      of them if yearly is null) and union their keepers.
+ *   3. For daily, skip the bucketing step — just keep the last N entries.
+ *   4. Return the union as a Set of filenames.
+ *
+ * A tier set to 0 contributes no keepers but doesn't disable the others.
+ * Sparse data (gaps) just means fewer buckets; no special-casing required.
+ */
+export function computeKeepSet(
+  entries: SnapshotEntry[],
+  policy: RetentionPolicy,
+): Set<string> {
+  const keep = new Set<string>();
+
+  // Daily: take the last N entries outright. No bucketing by day needed;
+  // if two backups land on the same day, they both count toward the daily
+  // tier's "last N" — this is the intuitive "keep my 7 most recent" promise.
+  if (policy.daily > 0) {
+    for (const entry of entries.slice(-policy.daily)) keep.add(entry.name);
+  }
+
+  // Weekly / monthly / yearly — all follow the same pattern: bucket by key,
+  // take the most recent entry per bucket, then cap to the N most recent
+  // buckets. Implemented once here with a small helper to avoid drift.
+  const tierByBucket = (
+    keyFn: (d: Date) => string,
+    limit: number | null,
+  ) => {
+    if (limit === 0) return;
+    const buckets = new Map<string, SnapshotEntry>();
+    for (const entry of entries) {
+      // Last-write-wins: because entries are sorted ascending, the final
+      // overwrite for a given key IS the most recent entry in that bucket.
+      buckets.set(keyFn(entry.date), entry);
+    }
+    // Sort bucket keys descending (most recent first) then cap. Our keys
+    // are all lex-sortable (ISO-like), so string compare == chronological.
+    const keysDesc = [...buckets.keys()].sort().reverse();
+    const chosen = limit === null ? keysDesc : keysDesc.slice(0, limit);
+    for (const k of chosen) keep.add(buckets.get(k)!.name);
+  };
+
+  tierByBucket(isoWeekKey, policy.weekly);
+  tierByBucket(localYearMonthKey, policy.monthly);
+  tierByBucket(localYearKey, policy.yearly);
+
+  return keep;
+}
+
+/**
+ * Per-tier breakdown of a destination's current keep set — how many snapshots
+ * each tier contributes. Sums are with respect to the un-pruned contents of
+ * `dir` (i.e., snapshot-of-current-state, not "what would we prune next"),
+ * which is what `backup status` wants to render.
+ *
+ * `total` is the number of snapshot files present on disk. Per-tier counts
+ * sum to the size of the union; because a single snapshot can satisfy
+ * multiple tiers, they can sum to more than `total`.
+ */
+export interface TierTally {
+  total: number;
+  daily: number;
+  weekly: number;
+  monthly: number;
+  yearly: number;
+}
+
+export function tierTally(dir: string, policy: RetentionPolicy): TierTally {
+  const entries = listSnapshots(dir);
+  const total = entries.length;
+  // Re-run each tier in isolation to count its individual contribution.
+  // Tiny N (usually < 100 snapshots), so the duplicated bucketing is fine.
+  const isolate = (tier: Partial<RetentionPolicy>): number => {
+    const p: RetentionPolicy = { daily: 0, weekly: 0, monthly: 0, yearly: 0, ...tier };
+    return computeKeepSet(entries, p).size;
+  };
+  return {
+    total,
+    daily: isolate({ daily: policy.daily }),
+    weekly: isolate({ weekly: policy.weekly }),
+    monthly: isolate({ monthly: policy.monthly }),
+    yearly: isolate({ yearly: policy.yearly }),
+  };
+}
+
+/**
+ * Tiered retention: keep the union of daily/weekly/monthly/yearly tiers,
+ * delete everything else. Returns the number of files deleted.
+ *
+ * Uses filename-embedded timestamps (NOT file mtime — mtime is unreliable
+ * after move/sync, especially under iCloud which rewrites timestamps).
+ */
+export function pruneRetention(dir: string, policy: RetentionPolicy): number {
   if (!existsSync(dir)) return 0;
-  const entries = readdirSync(dir).filter((n) => parseBackupFilename(n) !== null);
-  // Lexicographic sort works because our timestamp format is ISO8601 with
-  // colons replaced by hyphens — still left-padded and zero-aligned.
-  entries.sort();
-  const excess = entries.length - keep;
-  if (excess <= 0) return 0;
-  const doomed = entries.slice(0, excess);
-  for (const name of doomed) {
+  const entries = listSnapshots(dir);
+  const keep = computeKeepSet(entries, policy);
+  let deleted = 0;
+  for (const entry of entries) {
+    if (keep.has(entry.name)) continue;
     try {
-      rmSync(join(dir, name));
+      rmSync(join(dir, entry.name));
+      deleted++;
     } catch {
       // Prune failure is non-fatal; we'd rather keep making new backups
       // than abort because one stale file is locked.
     }
   }
-  return doomed.length;
+  return deleted;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,22 @@ import {
 import type { VaultConfig } from "./config.ts";
 import { VAULTS_DIR } from "./config.ts";
 import { installAgent, uninstallAgent, isAgentLoaded, restartAgent } from "./launchd.ts";
+import {
+  runBackup,
+  readLastBackup,
+  nextRunEstimate,
+  updateBackupConfig,
+  expandTilde,
+  checkDestinationWritable,
+} from "./backup.ts";
+import {
+  installBackupAgent,
+  uninstallBackupAgent,
+  isBackupAgentLoaded,
+  BACKUP_PLIST_PATH,
+} from "./backup-launchd.ts";
+import { defaultBackupConfig } from "./config.ts";
+import type { BackupSchedule } from "./config.ts";
 import { installSystemdService, uninstallSystemdService, restartSystemdService, isSystemdAvailable, isServiceActive } from "./systemd.ts";
 import { checkHealth, waitForHealthy, tailFile } from "./health.ts";
 import type { HealthResult } from "./health.ts";
@@ -148,6 +164,9 @@ switch (command) {
     break;
   case "url":
     cmdUrl();
+    break;
+  case "backup":
+    await cmdBackup(cmdArgs);
     break;
   case "import":
     await cmdImport(cmdArgs);
@@ -1023,6 +1042,10 @@ async function cmdUninstall(argsList: string[]) {
   if (process.platform === "darwin") {
     console.log("Removing launchd agent...");
     await uninstallAgent();
+    // Scheduled backup agent lives in a separate plist — uninstall it too,
+    // otherwise `uninstall` leaves the backup job firing forever on an
+    // install whose daemon has been removed.
+    await uninstallBackupAgent();
   } else if (isSystemdAvailable()) {
     console.log("Removing systemd service...");
     await uninstallSystemdService();
@@ -1270,6 +1293,48 @@ async function cmdDoctor() {
       break;
   }
 
+  // Backup — only verify when the user has asked for automatic backups.
+  // Manual mode is the default; showing a "not loaded" check when the user
+  // explicitly didn't configure scheduled backups is noise, not a finding.
+  const backupCfg = readGlobalConfig().backup;
+  if (backupCfg && backupCfg.schedule !== "manual") {
+    // 1. Agent loaded? (macOS only — systemd path for backup lands in a
+    // follow-up PR; on Linux we silently skip this half of the check.)
+    if (process.platform === "darwin") {
+      const loaded = await isBackupAgentLoaded();
+      checks.push({
+        name: "backup agent",
+        status: loaded ? "pass" : "warn",
+        detail: loaded ? `loaded (schedule: ${backupCfg.schedule})` : `not loaded (schedule: ${backupCfg.schedule})`,
+        fix: loaded ? undefined : `Re-run \`parachute vault backup --schedule ${backupCfg.schedule}\` to reinstall the agent.`,
+      });
+    }
+
+    // 2. Destination writability. A backup agent that fires into a path that
+    // doesn't exist (or is read-only) is the worst failure mode — silent
+    // until the user needs the backup, then "I have no backups." We try to
+    // mkdir the configured path and tap it for write access.
+    if (backupCfg.destinations.length === 0) {
+      checks.push({
+        name: "backup destinations",
+        status: "warn",
+        detail: "schedule is active but no destinations configured",
+        fix: "Edit ~/.parachute/config.yaml and add at least one destination under `backup.destinations`.",
+      });
+    } else {
+      for (const dest of backupCfg.destinations) {
+        const res = checkDestinationWritable(dest);
+        checks.push({
+          name: `backup destination (${dest.kind})`,
+          status: res.ok ? "pass" : "warn",
+          detail: res.ok ? res.path : `${res.path}: ${res.error}`,
+          fix: res.ok ? undefined : "Ensure the path exists and is writable, or update it in ~/.parachute/config.yaml.",
+        });
+      }
+    }
+  }
+
+
   // Render.
   const icons = { pass: " ✓", warn: " !", fail: " ✗" } as const;
   console.log("Parachute Vault — doctor\n");
@@ -1492,6 +1557,153 @@ async function describeProcess(pid: number): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Backup — parachute vault backup [--schedule <freq> | status]
+// ---------------------------------------------------------------------------
+
+async function cmdBackup(args: string[]) {
+  // Subcommand: `status`
+  if (args[0] === "status") {
+    await cmdBackupStatus();
+    return;
+  }
+
+  // Flag: `--schedule <freq>`
+  const schedFlag = args.indexOf("--schedule");
+  if (schedFlag !== -1) {
+    const raw = args[schedFlag + 1];
+    if (!raw) {
+      console.error("Usage: parachute vault backup --schedule <hourly|daily|weekly|manual>");
+      process.exit(1);
+    }
+    if (raw !== "hourly" && raw !== "daily" && raw !== "weekly" && raw !== "manual") {
+      console.error(`Invalid schedule: ${raw}. Must be one of: hourly, daily, weekly, manual.`);
+      process.exit(1);
+    }
+    await cmdBackupSchedule(raw);
+    return;
+  }
+
+  // Default: one-shot backup.
+  await cmdBackupRun();
+}
+
+async function cmdBackupRun() {
+  const cfg = readGlobalConfig().backup ?? defaultBackupConfig();
+  if (cfg.destinations.length === 0) {
+    console.error("No backup destinations configured. Edit ~/.parachute/config.yaml:");
+    console.error("  backup:");
+    console.error("    destinations:");
+    console.error("      - kind: local");
+    console.error(`        path: ~/Library/Mobile Documents/com~apple~CloudDocs/parachute-backups`);
+    process.exit(1);
+  }
+
+  console.log("Running backup...");
+  const result = await runBackup({ backup: cfg });
+  const bytes = result.bytes;
+  const kb = Math.round(bytes / 1024);
+  console.log(`  Snapshot: ${result.contents.dbSnapshots.length} DB(s), ${result.contents.configFiles.length} config file(s), ${kb} KB`);
+
+  let ok = 0;
+  for (const r of result.destinations) {
+    if (r.error) {
+      console.error(`  ${r.destination.kind} — FAILED: ${r.error}`);
+      continue;
+    }
+    ok++;
+    const prunedStr = r.pruned > 0 ? ` (pruned ${r.pruned} older)` : "";
+    console.log(`  ${r.destination.kind} → ${r.writtenPath}${prunedStr}`);
+  }
+  if (ok === 0) {
+    process.exit(1);
+  }
+}
+
+async function cmdBackupSchedule(schedule: BackupSchedule) {
+  const cfg = updateBackupConfig({ schedule });
+
+  if (process.platform !== "darwin") {
+    console.log(`Schedule set to: ${schedule}`);
+    console.log("Note: scheduled backups are only registered on macOS in this MVP.");
+    console.log("Linux systemd-timer support is a follow-up PR.");
+    return;
+  }
+
+  if (schedule === "manual") {
+    await uninstallBackupAgent();
+    console.log("Schedule: manual — backup agent removed.");
+    console.log("Run `parachute vault backup` to trigger a backup on demand.");
+    return;
+  }
+
+  if (cfg.destinations.length === 0) {
+    console.log(`Schedule set to: ${schedule}`);
+    console.log();
+    console.log("WARNING: no destinations configured — scheduled runs will fail.");
+    console.log("Edit ~/.parachute/config.yaml and add at least one destination under `backup.destinations`.");
+  }
+
+  await installBackupAgent(schedule);
+  console.log(`Schedule: ${schedule} — backup agent installed.`);
+  console.log(`  Plist:    ${BACKUP_PLIST_PATH}`);
+  console.log(`  Next run: ${describeNextRun(schedule)}`);
+}
+
+async function cmdBackupStatus() {
+  const cfg = readGlobalConfig().backup ?? defaultBackupConfig();
+  const last = readLastBackup();
+
+  console.log("Parachute Vault — backup\n");
+  console.log(`  Schedule:   ${cfg.schedule}`);
+  console.log(`  Retention:  ${cfg.retention} snapshot(s)`);
+
+  if (cfg.destinations.length === 0) {
+    console.log(`  Destinations: (none)`);
+  } else {
+    console.log(`  Destinations:`);
+    for (const d of cfg.destinations) {
+      if (d.kind === "local") {
+        console.log(`    - local: ${expandTilde(d.path)}`);
+      }
+    }
+  }
+
+  if (process.platform === "darwin") {
+    const loaded = await isBackupAgentLoaded();
+    console.log(`  Agent:      ${loaded ? "loaded (launchctl)" : "not loaded"}`);
+  }
+
+  if (last) {
+    console.log();
+    console.log(`  Last run:   ${last.timestamp}`);
+    console.log(`    Size:     ${Math.round(last.bytes / 1024)} KB`);
+    for (const d of last.destinations) {
+      if (d.error) {
+        console.log(`    FAILED:   ${d.error}`);
+      } else if (d.path) {
+        console.log(`    Wrote:    ${d.path}`);
+      }
+    }
+  } else {
+    console.log();
+    console.log("  Last run:   (never)");
+  }
+
+  if (cfg.schedule !== "manual") {
+    console.log();
+    console.log(`  Next run:   ${describeNextRun(cfg.schedule)}`);
+  }
+}
+
+function describeNextRun(schedule: BackupSchedule): string {
+  const est = nextRunEstimate(schedule, new Date());
+  if (!est) return "(manual — on demand only)";
+  // Render in local time so the user's sense of "around 3am" matches what
+  // launchd will actually do.
+  return est.toLocaleString();
 }
 
 // ---------------------------------------------------------------------------
@@ -1779,6 +1991,11 @@ Config:
   parachute vault config                   Show current configuration
   parachute vault config set <key> <val>   Set a config value
   parachute vault config unset <key>       Remove a config value
+
+Backup:
+  parachute vault backup                        One-shot backup to configured destinations
+  parachute vault backup --schedule <freq>      hourly | daily | weekly | manual (macOS launchd)
+  parachute vault backup status                 Show schedule, last run, destinations, next run
 
 Import/Export:
   parachute vault import <path>            Import an Obsidian vault

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,7 @@ import {
   updateBackupConfig,
   expandTilde,
   checkDestinationWritable,
+  tierTally,
 } from "./backup.ts";
 import {
   installBackupAgent,
@@ -1658,7 +1659,11 @@ async function cmdBackupStatus() {
 
   console.log("Parachute Vault — backup\n");
   console.log(`  Schedule:   ${cfg.schedule}`);
-  console.log(`  Retention:  ${cfg.retention} snapshot(s)`);
+  // Tiered retention is always rendered as a one-line summary; per-tier
+  // counts from real destinations go under each destination below.
+  const r = cfg.retention;
+  const yearlyStr = r.yearly === null ? "∞" : String(r.yearly);
+  console.log(`  Retention:  ${r.daily} daily / ${r.weekly} weekly / ${r.monthly} monthly / ${yearlyStr} yearly`);
 
   if (cfg.destinations.length === 0) {
     console.log(`  Destinations: (none)`);
@@ -1666,7 +1671,15 @@ async function cmdBackupStatus() {
     console.log(`  Destinations:`);
     for (const d of cfg.destinations) {
       if (d.kind === "local") {
-        console.log(`    - local: ${expandTilde(d.path)}`);
+        const path = expandTilde(d.path);
+        console.log(`    - local: ${path}`);
+        // Per-destination tier breakdown — counts the snapshots on disk and
+        // each tier's individual contribution to the keep set. A snapshot
+        // can satisfy multiple tiers, so per-tier counts may sum to > total.
+        const t = tierTally(path, cfg.retention);
+        if (t.total > 0) {
+          console.log(`        on-disk: ${t.total} snapshot(s) — ${t.daily}d / ${t.weekly}w / ${t.monthly}mo / ${t.yearly}y`);
+        }
       }
     }
   }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -140,3 +140,91 @@ describe("config", () => {
     expect(readGlobalConfig().discovery).toBe("disabled");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Backup config — round-trip through writeGlobalConfig + readGlobalConfig
+// ---------------------------------------------------------------------------
+
+import { describe as describe2, test as test2, expect as expect2, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+describe2("backup config round-trip", () => {
+  // We can't just call writeGlobalConfig / readGlobalConfig like above: they
+  // write into CONFIG_DIR, which is derived from PARACHUTE_HOME at import
+  // time. So we spawn a child process with an isolated PARACHUTE_HOME to
+  // test the full read/write cycle, matching the pattern in doctor.test.ts.
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "backup-cfg-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test2("writes and reads a backup section with a local destination", async () => {
+    // Child script writes a config, re-reads it, and prints the normalized
+    // result. This exercises the full YAML round-trip without mocking.
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const { writeGlobalConfig, readGlobalConfig } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      writeGlobalConfig({
+        port: 1940,
+        default_vault: "default",
+        backup: {
+          schedule: "daily",
+          retention: 7,
+          destinations: [{ kind: "local", path: "~/parachute-backups" }],
+        },
+      });
+      const read = readGlobalConfig();
+      console.log(JSON.stringify(read.backup));
+    `;
+    const proc = Bun.spawnSync({
+      cmd: ["bun", "-e", script],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = new TextDecoder().decode(proc.stdout);
+    const stderr = new TextDecoder().decode(proc.stderr);
+    expect2(proc.exitCode, stderr).toBe(0);
+
+    const parsed = JSON.parse(stdout.trim());
+    expect2(parsed.schedule).toBe("daily");
+    expect2(parsed.retention).toBe(7);
+    expect2(parsed.destinations.length).toBe(1);
+    expect2(parsed.destinations[0].kind).toBe("local");
+    expect2(parsed.destinations[0].path).toBe("~/parachute-backups");
+  });
+
+  test2("config without a backup section reads back with backup === undefined", async () => {
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const { writeGlobalConfig, readGlobalConfig } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      writeGlobalConfig({ port: 1940, default_vault: "default" });
+      const read = readGlobalConfig();
+      console.log(JSON.stringify({ backup: read.backup ?? null }));
+    `;
+    const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
+    const out = new TextDecoder().decode(proc.stdout);
+    expect2(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(out.trim());
+    expect2(parsed.backup).toBeNull();
+  });
+
+  test2("empty destinations round-trips as empty list (not missing key)", async () => {
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const { writeGlobalConfig, readGlobalConfig } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      writeGlobalConfig({
+        port: 1940,
+        backup: { schedule: "manual", retention: 14, destinations: [] },
+      });
+      const read = readGlobalConfig();
+      console.log(JSON.stringify(read.backup));
+    `;
+    const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
+    const out = new TextDecoder().decode(proc.stdout);
+    expect2(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(out.trim());
+    expect2(parsed.schedule).toBe("manual");
+    expect2(parsed.destinations).toEqual([]);
+  });
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -159,7 +159,7 @@ describe2("backup config round-trip", () => {
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "backup-cfg-")); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
-  test2("writes and reads a backup section with a local destination", async () => {
+  test2("writes and reads a backup section with tiered retention + local dest", async () => {
     // Child script writes a config, re-reads it, and prints the normalized
     // result. This exercises the full YAML round-trip without mocking.
     const script = `
@@ -170,7 +170,7 @@ describe2("backup config round-trip", () => {
         default_vault: "default",
         backup: {
           schedule: "daily",
-          retention: 7,
+          retention: { daily: 7, weekly: 4, monthly: 12, yearly: null },
           destinations: [{ kind: "local", path: "~/parachute-backups" }],
         },
       });
@@ -188,10 +188,74 @@ describe2("backup config round-trip", () => {
 
     const parsed = JSON.parse(stdout.trim());
     expect2(parsed.schedule).toBe("daily");
-    expect2(parsed.retention).toBe(7);
+    expect2(parsed.retention).toEqual({ daily: 7, weekly: 4, monthly: 12, yearly: null });
     expect2(parsed.destinations.length).toBe(1);
     expect2(parsed.destinations[0].kind).toBe("local");
     expect2(parsed.destinations[0].path).toBe("~/parachute-backups");
+  });
+
+  test2("retention defaults when the user omits the retention block entirely", async () => {
+    // A backup: with schedule only (no retention block) should pick up the
+    // shipped defaults: 7/4/12/null.
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const fs = await import("fs");
+      const path = await import("path");
+      fs.writeFileSync(path.join(${JSON.stringify(dir)}, "config.yaml"),
+        "port: 1940\\nbackup:\\n  schedule: daily\\n  destinations: []\\n");
+      const { readGlobalConfig } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      console.log(JSON.stringify(readGlobalConfig().backup));
+    `;
+    const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
+    const out = new TextDecoder().decode(proc.stdout);
+    expect2(proc.exitCode, new TextDecoder().decode(proc.stderr)).toBe(0);
+    const parsed = JSON.parse(out.trim());
+    expect2(parsed.retention).toEqual({ daily: 7, weekly: 4, monthly: 12, yearly: null });
+  });
+
+  test2("partial retention block: unspecified tiers default to 0 (explicit > merged)", async () => {
+    // If the user supplies a retention block with only `daily: 3`, the
+    // remaining tiers read as 0 rather than merging with shipped defaults.
+    // Predictable: what you write is what you get.
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const fs = await import("fs");
+      const path = await import("path");
+      fs.writeFileSync(path.join(${JSON.stringify(dir)}, "config.yaml"),
+        "port: 1940\\nbackup:\\n  schedule: daily\\n  retention:\\n    daily: 3\\n  destinations: []\\n");
+      const { readGlobalConfig } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      console.log(JSON.stringify(readGlobalConfig().backup));
+    `;
+    const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
+    const out = new TextDecoder().decode(proc.stdout);
+    expect2(proc.exitCode, new TextDecoder().decode(proc.stderr)).toBe(0);
+    const parsed = JSON.parse(out.trim());
+    expect2(parsed.retention.daily).toBe(3);
+    expect2(parsed.retention.weekly).toBe(0);
+    expect2(parsed.retention.monthly).toBe(0);
+    // yearly stays at 0 because the user didn't say null.
+    expect2(parsed.retention.yearly).toBe(0);
+  });
+
+  test2("yearly: null round-trips through write/read as JSON null", async () => {
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const { writeGlobalConfig, readGlobalConfig } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      writeGlobalConfig({
+        port: 1940,
+        backup: {
+          schedule: "manual",
+          retention: { daily: 0, weekly: 0, monthly: 0, yearly: null },
+          destinations: [],
+        },
+      });
+      console.log(JSON.stringify(readGlobalConfig().backup));
+    `;
+    const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
+    const out = new TextDecoder().decode(proc.stdout);
+    expect2(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(out.trim());
+    expect2(parsed.retention.yearly).toBeNull();
   });
 
   test2("config without a backup section reads back with backup === undefined", async () => {
@@ -215,7 +279,11 @@ describe2("backup config round-trip", () => {
       const { writeGlobalConfig, readGlobalConfig } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
       writeGlobalConfig({
         port: 1940,
-        backup: { schedule: "manual", retention: 14, destinations: [] },
+        backup: {
+          schedule: "manual",
+          retention: { daily: 7, weekly: 4, monthly: 12, yearly: null },
+          destinations: [],
+        },
       });
       const read = readGlobalConfig();
       console.log(JSON.stringify(read.backup));

--- a/src/config.ts
+++ b/src/config.ts
@@ -169,6 +169,46 @@ export interface GlobalConfig {
    *   callers.
    */
   discovery?: "enabled" | "disabled";
+  /** Backup configuration: schedule, retention, destinations. */
+  backup?: BackupConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Backup configuration
+// ---------------------------------------------------------------------------
+
+export type BackupSchedule = "hourly" | "daily" | "weekly" | "manual";
+
+/**
+ * Discriminated union over destination kinds. For the MVP we ship `local`
+ * only; `s3`, `rsync`, and `cloud` kinds will be added as additional variants
+ * without breaking existing configs. Unknown kinds are preserved verbatim so
+ * a forward-rolled config edited by a newer CLI isn't silently downgraded by
+ * an older CLI rewriting the file.
+ */
+export interface LocalBackupDestination {
+  kind: "local";
+  /** Absolute or `~/`-prefixed path. `~/` is expanded at use-time. */
+  path: string;
+}
+
+export type BackupDestination = LocalBackupDestination;
+
+export interface BackupConfig {
+  /** How often the scheduler fires. "manual" = scheduler is not registered. */
+  schedule: BackupSchedule;
+  /** Keep the most recent N snapshots per destination; older are pruned. */
+  retention: number;
+  /** Pluggable destinations. Runs in order; a destination error logs + continues. */
+  destinations: BackupDestination[];
+}
+
+export function defaultBackupConfig(): BackupConfig {
+  return {
+    schedule: "manual",
+    retention: 14,
+    destinations: [],
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -459,6 +499,125 @@ function parseTriggers(yaml: string): TriggerConfig[] | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Backup YAML parsing / serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `backup:` section. Returns undefined if no section is present so
+ * callers can tell "user hasn't configured backups" apart from "user asked
+ * for the default (schedule: manual, empty destinations)."
+ *
+ * Shape:
+ *   backup:
+ *     schedule: daily
+ *     retention: 14
+ *     destinations:
+ *       - kind: local
+ *         path: ~/Library/Mobile Documents/com~apple~CloudDocs/parachute-backups
+ */
+function parseBackup(yaml: string): BackupConfig | undefined {
+  const startMatch = yaml.match(/^backup:\s*$/m);
+  if (!startMatch) return undefined;
+
+  const startIdx = (startMatch.index ?? 0) + startMatch[0].length;
+  const lines = yaml.slice(startIdx).split("\n");
+
+  const backup: BackupConfig = defaultBackupConfig();
+  let section: "top" | "destinations" = "top";
+  let currentDest: Partial<BackupDestination> & { kind?: string } = {};
+  let hasDest = false;
+
+  const pushDest = () => {
+    if (!hasDest) return;
+    // For the MVP we only ship `local`. Unknown/malformed destination kinds
+    // are skipped rather than rejected: a forward-rolled config authored by
+    // a newer CLI mustn't break backup for the features this CLI does
+    // understand. The backup command itself warns about skipped kinds.
+    if (currentDest.kind === "local" && typeof currentDest.path === "string") {
+      backup.destinations.push({ kind: "local", path: currentDest.path });
+    }
+    currentDest = {};
+    hasDest = false;
+  };
+
+  for (const line of lines) {
+    // Stop at next top-level key.
+    if (line.match(/^\S/) && line.trim().length > 0) break;
+    if (line.trim().length === 0) continue;
+
+    const trimmed = line.trim();
+
+    // Section header: `destinations:` at 2-space indent.
+    if (/^destinations:\s*$/.test(trimmed)) {
+      section = "destinations";
+      continue;
+    }
+
+    if (section === "top") {
+      const schedMatch = trimmed.match(/^schedule:\s*(\S+)/);
+      if (schedMatch) {
+        const v = schedMatch[1];
+        if (v === "hourly" || v === "daily" || v === "weekly" || v === "manual") {
+          backup.schedule = v;
+        }
+        continue;
+      }
+      const retMatch = trimmed.match(/^retention:\s*(\d+)/);
+      if (retMatch) {
+        const n = parseInt(retMatch[1], 10);
+        if (Number.isFinite(n) && n >= 1) backup.retention = n;
+        continue;
+      }
+    }
+
+    if (section === "destinations") {
+      // Start of a new list item: "- kind: local" or just "- kind:"
+      const itemMatch = trimmed.match(/^-\s+(\w+):\s*(.*)$/);
+      if (itemMatch) {
+        pushDest();
+        hasDest = true;
+        currentDest = {};
+        (currentDest as Record<string, string>)[itemMatch[1]] = itemMatch[2].trim();
+        continue;
+      }
+      // Continuation line inside the current list item.
+      const fieldMatch = trimmed.match(/^(\w+):\s*(.*)$/);
+      if (fieldMatch && hasDest) {
+        (currentDest as Record<string, string>)[fieldMatch[1]] = fieldMatch[2].trim();
+        continue;
+      }
+    }
+  }
+  pushDest();
+
+  return backup;
+}
+
+function serializeBackup(backup: BackupConfig): string[] {
+  const lines: string[] = [];
+  lines.push("backup:");
+  lines.push(`  schedule: ${backup.schedule}`);
+  lines.push(`  retention: ${backup.retention}`);
+  if (backup.destinations.length > 0) {
+    lines.push("  destinations:");
+    for (const dest of backup.destinations) {
+      lines.push(`    - kind: ${dest.kind}`);
+      // Paths may contain ~, spaces, and `.` — the whole line being on its
+      // own key line means we don't need to quote unless the value begins
+      // with a YAML-special character. Quoting defensively keeps the
+      // hand-rolled parser happy under future path-with-colons pressure.
+      if ("path" in dest) {
+        const needsQuote = /[:#]/.test(dest.path);
+        lines.push(`      path: ${needsQuote ? `"${dest.path}"` : dest.path}`);
+      }
+    }
+  } else {
+    lines.push("  destinations: []");
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
 // Directory management
 // ---------------------------------------------------------------------------
 
@@ -538,6 +697,9 @@ export function readGlobalConfig(): GlobalConfig {
       // Parse triggers
       config.triggers = parseTriggers(yaml);
 
+      // Parse backup section
+      config.backup = parseBackup(yaml);
+
       return config;
     }
   } catch {}
@@ -604,6 +766,10 @@ export function writeGlobalConfig(config: GlobalConfig): void {
         lines.push(`      timeout: ${trigger.action.timeout}`);
       }
     }
+  }
+
+  if (config.backup) {
+    lines.push(...serializeBackup(config.backup));
   }
 
   // 0600 — owner read/write only. This file may contain the bcrypt password

--- a/src/config.ts
+++ b/src/config.ts
@@ -194,19 +194,56 @@ export interface LocalBackupDestination {
 
 export type BackupDestination = LocalBackupDestination;
 
+/**
+ * Tiered (grandfather-father-son) retention policy. After each backup we keep
+ * the union of four tier queries:
+ *
+ *   daily   — the N most recent snapshots (unconditionally).
+ *   weekly  — one snapshot per ISO week, for the N most recent such weeks.
+ *   monthly — one snapshot per calendar month, for the N most recent months.
+ *   yearly  — one snapshot per calendar year; `null` means keep every year
+ *             (never prune by age — the long-tail archive).
+ *
+ * A tier set to 0 is disabled (it contributes no keepers, but the other tiers
+ * still apply). All bucketing uses the local timezone so calendar alignment
+ * matches the user's expectations, not UTC.
+ */
+export interface RetentionPolicy {
+  /** Keep the last N daily snapshots. 0 disables the daily tier. */
+  daily: number;
+  /** Keep the last snapshot from each of the last N ISO weeks. 0 disables. */
+  weekly: number;
+  /** Keep the last snapshot from each of the last N months. 0 disables. */
+  monthly: number;
+  /**
+   * Keep the last snapshot from each of the last N years. `null` or `undefined`
+   * means unbounded — keep one snapshot per year, forever, across the full
+   * history. 0 disables the yearly tier entirely.
+   */
+  yearly: number | null;
+}
+
 export interface BackupConfig {
   /** How often the scheduler fires. "manual" = scheduler is not registered. */
   schedule: BackupSchedule;
-  /** Keep the most recent N snapshots per destination; older are pruned. */
-  retention: number;
+  /** Tiered retention policy — grandfather/father/son. */
+  retention: RetentionPolicy;
   /** Pluggable destinations. Runs in order; a destination error logs + continues. */
   destinations: BackupDestination[];
+}
+
+export function defaultRetentionPolicy(): RetentionPolicy {
+  // Defaults balance "I want to roll back yesterday's accidental delete"
+  // against "my iCloud folder shouldn't blow up in a year." The yearly tier
+  // is unbounded by default — the whole point of the tiered policy is that
+  // one-per-year is cheap forever.
+  return { daily: 7, weekly: 4, monthly: 12, yearly: null };
 }
 
 export function defaultBackupConfig(): BackupConfig {
   return {
     schedule: "manual",
-    retention: 14,
+    retention: defaultRetentionPolicy(),
     destinations: [],
   };
 }
@@ -510,7 +547,11 @@ function parseTriggers(yaml: string): TriggerConfig[] | undefined {
  * Shape:
  *   backup:
  *     schedule: daily
- *     retention: 14
+ *     retention:
+ *       daily: 7
+ *       weekly: 4
+ *       monthly: 12
+ *       yearly: null       # or omit for unbounded; 0 disables the tier
  *     destinations:
  *       - kind: local
  *         path: ~/Library/Mobile Documents/com~apple~CloudDocs/parachute-backups
@@ -523,9 +564,14 @@ function parseBackup(yaml: string): BackupConfig | undefined {
   const lines = yaml.slice(startIdx).split("\n");
 
   const backup: BackupConfig = defaultBackupConfig();
-  let section: "top" | "destinations" = "top";
+  let section: "top" | "retention" | "destinations" = "top";
   let currentDest: Partial<BackupDestination> & { kind?: string } = {};
   let hasDest = false;
+  // Track whether the user supplied a retention block at all. If they did,
+  // we start from a clean slate (all tiers default 0, yearly null) so that
+  // an explicit partial policy overrides defaults rather than merging with
+  // them — predictable semantics beat magical merging.
+  let retentionSeen = false;
 
   const pushDest = () => {
     if (!hasDest) return;
@@ -547,13 +593,33 @@ function parseBackup(yaml: string): BackupConfig | undefined {
 
     const trimmed = line.trim();
 
-    // Section header: `destinations:` at 2-space indent.
-    if (/^destinations:\s*$/.test(trimmed)) {
-      section = "destinations";
-      continue;
+    // A 2-space-indented line starting a new sub-section closes the previous
+    // section. The only 2-space keys under `backup:` today are `schedule`,
+    // `retention`, and `destinations`, so we key off indent depth here.
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+
+    if (indent === 2) {
+      if (/^retention:\s*$/.test(trimmed)) {
+        section = "retention";
+        retentionSeen = true;
+        // Zero-out tiers so partially specified blocks don't silently merge
+        // with defaults in surprising ways.
+        backup.retention = { daily: 0, weekly: 0, monthly: 0, yearly: 0 };
+        continue;
+      }
+      if (/^destinations:\s*$/.test(trimmed)) {
+        pushDest();
+        section = "destinations";
+        continue;
+      }
+      // Any other 2-space top field terminates the current sub-section.
+      if (section !== "top") {
+        pushDest();
+        section = "top";
+      }
     }
 
-    if (section === "top") {
+    if (section === "top" && indent === 2) {
       const schedMatch = trimmed.match(/^schedule:\s*(\S+)/);
       if (schedMatch) {
         const v = schedMatch[1];
@@ -562,10 +628,25 @@ function parseBackup(yaml: string): BackupConfig | undefined {
         }
         continue;
       }
-      const retMatch = trimmed.match(/^retention:\s*(\d+)/);
-      if (retMatch) {
-        const n = parseInt(retMatch[1], 10);
-        if (Number.isFinite(n) && n >= 1) backup.retention = n;
+    }
+
+    if (section === "retention" && indent === 4) {
+      const tierMatch = trimmed.match(/^(daily|weekly|monthly|yearly):\s*(\S+)/);
+      if (tierMatch) {
+        const tier = tierMatch[1] as keyof RetentionPolicy;
+        const raw = tierMatch[2].trim();
+        // "null" / "~" / "unbounded" all mean "keep every year" for the
+        // yearly tier. For the other tiers they'd be meaningless; we
+        // silently treat them as disabled (0) rather than erroring.
+        if (raw === "null" || raw === "~" || raw === "unbounded") {
+          if (tier === "yearly") backup.retention.yearly = null;
+          // Other tiers stay at 0.
+          continue;
+        }
+        const n = parseInt(raw, 10);
+        if (Number.isFinite(n) && n >= 0) {
+          backup.retention[tier] = n as never;
+        }
         continue;
       }
     }
@@ -590,6 +671,11 @@ function parseBackup(yaml: string): BackupConfig | undefined {
   }
   pushDest();
 
+  // If the user left retention out entirely, fall back to the shipped default.
+  if (!retentionSeen) {
+    backup.retention = defaultRetentionPolicy();
+  }
+
   return backup;
 }
 
@@ -597,7 +683,13 @@ function serializeBackup(backup: BackupConfig): string[] {
   const lines: string[] = [];
   lines.push("backup:");
   lines.push(`  schedule: ${backup.schedule}`);
-  lines.push(`  retention: ${backup.retention}`);
+  lines.push("  retention:");
+  lines.push(`    daily: ${backup.retention.daily}`);
+  lines.push(`    weekly: ${backup.retention.weekly}`);
+  lines.push(`    monthly: ${backup.retention.monthly}`);
+  // `null` is serialized as the YAML literal `null` so round-trips preserve
+  // "unbounded." Numbers render as-is, including 0 (disabled).
+  lines.push(`    yearly: ${backup.retention.yearly === null ? "null" : backup.retention.yearly}`);
   if (backup.destinations.length > 0) {
     lines.push("  destinations:");
     for (const dest of backup.destinations) {


### PR DESCRIPTION
## Summary

Ships the backup MVP scoped for launch T-6. Three subcommands under `parachute vault backup`:

- **`parachute vault backup`** — one-shot: atomic `VACUUM INTO` snapshots of every `.db` file under `~/.parachute/` (top-level + per-vault), plus `config.yaml` and each `vaults/<name>/vault.yaml`, bundled into `parachute-backup-<ISO8601>.tar.gz`, copied to each configured destination, with per-destination retention pruning.
- **`parachute vault backup --schedule <freq>`** — `hourly` / `daily` / `weekly` / `manual`. Registers a macOS launchd agent (`computer.parachute.vault.backup`) that reuses the same server-path pointer the daemon uses, so repo moves don't break the agent. `manual` unregisters it.
- **`parachute vault backup status`** — schedule, retention, destinations, agent state, last run (from `backup-last.json`), next-run estimate.

Config shape added under `~/.parachute/config.yaml`:

```yaml
backup:
  schedule: daily
  retention: 14
  destinations:
    - kind: local
      path: ~/Library/Mobile Documents/com~apple~CloudDocs/parachute-backups
```

Only `local` destination kind ships here. The pipeline is split into stage / tar / dispatch layers so `s3`, `rsync`, and future `cloud` destinations plug in as new variants of `BackupDestination` without touching the snapshot, tarball, or scheduler code. An encryption hook would slot between `assembleTarball` and `writeToDestinations`.

`doctor` gains two checks (only when `backup.schedule != manual`):
- `backup agent` loaded (macOS)
- `backup destination (<kind>)` writable (via mkdir + write-probe)

## Out of scope (per the handoff)
- `s3`, `rsync`, `cloud` destination kinds (follow-up PRs)
- Encryption of snapshots (age/gpg) — the tarball stage is the insertion point for it, but not wired up
- Linux systemd-timer variant — `parachute vault backup` works on Linux but scheduled runs are macOS-only this PR
- Restore command — likely the next PR

## Test plan
- [x] `bun test src/` — 474/0 (up from 452/0); 22 new tests
- [x] `bun test core/src/` — 201/0, unchanged
- [x] Manual end-to-end: `parachute vault backup` produces a valid tarball, `vault backup status` renders, `vault backup --schedule manual` round-trips through config.yaml, invalid schedule values exit non-zero with a clear message, `vault doctor` surfaces backup agent + destination checks only when schedule is not manual
- [x] `VACUUM INTO` snapshots preserve DB contents (verified by round-tripping a marker row through the tarball in `backup.test.ts`)
- [x] Retention pruning keeps the N most recent by filename timestamp; non-backup files in the destination dir are ignored
- [x] Per-destination failure doesn't poison sibling destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)