### PR TITLE
docs: fix Claude Code MCP URL + drop stale localhost-bypass claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,14 +285,14 @@ Settings → Integrations → Add MCP → URL: `https://vault.yourdomain.com/mcp
 
 ### Claude Code
 
-`vault init` auto-configures `~/.claude.json`. To set manually:
+`vault init` auto-configures `~/.claude.json`. To set manually, use the vault-scoped endpoint — `{name}` is the vault to target (`default` on a fresh install, whatever you passed to `vault create` otherwise):
 
 ```json
 {
   "mcpServers": {
     "parachute-vault": {
       "type": "http",
-      "url": "http://127.0.0.1:1940/mcp",
+      "url": "http://127.0.0.1:1940/vaults/{name}/mcp",
       "headers": { "Authorization": "Bearer pvk_..." }
     }
   }

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -46,8 +46,10 @@ Authorization: Bearer <key>
 X-API-Key: <key>
 ```
 
-Requests from localhost bypass auth (you can hit the server directly without a
-key for local dev).
+Every request is authenticated — localhost and remote traffic go through the
+same path, there is no bypass. Local dev feels friction-free because you can
+hand the CLI-generated API key to your script without exposing it to the
+network, not because the auth check is skipped.
 
 Keys have a **scope**:
 


### PR DESCRIPTION
## Summary

Two concrete factual corrections a first-wave user will hit the moment they compare the docs to their actual install. PR 1 of a planned 6-step documentation polish sequence; scope is deliberately tight — accuracy only, no new content.

### 1. `README.md:295` — Claude Code MCP URL
The manual-config JSON example showed `http://127.0.0.1:1940/mcp`, but `vault init` (via `installMcpConfig` in `src/cli.ts:1940`) actually writes the vault-scoped form `http://127.0.0.1:1940/vaults/{name}/mcp`. Fixed to match what the CLI writes and added a one-line clarification for what `{name}` resolves to.

### 2. `docs/HTTP_API.md:49-50` — localhost bypass claim
"Requests from localhost bypass auth" was never true. `src/auth.ts` does no address-based bypass anywhere, and the README already states the correct policy at lines 263 and 334 ("No exceptions — localhost gets no special treatment"). Replaced with an accurate note.

### Scope search
Grepped `README.md` and `docs/` for the same classes of error:
- Other `/mcp` references: the route-table entries at `README.md:242,247` and `docs/HTTP_API.md:313-314` correctly document both unscoped and scoped forms as existing routes — not examples of what `vault init` writes. No fix needed.
- The Claude Desktop prose at `README.md:284, 384` uses the unscoped `/mcp` for a remote-access example. This *does* work post-#112 single-vault auto-default, and is adjacent to the OAuth walkthrough work slated for PR 2 — deliberately leaving it alone.
- No other localhost-bypass claims found.

## Test plan
- [x] No code changed; `bun test` not rerun (doc-only diff).
- [x] `git diff` verified: 6 lines added, 4 removed across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)