### PR TITLE
docs: OAuth 2.1 + PKCE walkthrough and client-connection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Daily uses the same OAuth flow. On first launch: enter the server URL, pick the 
 
 ### Multi-vault note
 
-OAuth tokens are vault-scoped — a token minted via `/vaults/work/oauth/token` only authenticates against `work`. The cross-vault code-replay attack was closed in #111: an auth code issued for one vault will be rejected at another vault's token endpoint.
+OAuth tokens are vault-scoped — a token minted via `/vaults/work/oauth/token` only authenticates against `work`. Cross-vault substitution is enforced at the OAuth layer: an auth code minted for one vault cannot be redeemed at another vault's token endpoint.
 
 On a **single-vault deployment**, the unscoped `/oauth/*` and `/mcp` paths transparently resolve to the lone vault — regardless of its name. A vault named `journal` works at `https://vault.example.com/mcp` with no vault-in-URL needed. On a **multi-vault deployment**, always use the vault-scoped path (`/vaults/{name}/mcp`, `/vaults/{name}/oauth/authorize`) so OAuth tokens mint against the intended vault.
 
@@ -327,7 +327,7 @@ Metadata is a JSON column. Vaults start blank — no predefined tags or schema.
 
 **All API and MCP requests require a valid API key.** No exceptions — localhost gets no special treatment.
 
-For wiring up an AI client (Claude Code, Claude Desktop, Parachute Daily), see [Connecting a client](#connecting-a-client) above. This section covers token-level details: how to pass a key, how to manage tokens, and which endpoints bypass auth.
+For wiring up an AI client (Claude Code, Claude Desktop, Parachute Daily), see [Connecting a client](#connecting-a-client) above. This section covers token-level details: how to pass a key, how to manage tokens, and which endpoints are public by design (`/health`, published notes at `/view/:id`).
 
 ### Passing the key
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,71 @@ A server on port 1940 with:
 
 Each vault is its own SQLite database. Run multiple vaults on one server.
 
+## Connecting a client
+
+Two ways to authenticate — pick based on the client, not the deployment:
+
+| Path | When to use | User action |
+|---|---|---|
+| **OAuth 2.1 + PKCE (browser flow)** | Claude Desktop, Parachute Daily, any third-party MCP client set up interactively | Click "Add integration", enter server URL, a browser opens to the vault's consent page, you enter the owner password, done — no token ever touches your clipboard |
+| **Bearer token** | Claude Code (auto-wired by `vault init`), CLI scripts, cron jobs, any non-interactive caller | `curl -H "Authorization: Bearer pvt_..."` — the token is printed once at `vault init` (save it) or minted on demand with `parachute vault tokens create` |
+
+Both paths end up with the same kind of token in the vault's DB — a `pvt_` string, scoped to one vault and one permission level (`full` or `read`). OAuth just moves the "how does the client get that token" step from "human copy-pastes it" to "browser-based handshake with the owner's consent."
+
+### Owner password (needed for OAuth)
+
+`vault init` prompts you to set an owner password (minimum 12 characters). This is what the OAuth consent page asks for when a client requests access. If you skip the prompt, OAuth still works but the consent page falls back to asking for a vault token instead — functional but clunky. Set it later with:
+
+```bash
+parachute vault set-password                # set / change
+parachute vault set-password --clear        # remove (reverts to token fallback)
+parachute vault 2fa enroll                  # optional: add TOTP 2FA on top
+```
+
+Password and 2FA secrets live in `~/.parachute/config.yaml` at mode 0600 (bcrypt hash + base32 TOTP secret).
+
+### Claude Code
+
+`vault init` fully auto-configures `~/.claude.json` — there's nothing else to do. The entry it writes uses a baked-in `pvt_` token rather than OAuth:
+
+```json
+{
+  "mcpServers": {
+    "parachute-vault": {
+      "type": "http",
+      "url": "http://127.0.0.1:1940/vaults/{name}/mcp",
+      "headers": { "Authorization": "Bearer pvt_..." }
+    }
+  }
+}
+```
+
+Where `{name}` is `default` on a fresh install, or whatever vault you pointed `vault init` at. **First MCP call after `vault init` requires no browser handoff — Claude Code uses the baked-in token and the vault's tools show up in your next session.** This is intentional: for an owner connecting their own machine's vault to their own Claude Code, the token is already there and OAuth would add friction.
+
+To re-point Claude Code at a different vault or rotate the token, re-run `parachute vault mcp-install` (idempotent) or edit `~/.claude.json` by hand.
+
+### Claude Desktop (OAuth)
+
+For Claude Desktop — or any install where the server is on a different machine from the client — use the browser-based OAuth flow:
+
+1. Claude Desktop → Settings → Integrations → Add MCP server.
+2. Enter the URL: `https://vault.yourdomain.com/vaults/{name}/mcp` (replace `{name}`, or use the unscoped `https://vault.yourdomain.com/mcp` on a single-vault deployment). **Do not paste a bearer token** — leave the auth field empty.
+3. An OAuth-capable MCP client discovers the vault's authorization server at `/.well-known/oauth-authorization-server`, registers itself via Dynamic Client Registration (RFC 7591), and opens your browser to the vault's consent page.
+4. Enter your owner password (plus TOTP code / backup code if 2FA is enabled), pick a scope (`full` or `read`), click Authorize.
+5. Browser redirects back. The connection is live. The client now holds a `pvt_` token scoped to this vault.
+
+If you'd rather skip OAuth — e.g. you're scripting the setup — Claude Desktop also accepts a bearer token via the integration's auth header field. Use a token from `parachute vault tokens create` (or the one from `vault init` if you still have it). This is the "manual bearer" fallback; OAuth is the recommended path.
+
+### Parachute Daily (mobile)
+
+Daily uses the same OAuth flow. On first launch: enter the server URL, pick the vault from the drop-down (populated from the public `GET /vaults/list` endpoint), tap **Connect to Vault**. The same consent-page handoff runs in your phone's browser, then redirects back to the app via the `parachute://oauth/callback` deep link. The app stores the `pvt_` token in platform secure storage.
+
+### Multi-vault note
+
+OAuth tokens are vault-scoped — a token minted via `/vaults/work/oauth/token` only authenticates against `work`. The cross-vault code-replay attack was closed in #111: an auth code issued for one vault will be rejected at another vault's token endpoint.
+
+On a **single-vault deployment**, the unscoped `/oauth/*` and `/mcp` paths transparently resolve to the lone vault — regardless of its name. A vault named `journal` works at `https://vault.example.com/mcp` with no vault-in-URL needed. On a **multi-vault deployment**, always use the vault-scoped path (`/vaults/{name}/mcp`, `/vaults/{name}/oauth/authorize`) so OAuth tokens mint against the intended vault.
+
 ## CLI
 
 ```bash
@@ -262,11 +327,14 @@ Metadata is a JSON column. Vaults start blank — no predefined tags or schema.
 
 **All API and MCP requests require a valid API key.** No exceptions — localhost gets no special treatment.
 
-`vault init` generates an API key automatically and configures Claude Code's MCP with it.
+For wiring up an AI client (Claude Code, Claude Desktop, Parachute Daily), see [Connecting a client](#connecting-a-client) above. This section covers token-level details: how to pass a key, how to manage tokens, and which endpoints bypass auth.
 
 ### Passing the key
 
-Both legacy API keys (`pvk_...`) and scoped tokens (`pvt_...`) work interchangeably:
+Tokens come in two shapes. Both work interchangeably at every authenticated endpoint:
+
+- `pvt_...` — per-vault scoped tokens (the modern format; what `vault init` mints, what OAuth issues, what `parachute vault tokens create` produces)
+- `pvk_...` — legacy global API keys from `config.yaml` (still honored for existing deployments)
 
 ```bash
 # Header (preferred)
@@ -277,26 +345,6 @@ curl -H "X-API-Key: pvt_..." http://localhost:1940/api/notes
 
 # Query param (for /view endpoint only — convenient for browsers)
 curl http://localhost:1940/view/noteId?key=pvt_...
-```
-
-### Claude Desktop
-
-Settings → Integrations → Add MCP → URL: `https://vault.yourdomain.com/mcp`, Header: `Authorization: Bearer pvk_...`
-
-### Claude Code
-
-`vault init` auto-configures `~/.claude.json`. To set manually, use the vault-scoped endpoint — `{name}` is the vault to target (`default` on a fresh install, whatever you passed to `vault create` otherwise):
-
-```json
-{
-  "mcpServers": {
-    "parachute-vault": {
-      "type": "http",
-      "url": "http://127.0.0.1:1940/vaults/{name}/mcp",
-      "headers": { "Authorization": "Bearer pvk_..." }
-    }
-  }
-}
 ```
 
 ### Token management


### PR DESCRIPTION
## Summary

PR 2 of 6 in the documentation-polish sequence. Biggest single onboarding win: a first-wave user hits `vault init`, sees a token printed once, and has no idea how it gets from there into Claude Desktop or Parachute Daily. This adds a new **Connecting a client** section (between "What you get" and "CLI") that walks each AI client through to first successful connection, and fixes the `pvk_`/`pvt_` token-shape inaccuracy in the related Claude Code example.

## The walkthrough covers

- **Two-auth-modes framing** — OAuth 2.1 + PKCE for interactive clients (Claude Desktop, Parachute Daily, third-party MCP); bearer token for non-interactive (Claude Code via `vault init`, CLI, cron). Clarifies that both paths mint the same `pvt_` token shape in the end.
- **Owner password + 2FA** — brief: what the `vault init` prompt is for, how to set/change later, what happens if you skip (consent page falls back to requiring a vault token). Not a full admin guide.
- **Claude Code** — describes what `vault init` actually does: writes `~/.claude.json` with a baked-in `pvt_` bearer header. First MCP call uses that token, no browser handoff. Verified by reading `installMcpConfig` in `src/cli.ts:1915-1947`.
- **Claude Desktop (OAuth)** — 5-step flow, protocol described in OAuth-capable-client-generic terms rather than claiming specific behavior of the Claude Desktop MCP client impl (which I can't verify from the vault repo).
- **Parachute Daily (mobile)** — one paragraph: same OAuth flow, plus the `parachute://oauth/callback` deep link for the redirect.
- **Multi-vault note** — OAuth tokens are vault-scoped (#111 pinned codes to issuing vault); single-vault deployments resolve unscoped paths to the lone vault (#112 single-vault auto-default); multi-vault deployments should always use `/vaults/{name}/...`.

## In-scope factual fixes

Per the PR instructions, corrected factual errors *in the section being rewritten*:

- **`pvk_` vs `pvt_`**: existing Claude Code example at README:296 showed `"Authorization": "Bearer pvk_..."`. But `vault init` mints `pvt_` tokens (via `generateToken()` in `src/token-store.ts`, called from `createVault()` in `src/cli.ts:1910`). Switched the new walkthrough to `pvt_` throughout. One reference to legacy `pvk_` remains in the "Passing the key" sub-section under `## Auth` as context for existing deployments — the server still honors both formats.
- **Old Claude Desktop one-liner** (README:282-284) advertised pasting a bearer token directly. That's still a supported fallback, but OAuth is the recommended path post-#111. Replaced with the full OAuth walkthrough; bearer-token fallback noted explicitly.
- **Old Claude Code subsection** at README:286-300 was correct post-PR #114 but less informative than what belongs here; superseded by the new section with an extra line of narrative about what the first MCP call looks like.

## Structural change to `## Auth`

Removed `### Claude Desktop` and `### Claude Code` subsections from inside `## Auth` (they're now in the new walkthrough). Rewrote the `## Auth` intro paragraph to point upward at the new section, so `## Auth` becomes a pure reference section for token shapes, passing methods, and token CLI — without duplicating the client-wiring walkthrough.

## Auth-flow facts I verified (for your double-check)

All of these are load-bearing for the walkthrough being accurate. Read the corresponding code before writing the prose.

| # | Claim in the walkthrough | Source file / function |
|---|---|---|
| 1 | `vault init` mints a `pvt_` token, not `pvk_` | `src/cli.ts:1900-1913` (`createVault`), `src/token-store.ts:56-58` (`generateToken` → `pvt_` prefix) |
| 2 | That token goes into `~/.claude.json` with a baked-in `Authorization: Bearer ...` header | `src/cli.ts:1915-1947` (`installMcpConfig`) |
| 3 | The MCP URL written is `/vaults/{defaultVault}/mcp`, not `/mcp` | `src/cli.ts:1940` |
| 4 | `vault init` prompts for owner password; skippable; minimum 12 chars | `src/cli.ts:267-270` (prompt call), `src/cli.ts:321-349` (`promptForOwnerPassword`) |
| 5 | If no owner password set, OAuth consent falls back to requiring a valid vault token | `src/oauth.ts:314-336` (`handleAuthorizePost`, `passwordMode` branch) |
| 6 | OAuth discovery endpoints live at `/.well-known/oauth-authorization-server` + `/.well-known/oauth-protected-resource`, both unscoped and vault-scoped | `src/oauth.ts:75-110` (`handleProtectedResource`, `handleAuthorizationServer`), `src/routing.ts:78-83, 300-311` |
| 7 | Unscoped `/oauth/*` routes via `resolveDefaultVault()` — single-vault deployments resolve to the lone vault regardless of name | `src/routing.ts:85-123` |
| 8 | OAuth codes are pinned to the issuing vault (#111); cross-vault code replay returns `invalid_grant` | `src/oauth.ts:480-486` (vault-mismatch rejection) |
| 9 | OAuth token response returns `{ access_token, token_type, scope, vault }` so the client learns which vault it connected to | `src/oauth.ts:509-514` |
| 10 | Server does NOT emit a `WWW-Authenticate` challenge on 401, so MCP clients must probe `/.well-known/*` themselves to discover OAuth | Confirmed by grep: no `WWW-Authenticate` header emitted anywhere in `src/` |
| 11 | Parachute Daily's flow matches: discovery → DCR → browser to `/oauth/authorize` → `parachute://oauth/callback` deep link → `/oauth/token` exchange | `parachute-daily/lib/features/settings/services/oauth_service.dart:62-125` (the `connect()` method and `_discover()`) |

Please spot-check any of these — the whole PR's value is that the walkthrough tells the truth about the system.

## Test plan
- [x] No code changed; `bun test` not rerun (doc-only diff).
- [x] `git diff --stat`: 1 file changed, 70 insertions(+), 22 deletions(-).
- [ ] Optional: skim the rendered README on the PR preview to catch any markdown formatting issues in the new table / code block / numbered list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)