### PR TITLE
docs: Tailscale Funnel walkthrough + uninstall CLI entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ parachute vault remove work --yes
 parachute vault init                       # one-command setup
 parachute vault status                     # check what's running
 parachute vault doctor                     # diagnose install/config issues (see Troubleshooting)
+parachute vault uninstall                  # remove daemon + MCP entry; keeps user data
+parachute vault uninstall --wipe           # ...and also remove vaults, .env, config.yaml, logs
+parachute vault uninstall --yes --wipe     # scripted destructive wipe (prints an audit line)
 
 # Vaults
 parachute vault create work                # create a new vault
@@ -474,6 +477,36 @@ sudo systemctl start cloudflared
 ```
 
 Then in Claude Desktop: Settings → Integrations → Add MCP → `https://vault.yourdomain.com/mcp` with `Authorization: Bearer pvk_...`.
+
+### Remote access via Tailscale Funnel
+
+If you're already on [Tailscale](https://tailscale.com), Funnel is the shortest path to a public HTTPS URL — no custom domain, no reverse-proxy config, no cert management. Good for a single-user vault or a vault shared with a handful of people; the edge has bandwidth and connection-count caps, so not suited to heavy traffic.
+
+Prerequisites: Tailscale v1.52 or later (earlier versions use a two-command `tailscale serve` + `tailscale funnel on` form that is now deprecated), the tailnet must have MagicDNS and HTTPS enabled in the admin console, and the `funnel` node attribute must be granted in your ACLs. The CLI adds the ACL entry on first use if you're the tailnet owner.
+
+Expose the vault:
+
+```bash
+# One command — Tailscale provisions the HTTPS cert, updates the ACL if needed,
+# and registers a persistent funnel that survives reboots.
+tailscale funnel --bg --https=443 localhost:1940
+
+# See what's being served and on which tailnet hostname
+tailscale funnel status
+
+# Take it down later
+tailscale funnel --https=443 localhost:1940 off
+# ...or nuke the whole funnel config
+tailscale funnel reset
+```
+
+The resulting URL is `https://<your-device>.<your-tailnet>.ts.net/` — `tailscale funnel status` prints it verbatim. You can also use ports `8443` or `10000` via `--https=<port>`; no other public ports are available to Funnel.
+
+Point any MCP client at the Tailscale URL:
+- Claude Desktop → Settings → Integrations → Add MCP → `https://<your-device>.<your-tailnet>.ts.net/vaults/{name}/mcp` (leave the Authorization field empty; the OAuth flow will handle it — see [Connecting a client](#connecting-a-client)).
+- Parachute Daily → enter the base URL `https://<your-device>.<your-tailnet>.ts.net`, pick the vault, tap Connect.
+
+**Cloudflare vs Tailscale, at a glance.** Pick Cloudflare when you want a custom domain, bandwidth headroom for heavier traffic, or to share the vault with people who aren't on your tailnet. Pick Tailscale when you're already running it, you're fine with a `*.ts.net` URL, and you want the setup to fit in two commands.
 
 ### Docker
 


### PR DESCRIPTION
## Summary

PR 4 of 6 in the documentation-polish sequence. Two additions:

1. **Tailscale Funnel walkthrough** as a new `### Remote access via Tailscale Funnel` subsection under `## Deployment`, parallel to the existing Cloudflare Tunnel subsection. For anyone already on Tailscale, this is a two-command path to a public HTTPS vault URL.
2. **`uninstall` CLI entry** — three rows in the Setup group of the main CLI block (bare, `--wipe`, `--yes --wipe`).

## Tailscale command shape I verified

Against the current Tailscale KB (links below), the v1.52+ unified form is:

```bash
tailscale funnel --bg --https=443 localhost:1940
tailscale funnel status
tailscale funnel --https=443 localhost:1940 off      # or: tailscale funnel reset
```

Two sources double-checked:
- https://tailscale.com/kb/1223/funnel — overall Funnel docs, confirms the simplified `tailscale funnel <target>` form post-1.52 and the 443/8443/10000 public-port list.
- https://tailscale.com/kb/1311/tailscale-funnel-http-https — confirms the exact `--bg --https=443 localhost:1940` invocation, the `off` subcommand, and `tailscale funnel reset`.
- https://tailscale.com/kb/1242/tailscale-serve — confirms the serve/funnel split: `serve` is tailnet-only, `funnel` is public.

The older two-step `tailscale serve https / http://127.0.0.1:1940` + `tailscale funnel 443 on` form that your task description mentions is what got superseded in v1.52 — the README flags v1.52+ as the prereq so users on current Tailscale get a command that actually runs.

Prereqs I included, all from the docs: Tailscale v1.52+, MagicDNS enabled, HTTPS enabled on the tailnet, funnel node attribute in the ACL (the CLI adds it on first use for tailnet owners). The walkthrough ends with a concise "when to prefer which" comparison against the Cloudflare section.

## `uninstall` behavior I verified (vs. your summary)

Read `cmdUninstall` in `src/cli.ts:1011-1112` end-to-end. Your summary is accurate; one small nuance to note:

- **Bare `vault uninstall`** tears down the main launchd agent **and the backup launchd agent** on macOS (line 1049) — so a user who ran `vault backup --schedule daily` doesn't need to set `--schedule manual` first; uninstall takes it all down.
- **`--wipe` uses two interactive confirms** ("Proceed?" then "Delete this data? (cannot be undone)"), not one. The second confirm defaults to NO so a distracted Enter-presser can't lose their vault. `--yes` skips both.
- **`--yes --wipe` audit line** lists all five target paths (`VAULTS_DIR, ENV_PATH, GLOBAL_CONFIG_PATH, LOG_PATH, ERR_PATH`) regardless of whether they exist on disk — it's documenting intent, not actual deletions. Acceptable behavior, worth knowing.

Nothing in your summary was wrong; these are just details the README gestures at without belaboring.

## Out-of-scope rot I noticed (flagging for a later PR, not touching here)

Line 476 of the existing Cloudflare Tunnel walkthrough still says `Authorization: Bearer pvk_...` and uses the unscoped `/mcp` path — that's the same pattern of staleness we cleaned up in PR #114 and #115 elsewhere in the README. I deliberately didn't touch it since it's in a section I wasn't assigned. Could pick up in PR 6/6 or a dedicated cleanup pass.

## Test plan
- [x] No code changed; `bun test` not rerun (docs-only).
- [x] `git diff --stat`: 1 file changed, +33 / -0.
- [ ] Optional: render preview on the GitHub PR to sanity-check the new subsection formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)