### PR TITLE
docs: pre-launch polish — value prop, prereqs, Cloudflare + view rot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Agent-native knowledge graph. Notes, tags, links over MCP. Self-hosted, one comm
 
 ```
 parachute vault init     →  ~/.parachute/ (config, .env, daemon, MCP)
-parachute vault create   →  new vault (SQLite DB + vault.yaml + API key)
+parachute vault create   →  new vault (SQLite DB + vault.yaml + pvt_ token)
 parachute vault config   →  manage env vars (PORT, etc.)
-parachute vault keys     →  list / create / revoke API keys
+parachute vault tokens   →  list / create / revoke per-vault tokens
 
 CLI  →  Bun server (port 1940)  →  multiple vaults (each its own SQLite DB)
                                          ↑

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Parachute Vault
 
-A self-hosted knowledge graph for AI agents. Notes, tags, links — exposed over MCP. Any AI gets a personal knowledge vault in one command.
+**Parachute Vault is a self-hosted knowledge graph that any AI can read and write, over the open [MCP](https://modelcontextprotocol.io) protocol.** Your notes, tags, links, and attachments live on your machine — in plain SQLite databases under `~/.parachute/`, not in a vendor's cloud.
+
+Works with Claude, ChatGPT, Gemini, or any future MCP-capable AI. Switch tools without losing your knowledge. No vendor lock-in, no re-import step when the next model lands. One command to install; one OAuth consent to connect each AI client.
 
 ## Quick start
 
-Requires [Bun](https://bun.sh) (`curl -fsSL https://bun.sh/install | bash`).
+Requires [Bun](https://bun.sh) (`curl -fsSL https://bun.sh/install | bash`) and macOS 13+ or Linux. No root needed — see [Requirements](#requirements) below for specifics.
 
 ```bash
 # Install globally (registers the `parachute` CLI)
@@ -366,7 +368,7 @@ On Linux, scheduled runs via systemd timers are a follow-up; for now `parachute 
 Serve notes as clean HTML pages at `/view/:noteId`:
 
 - **Without auth**: only serves notes tagged `published` (or with `metadata.published: true`). Returns 404 for unpublished notes.
-- **With auth**: serves any note. Pass API key via `Authorization: Bearer pvk_...` header or `?key=pvk_...` query param.
+- **With auth**: serves any note. Pass your token via `Authorization: Bearer pvt_...` header or `?key=pvt_...` query param.
 - **Custom tag**: set `published_tag` in vault.yaml to use a different tag name (default: `publish`).
 
 ```yaml
@@ -542,7 +544,7 @@ sudo cloudflared service install
 sudo systemctl start cloudflared
 ```
 
-Then in Claude Desktop: Settings → Integrations → Add MCP → `https://vault.yourdomain.com/mcp` with `Authorization: Bearer pvk_...`.
+Then point any client at `https://vault.yourdomain.com/vaults/{name}/mcp` (or `https://vault.yourdomain.com/mcp` for a single-vault deployment). See [Connecting a client → Claude Desktop (OAuth)](#claude-desktop-oauth) — the flow is identical to the local case once the URL is remote; the browser-based OAuth handshake makes the connection without pasting a bearer token.
 
 ### Remote access via Tailscale Funnel
 
@@ -588,9 +590,11 @@ docker compose up -d
 
 ## Requirements
 
-- [Bun](https://bun.sh) — `curl -fsSL https://bun.sh/install | bash`
-- macOS (launchd) or Linux (systemd) for background daemon
-- [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) for remote access (optional)
+- **Bun** — `curl -fsSL https://bun.sh/install | bash` ([bun.sh](https://bun.sh)).
+- **macOS 13+** (launchd user agent) **or Linux** (systemd user service; other init systems work if you start the server yourself).
+- **No root / sudo required** — `vault init` writes to your user home (`~/.parachute/`) and registers the daemon in your user scope only. Never touches system paths or global services.
+- **Not supported on Windows natively.** WSL2 hasn't been tested; file an issue if you try it and want it to work.
+- Optional, for remote access: [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) (Cloudflare Tunnel) or [Tailscale](https://tailscale.com) — see [Deployment](#deployment).
 
 ## License
 


### PR DESCRIPTION
## Summary

PR 6 of 6 — the final pre-launch docs pass before the 0.2.0 cut and npm publish. Five targeted edits across `README.md` + `CLAUDE.md`. No new sections; pure polish.

## Touchups

### A. Sharpened value-prop opening (`README.md:1-6`)
Replaced "A self-hosted knowledge graph for AI agents" with a two-paragraph lead that:
- Names the differentiator in the first sentence (self-hosted + any AI + open MCP).
- Follows with why it matters: data on your machine, works across Claude/ChatGPT/Gemini/any future MCP-capable AI, no vendor lock-in, no re-import when the next model lands.

### B. Prerequisites specifics (Quick start + Requirements)
- Quick start's one-liner expanded to name macOS 13+ or Linux and "no root needed," with a pointer to Requirements.
- Requirements section rewritten to spell out: Bun, macOS 13+ / Linux (systemd or manual-start), no root required, Windows-native not supported (WSL2 untested), optional remote-access deps (cloudflared / Tailscale).

### C. Cloudflare Tunnel staleness (`README.md:545`)
The wrap-up line still had the legacy `Authorization: Bearer pvk_...` bearer-token paste pattern from before #114 / #115. Rewrote to point at `Connecting a client → Claude Desktop (OAuth)`, since once the URL is remote the OAuth flow is the recommended path. Also names the vault-scoped `/vaults/{name}/mcp` URL (with a reminder that single-vault deployments can use the unscoped `/mcp`).

### D. `CLAUDE.md` `vault keys` → `vault tokens` (CLAUDE.md:8-11)
The architecture block referenced a removed subcommand. Verified at `src/cli.ts:139` that the actual subcommand is `tokens` (no `case "keys"` exists). Tightened the `create` line to `pvt_ token` while in the neighborhood.

### E. View endpoint token prefix (`README.md:369`)
`Authorization: Bearer pvk_...` → `Authorization: Bearer pvt_...` in the one remaining user-facing example that still used the legacy format. Legacy-format callouts at README:419 and :452 are deliberate and stay.

## Scope sweep

Before writing, I grepped `README.md`, `CLAUDE.md`, and `docs/` for the usual rot patterns:
- `pvk_` → 4 occurrences. Two legacy-callout mentions at :419 and :452 (deliberate, stay). Two stale user-facing examples at :369 and :545 (fixed).
- `vault keys` → 2 occurrences. README:452 is a past-tense "commands have been removed" acknowledgment (correct). CLAUDE.md:11 was the stale architecture-block ref (fixed).
- `localhost.*bypass` → 0. Cleaned up in PR #114.

Nothing else jumped out that's in scope for a polish pass.

## Test plan
- [x] No code changed; `bun test` not rerun (docs-only).
- [x] `git diff --stat`: 2 files, +13 / -9.
- [ ] Optional: render preview on the GitHub PR to sanity-check the reworked opening paragraph and the Requirements block.

After this merges, the README is launch-ready. Next: version bump → 0.2.0 → npm publish per issue #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)