### PR TITLE
fix(daemon): harden start.sh against set-u; add --version; cut 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Parachute Vault are documented here.
 
 This project loosely follows [Keep a Changelog](https://keepachangelog.com) and [Semantic Versioning](https://semver.org).
 
+## [0.2.2] — 2026-04-17
+
+### Fixed
+
+- **`start.sh` daemon wrapper no longer crashes on user shell profiles that reference unbound variables.** The generated wrapper ran `source ~/.zprofile` and `source ~/.zshrc` under `set -u`, so a zsh plugin framework or any conditional profile setup that touched an unset variable would abort the wrapper with exit 1. The `2>/dev/null` redirect swallowed the error, launchd saw repeated exit 1s, and the daemon silently refused to start with an empty `vault.err`. The wrapper now brackets the profile-source lines with `set +u` / `set -u` so -u is only active for code the wrapper owns. Run `parachute vault init` once on 0.2.2 to rewrite `~/.parachute/start.sh` — the rewrite is idempotent.
+
+### Added
+
+- **`parachute --version` / `parachute -v` / `parachute version`** print the installed package version to stdout. Works at the root and with the `vault` prefix (`parachute vault --version`, etc.). Reads from the installed `package.json` at module load, not a hardcoded string.
+
 ## [0.2.1] — 2026-04-17
 
 ### Fixed
@@ -83,5 +93,6 @@ First tagged public release. Ships the auth, backup, and onboarding surface the 
 - **`core/src/test-preload.ts`** isolates `PARACHUTE_HOME` for tests so `bun test` never touches a user's real `~/.parachute/`.
 - Test suite at release cut: **538 passing / 0 failing / 3 skipped** across 22 files (541 tests total).
 
+[0.2.2]: https://github.com/ParachuteComputer/parachute-vault/releases/tag/v0.2.2
 [0.2.1]: https://github.com/ParachuteComputer/parachute-vault/releases/tag/v0.2.1
 [0.2.0]: https://github.com/ParachuteComputer/parachute-vault/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ parachute vault init                       # one-command setup (idempotent — s
 parachute vault status                     # check what's running
 parachute vault doctor                     # diagnose install/config issues (see Troubleshooting)
 parachute vault url                        # print the local server URL (for scripts)
+parachute --version                        # print the installed version (aliases: -v, version)
 parachute vault uninstall                  # remove daemon + MCP entry; keeps user data
 parachute vault uninstall --wipe           # ...and also remove vaults, .env, config.yaml, logs
 parachute vault uninstall --yes --wipe     # scripted destructive wipe (prints an audit line)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,10 @@
 import { resolve } from "path";
 import { homedir } from "os";
 import { existsSync, readFileSync, writeFileSync, rmSync, mkdirSync } from "fs";
+// JSON import — resolved at module load, works for both dev runs
+// (`bun src/cli.ts …`) and the published package (`bunx @openparachute/vault`)
+// because package.json ships at the root next to src/.
+import pkg from "../package.json" with { type: "json" };
 import {
   ensureConfigDirSync,
   readVaultConfig,
@@ -179,6 +183,14 @@ switch (command) {
   case "--help":
   case "-h":
     usage();
+    break;
+  case "version":
+  case "--version":
+  case "-v":
+    // Intentionally minimal — just the version string on stdout. Scripts
+    // (and `parachute vault doctor` in a future check) rely on this being
+    // a bare-number line; anything else belongs in `vault status`.
+    console.log(pkg.version);
     break;
   default:
     console.error(`Unknown command: ${command}`);
@@ -1976,6 +1988,7 @@ Setup:
                                            config.yaml, and daemon logs (vault.log, vault.err).
                                            --yes skips prompts (DANGEROUS with --wipe: no confirmation).
   parachute vault url                      Print the local server URL (for scripts)
+  parachute --version                      Print the installed version (alias: -v, version)
 
 Vaults:
   parachute vault create <name>            Create a new vault

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -55,8 +55,17 @@ export function generateWrapper(opts: {
 set -u
 
 # Source user shell profile for PATH (needed for parakeet-mlx, ffmpeg, etc.)
+# Temporarily disable -u around these: user rc files routinely reference
+# unbound variables (zsh plugin frameworks, conditional setups), and a bare
+# \`set -u\` source would crash the wrapper with exit 1 and leave vault.err
+# empty because of the 2>/dev/null below — launchd would respawn silently
+# until it gave up. Keep the stderr redirect so expected "command not found"
+# noise from incomplete setups doesn't fill vault.err; to debug silent
+# wrapper failures, run \`bash -x ~/.parachute/start.sh\` by hand.
+set +u
 [ -f "$HOME/.zprofile" ] && source "$HOME/.zprofile" 2>/dev/null
 [ -f "$HOME/.zshrc" ] && source "$HOME/.zshrc" 2>/dev/null
+set -u
 
 if [ -f "${envPath}" ]; then
   set -a

--- a/src/launchd.test.ts
+++ b/src/launchd.test.ts
@@ -78,6 +78,84 @@ describe("generateWrapper", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // ---------------------------------------------------------------------------
+  // The incident this guards against (0.2.2): sourcing the user's ~/.zshrc or
+  // ~/.zprofile under `set -u` crashes the wrapper if any line in the rc file
+  // references an unbound variable — which is routine in zsh plugin frameworks
+  // and half-configured setups. The 2>/dev/null redirect swallowed the error
+  // so vault.err stayed empty and launchd silently gave up after repeated
+  // exit 1s. The fix brackets the profile-source lines with `set +u` / `set -u`
+  // so strict-unset-vars only applies to code the wrapper itself owns.
+  // ---------------------------------------------------------------------------
+
+  test("brackets profile sourcing with set +u / set -u to survive user rc files", () => {
+    const wrapper = generateWrapper({ bunPath: "/bin/bun" });
+    // Textual shape check — quickest canary.
+    const lines = wrapper.split("\n");
+    const zprofileIdx = lines.findIndex((l) => l.includes(".zprofile"));
+    const zshrcIdx = lines.findIndex((l) => l.includes(".zshrc"));
+    expect(zprofileIdx).toBeGreaterThan(-1);
+    expect(zshrcIdx).toBeGreaterThan(-1);
+    // Both source lines must be sandwiched between a `set +u` and a `set -u`.
+    // Walk back for `set +u` and forward for `set -u` from whichever source
+    // line comes first / last so ordering stays flexible.
+    const firstIdx = Math.min(zprofileIdx, zshrcIdx);
+    const lastIdx = Math.max(zprofileIdx, zshrcIdx);
+    const preceding = lines.slice(0, firstIdx).reverse().find((l) => l.trim().startsWith("set "));
+    const following = lines.slice(lastIdx + 1).find((l) => l.trim().startsWith("set "));
+    expect(preceding?.trim()).toBe("set +u");
+    expect(following?.trim()).toBe("set -u");
+  });
+
+  test("surviving profile source under set -u: running the generated wrapper with a rc file that trips set -u does not abort before reaching the pointer-file logic", async () => {
+    // The integration proof. Build a fake HOME where ~/.zshrc expands an
+    // unbound variable ($UNSET_IN_TEST), point the wrapper at it via HOME,
+    // and expect the wrapper to exit on the "server path not configured"
+    // path (exit 1 from the explicit check) rather than on the zshrc crash
+    // (exit 1 from set -u). The signal we compare on is the stderr message:
+    // the pointer-missing branch prints a specific error; a set-u crash
+    // prints zsh's own "parameter not set" message and no vault-branded
+    // text at all.
+    //
+    // Skipping stderr here would let a regressed wrapper silently exit 1
+    // and still pass the test, so we assert on the presence of the
+    // pointer-missing message.
+    const dir = mkdtempSync(join(tmpdir(), "vault-wrapper-setu-"));
+    try {
+      const fakeHome = join(dir, "home");
+      writeFileSync(join(dir, "mkdir.marker"), ""); // ensure dir exists
+      await $`mkdir -p ${fakeHome}`.quiet();
+      // A ~/.zshrc that blows up under set -u.
+      writeFileSync(join(fakeHome, ".zshrc"), 'echo "$UNSET_IN_TEST"\n');
+      // Wrapper with explicit env/pointer paths that do NOT exist. We do not
+      // pass PARACHUTE_VAULT_SERVER_PATH either. So the wrapper should take
+      // the "no server path configured" branch and exit 1 with the branded
+      // message — but only if it survives the zshrc source.
+      const wrapper = generateWrapper({
+        bunPath: "/bin/echo", // won't be reached; a safe no-op if it is
+        serverPathFile: join(dir, "nonexistent-pointer"),
+        envPath: join(dir, "nonexistent.env"),
+      });
+      const path = join(dir, "start.sh");
+      writeFileSync(path, wrapper);
+      // Override HOME so the wrapper sources our crafted zshrc.
+      // Clear PARACHUTE_VAULT_SERVER_PATH in case the test runner has it set.
+      const result = await $`HOME=${fakeHome} PARACHUTE_VAULT_SERVER_PATH= bash ${path}`
+        .quiet()
+        .nothrow();
+      const stderr = result.stderr.toString();
+      // Positive: we reached the branded pointer-missing branch.
+      expect(stderr).toMatch(/parachute-vault: server path not configured/);
+      // Negative: we did NOT crash in zshrc with a zsh/bash unbound-variable
+      // message. Catches a future regression where someone drops the
+      // `set +u` bracket.
+      expect(stderr).not.toMatch(/UNSET_IN_TEST: unbound variable/);
+      expect(result.exitCode).toBe(1); // the branded branch
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("generatePlist", () => {

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Integration tests for `parachute --version` and its aliases.
+ *
+ * Spawns the real CLI as a subprocess so the argv-dispatch path is exercised
+ * end-to-end. Every accepted spelling must produce the exact version string
+ * from package.json on stdout, with exit code 0, and nothing else.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+import pkg from "../package.json" with { type: "json" };
+
+const CLI = resolve(import.meta.dir, "cli.ts");
+
+function runCli(args: string[]): {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+} {
+  const proc = Bun.spawnSync({
+    cmd: ["bun", CLI, ...args],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+describe("parachute version", () => {
+  // Every spelling must print the package's version and nothing else.
+  // `parachute vault --version` works via the argv parser's existing
+  // `args[0] === "vault"` branch, which shifts "vault" off and treats
+  // `--version` as the command — so the same switch case handles both
+  // root and vault-prefixed invocations.
+  for (const form of [
+    ["--version"],
+    ["-v"],
+    ["version"],
+    ["vault", "--version"],
+    ["vault", "-v"],
+    ["vault", "version"],
+  ]) {
+    test(`parachute ${form.join(" ")} prints the package version`, () => {
+      const { exitCode, stdout, stderr } = runCli(form);
+      expect(exitCode).toBe(0);
+      // Exact match — no banner, no trailing whitespace other than the single
+      // trailing newline from console.log. Scripts will pipe this through
+      // things like `$(parachute --version)`.
+      expect(stdout).toBe(`${pkg.version}\n`);
+      // Stderr must be empty. If the dispatcher drops into the default branch
+      // it would print "Unknown command:" plus the full usage() block to
+      // stderr, which is exactly the regression this test catches.
+      expect(stderr).toBe("");
+    });
+  }
+
+  test("version string looks like semver (sanity check)", () => {
+    // Defense-in-depth: if someone ever replaces the JSON import with a
+    // hardcoded string, a malformed value still won't slip through.
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/);
+  });
+});


### PR DESCRIPTION
## Summary

Two small fixes bundled as `0.2.2`:

- **Fix A** — daemon `start.sh` no longer dies silently when a user's `.zshrc` / `.zprofile` trips `set -u`. Root cause of Aaron's laptop-migration failure.
- **Fix B** — `parachute --version` / `-v` / `version` now prints the installed version. Every spelling (`parachute`, `parachute vault`, both with `--version` / `-v` / `version`) resolves.

Plus: `package.json` 0.2.1 → 0.2.2, CHANGELOG entry, CLI reference row.

## Fix A — start.sh set-u hardening

The generated wrapper ran `source ~/.zprofile` and `source ~/.zshrc` under `set -u`. If either rc file touches an unbound variable (routine in zsh plugin frameworks, conditional setups), bash aborts with exit 1 and the inline `2>/dev/null` swallows the error. launchd sees repeated exit-1s and eventually gives up; `vault.err` stays empty; the user has no signal anything went wrong.

The fix brackets the two profile-source lines with `set +u` / `set -u` so strict-unset behavior only applies to code the wrapper itself owns. Stderr redirect stays (expected command-not-found noise shouldn't fill `vault.err`), but a long comment in the template now tells future debuggers where to look (`bash -x ~/.parachute/start.sh`).

Upgrade path is zero-work: `parachute vault init` is idempotent and rewrites `start.sh` on every run, so users who upgrade to 0.2.2 and run `init` once pick up the hardened template.

### Test coverage

Two new tests in `src/launchd.test.ts`:

1. **Textual shape**: `generateWrapper()` output must sandwich both `.zprofile`/`.zshrc` source lines between `set +u` and `set -u`. Regresses loudly if someone drops a bracket.
2. **Integration**: builds a fake `$HOME` with a `~/.zshrc` that expands `$UNSET_IN_TEST`, runs the real generated wrapper with `HOME=fakehome`, and asserts the wrapper reaches the branded `parachute-vault: server path not configured` branch (meaning it survived the zshrc source). Negatively: stderr must NOT contain `UNSET_IN_TEST: unbound variable` — which is the failure mode the patch closes.

## Fix B — `--version` flag

Before 0.2.2 every spelling of version-query hit the dispatcher's default branch, printed `Unknown command:` + the full usage block to stderr, and exited 1.

The fix adds a three-alias switch case (`--version`, `-v`, `version`) that prints `pkg.version` on stdout and exits 0. Version is a JSON import resolved at module load (`import pkg from "../package.json" with { type: "json" }`), so there's no hardcoded string to drift. Works at both the root (`parachute --version`) and with the vault prefix (`parachute vault --version`) via the existing argv parser.

### Test coverage

New file `src/version.test.ts` spawns the real CLI as a subprocess for each of six accepted spellings:

```
parachute --version
parachute -v
parachute version
parachute vault --version
parachute vault -v
parachute vault version
```

…and asserts stdout is exactly `${pkg.version}\n`, stderr is empty, and exit code is 0. Also a semver-shape sanity check on `pkg.version` itself.

## Release

- `package.json`: 0.2.1 → 0.2.2
- `CHANGELOG.md`: prepend `[0.2.2]` block with `### Fixed` (start.sh) and `### Added` (--version).
- `README.md`: add `parachute --version` row to the Setup group of the CLI reference.

**Test suite: 544 → 553 passing, 0 failures, 3 skipped.** Stable across 3 consecutive runs. +9 new tests (2 hardening + 7 version forms).

Post-merge (team-lead, not this PR):

```
git tag v0.2.2 && git push origin v0.2.2
npm publish
```

## Not in this PR (acknowledged, deferred)

- `link_count` in the stats endpoint (Benjamin's item) — different surface, queued for 0.2.3.
- `doctor` check for the hardened `start.sh` pattern — nice-to-have follow-up. The test coverage in this PR already catches a regression at `generateWrapper()` time, so a runtime doctor check is belt-and-braces rather than load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)