### PR TITLE
fix(oauth): serve discovery at RFC 8414 §3.1 path-insertion URLs; cut 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Parachute Vault are documented here.
 
 This project loosely follows [Keep a Changelog](https://keepachangelog.com) and [Semantic Versioning](https://semver.org).
 
+## [0.2.3] — 2026-04-17
+
+### Fixed
+
+- **OAuth discovery endpoints now served at RFC-compliant path-insertion URLs (`/.well-known/oauth-authorization-server/{path}`) in addition to the existing path-append form.** Restores Claude Code's MCP OAuth SDK compatibility, which follows RFC 8414 §3.1 and RFC 9728 §3 strictly and probes only the path-insertion shape. Before 0.2.3, the SDK's AS-metadata fetch 404'd, leaving it without a `registration_endpoint` and cascading into a 404 on the `/register` fallback. Both scoped forms now work: `/.well-known/oauth-authorization-server/vaults/<name>` and the longer `/.well-known/oauth-authorization-server/vaults/<name>/mcp`; same shapes on `/.well-known/oauth-protected-resource/...`. Path-append routes (`/vaults/<name>/.well-known/<type>`) are unchanged so lax clients keep working.
+
 ## [0.2.2] — 2026-04-17
 
 ### Fixed
@@ -93,6 +99,7 @@ First tagged public release. Ships the auth, backup, and onboarding surface the 
 - **`core/src/test-preload.ts`** isolates `PARACHUTE_HOME` for tests so `bun test` never touches a user's real `~/.parachute/`.
 - Test suite at release cut: **538 passing / 0 failing / 3 skipped** across 22 files (541 tests total).
 
+[0.2.3]: https://github.com/ParachuteComputer/parachute-vault/releases/tag/v0.2.3
 [0.2.2]: https://github.com/ParachuteComputer/parachute-vault/releases/tag/v0.2.2
 [0.2.1]: https://github.com/ParachuteComputer/parachute-vault/releases/tag/v0.2.1
 [0.2.0]: https://github.com/ParachuteComputer/parachute-vault/releases/tag/v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -476,3 +476,186 @@ describe("MCP 401 WWW-Authenticate challenge (RFC 9728)", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// RFC 8414 §3.1 / RFC 9728 §3 path-insertion discovery.
+//
+// For a resource at `/vaults/<name>/mcp`, the spec-mandated metadata URLs are
+//   /.well-known/oauth-authorization-server/vaults/<name>[/mcp]
+//   /.well-known/oauth-protected-resource/vaults/<name>[/mcp]
+// rather than the path-append form
+//   /vaults/<name>/.well-known/<type>
+// that PR #111 also ships. Strict clients (including Claude Code's MCP OAuth
+// SDK) probe only the path-insertion form; lax clients try path-append. We
+// serve both so any conformant probe hits a live endpoint.
+// ---------------------------------------------------------------------------
+
+describe("path-insertion OAuth discovery (RFC 8414 §3.1 / RFC 9728 §3)", () => {
+  test("/.well-known/oauth-authorization-server/vaults/<name> returns vault-scoped AS metadata", async () => {
+    createVault("journal");
+    const path = "/.well-known/oauth-authorization-server/vaults/journal";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      issuer: string;
+      authorization_endpoint: string;
+      token_endpoint: string;
+      registration_endpoint: string;
+    };
+    // All four endpoints must be vault-scoped — otherwise Claude Code's
+    // registration_endpoint falls back to root `/register` and cascades 404.
+    expect(body.issuer).toBe("http://localhost:1940/vaults/journal");
+    expect(body.authorization_endpoint).toBe("http://localhost:1940/vaults/journal/oauth/authorize");
+    expect(body.token_endpoint).toBe("http://localhost:1940/vaults/journal/oauth/token");
+    expect(body.registration_endpoint).toBe("http://localhost:1940/vaults/journal/oauth/register");
+  });
+
+  test("/.well-known/oauth-authorization-server/vaults/<name>/mcp (longer form) also returns AS metadata", async () => {
+    // Aaron's log shows Claude Code probes this longer form too; cheap to
+    // support since it resolves to the same AS for the same vault.
+    createVault("journal");
+    const path = "/.well-known/oauth-authorization-server/vaults/journal/mcp";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { issuer: string; registration_endpoint: string };
+    expect(body.issuer).toBe("http://localhost:1940/vaults/journal");
+    expect(body.registration_endpoint).toBe("http://localhost:1940/vaults/journal/oauth/register");
+  });
+
+  test("/.well-known/oauth-protected-resource/vaults/<name> returns vault-scoped PRM", async () => {
+    createVault("journal");
+    const path = "/.well-known/oauth-protected-resource/vaults/journal";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resource: string; authorization_servers: string[] };
+    expect(body.resource).toBe("http://localhost:1940/vaults/journal/mcp");
+    expect(body.authorization_servers).toEqual(["http://localhost:1940/vaults/journal"]);
+  });
+
+  test("/.well-known/oauth-protected-resource/vaults/<name>/mcp (longer form) also returns PRM", async () => {
+    createVault("journal");
+    const path = "/.well-known/oauth-protected-resource/vaults/journal/mcp";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resource: string };
+    expect(body.resource).toBe("http://localhost:1940/vaults/journal/mcp");
+  });
+
+  test("path-insertion and path-append forms return identical metadata", async () => {
+    // The coherence guarantee: a client that follows either spec shape MUST
+    // land on the same AS config. If these drift, a mixed-toolchain deploy
+    // (CLI using one form, daemon using the other) would mint tokens
+    // against inconsistent endpoints.
+    createVault("journal");
+
+    // AS metadata
+    const insertAsPath = "/.well-known/oauth-authorization-server/vaults/journal";
+    const appendAsPath = "/vaults/journal/.well-known/oauth-authorization-server";
+    const insertAsRes = await route(new Request(`http://localhost:1940${insertAsPath}`), insertAsPath);
+    const appendAsRes = await route(new Request(`http://localhost:1940${appendAsPath}`), appendAsPath);
+    expect(await insertAsRes.json()).toEqual(await appendAsRes.json());
+
+    // PRM
+    const insertPrmPath = "/.well-known/oauth-protected-resource/vaults/journal";
+    const appendPrmPath = "/vaults/journal/.well-known/oauth-protected-resource";
+    const insertPrmRes = await route(new Request(`http://localhost:1940${insertPrmPath}`), insertPrmPath);
+    const appendPrmRes = await route(new Request(`http://localhost:1940${appendPrmPath}`), appendPrmPath);
+    expect(await insertPrmRes.json()).toEqual(await appendPrmRes.json());
+  });
+
+  test("unknown vault in path-insertion URL returns 404, not boilerplate metadata", async () => {
+    // Don't leak metadata for phantom vaults. The equivalent path-append
+    // route also 404s when the vault doesn't exist (`readVaultConfig` miss
+    // at the vault-scoped routes branch); path-insertion must match.
+    createVault("journal");
+    for (const path of [
+      "/.well-known/oauth-authorization-server/vaults/nonexistent",
+      "/.well-known/oauth-authorization-server/vaults/nonexistent/mcp",
+      "/.well-known/oauth-protected-resource/vaults/nonexistent",
+      "/.well-known/oauth-protected-resource/vaults/nonexistent/mcp",
+    ]) {
+      const res = await route(new Request(`http://localhost:1940${path}`), path);
+      expect(res.status).toBe(404);
+    }
+  });
+
+  test("x-forwarded-* headers propagate into the generated metadata URLs", async () => {
+    // Same contract as the WWW-Authenticate challenge and the root/append
+    // discovery endpoints: metadata must match the public-facing origin so
+    // a Cloudflare Tunnel / Tailscale Funnel deployment doesn't advertise
+    // internal localhost:1940 URLs.
+    createVault("journal");
+    const path = "/.well-known/oauth-authorization-server/vaults/journal";
+    const res = await route(
+      new Request(`http://127.0.0.1:1940${path}`, {
+        headers: {
+          "x-forwarded-host": "vault.example.com",
+          "x-forwarded-proto": "https",
+        },
+      }),
+      path,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { issuer: string; registration_endpoint: string };
+    expect(body.issuer).toBe("https://vault.example.com/vaults/journal");
+    expect(body.registration_endpoint).toBe(
+      "https://vault.example.com/vaults/journal/oauth/register",
+    );
+  });
+
+  test("end-to-end flow: WWW-Authenticate → PRM → AS metadata → registration_endpoint is live", async () => {
+    // The actual Claude-Code bug: on 401, follow the challenge to the PRM,
+    // then follow PRM.authorization_servers[0] to the AS metadata (via
+    // path-insertion), then hit the `registration_endpoint`. Every hop
+    // must resolve — before the fix, the AS-metadata-via-path-insertion
+    // step 404'd and the SDK fell back to `/register` which also 404'd.
+    createVault("journal");
+
+    // Step 1: unauthenticated MCP → 401 + WWW-Authenticate.
+    const mcpRes = await route(
+      new Request("http://localhost:1940/vaults/journal/mcp"),
+      "/vaults/journal/mcp",
+    );
+    expect(mcpRes.status).toBe(401);
+    const challenge = mcpRes.headers.get("WWW-Authenticate")!;
+    const prmUrl = challenge.match(/resource_metadata="([^"]+)"/)![1];
+
+    // Step 2: fetch PRM. The challenge points at the path-append form, but
+    // a strict client might also try path-insertion — both must work.
+    // Follow the advertised URL (path-append in this case) and note the
+    // authorization_servers pointer.
+    const prmPath = new URL(prmUrl).pathname;
+    const prmRes = await route(new Request(`http://localhost:1940${prmPath}`), prmPath);
+    expect(prmRes.status).toBe(200);
+    const prm = (await prmRes.json()) as { authorization_servers: string[] };
+    const asBase = prm.authorization_servers[0]; // "http://localhost:1940/vaults/journal"
+
+    // Step 3: strict-client path-insertion probe for AS metadata.
+    const asBasePath = new URL(asBase).pathname; // "/vaults/journal"
+    const asInsertPath = `/.well-known/oauth-authorization-server${asBasePath}`;
+    const asRes = await route(
+      new Request(`http://localhost:1940${asInsertPath}`),
+      asInsertPath,
+    );
+    // This was the 404 before the fix — the reason Claude Code's SDK gave
+    // up and cascade-404'd on `/register`.
+    expect(asRes.status).toBe(200);
+    const asMeta = (await asRes.json()) as { registration_endpoint: string };
+
+    // Step 4: the advertised registration_endpoint must be live (POST-only).
+    const regPath = new URL(asMeta.registration_endpoint).pathname;
+    const regRes = await route(
+      new Request(`http://localhost:1940${regPath}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Test",
+          redirect_uris: ["https://example.com/cb"],
+        }),
+      }),
+      regPath,
+    );
+    // Successful DCR is 201; anything but 404 proves the endpoint is wired.
+    expect(regRes.status).toBe(201);
+  });
+});

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -115,7 +115,43 @@ export async function route(
   path: string,
   clientIp?: string,
 ): Promise<Response> {
-  // OAuth discovery endpoints (no auth required)
+  // OAuth discovery endpoints (no auth required).
+  //
+  // RFC 8414 §3.1 and RFC 9728 §3 specify the discovery URL shape when an
+  // authorization server (or protected resource) has a path component `/p`:
+  //
+  //   Path-insertion (spec-mandated):
+  //     <host>/.well-known/<metadata-type>/p
+  //   Path-append (widespread in the wild, shipped in PR #111):
+  //     <host>/p/.well-known/<metadata-type>
+  //
+  // Strict clients — including Claude Code's MCP OAuth SDK — probe only the
+  // path-insertion form. Lax clients try path-append. We serve both so any
+  // conformant probe hits a live endpoint. Unscoped root forms
+  // (`/.well-known/oauth-*`) are the third accepted shape, and the
+  // path-append branch for scoped discovery lives further down alongside the
+  // other `/vaults/{name}/*` routing.
+  const protectedResourceInsert = path.match(
+    /^\/\.well-known\/oauth-protected-resource\/vaults\/([^/]+)(?:\/mcp)?$/,
+  );
+  if (protectedResourceInsert) {
+    const vaultName = protectedResourceInsert[1];
+    if (!readVaultConfig(vaultName)) {
+      return Response.json({ error: "Vault not found", vault: vaultName }, { status: 404 });
+    }
+    return handleProtectedResource(req, `/vaults/${vaultName}/mcp`, `/vaults/${vaultName}`);
+  }
+  const authServerInsert = path.match(
+    /^\/\.well-known\/oauth-authorization-server\/vaults\/([^/]+)(?:\/mcp)?$/,
+  );
+  if (authServerInsert) {
+    const vaultName = authServerInsert[1];
+    if (!readVaultConfig(vaultName)) {
+      return Response.json({ error: "Vault not found", vault: vaultName }, { status: 404 });
+    }
+    return handleAuthorizationServer(req, vaultName);
+  }
+
   if (path === "/.well-known/oauth-protected-resource") {
     return handleProtectedResource(req);
   }


### PR DESCRIPTION
## The bug

From Aaron's live logs on 0.2.2, Claude Code's MCP OAuth handshake:

```
GET /vaults/default/.well-known/oauth-protected-resource   → 200  ← path-append, we serve
GET /.well-known/oauth-authorization-server/vaults/default → 404  ← path-insertion, spec says we MUST serve
POST /register                                             → 404  ← cascade failure
```

RFC 8414 §3.1 and RFC 9728 §3 specify that for a resource at `/vaults/<name>/mcp`, metadata documents live at the **path-insertion** URL (`/.well-known/<type>/vaults/<name>`), not the **path-append** URL (`/vaults/<name>/.well-known/<type>`). PR #111 shipped path-append only. Strict clients (Claude Code) probe path-insertion, 404, and — with no `authorization_server` metadata — fall back to guessing `/register`, which also 404s.

Blocking Benjamin's onboarding and Aaron's laptop migration.

## The fix

Serve both URL shapes. In `src/routing.ts`, two new regex-matched routes intercept `/.well-known/oauth-<type>/vaults/<name>[/mcp]` *before* the existing root-level exact matches, and delegate to the same `handleProtectedResource` / `handleAuthorizationServer` handlers PR #111 wired up for path-append. Path-append routes stay — lax clients should keep working.

**Vault-existence validation**: unknown vault names in a path-insertion URL return 404 rather than boilerplate metadata — matches path-append's behavior and avoids leaking a phantom authorization server for any string.

## Test coverage

8 new tests in `src/routing.test.ts`:

- AS metadata via short (`/vaults/<name>`) and long (`/vaults/<name>/mcp`) path-insertion forms.
- PRM via short and long forms.
- **Coherence**: path-insertion and path-append return deep-equal JSON. Prevents mixed-toolchain drift.
- Unknown vault → 404 on all four shapes.
- `x-forwarded-host` / `x-forwarded-proto` propagate into generated URLs.
- **End-to-end**: 401 → follow `WWW-Authenticate` → fetch PRM → fetch AS metadata via path-insertion → POST `registration_endpoint` → 201. This is the exact SDK handshake that was 404'ing before the fix.

**Test suite: 553 → 561 passing, 0 failures, 3 skipped.** Stable across 3 consecutive runs.

## Live-server curl verification

Spun up a real `bun src/server.ts` on `PORT=19402` with fresh `PARACHUTE_HOME`:

```
GET /.well-known/oauth-authorization-server/vaults/default
  → HTTP 200 + full AS metadata with vault-scoped endpoints

GET /.well-known/oauth-authorization-server/vaults/default/mcp
  → HTTP 200 + same AS metadata (longer form from Claude Code logs)

GET /.well-known/oauth-protected-resource/vaults/default
  → HTTP 200 + resource="http://localhost:19402/vaults/default/mcp"

GET /.well-known/oauth-protected-resource/vaults/default/mcp
  → HTTP 200 + same PRM

GET /vaults/default/.well-known/oauth-authorization-server
  → HTTP 200 + same AS metadata (path-append, unchanged)

GET /.well-known/oauth-authorization-server/vaults/nonexistent
  → HTTP 404 (no phantom metadata)
```

All six checks match expectations.

## Release

- `package.json` 0.2.2 → 0.2.3
- `CHANGELOG.md` prepends `[0.2.3] — 2026-04-17` with `### Fixed` describing the fix in terms users care about.

Post-merge (team-lead, not this PR):
```
git tag v0.2.3 && git push origin v0.2.3
npm publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)