### PR TITLE
feat(stats): surface linkCount in vault stats; cut 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Parachute Vault are documented here.
 
 This project loosely follows [Keep a Changelog](https://keepachangelog.com) and [Semantic Versioning](https://semver.org).
 
+## [0.2.4] — 2026-04-18
+
+### Added
+
+- `link_count` surfaced in the vault stats response (REST + MCP `vault-info`), matching the existing note and tag counts.
+
 ## [0.2.3] — 2026-04-17
 
 ### Fixed

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -163,6 +163,7 @@ describe("vault stats", async () => {
     expect(stats.notesByMonth).toEqual([]);
     expect(stats.topTags).toEqual([]);
     expect(stats.tagCount).toBe(0);
+    expect(stats.linkCount).toBe(0);
   });
 
   it("counts total notes and tagCount", async () => {
@@ -231,6 +232,17 @@ describe("vault stats", async () => {
     expect(stats).toHaveProperty("notesByMonth");
     expect(stats).toHaveProperty("topTags");
     expect(stats).toHaveProperty("tagCount");
+    expect(stats).toHaveProperty("linkCount");
+  });
+
+  it("counts resolved wikilinks in linkCount", async () => {
+    await store.createNote("Target A", { path: "alpha" });
+    await store.createNote("Target B", { path: "beta" });
+    await store.createNote("Refs both [[alpha]] and [[beta]]", { path: "hub" });
+    await store.createNote("Refs alpha only [[alpha]]", { path: "solo" });
+
+    const stats = await store.getVaultStats();
+    expect(stats.linkCount).toBe(3);
   });
 
   it("getVaultStats returns correct stats", async () => {

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -475,6 +475,9 @@ export function getVaultStats(
   const tagCountRow = db.prepare("SELECT COUNT(DISTINCT tag_name) as c FROM note_tags").get() as { c: number };
   const tagCount = tagCountRow.c;
 
+  const linkCountRow = db.prepare("SELECT COUNT(*) as c FROM links").get() as { c: number };
+  const linkCount = linkCountRow.c;
+
   return {
     totalNotes,
     earliestNote: earliestRow
@@ -486,6 +489,7 @@ export function getVaultStats(
     notesByMonth: monthRows,
     topTags: topTagRows,
     tagCount,
+    linkCount,
   };
 }
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -41,6 +41,7 @@ export interface VaultStats {
   notesByMonth: { month: string; count: number }[];
   topTags: { tag: string; count: number }[];
   tagCount: number;
+  linkCount: number;
 }
 
 // ---- Query Options ----

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

- `getVaultStats` now runs a `SELECT COUNT(*) FROM links` alongside the existing total-note and tag-count queries; result surfaces as `linkCount` on the REST `/api/vault?include_stats=1` response and the MCP `vault-info` tool output.
- Unblocks Benjamin's Prism-migration stats widget, which was reading the vault stats payload and always rendering `Links: 0` because the field didn't exist.
- The JSON field is `linkCount` (camelCase) to match the shipped shape (`totalNotes`, `tagCount`). Callers that speak snake_case should read `linkCount`.

## Test plan

- [x] `bun test core/src/` — 202 pass
- [x] `bun test src/` — 562 pass
- [x] New test: notes with `[[wikilinks]]` → `stats.linkCount` equals the resolved-link count
- [x] Empty-vault case returns `linkCount: 0`
- [x] Response-shape test includes `linkCount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)