### PR TITLE
feat(attachments): DELETE /api/notes/:id/attachments/:attId

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -445,6 +445,41 @@ describe("attachments", async () => {
     const attachments = await store.getAttachments(note.id);
     expect(attachments).toHaveLength(0);
   });
+
+  it("deleteAttachment removes row and reports orphaned path", async () => {
+    const note = await store.createNote("Has attachment");
+    const att = await store.addAttachment(note.id, "2026-04-18/pic.png", "image/png");
+
+    const result = await store.deleteAttachment(note.id, att.id);
+    expect(result).toEqual({ deleted: true, path: "2026-04-18/pic.png", orphaned: true });
+    expect(await store.getAttachments(note.id)).toHaveLength(0);
+  });
+
+  it("deleteAttachment returns deleted:false for nonexistent id", async () => {
+    const note = await store.createNote("x");
+    const result = await store.deleteAttachment(note.id, "does-not-exist");
+    expect(result).toEqual({ deleted: false, path: null, orphaned: false });
+  });
+
+  it("deleteAttachment is scoped to noteId (cross-note attempt is a no-op)", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    const attA = await store.addAttachment(a.id, "files/a.png", "image/png");
+
+    const result = await store.deleteAttachment(b.id, attA.id);
+    expect(result.deleted).toBe(false);
+    expect(await store.getAttachments(a.id)).toHaveLength(1);
+  });
+
+  it("deleteAttachment reports orphaned:false when a sibling attachment shares the path", async () => {
+    const a = await store.createNote("A");
+    const b = await store.createNote("B");
+    const attA = await store.addAttachment(a.id, "shared/pic.png", "image/png");
+    await store.addAttachment(b.id, "shared/pic.png", "image/png");
+
+    const result = await store.deleteAttachment(a.id, attA.id);
+    expect(result).toEqual({ deleted: true, path: "shared/pic.png", orphaned: false });
+  });
 });
 
 // ---- MCP Tools ----

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -291,6 +291,25 @@ export class BunSqliteStore implements Store {
       };
     });
   }
+
+  async deleteAttachment(
+    noteId: string,
+    attachmentId: string,
+  ): Promise<{ deleted: boolean; path: string | null; orphaned: boolean }> {
+    // Scope by noteId so a token authorized for note A can't delete note B's attachments.
+    const row = this.db.prepare(
+      "SELECT path FROM attachments WHERE id = ? AND note_id = ?",
+    ).get(attachmentId, noteId) as { path: string } | undefined;
+    if (!row) return { deleted: false, path: null, orphaned: false };
+
+    this.db.prepare("DELETE FROM attachments WHERE id = ? AND note_id = ?").run(attachmentId, noteId);
+
+    // Orphan check: caller uses this to decide whether to unlink the file on disk.
+    const other = this.db.prepare(
+      "SELECT 1 FROM attachments WHERE path = ? LIMIT 1",
+    ).get(row.path);
+    return { deleted: true, path: row.path, orphaned: !other };
+  }
 }
 
 /** @deprecated Renamed to `BunSqliteStore` to make the runtime split explicit. Kept as an alias for backward compatibility. */

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -138,4 +138,5 @@ export interface Store {
   // Attachments
   addAttachment(noteId: string, path: string, mimeType: string, metadata?: Record<string, unknown>): Promise<Attachment>;
   getAttachments(noteId: string): Promise<Attachment[]>;
+  deleteAttachment(noteId: string, attachmentId: string): Promise<{ deleted: boolean; path: string | null; orphaned: boolean }>;
 }

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -209,6 +209,12 @@ Body: `{"path": "files/a.png", "mimeType": "image/png"}`.
 #### `GET /notes/{id}/attachments`
 Returns `Attachment[]`.
 
+#### `DELETE /notes/{id}/attachments/{attId}`
+Returns `204 No Content`. The attachment record is removed and the underlying
+storage file is unlinked when no other attachment still references the same
+path (orphan-check). Returns `404` if the attachment doesn't exist or belongs
+to a different note. Idempotent: a second delete of the same id returns `404`.
+
 ### Links
 
 #### `GET /links`

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -24,7 +24,7 @@ import {
   type ExpandMode,
 } from "../core/src/expand.ts";
 import { join, extname, normalize } from "path";
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { vaultDir } from "./config.ts";
 
 // ---------------------------------------------------------------------------
@@ -124,6 +124,7 @@ export async function handleNotes(
   req: Request,
   store: Store,
   subpath: string,
+  vault?: string,
 ): Promise<Response> {
   const url = new URL(req.url);
   const method = req.method;
@@ -317,6 +318,29 @@ export async function handleNotes(
       const note = await resolveNote(store, idOrPath);
       if (!note) return json({ error: "Not found" }, 404);
       return json(await store.getAttachments(note.id));
+    }
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  const attMatch = sub.match(/^\/attachments\/([^/]+)$/);
+  if (attMatch) {
+    const attId = decodeURIComponent(attMatch[1]!);
+    if (method === "DELETE") {
+      const note = await resolveNote(store, idOrPath);
+      if (!note) return json({ error: "Not found" }, 404);
+      const result = await store.deleteAttachment(note.id, attId);
+      if (!result.deleted) return json({ error: "Not found" }, 404);
+      // Unlink the storage file only if no other attachment still references
+      // the same path. Best-effort: the row is already gone, so a missing
+      // file or unlink error should not flip the DELETE to an error.
+      if (vault && result.path && result.orphaned) {
+        const assets = assetsDir(vault);
+        const filePath = normalize(join(assets, result.path));
+        if (filePath.startsWith(normalize(assets)) && existsSync(filePath)) {
+          try { unlinkSync(filePath); } catch {}
+        }
+      }
+      return new Response(null, { status: 204 });
     }
     return json({ error: "Method not allowed" }, 405);
   }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -288,7 +288,7 @@ export async function route(
       );
     }
     const apiPath = path.slice(4); // strip "/api"
-    if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6));
+    if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6), defaultVault);
     if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
     if (apiPath === "/find-path") return handleFindPath(req, store);
     if (apiPath === "/vault") {
@@ -432,7 +432,7 @@ export async function route(
 
   const apiPath = apiMatch[1] ?? "";
 
-  if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6));
+  if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6), vaultName);
   if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
   if (apiPath === "/find-path") return handleFindPath(req, store);
   if (apiPath === "/vault") {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdirSync, rmSync, existsSync } from "fs";
+import { mkdirSync, rmSync, existsSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { BunStore } from "./vault-store.ts";
@@ -961,6 +961,117 @@ describe("HTTP /notes", async () => {
     expect(res.status).toBe(201);
     const body = await res.json() as any;
     expect(body.mimeType).toBe("image/png");
+  });
+
+  describe("DELETE /notes/:id/attachments/:attId", async () => {
+    test("happy path: 204, DB row gone, storage file unlinked", async () => {
+      const assetsRoot = join(tmpDir, "assets");
+      mkdirSync(join(assetsRoot, "2026-04-18"), { recursive: true });
+      const relPath = "2026-04-18/shot.png";
+      const filePath = join(assetsRoot, relPath);
+      writeFileSync(filePath, Buffer.from([1, 2, 3]));
+      process.env.ASSETS_DIR = assetsRoot;
+
+      const n = await store.createNote("x", { id: "n1" });
+      const att = await store.addAttachment(n.id, relPath, "image/png");
+
+      const res = await handleNotes(
+        mkReq("DELETE", `/notes/n1/attachments/${att.id}`),
+        store,
+        `/n1/attachments/${att.id}`,
+        "default",
+      );
+      expect(res.status).toBe(204);
+      expect((await store.getAttachments(n.id)).length).toBe(0);
+      expect(existsSync(filePath)).toBe(false);
+
+      delete process.env.ASSETS_DIR;
+    });
+
+    test("404 when attachment does not exist", async () => {
+      await store.createNote("x", { id: "n2" });
+      const res = await handleNotes(
+        mkReq("DELETE", "/notes/n2/attachments/nonexistent"),
+        store,
+        "/n2/attachments/nonexistent",
+        "default",
+      );
+      expect(res.status).toBe(404);
+    });
+
+    test("second delete is idempotent (404)", async () => {
+      const n = await store.createNote("x", { id: "n3" });
+      const att = await store.addAttachment(n.id, "files/a.png", "image/png");
+      const first = await handleNotes(
+        mkReq("DELETE", `/notes/n3/attachments/${att.id}`),
+        store,
+        `/n3/attachments/${att.id}`,
+      );
+      expect(first.status).toBe(204);
+      const second = await handleNotes(
+        mkReq("DELETE", `/notes/n3/attachments/${att.id}`),
+        store,
+        `/n3/attachments/${att.id}`,
+      );
+      expect(second.status).toBe(404);
+    });
+
+    test("cross-note delete attempt returns 404 and leaves record intact", async () => {
+      const a = await store.createNote("a", { id: "na" });
+      const b = await store.createNote("b", { id: "nb" });
+      const attA = await store.addAttachment(a.id, "files/a.png", "image/png");
+
+      const res = await handleNotes(
+        mkReq("DELETE", `/notes/nb/attachments/${attA.id}`),
+        store,
+        `/nb/attachments/${attA.id}`,
+      );
+      expect(res.status).toBe(404);
+      expect((await store.getAttachments(a.id)).length).toBe(1);
+    });
+
+    test("file survives first delete when a sibling attachment still references it", async () => {
+      const assetsRoot = join(tmpDir, "assets");
+      mkdirSync(join(assetsRoot, "shared"), { recursive: true });
+      const relPath = "shared/pic.png";
+      const filePath = join(assetsRoot, relPath);
+      writeFileSync(filePath, Buffer.from([9]));
+      process.env.ASSETS_DIR = assetsRoot;
+
+      const a = await store.createNote("a", { id: "sa" });
+      const b = await store.createNote("b", { id: "sb" });
+      const attA = await store.addAttachment(a.id, relPath, "image/png");
+      const attB = await store.addAttachment(b.id, relPath, "image/png");
+
+      await handleNotes(
+        mkReq("DELETE", `/notes/sa/attachments/${attA.id}`),
+        store,
+        `/sa/attachments/${attA.id}`,
+        "default",
+      );
+      expect(existsSync(filePath)).toBe(true);
+
+      await handleNotes(
+        mkReq("DELETE", `/notes/sb/attachments/${attB.id}`),
+        store,
+        `/sb/attachments/${attB.id}`,
+        "default",
+      );
+      expect(existsSync(filePath)).toBe(false);
+
+      delete process.env.ASSETS_DIR;
+    });
+
+    test("method not allowed on /attachments/:attId returns 405", async () => {
+      const n = await store.createNote("x", { id: "nm" });
+      const att = await store.addAttachment(n.id, "files/a.png", "image/png");
+      const res = await handleNotes(
+        mkReq("PATCH", `/notes/nm/attachments/${att.id}`),
+        store,
+        `/nm/attachments/${att.id}`,
+      );
+      expect(res.status).toBe(405);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- `DELETE /api/notes/:idOrPath/attachments/:attId` — removes the attachment row scoped to the note, unlinks the underlying storage file when no other row references the same path (orphan check)
- 404 when the attachment doesn't exist or belongs to a different note (cross-note delete is a no-op — token scoped to note A can't reach note B's attachments)
- 204 No Content on success; second delete of the same id returns 404 (idempotent)
- File-cleanup is best-effort: if the file is already gone or unlinking fails, the DB delete still succeeds

## Motivation
Lens PR #8 (attachment upload) shipped with a read-only attachment sidebar — remove button sequenced to Lens PR #8.5 behind this endpoint.

## Test plan
- [x] `bun test` — 575/3-skipped pass (added 6 new tests: happy-path delete with file cleanup, idempotent second delete 404, nonexistent 404, cross-note delete 404 + record intact, orphan-check with shared path, 405 for wrong method)
- [x] `bunx tsc --noEmit` — no new errors introduced (baseline strict-mode noise unchanged)
- [x] Docs updated (`docs/HTTP_API.md`)
- [ ] Smoke against running vault deferred — ship via hosted vault after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)