### PR TITLE
fix(notes): set updated_at = created_at on insert + backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fresh notes now have `updated_at = created_at` instead of `NULL`.** Clients that fall back to `createdAt` when computing an optimistic-concurrency token (the common `updatedAt ?? createdAt` pattern, used by the Lens editor) were being rejected with a `409 CONFLICT` on the very first edit of a just-created note, because the stored `updated_at IS NULL` never matched the sent timestamp. The insert path now writes both columns at once; a one-time idempotent migration backfills `updated_at = created_at` for any existing rows with `NULL`. Rows that already had a real `updated_at` are untouched. Hook-style writes with `skipUpdatedAt` continue to preserve the column, so `updated_at > created_at` still means "user-touched since creation."
+
 ### Changed
 
 - **CLI renamed: `parachute` → `parachute-vault`.** The published `@openparachute/vault` package now exposes its binary as `parachute-vault`, freeing the `parachute` name for the forthcoming `@openparachute/cli` dispatcher that will front this service alongside sibling Parachute Computer services. Direct invocations become `parachute-vault init`, `parachute-vault status`, etc. Users installing the upcoming dispatcher can keep typing `parachute vault <cmd>` — the dispatcher forwards to `parachute-vault <cmd>` transparently. The CLI's own arg-parser still accepts a leading `vault` prefix (`parachute-vault vault init` works), so existing launchd / systemd wrappers that hardcode the full form continue to work across the upgrade.

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { SqliteStore } from "./store.js";
 import { generateMcpTools } from "./mcp.js";
+import { initSchema } from "./schema.js";
 
 let store: SqliteStore;
 let db: Database;
@@ -68,7 +69,11 @@ describe("notes", async () => {
     const updated = await store.updateNote(note.id, { created_at: newDate });
     expect(updated.createdAt).toBe(newDate);
     expect(updated.content).toBe("Test"); // content unchanged
-    expect(updated.updatedAt).not.toBe(note.updatedAt); // updated_at bumped
+    // updated_at is bumped to "now" by the update path. Can't strictly
+    // differ from note.updatedAt (same-ms collision possible) but must be
+    // monotonically non-decreasing from the prior value.
+    expect(updated.updatedAt).toBeTruthy();
+    expect(updated.updatedAt! >= note.updatedAt!).toBe(true);
   });
 
   it("updates metadata and created_at together", async () => {
@@ -87,6 +92,36 @@ describe("notes", async () => {
     expect(updated.createdAt).toBe(note.createdAt);
   });
 
+  it("sets updatedAt === createdAt on insert", async () => {
+    const note = await store.createNote("Fresh");
+    expect(note.updatedAt).toBe(note.createdAt);
+    const fetched = (await store.getNote(note.id))!;
+    expect(fetched.updatedAt).toBe(fetched.createdAt);
+  });
+
+  it("create-insert updatedAt respects an explicit created_at", async () => {
+    const note = await store.createNote("Imported", {
+      created_at: "2024-02-14T09:30:00.000Z",
+    });
+    expect(note.createdAt).toBe("2024-02-14T09:30:00.000Z");
+    expect(note.updatedAt).toBe("2024-02-14T09:30:00.000Z");
+  });
+
+  it("fresh note: if_updated_at with createdAt as the token succeeds", async () => {
+    // Regression guard: clients that pass `updatedAt ?? createdAt` as the
+    // OC token used to hit a CONFLICT on the very first edit because stored
+    // `updated_at` was NULL. Insert-time backfill removes that class of
+    // spurious conflict.
+    const note = await store.createNote("First");
+    const updated = await store.updateNote(note.id, {
+      content: "Second",
+      if_updated_at: note.createdAt,
+    });
+    expect(updated.content).toBe("Second");
+    expect(updated.updatedAt).toBeTruthy();
+    expect(updated.updatedAt).not.toBe(note.createdAt);
+  });
+
   it("deletes a note", async () => {
     const note = await store.createNote("Delete me");
     await store.deleteNote(note.id);
@@ -100,6 +135,57 @@ describe("notes", async () => {
 
     await store.deleteNote("a");
     expect(await store.getLinks("b")).toHaveLength(0);
+  });
+});
+
+// ---- Backfill migration: legacy rows with NULL updated_at ----
+
+describe("updated_at backfill on init", async () => {
+  it("backfills updated_at = created_at for pre-existing NULL rows", () => {
+    const raw = new Database(":memory:");
+    initSchema(raw); // create tables
+
+    // Simulate a legacy row (pre-fix insert path left updated_at NULL).
+    raw.prepare(
+      "INSERT INTO notes (id, content, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    ).run("legacy", "old", "2024-01-01T00:00:00.000Z", null);
+    const before = raw.prepare("SELECT updated_at FROM notes WHERE id = ?").get("legacy") as {
+      updated_at: string | null;
+    };
+    expect(before.updated_at).toBeNull();
+
+    // Re-run init: migration should backfill without touching the row otherwise.
+    initSchema(raw);
+    const after = raw.prepare("SELECT created_at, updated_at FROM notes WHERE id = ?").get(
+      "legacy",
+    ) as { created_at: string; updated_at: string };
+    expect(after.updated_at).toBe(after.created_at);
+    expect(after.created_at).toBe("2024-01-01T00:00:00.000Z");
+  });
+
+  it("leaves rows whose updated_at is already set untouched", () => {
+    const raw = new Database(":memory:");
+    initSchema(raw);
+
+    raw.prepare(
+      "INSERT INTO notes (id, content, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    ).run("edited", "content", "2024-01-01T00:00:00.000Z", "2024-06-15T12:00:00.000Z");
+
+    initSchema(raw); // migration is idempotent
+
+    const row = raw.prepare("SELECT created_at, updated_at FROM notes WHERE id = ?").get(
+      "edited",
+    ) as { created_at: string; updated_at: string };
+    expect(row.created_at).toBe("2024-01-01T00:00:00.000Z");
+    expect(row.updated_at).toBe("2024-06-15T12:00:00.000Z");
+  });
+
+  it("is a no-op for a fresh vault with zero notes", () => {
+    const raw = new Database(":memory:");
+    initSchema(raw);
+    initSchema(raw);
+    const count = raw.prepare("SELECT COUNT(*) as c FROM notes").get() as { c: number };
+    expect(count.c).toBe(0);
   });
 });
 
@@ -808,9 +894,11 @@ describe("MCP tools", async () => {
     expect((await store.getNote(note.id))!.content).toBe("Second");
   });
 
-  it("update-note if_updated_at conflicts for a never-updated note when caller expects a value", async () => {
+  it("update-note if_updated_at conflicts when the caller's timestamp doesn't match", async () => {
     const note = await store.createNote("First");
-    expect(note.updatedAt).toBeUndefined();
+    // A fresh note has updatedAt === createdAt. Sending a
+    // mismatching timestamp must still be rejected as a conflict.
+    expect(note.updatedAt).toBe(note.createdAt);
     const tools = generateMcpTools(store);
     const updateNote = tools.find((t) => t.name === "update-note")!;
 
@@ -826,7 +914,7 @@ describe("MCP tools", async () => {
     }
     expect(err).toBeTruthy();
     expect(err.code).toBe("CONFLICT");
-    expect(err.current_updated_at).toBeNull();
+    expect(err.current_updated_at).toBe(note.createdAt);
   });
 
   it("update-note batch aborts on first conflict without touching subsequent items", async () => {

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -30,9 +30,15 @@ export function createNote(
   const metadata = opts?.metadata ? JSON.stringify(opts.metadata) : "{}";
   const path = normalizePath(opts?.path);
 
+  // `updated_at` is set to `created_at` on insert so a client whose optimistic
+  // concurrency check falls back to `createdAt` on a never-updated note
+  // (the common shape: `note.updatedAt ?? note.createdAt`) matches the stored
+  // value. Hook-style writes with `skipUpdatedAt` preserve this; real user
+  // edits bump it strictly upward, so `updated_at > created_at` still means
+  // "user-touched since creation."
   db.prepare(
-    `INSERT INTO notes (id, content, path, metadata, created_at) VALUES (?, ?, ?, ?, ?)`,
-  ).run(id, content, path, metadata, createdAt);
+    `INSERT INTO notes (id, content, path, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(id, content, path, metadata, createdAt, createdAt);
 
   if (opts?.tags && opts.tags.length > 0) {
     tagNote(db, id, opts.tags);

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { normalizePath } from "./paths.js";
 import { rebuildIndexes } from "./indexed-fields.js";
 
-export const SCHEMA_VERSION = 10;
+export const SCHEMA_VERSION = 11;
 
 export const SCHEMA_SQL = `
 -- Notes: the universal record
@@ -177,6 +177,9 @@ export function initSchema(db: Database): void {
   // Migrate v9 → v10: indexed_fields table (created by SCHEMA_SQL above).
   migrateToV10(db);
 
+  // Migrate v10 → v11: backfill updated_at = created_at for legacy rows.
+  migrateToV11(db);
+
   // Rebuild any generated columns + indexes declared in indexed_fields.
   // No-op for a fresh vault; idempotent on existing vaults.
   rebuildIndexes(db);
@@ -293,6 +296,19 @@ function migrateToV10(db: Database): void {
   // ensures indexed_fields exists on vaults created before v10. No data
   // migration — rebuildIndexes() downstream handles column/index creation
   // if any rows are already present.
+}
+
+/**
+ * Migrate v10 → v11: backfill `updated_at = created_at` for notes that never
+ * received an update. Pre-v11 inserts left `updated_at` NULL, which broke
+ * optimistic concurrency for clients that fall back to `createdAt` (the
+ * common `updatedAt ?? createdAt` pattern) — the `updated_at IS ?` guard
+ * never matched. From v11 onward, `createNote` sets both columns at insert.
+ * Idempotent — safe to run on every boot.
+ */
+function migrateToV11(db: Database): void {
+  if (!hasTable(db, "notes")) return;
+  db.exec("UPDATE notes SET updated_at = created_at WHERE updated_at IS NULL");
 }
 
 function hasTable(db: Database, name: string): boolean {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -60,25 +60,31 @@ describe("BunStore", async () => {
 
   test("user updates bump updatedAt", async () => {
     const note = await store.createNote("Original");
-    expect(note.updatedAt).toBeUndefined();
+    expect(note.updatedAt).toBe(note.createdAt);
     const updated = await store.updateNote(note.id, { content: "Edited by user" });
     expect(updated.updatedAt).toBeTruthy();
+    // Must be monotonically non-decreasing — and strictly greater when the
+    // caller passed if_updated_at (tested elsewhere). Same-millisecond
+    // collisions are possible here since no if_updated_at is supplied.
+    expect(updated.updatedAt! >= note.createdAt).toBe(true);
   });
 
   test("skipUpdatedAt preserves updatedAt (hook-style writes)", async () => {
     // Hook writes (e.g., the reader-audio hook's metadata markers) must not
     // count as user activity. See issue #44 — hook writes were bumping
-    // updatedAt and wrecking Daily's reader sort.
+    // updatedAt and wrecking Daily's reader sort. Fresh notes have
+    // `updatedAt === createdAt`; a hook write must leave it at that value so
+    // `updatedAt > createdAt` remains the correct "user-touched" signal.
     const note = await store.createNote("Content");
-    expect(note.updatedAt).toBeUndefined();
+    expect(note.updatedAt).toBe(note.createdAt);
 
-    // Fresh note: a machine write must not set updatedAt.
+    // Fresh note: a machine write must not advance updatedAt past createdAt.
     await store.updateNote(note.id, {
       metadata: { audio_pending_at: "2026-04-09T10:00:00.000Z" },
       skipUpdatedAt: true,
     });
     let fetched = (await store.getNote(note.id))!;
-    expect(fetched.updatedAt).toBeUndefined();
+    expect(fetched.updatedAt).toBe(note.createdAt);
     expect((fetched.metadata as { audio_pending_at?: string } | undefined)?.audio_pending_at).toBe(
       "2026-04-09T10:00:00.000Z",
     );


### PR DESCRIPTION
## Summary

- Fresh notes left \`updated_at\` as \`NULL\`. Clients that fall back to
  \`createdAt\` when computing the optimistic-concurrency token (the
  \`updatedAt ?? createdAt\` pattern — see \`NoteEditor.tsx:116\` in Lens)
  hit 409 CONFLICT on the very first edit of a just-created note,
  because \`updated_at IS 'some-iso-string'\` never matches \`NULL\`.
- \`createNote\` now writes both columns at insert time.
- \`migrateToV11(db)\` backfills \`updated_at = created_at\` for any row
  with \`updated_at IS NULL\` on every boot — idempotent; rows with
  real \`updated_at\` are untouched.
- Hook-style writes with \`skipUpdatedAt\` still preserve the column,
  so \`updated_at > created_at\` remains the correct "user-touched
  since creation" signal for Daily's reader sort.

## Test plan

- [x] \`bun test src/ core/src/\` — 660/660 (was 654, +6 new)
- [x] \`bunx --bun tsc --noEmit\` — 331 errors, unchanged from main
- [x] Insert path: \`updatedAt === createdAt\`, survives round-trip via \`getNote\`
- [x] Explicit \`created_at\` in opts propagates to both columns
- [x] Regression guard: first edit with \`if_updated_at: note.createdAt\` succeeds
- [x] Backfill migration: legacy NULL rows get backfilled on second \`initSchema\`
- [x] Backfill migration: rows with real \`updated_at\` left untouched (idempotent)
- [x] Backfill migration: no-op on fresh vault with zero rows
- [x] \`skipUpdatedAt\` hook-write test updated — fresh note \`updatedAt === createdAt\`, hook write preserves, user edit bumps strictly above