### PR TITLE
refactor!: unify every vault route under /vault/<name>/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking: every vault-touching route moved to `/vault/<name>/...`; unscoped routes removed.** There is one URL shape for every client, same layout whether you have one vault or ten. The API lives at `/vault/<name>/api/...`, MCP at `/vault/<name>/mcp`, OAuth at `/vault/<name>/oauth/{register,authorize,token}`, discovery at `/vault/<name>/.well-known/oauth-*`, published notes at `/vault/<name>/view/:id`. The old unscoped `/api`, `/mcp`, `/oauth/*`, `/view/*` paths — and the previous `/vaults/<name>/...` prefix — are gone; requests to them return 404. Cross-vault endpoints (`GET /vaults`, `GET /vaults/list`, `GET /health`) are unchanged. The unified MCP endpoint that fanned tool calls across vaults via a `vault` param has been dropped — each MCP session now pins to one vault by the URL and the `list-vaults` tool is no longer exposed. A new `WWW-Authenticate: Bearer resource_metadata="..."` header decorates every MCP 401 so OAuth-capable clients can discover the right authorization server directly from the challenge (RFC 9728).
+
+#### Upgrading from 0.2.x
+
+- **Claude Code**: run `parachute-vault mcp-install` (or re-run `parachute-vault init`) to rewrite `~/.claude.json` with the new `/vault/<name>/mcp` URL. Existing `pvt_` tokens are kept; no re-auth needed.
+- **Claude Desktop / Parachute Daily / any OAuth client**: remove the integration and add it back pointing at `https://<your-host>/vault/<name>/mcp`. The OAuth handshake will re-run and mint a fresh per-vault token. Pasted bearer-token integrations need only the URL updated.
+- **curl / scripts**: rewrite hardcoded URLs. Old `/api/notes` → `/vault/default/api/notes`; old `/vaults/work/api/...` → `/vault/work/api/...`; old unscoped `/mcp` → `/vault/default/mcp`. Tokens keep working.
+- **Published-note permalinks**: `/view/<id>` and `/vaults/<name>/view/<id>` now 404. Update to `/vault/<name>/view/<id>`.
+
 ### Fixed
 
 - **Fresh notes now have `updated_at = created_at` instead of `NULL`.** Clients that fall back to `createdAt` when computing an optimistic-concurrency token (the common `updatedAt ?? createdAt` pattern, used by the Lens editor) were being rejected with a `409 CONFLICT` on the very first edit of a just-created note, because the stored `updated_at IS NULL` never matched the sent timestamp. The insert path now writes both columns at once; a one-time idempotent migration backfills `updated_at = created_at` for any existing rows with `NULL`. Rows that already had a real `updated_at` are untouched. Hook-style writes with `skipUpdatedAt` continue to preserve the column, so `updated_at > created_at` still means "user-touched since creation."

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The daemon binds `0.0.0.0:1940` (or whatever you set in `PORT`) and serves REST,
 
 ### `~/.claude.json`
 
-`vault init` adds one entry — `mcpServers["parachute-vault"]` — pointing at `http://127.0.0.1:<port>/vaults/<default-vault>/mcp` with a baked-in `Authorization: Bearer pvt_...` header. Next Claude Code session picks it up; there's no further wiring. See [Connecting a client](#connecting-a-client) for rotating that token or pointing it elsewhere.
+`vault init` adds one entry — `mcpServers["parachute-vault"]` — pointing at `http://127.0.0.1:<port>/vault/<default-vault>/mcp` with a baked-in `Authorization: Bearer pvt_...` header. Next Claude Code session picks it up; there's no further wiring. See [Connecting a client](#connecting-a-client) for rotating that token or pointing it elsewhere.
 
 ### Your API token
 
@@ -119,7 +119,7 @@ Password and 2FA secrets live in `~/.parachute/config.yaml` at mode 0600 (bcrypt
   "mcpServers": {
     "parachute-vault": {
       "type": "http",
-      "url": "http://127.0.0.1:1940/vaults/{name}/mcp",
+      "url": "http://127.0.0.1:1940/vault/{name}/mcp",
       "headers": { "Authorization": "Bearer pvt_..." }
     }
   }
@@ -135,8 +135,8 @@ To re-point Claude Code at a different vault, change `default_vault` in `~/.para
 For Claude Desktop — or any install where the server is on a different machine from the client — use the browser-based OAuth flow:
 
 1. Claude Desktop → Settings → Integrations → Add MCP server.
-2. Enter the URL: `https://vault.yourdomain.com/vaults/{name}/mcp` (replace `{name}`, or use the unscoped `https://vault.yourdomain.com/mcp` on a single-vault deployment). **Do not paste a bearer token** — leave the auth field empty.
-3. An OAuth-capable MCP client discovers the vault's authorization server at `/.well-known/oauth-authorization-server`, registers itself via Dynamic Client Registration (RFC 7591), and opens your browser to the vault's consent page.
+2. Enter the URL: `https://vault.yourdomain.com/vault/{name}/mcp` (replace `{name}` with your vault name — e.g. `default`). **Do not paste a bearer token** — leave the auth field empty.
+3. An OAuth-capable MCP client discovers the vault's authorization server at `/vault/{name}/.well-known/oauth-authorization-server`, registers itself via Dynamic Client Registration (RFC 7591), and opens your browser to the vault's consent page.
 4. Enter your owner password (plus TOTP code / backup code if 2FA is enabled), pick a scope (`full` or `read`), click Authorize.
 5. Browser redirects back. The connection is live. The client now holds a `pvt_` token scoped to this vault.
 
@@ -158,9 +158,7 @@ parachute-vault remove work --yes
 
 **The default vault is managed for you.** `vault init` creates `default` on first install and records it as `default_vault` in `~/.parachute/config.yaml`. `vault create <name>` promotes the newly-created vault to default when no default exists or when the configured default points at a missing vault. `vault remove <name>` promotes the sole survivor when you delete the default and one vault remains; if multiple remain after removing the default, it clears the setting and tells you to edit `config.yaml` yourself. There is no `vault set-default` subcommand — to point the server at a different existing vault, edit the `default_vault:` line in `~/.parachute/config.yaml` and `parachute-vault restart`.
 
-**Single-vault rule.** When the server has exactly one vault, the unscoped `/oauth/*` and `/mcp` paths transparently resolve to it — regardless of its name. A lone vault named `journal` works at `https://vault.example.com/mcp` with no vault-in-URL needed.
-
-**Multi-vault rule.** When the server has two or more vaults, always use the vault-scoped path (`/vaults/{name}/mcp`, `/vaults/{name}/oauth/authorize`). OAuth tokens minted there are scoped to that vault alone — cross-vault substitution is enforced at the OAuth layer: an auth code minted for one vault cannot be redeemed at another vault's token endpoint.
+**URL shape.** Every vault-touching route lives under `/vault/{name}/...`: `/vault/{name}/mcp`, `/vault/{name}/oauth/authorize`, `/vault/{name}/api/notes`, `/vault/{name}/view/{id}`. There is no unscoped fallback — pick the vault in the URL even if you only have one. OAuth tokens are scoped to the vault in their issuing URL; cross-vault substitution is rejected at the OAuth layer (an auth code minted for one vault cannot be redeemed at another vault's token endpoint).
 
 **Listing vaults from a client.** The authenticated `GET /vaults` endpoint returns full vault metadata. The public `GET /vaults/list` endpoint returns names only, no metadata, no auth required — this is what Parachute Daily's vault picker calls before the user authenticates. Operators who want to hide the vault list from unauthenticated callers can set `discovery: disabled` in `~/.parachute/config.yaml` to make `/vaults/list` return 404.
 
@@ -400,24 +398,28 @@ published_tag: public
 
 ## REST API
 
-```
-GET/POST       /api/notes                         query or create notes
-GET/PATCH/DEL  /api/notes/:idOrPath                read, update, delete a single note
-GET/POST       /api/notes/:id/attachments          list or add attachments
-GET            /api/tags                           list tags (?include_schema=true for schemas)
-GET/PUT/DEL    /api/tags/:name                     get, update, or delete a tag
-POST           /api/tags/:name/rename              atomic rename (409 if target_exists)
-POST           /api/tags/merge                     atomic multi-source merge into a target tag
-GET            /api/find-path?source=...&target=...  shortest path between two notes
-GET/PATCH      /api/vault                          vault info (get or update description)
-POST           /api/storage/upload                 upload file (audio/image)
-GET            /api/storage/:path                  download file
-POST           /mcp                                MCP endpoint (unified, all vaults)
-GET            /view/:idOrPath                     render note as HTML (public or auth)
-GET            /health                             health check
-```
+Every vault-touching path is scoped under `/vault/{name}/` — substitute your vault name (e.g. `default`) for `{name}`:
 
-Per-vault routes at `/vaults/{name}/api/...`, `/vaults/{name}/mcp`, and `/vaults/{name}/view/:idOrPath`.
+```
+GET/POST       /vault/{name}/api/notes                           query or create notes
+GET/PATCH/DEL  /vault/{name}/api/notes/:idOrPath                  read, update, delete a single note
+GET/POST       /vault/{name}/api/notes/:id/attachments            list or add attachments
+GET            /vault/{name}/api/tags                             list tags (?include_schema=true for schemas)
+GET/PUT/DEL    /vault/{name}/api/tags/:name                       get, update, or delete a tag
+POST           /vault/{name}/api/tags/:name/rename                atomic rename (409 if target_exists)
+POST           /vault/{name}/api/tags/merge                       atomic multi-source merge into a target tag
+GET            /vault/{name}/api/find-path?source=...&target=...  shortest path between two notes
+GET/PATCH      /vault/{name}/api/vault                            vault info (get or update description)
+POST           /vault/{name}/api/storage/upload                   upload file (audio/image)
+GET            /vault/{name}/api/storage/:path                    download file
+POST           /vault/{name}/mcp                                  MCP endpoint (per-vault session)
+*              /vault/{name}/oauth/{register,authorize,token}     OAuth 2.1 + PKCE flow
+*              /vault/{name}/.well-known/oauth-*                  RFC 8414 / RFC 9728 discovery
+GET            /vault/{name}/view/:idOrPath                       render note as HTML (public or auth)
+GET            /vaults                                            authenticated: full metadata
+GET            /vaults/list                                       public: vault names only (unless discovery: disabled)
+GET            /health                                            health check
+```
 
 ## Data model
 
@@ -435,7 +437,7 @@ Metadata is a JSON column. Vaults start blank — no predefined tags or schema.
 
 **All API and MCP requests require a valid API key.** No exceptions — localhost gets no special treatment.
 
-For wiring up an AI client (Claude Code, Claude Desktop, Parachute Daily), see [Connecting a client](#connecting-a-client) above. This section covers token-level details: how to pass a key, how to manage tokens, and which endpoints are public by design (`/health`, published notes at `/view/:id`).
+For wiring up an AI client (Claude Code, Claude Desktop, Parachute Daily), see [Connecting a client](#connecting-a-client) above. This section covers token-level details: how to pass a key, how to manage tokens, and which endpoints are public by design (`/health`, `/vaults/list`, published notes at `/vault/{name}/view/:id`).
 
 ### Passing the key
 
@@ -446,13 +448,13 @@ Tokens come in two shapes. Both work interchangeably at every authenticated endp
 
 ```bash
 # Header (preferred)
-curl -H "Authorization: Bearer pvt_..." http://localhost:1940/api/notes
+curl -H "Authorization: Bearer pvt_..." http://localhost:1940/vault/default/api/notes
 
 # Alternative header
-curl -H "X-API-Key: pvt_..." http://localhost:1940/api/notes
+curl -H "X-API-Key: pvt_..." http://localhost:1940/vault/default/api/notes
 
 # Query param (for /view endpoint only — convenient for browsers)
-curl http://localhost:1940/view/noteId?key=pvt_...
+curl http://localhost:1940/vault/default/view/noteId?key=pvt_...
 ```
 
 ### Token management
@@ -479,9 +481,10 @@ Legacy API keys (`pvk_...`) from config.yaml still work at runtime but the `vaul
 
 ### Public endpoints
 
-Only two endpoints work without auth:
+Three endpoints work without auth:
 - `GET /health` — returns `{ status: "ok" }` (no sensitive data)
-- `GET /view/:noteId` — serves published notes only (returns 404 for unpublished)
+- `GET /vaults/list` — vault names only (set `discovery: disabled` in `config.yaml` to hide)
+- `GET /vault/{name}/view/:noteId` — serves published notes only (returns 404 for unpublished)
 
 ## Network security
 
@@ -568,7 +571,7 @@ sudo cloudflared service install
 sudo systemctl start cloudflared
 ```
 
-Then point any client at `https://vault.yourdomain.com/vaults/{name}/mcp` (or `https://vault.yourdomain.com/mcp` for a single-vault deployment). See [Connecting a client → Claude Desktop (OAuth)](#claude-desktop-oauth) — the flow is identical to the local case once the URL is remote; the browser-based OAuth handshake makes the connection without pasting a bearer token.
+Then point any client at `https://vault.yourdomain.com/vault/{name}/mcp`. See [Connecting a client → Claude Desktop (OAuth)](#claude-desktop-oauth) — the flow is identical to the local case once the URL is remote; the browser-based OAuth handshake makes the connection without pasting a bearer token.
 
 ### Remote access via Tailscale Funnel
 
@@ -595,7 +598,7 @@ tailscale funnel reset
 The resulting URL is `https://<your-device>.<your-tailnet>.ts.net/` — `tailscale funnel status` prints it verbatim. You can also use ports `8443` or `10000` via `--https=<port>`; no other public ports are available to Funnel.
 
 Point any MCP client at the Tailscale URL:
-- Claude Desktop → Settings → Integrations → Add MCP → `https://<your-device>.<your-tailnet>.ts.net/vaults/{name}/mcp` (leave the Authorization field empty; the OAuth flow will handle it — see [Connecting a client](#connecting-a-client)).
+- Claude Desktop → Settings → Integrations → Add MCP → `https://<your-device>.<your-tailnet>.ts.net/vault/{name}/mcp` (leave the Authorization field empty; the OAuth flow will handle it — see [Connecting a client](#connecting-a-client)).
 - Parachute Daily → enter the base URL `https://<your-device>.<your-tailnet>.ts.net`, pick the vault, tap Connect.
 
 **Cloudflare vs Tailscale, at a glance.** Pick Cloudflare when you want a custom domain, bandwidth headroom for heavier traffic, or to share the vault with people who aren't on your tailnet. Pick Tailscale when you're already running it, you're fine with a `*.ts.net` URL, and you want the setup to fit in two commands.

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,11 +1,10 @@
 /**
- * Auth invariants — routing coherence between unscoped and scoped paths.
+ * Auth invariants — per-vault routing with strict isolation.
  *
- * See Fix 2 in the OAuth-to-Daily launch work: a vault token minted by one
- * path (unscoped `/oauth/token` or scoped `/vaults/X/oauth/token`) must
- * authenticate identically at every endpoint that addresses the same vault,
- * regardless of whether the URL uses `/api/*` (default-vault shortcut) or
- * `/vaults/X/api/*` (explicit). Same for `/mcp` vs `/vaults/X/mcp`.
+ * Every HTTP path that touches a vault lives under `/vault/<name>/...`, so
+ * a token minted for vault A must authenticate at vault A endpoints and
+ * must not authenticate at vault B endpoints. The global auth path still
+ * exists for cross-vault listings (`/vaults`) and scans every vault's DB.
  *
  * These tests isolate `PARACHUTE_HOME` so they don't touch the user's real
  * config. Each test builds 1-2 vaults from scratch.
@@ -83,51 +82,35 @@ function bearer(token: string): Request {
   });
 }
 
-describe("auth — default-vault routing coherence", () => {
-  test("token minted in default vault authenticates at both unscoped and scoped paths", () => {
-    seedVault("default", { isDefault: true });
-    const token = mintTokenInVault("default");
-    const defaultConfig = readVaultConfig("default")!;
-    const defaultStore = getVaultStore("default");
+describe("auth — per-vault routing", () => {
+  test("token minted in a vault authenticates at its own /vault/<name>/* endpoints", () => {
+    seedVault("journal");
+    const token = mintTokenInVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
 
-    // Unscoped `/api/*` flow: server resolves default vault, calls
-    // authenticateVaultRequest with default's config + DB. Token must resolve.
-    const unscoped = authenticateVaultRequest(bearer(token), defaultConfig, defaultStore.db);
-    expect("error" in unscoped).toBe(false);
-    if (!("error" in unscoped)) expect(unscoped.permission).toBe("full");
+    // /vault/journal/api/* and /vault/journal/mcp both funnel into
+    // authenticateVaultRequest with journal's config + DB.
+    const vaultAuth = authenticateVaultRequest(bearer(token), journalConfig, journalStore.db);
+    expect("error" in vaultAuth).toBe(false);
+    if (!("error" in vaultAuth)) expect(vaultAuth.permission).toBe("full");
 
-    // Scoped `/vaults/default/api/*` flow: same defaultConfig + DB. Must also
-    // resolve — this is the invariant Aaron's complaint hinges on.
-    const scoped = authenticateVaultRequest(bearer(token), defaultConfig, defaultStore.db);
-    expect("error" in scoped).toBe(false);
-
-    // Unified `/mcp` flow: authenticateGlobalRequest scans every vault's DB.
-    // Since the token is in default's DB, this must also resolve.
+    // /vaults (global metadata listing) uses authenticateGlobalRequest which
+    // scans every vault's DB. Since the token is in journal's DB, it must resolve.
     const global = authenticateGlobalRequest(bearer(token));
     expect("error" in global).toBe(false);
   });
 
-  // HTTP-level routing stand-in. Mirrors server.ts's vault-resolution step:
-  // unscoped `/api/*` resolves to the default vault; scoped `/vaults/X/api/*`
-  // extracts the name from the URL. After resolution both paths funnel into
-  // `authenticateVaultRequest` with that vault's config + DB. The earlier
-  // version of this test called `authenticateVaultRequest` twice with the same
-  // args and labelled the calls "scoped"/"unscoped" — tautological, because
-  // routing was never exercised. This variant drives the resolver from the
-  // URL, so the routing step is the thing under test.
+  // HTTP-level routing stand-in. Mirrors routing.ts: every vault-scoped path
+  // matches `/vault/<name>/...`, we look the vault up, then authenticate the
+  // request against that vault's DB.
   function dispatchAuthFromPath(path: string, req: Request): {
     status: number;
     permission?: string;
   } {
-    let vaultName: string;
-    if (path.startsWith("/vaults/")) {
-      vaultName = path.split("/")[2];
-    } else if (path.startsWith("/api/")) {
-      const gc = readGlobalConfig();
-      vaultName = gc.default_vault ?? "default";
-    } else {
-      return { status: 404 };
-    }
+    const match = path.match(/^\/vault\/([^/]+)(\/.*)?$/);
+    if (!match) return { status: 404 };
+    const vaultName = match[1];
     const vaultConfig = readVaultConfig(vaultName);
     if (!vaultConfig) return { status: 404 };
     const store = getVaultStore(vaultName);
@@ -136,77 +119,71 @@ describe("auth — default-vault routing coherence", () => {
     return { status: 200, permission: res.permission };
   }
 
-  test("routing coherence: unscoped and scoped /api/health accept a default-vault token identically", () => {
-    seedVault("default", { isDefault: true });
-    const token = mintTokenInVault("default");
+  test("routing: /vault/<name>/api/health accepts a token minted in that vault", () => {
+    seedVault("journal");
+    const token = mintTokenInVault("journal");
 
-    // (a) unscoped /api/health with default-vault token
-    const unscoped = dispatchAuthFromPath("/api/health", bearer(token));
-    expect(unscoped.status).toBe(200);
-
-    // (b) scoped /vaults/default/api/health with the same token
-    const scoped = dispatchAuthFromPath("/vaults/default/api/health", bearer(token));
-    expect(scoped.status).toBe(200);
-
-    // Both paths resolve the same vault → same permission level comes back.
-    expect(unscoped.permission).toBe(scoped.permission);
+    const result = dispatchAuthFromPath("/vault/journal/api/health", bearer(token));
+    expect(result.status).toBe(200);
+    expect(result.permission).toBe("full");
   });
 
-  test("routing coherence: scoped /vaults/X/api/health rejects a token issued for vault Y", () => {
+  test("routing: /vault/A/api/* rejects a token issued for vault B", () => {
     // The privilege-escalation barrier: a valid token for vault A must not
-    // authenticate at vault B's scoped endpoint, even though the URL is
-    // well-formed and the token itself is valid for *some* vault.
-    seedVault("default", { isDefault: true });
+    // authenticate at vault B's endpoint, even though the token is valid
+    // for some vault. This is the point of per-vault DBs.
+    seedVault("journal");
     seedVault("work");
     const workToken = mintTokenInVault("work");
 
-    const crossVault = dispatchAuthFromPath("/vaults/default/api/health", bearer(workToken));
+    const crossVault = dispatchAuthFromPath("/vault/journal/api/health", bearer(workToken));
     expect(crossVault.status).toBe(401);
+  });
+
+  test("routing: /vault/<unknown> returns 404 (not 401)", () => {
+    seedVault("journal");
+    const token = mintTokenInVault("journal");
+    const result = dispatchAuthFromPath("/vault/nonexistent/api/health", bearer(token));
+    expect(result.status).toBe(404);
   });
 });
 
-describe("auth — named-vault routing coherence", () => {
+describe("auth — cross-vault isolation", () => {
   test("token minted in a non-default vault authenticates via scoped and global paths", () => {
-    seedVault("default", { isDefault: true });
+    seedVault("journal", { isDefault: true });
     seedVault("work");
     const workToken = mintTokenInVault("work");
     const workConfig = readVaultConfig("work")!;
     const workStore = getVaultStore("work");
 
-    // Scoped `/vaults/work/api/*` — must resolve against work's DB.
     const scoped = authenticateVaultRequest(bearer(workToken), workConfig, workStore.db);
     expect("error" in scoped).toBe(false);
 
-    // Unified `/mcp` — global auth scans all vaults, must find it.
+    // Global auth scans every vault, must find the token in work's DB.
     const global = authenticateGlobalRequest(bearer(workToken));
     expect("error" in global).toBe(false);
   });
 
-  test("a work-vault token does NOT authenticate against the default vault's /api/*", () => {
-    // This is the correct isolation behavior: a token scoped to vault X has no
-    // business being accepted at endpoints that address vault Y. If this ever
-    // regressed, we'd have a privilege-escalation bug (read a different vault
-    // by just sending a valid token at the wrong URL).
-    seedVault("default", { isDefault: true });
+  test("a work-vault token does NOT authenticate against the journal vault", () => {
+    seedVault("journal", { isDefault: true });
     seedVault("work");
     const workToken = mintTokenInVault("work");
-    const defaultConfig = readVaultConfig("default")!;
-    const defaultStore = getVaultStore("default");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
 
-    const res = authenticateVaultRequest(bearer(workToken), defaultConfig, defaultStore.db);
+    const res = authenticateVaultRequest(bearer(workToken), journalConfig, journalStore.db);
     expect("error" in res).toBe(true);
   });
 });
 
 // ---------------------------------------------------------------------------
-// End-to-end: OAuth flow → resulting token authenticates at expected paths
+// End-to-end: OAuth flow → resulting token authenticates against its vault
 // ---------------------------------------------------------------------------
 
-describe("OAuth-minted tokens — cross-endpoint coherence", () => {
+describe("OAuth-minted tokens — per-vault coherence", () => {
   // These tests drive the OAuth handlers directly (no HTTP), then take the
-  // resulting access_token and verify it resolves at every endpoint that
-  // addresses its issuing vault. This is the key coherence invariant for
-  // Aaron's launch complaint.
+  // resulting access_token and verify it resolves at endpoints addressing
+  // its issuing vault — and only its issuing vault.
 
   async function runOAuthFlow(vaultName: string): Promise<string> {
     const store = getVaultStore(vaultName);
@@ -218,7 +195,7 @@ describe("OAuth-minted tokens — cross-endpoint coherence", () => {
 
     // 1. Register client
     const regRes = await handleRegister(
-      new Request("https://vault.test/oauth/register", {
+      new Request(`https://vault.test/vault/${vaultName}/oauth/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -234,7 +211,7 @@ describe("OAuth-minted tokens — cross-endpoint coherence", () => {
     const codeVerifier = crypto.randomBytes(32).toString("base64url");
     const codeChallenge = crypto.createHash("sha256").update(codeVerifier).digest("base64url");
     const authRes = await handleAuthorizePost(
-      new Request("https://vault.test/oauth/authorize", {
+      new Request(`https://vault.test/vault/${vaultName}/oauth/authorize`, {
         method: "POST",
         body: new URLSearchParams({
           action: "authorize",
@@ -253,7 +230,7 @@ describe("OAuth-minted tokens — cross-endpoint coherence", () => {
 
     // 3. Token exchange
     const tokRes = await handleToken(
-      new Request("https://vault.test/oauth/token", {
+      new Request(`https://vault.test/vault/${vaultName}/oauth/token`, {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: new URLSearchParams({
@@ -272,48 +249,40 @@ describe("OAuth-minted tokens — cross-endpoint coherence", () => {
     return tokBody.access_token;
   }
 
-  test("default-vault OAuth: token works at /api/*, /mcp, /vaults/default/api/*, /vaults/default/mcp", async () => {
-    seedVault("default", { isDefault: true });
-    const token = await runOAuthFlow("default");
-    const cfg = readVaultConfig("default")!;
-    const store = getVaultStore("default");
+  test("OAuth-minted token works at /vault/<name>/api/* and /vault/<name>/mcp", async () => {
+    seedVault("journal", { isDefault: true });
+    const token = await runOAuthFlow("journal");
+    const cfg = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
 
-    // `/api/*` — unscoped path resolves default vault, calls authenticateVaultRequest.
-    const apiUnscoped = authenticateVaultRequest(bearer(token), cfg, store.db);
-    expect("error" in apiUnscoped).toBe(false);
+    // /vault/journal/api/* and /vault/journal/mcp both reach this auth call.
+    const vaultAuth = authenticateVaultRequest(bearer(token), cfg, store.db);
+    expect("error" in vaultAuth).toBe(false);
 
-    // `/vaults/default/api/*` — scoped path resolves same default, same DB, same call.
-    const apiScoped = authenticateVaultRequest(bearer(token), cfg, store.db);
-    expect("error" in apiScoped).toBe(false);
-
-    // `/mcp` — unified endpoint uses authenticateGlobalRequest which scans all DBs.
-    const mcpUnscoped = authenticateGlobalRequest(bearer(token));
-    expect("error" in mcpUnscoped).toBe(false);
-
-    // `/vaults/default/mcp` — scoped MCP uses authenticateVaultRequest (same as api).
-    const mcpScoped = authenticateVaultRequest(bearer(token), cfg, store.db);
-    expect("error" in mcpScoped).toBe(false);
+    // /vaults (authenticated listing) uses authenticateGlobalRequest.
+    const global = authenticateGlobalRequest(bearer(token));
+    expect("error" in global).toBe(false);
   });
 
-  test("named-vault OAuth: token works at /vaults/X/api/*, /vaults/X/mcp, /mcp", async () => {
-    seedVault("default", { isDefault: true });
+  test("named-vault OAuth: token works for its vault, rejected by others", async () => {
+    seedVault("journal", { isDefault: true });
     seedVault("work");
     const token = await runOAuthFlow("work");
     const workCfg = readVaultConfig("work")!;
     const workStore = getVaultStore("work");
 
-    // Scoped endpoints addressing vault work — must resolve.
-    const apiScoped = authenticateVaultRequest(bearer(token), workCfg, workStore.db);
-    expect("error" in apiScoped).toBe(false);
+    // Valid at work's own endpoints.
+    const scoped = authenticateVaultRequest(bearer(token), workCfg, workStore.db);
+    expect("error" in scoped).toBe(false);
 
-    // Unified /mcp scans all vaults, must find the token in work's DB.
-    const mcpUnified = authenticateGlobalRequest(bearer(token));
-    expect("error" in mcpUnified).toBe(false);
+    // Global auth finds the token in work's DB.
+    const global = authenticateGlobalRequest(bearer(token));
+    expect("error" in global).toBe(false);
 
-    // Defensive: the same token is NOT usable against the default vault's /api/*.
-    const defaultCfg = readVaultConfig("default")!;
-    const defaultStore = getVaultStore("default");
-    const crossCheck = authenticateVaultRequest(bearer(token), defaultCfg, defaultStore.db);
+    // Isolation: the token is NOT usable against the journal vault.
+    const journalCfg = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+    const crossCheck = authenticateVaultRequest(bearer(token), journalCfg, journalStore.db);
     expect("error" in crossCheck).toBe(true);
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,7 +33,6 @@ const READ_TOOLS = new Set([
   "list-tags",
   "find-path",
   "vault-info",
-  "list-vaults",
 ]);
 
 /** Check if a tool call is allowed for a given permission level. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -588,9 +588,9 @@ function cmdCreate(args: string[]) {
     process.exit(1);
   }
   if (name === "list") {
-    // Reserved — /vaults/list is the public discovery endpoint. Allowing a
-    // vault with this name would let its routes (/vaults/list/mcp, etc.) be
-    // shadowed by the discovery handler.
+    // Reserved — keeps the "list" vault name out of play even though per-vault
+    // routes now live under /vault/<name>/ and no longer collide with the
+    // /vaults/list discovery endpoint.
     console.error(`"list" is a reserved vault name.`);
     process.exit(1);
   }
@@ -1416,7 +1416,7 @@ type McpEntryLookup =
 /**
  * Read `~/.claude.json` and return the shape of the `parachute-vault` MCP
  * entry if present. The entry is always an HTTP MCP pointing at the local
- * daemon — `{ type: "http", url: "http://127.0.0.1:<port>/vaults/<name>/mcp" }`
+ * daemon — `{ type: "http", url: "http://127.0.0.1:<port>/vault/<name>/mcp" }`
  * — so we parse the URL's port for the port-match check.
  *
  * Invariant: the check is NON-fatal. A missing ~/.claude.json is a warn,
@@ -1967,7 +1967,7 @@ function installMcpConfig(apiKey?: string) {
   const defaultVault = globalConfig.default_vault || "default";
   const mcpEntry: Record<string, unknown> = {
     type: "http",
-    url: `http://127.0.0.1:${port}/vaults/${defaultVault}/mcp`,
+    url: `http://127.0.0.1:${port}/vault/${defaultVault}/mcp`,
   };
   if (apiKey) {
     mcpEntry.headers = { Authorization: `Bearer ${apiKey}` };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1037,15 +1037,15 @@ export function listVaults(): string[] {
 }
 
 /**
- * Resolve the vault that unscoped routes (`/mcp`, `/api/*`, `/oauth/*`,
- * `/view/*`) should target.
+ * Resolve the vault that tooling-level defaults (e.g. the `parachute-vault`
+ * MCP entry the CLI writes into `~/.claude.json`) should target. HTTP routing
+ * is vault-scoped — `/vault/<name>/...` is the only URL shape — so this helper
+ * is no longer on the request path; it just picks the one vault the CLI wires
+ * up by default.
  *
  * Resolution order:
  *  1. If `default_vault` is set in config.yaml AND that vault exists → use it.
  *  2. Else if exactly one vault exists → use that vault regardless of its name.
- *     This is the "single-vault auto-default": if you only have `journal`,
- *     `/mcp` transparently targets `journal` without requiring you to visit
- *     `/vaults/journal/mcp`.
  *  3. Otherwise → return `null` (multi-vault deployment with no/bad default;
  *     the caller should surface an explicit error rather than guess).
  *
@@ -1053,8 +1053,7 @@ export function listVaults(): string[] {
  *  - If `default_vault` points to a deleted vault, step 2 still kicks in so
  *    operators aren't stranded after `vault remove`.
  *  - The name "default" has no special meaning here; it's just whatever
- *    `vault init` happens to create on first run. A single vault named
- *    "journal" behaves identically.
+ *    `vault init` happens to create on first run.
  */
 export function resolveDefaultVault(): string | null {
   const globalConfig = readGlobalConfig();

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -172,7 +172,7 @@ describe("vault doctor — extended checks", () => {
     // Use a non-default port to prove we're actually reading config.yaml,
     // not just matching against DEFAULT_PORT.
     writeFileSync(join(dir, "config.yaml"), "port: 4321\n");
-    writeClaudeJson(dir, "http://127.0.0.1:4321/vaults/default/mcp");
+    writeClaudeJson(dir, "http://127.0.0.1:4321/vault/default/mcp");
     const res = runCli(["doctor"], dir, { HOME: dir });
     expect(res.stdout).toMatch(/✓ MCP entry in ~\/\.claude\.json/);
     expect(res.stdout).toMatch(/✓ MCP URL port matches vault\s+\(port 4321\)/);
@@ -184,7 +184,7 @@ describe("vault doctor — extended checks", () => {
 
   test("warns when MCP URL port does not match the vault's configured port", () => {
     writeFileSync(join(dir, "config.yaml"), "port: 4321\n");
-    writeClaudeJson(dir, "http://127.0.0.1:9999/vaults/default/mcp");
+    writeClaudeJson(dir, "http://127.0.0.1:9999/vault/default/mcp");
     const res = runCli(["doctor"], dir, { HOME: dir });
     expect(res.stdout).toMatch(/✓ MCP entry in ~\/\.claude\.json/);
     expect(res.stdout).toMatch(/! MCP URL port matches vault/);

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -10,12 +10,9 @@
  * root cause of vault#56. The `initialize` method still works if a
  * client sends it (the Server class handles it natively).
  *
- * Two modes:
- *   /mcp              — unified, all vaults via `vault` param + list-vaults
- *   /vaults/{name}/mcp — scoped to one vault, no vault param
- *
- * Vault description is sent as the MCP server instruction.
- * Read-only keys see fewer tools.
+ * Every MCP session is scoped to one vault via `/vault/{name}/mcp`.
+ * The vault's description is sent as the MCP server instruction, and
+ * read-only keys see a filtered tool list.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -24,18 +21,12 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { generateUnifiedMcpTools, generateScopedMcpTools, getServerInstruction } from "./mcp-tools.ts";
+import { generateScopedMcpTools, getServerInstruction } from "./mcp-tools.ts";
 import { isToolAllowed } from "./auth.ts";
 import type { AuthResult } from "./auth.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
 
-/** Handle unified MCP at /mcp (all vaults). */
-export async function handleUnifiedMcp(req: Request, auth: AuthResult): Promise<Response> {
-  const instruction = getServerInstruction();
-  return handleMcp(req, () => generateUnifiedMcpTools(), "parachute-vault", auth, instruction);
-}
-
-/** Handle scoped MCP at /vaults/{name}/mcp (single vault). */
+/** Handle scoped MCP at /vault/{name}/mcp (single vault). */
 export async function handleScopedMcp(req: Request, vaultName: string, auth: AuthResult): Promise<Response> {
   const instruction = getServerInstruction(vaultName);
   return handleMcp(req, () => generateScopedMcpTools(vaultName), `parachute-vault/${vaultName}`, auth, instruction);

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,25 +1,24 @@
 /**
- * MCP tool generation for multi-vault.
+ * MCP tool generation for the scoped (per-vault) MCP endpoint.
  *
- * Wraps core tools with vault resolution (optional `vault` param) and
- * overrides vault-info with actual vault config access.
+ * Every MCP session is now bound to one vault via `/vault/<name>/mcp`, so
+ * tools operate on that vault and vault-info picks up its config directly.
  */
 
 import { generateMcpTools } from "../core/src/mcp.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
-import { readVaultConfig, writeVaultConfig, listVaults as getVaultNames, resolveDefaultVault } from "./config.ts";
+import { readVaultConfig, writeVaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
 
 /**
- * Get the MCP server instruction for a vault (or the default vault).
+ * Get the MCP server instruction for a vault.
  * Sent once at session init — not per tool.
  */
-export function getServerInstruction(vaultName?: string): string {
-  const name = vaultName ?? resolveDefaultVault() ?? "default";
-  const config = readVaultConfig(name);
+export function getServerInstruction(vaultName: string): string {
+  const config = readVaultConfig(vaultName);
 
   const parts: string[] = [
-    `You are connected to Parachute Vault "${name}".`,
+    `You are connected to Parachute Vault "${vaultName}".`,
   ];
 
   if (config?.description) {
@@ -27,83 +26,6 @@ export function getServerInstruction(vaultName?: string): string {
   }
 
   return parts.join("\n");
-}
-
-/**
- * Generate the unified MCP tool set.
- * Each tool has an optional `vault` param that defaults to the default vault.
- */
-export function generateUnifiedMcpTools(): McpToolDef[] {
-  const vaultNames = getVaultNames();
-  const defaultVault = resolveDefaultVault() ?? "default";
-  const multiVault = vaultNames.length > 1;
-
-  // Get tool definitions from core (using default vault for schema)
-  const defaultStore = getVaultStore(defaultVault);
-  const coreTools = generateMcpTools(defaultStore);
-
-  // Wrap each core tool with vault resolution
-  const tools: McpToolDef[] = coreTools.map((coreTool) => {
-    let description = coreTool.description;
-    if (multiVault) {
-      description += `\n\nMulti-vault: pass 'vault' to target a specific vault. Default: "${defaultVault}". Available: ${vaultNames.join(", ")}`;
-    }
-
-    const inputSchema = {
-      ...coreTool.inputSchema,
-      properties: {
-        vault: {
-          type: "string",
-          description: `Vault name (default: "${defaultVault}")`,
-        },
-        ...(coreTool.inputSchema as any).properties,
-      },
-    };
-
-    return {
-      name: coreTool.name,
-      description,
-      inputSchema,
-      execute: async (params) => {
-        const vaultName = (params.vault as string) ?? defaultVault;
-        const config = readVaultConfig(vaultName);
-        if (!config) {
-          throw new Error(`Vault "${vaultName}" not found. Available: ${getVaultNames().join(", ")}`);
-        }
-        const store = getVaultStore(vaultName);
-        const vaultTools = generateMcpTools(store);
-        const tool = vaultTools.find((t) => t.name === coreTool.name)!;
-        const { vault: _, ...rest } = params;
-        return await tool.execute(rest);
-      },
-    };
-  });
-
-  // Override vault-info with actual vault config access
-  overrideVaultInfo(tools, defaultVault);
-
-  // Add list-vaults (multi-vault only, not in core)
-  if (multiVault) {
-    tools.push({
-      name: "list-vaults",
-      description: "List all available vaults with their descriptions.",
-      inputSchema: { type: "object", properties: {} },
-      execute: () => {
-        const names = getVaultNames();
-        return names.map((name) => {
-          const config = readVaultConfig(name);
-          return {
-            name,
-            description: config?.description,
-            created_at: config?.created_at,
-            is_default: name === defaultVault,
-          };
-        });
-      },
-    });
-  }
-
-  return tools;
 }
 
 /**
@@ -123,12 +45,11 @@ export function generateScopedMcpTools(vaultName: string): McpToolDef[] {
 /**
  * Override vault-info's placeholder execute with real vault config access.
  */
-function overrideVaultInfo(tools: McpToolDef[], defaultVault: string): void {
+function overrideVaultInfo(tools: McpToolDef[], vaultName: string): void {
   const vaultInfo = tools.find((t) => t.name === "vault-info");
   if (!vaultInfo) return;
 
   vaultInfo.execute = async (params) => {
-    const vaultName = (params.vault as string) ?? defaultVault;
     const config = readVaultConfig(vaultName);
     if (!config) throw new Error(`Vault "${vaultName}" not found`);
 

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -113,44 +113,45 @@ async function fullOAuthFlow(opts?: { scope?: string }): Promise<string> {
 
 describe("OAuth discovery", () => {
   test("protected resource metadata", async () => {
-    const req = makeRequest("https://vault.test/.well-known/oauth-protected-resource");
-    const res = handleProtectedResource(req);
+    const req = makeRequest("https://vault.test/vault/default/.well-known/oauth-protected-resource");
+    const res = handleProtectedResource(req, "default");
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.resource).toBe("https://vault.test/mcp");
+    expect(body.resource).toBe("https://vault.test/vault/default/mcp");
+    expect(body.authorization_servers).toEqual(["https://vault.test/vault/default"]);
     expect(body.scopes_supported).toContain("full");
     expect(body.scopes_supported).toContain("read");
   });
 
   test("authorization server metadata", async () => {
-    const req = makeRequest("https://vault.test/.well-known/oauth-authorization-server");
-    const res = handleAuthorizationServer(req);
+    const req = makeRequest("https://vault.test/vault/default/.well-known/oauth-authorization-server");
+    const res = handleAuthorizationServer(req, "default");
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.issuer).toBe("https://vault.test");
-    expect(body.authorization_endpoint).toBe("https://vault.test/oauth/authorize");
-    expect(body.token_endpoint).toBe("https://vault.test/oauth/token");
-    expect(body.registration_endpoint).toBe("https://vault.test/oauth/register");
+    expect(body.issuer).toBe("https://vault.test/vault/default");
+    expect(body.authorization_endpoint).toBe("https://vault.test/vault/default/oauth/authorize");
+    expect(body.token_endpoint).toBe("https://vault.test/vault/default/oauth/token");
+    expect(body.registration_endpoint).toBe("https://vault.test/vault/default/oauth/register");
     expect(body.code_challenge_methods_supported).toEqual(["S256"]);
   });
 
-  test("resource URL includes custom mcpPath for per-vault", async () => {
-    const req = makeRequest("https://vault.test/.well-known/oauth-protected-resource");
-    const res = handleProtectedResource(req, "/vaults/work/mcp");
+  test("resource URL reflects the vault name", async () => {
+    const req = makeRequest("https://vault.test/vault/work/.well-known/oauth-protected-resource");
+    const res = handleProtectedResource(req, "work");
     const body = await res.json();
-    expect(body.resource).toBe("https://vault.test/vaults/work/mcp");
+    expect(body.resource).toBe("https://vault.test/vault/work/mcp");
   });
 
   test("uses x-forwarded-proto and x-forwarded-host", async () => {
-    const req = makeRequest("http://localhost:1940/.well-known/oauth-protected-resource", {
+    const req = makeRequest("http://localhost:1940/vault/default/.well-known/oauth-protected-resource", {
       headers: {
         "x-forwarded-proto": "https",
         "x-forwarded-host": "vault.example.com",
       },
     });
-    const res = handleProtectedResource(req);
+    const res = handleProtectedResource(req, "default");
     const body = await res.json();
-    expect(body.resource).toBe("https://vault.example.com/mcp");
+    expect(body.resource).toBe("https://vault.example.com/vault/default/mcp");
   });
 });
 
@@ -1316,7 +1317,7 @@ describe("OAuth token response — vault name", () => {
     const redirectUri = "https://example.com/callback";
 
     const authRes = await handleAuthorizePost(
-      makeRequest("https://vault.test/vaults/work/oauth/authorize", {
+      makeRequest("https://vault.test/vault/work/oauth/authorize", {
         method: "POST",
         body: new URLSearchParams({
           action: "authorize",
@@ -1334,7 +1335,7 @@ describe("OAuth token response — vault name", () => {
     const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
 
     const tokenRes = await handleToken(
-      makeRequest("https://vault.test/vaults/work/oauth/token", {
+      makeRequest("https://vault.test/vault/work/oauth/token", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: new URLSearchParams({
@@ -1359,49 +1360,31 @@ describe("OAuth token response — vault name", () => {
 
 describe("OAuth discovery — vault-scoped", () => {
   test("authorization-server metadata scopes all endpoints to the vault", async () => {
-    const req = makeRequest("https://vault.test/vaults/work/.well-known/oauth-authorization-server");
+    const req = makeRequest("https://vault.test/vault/work/.well-known/oauth-authorization-server");
     const res = handleAuthorizationServer(req, "work");
     const body = await res.json();
-    // Issuer and endpoints all live under /vaults/work. This is what makes
-    // vault-scoped OAuth work end-to-end: a client following the scoped
-    // discovery gets redirected to the scoped authorize/token endpoints,
+    // Issuer and endpoints all live under /vault/work. A client following the
+    // scoped discovery gets redirected to the scoped authorize/token endpoints,
     // which in turn mint the token into the named vault's DB.
-    expect(body.issuer).toBe("https://vault.test/vaults/work");
-    expect(body.authorization_endpoint).toBe("https://vault.test/vaults/work/oauth/authorize");
-    expect(body.token_endpoint).toBe("https://vault.test/vaults/work/oauth/token");
-    expect(body.registration_endpoint).toBe("https://vault.test/vaults/work/oauth/register");
+    expect(body.issuer).toBe("https://vault.test/vault/work");
+    expect(body.authorization_endpoint).toBe("https://vault.test/vault/work/oauth/authorize");
+    expect(body.token_endpoint).toBe("https://vault.test/vault/work/oauth/token");
+    expect(body.registration_endpoint).toBe("https://vault.test/vault/work/oauth/register");
     expect(body.code_challenge_methods_supported).toEqual(["S256"]);
   });
 
-  test("authorization-server metadata defaults to unscoped endpoints when no vaultName", async () => {
-    // Regression check — the unscoped form still returns unscoped endpoints.
-    const req = makeRequest("https://vault.test/.well-known/oauth-authorization-server");
-    const res = handleAuthorizationServer(req);
-    const body = await res.json();
-    expect(body.issuer).toBe("https://vault.test");
-    expect(body.authorization_endpoint).toBe("https://vault.test/oauth/authorize");
-    expect(body.token_endpoint).toBe("https://vault.test/oauth/token");
-  });
-
   test("protected-resource advertises a vault-scoped authorization server", async () => {
-    const req = makeRequest("https://vault.test/vaults/work/.well-known/oauth-protected-resource");
-    const res = handleProtectedResource(req, "/vaults/work/mcp", "/vaults/work");
+    const req = makeRequest("https://vault.test/vault/work/.well-known/oauth-protected-resource");
+    const res = handleProtectedResource(req, "work");
     const body = await res.json();
-    expect(body.resource).toBe("https://vault.test/vaults/work/mcp");
+    expect(body.resource).toBe("https://vault.test/vault/work/mcp");
     // The authorization server the client should fetch next is the scoped one,
     // so the client discovers the scoped authorize/token endpoints.
-    expect(body.authorization_servers).toEqual(["https://vault.test/vaults/work"]);
-  });
-
-  test("protected-resource defaults to root authorization server when no prefix", async () => {
-    const req = makeRequest("https://vault.test/.well-known/oauth-protected-resource");
-    const res = handleProtectedResource(req);
-    const body = await res.json();
-    expect(body.authorization_servers).toEqual(["https://vault.test"]);
+    expect(body.authorization_servers).toEqual(["https://vault.test/vault/work"]);
   });
 
   test("scoped discovery honors x-forwarded-host", async () => {
-    const req = makeRequest("http://localhost:1940/vaults/work/.well-known/oauth-authorization-server", {
+    const req = makeRequest("http://localhost:1940/vault/work/.well-known/oauth-authorization-server", {
       headers: {
         "x-forwarded-proto": "https",
         "x-forwarded-host": "vault.example.com",
@@ -1409,8 +1392,8 @@ describe("OAuth discovery — vault-scoped", () => {
     });
     const res = handleAuthorizationServer(req, "work");
     const body = await res.json();
-    expect(body.issuer).toBe("https://vault.example.com/vaults/work");
-    expect(body.authorization_endpoint).toBe("https://vault.example.com/vaults/work/oauth/authorize");
+    expect(body.issuer).toBe("https://vault.example.com/vault/work");
+    expect(body.authorization_endpoint).toBe("https://vault.example.com/vault/work/oauth/authorize");
   });
 });
 
@@ -1432,7 +1415,7 @@ describe("OAuth token — cross-vault code replay", () => {
 
     // Issue a code under vault A's authorize endpoint
     const authRes = await handleAuthorizePost(
-      makeRequest("https://vault.test/vaults/vault-a/oauth/authorize", {
+      makeRequest("https://vault.test/vault/vault-a/oauth/authorize", {
         method: "POST",
         body: new URLSearchParams({
           action: "authorize",
@@ -1455,7 +1438,7 @@ describe("OAuth token — cross-vault code replay", () => {
     // barrier: without the vault_name pinning, the code would mint a token
     // into whichever vault's DB this handleToken was called against.
     const tokenRes = await handleToken(
-      makeRequest("https://vault.test/vaults/vault-b/oauth/token", {
+      makeRequest("https://vault.test/vault/vault-b/oauth/token", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: new URLSearchParams({
@@ -1483,7 +1466,7 @@ describe("OAuth token — cross-vault code replay", () => {
     const redirectUri = "https://example.com/callback";
 
     const authRes = await handleAuthorizePost(
-      makeRequest("https://vault.test/vaults/vault-a/oauth/authorize", {
+      makeRequest("https://vault.test/vault/vault-a/oauth/authorize", {
         method: "POST",
         body: new URLSearchParams({
           action: "authorize",
@@ -1501,7 +1484,7 @@ describe("OAuth token — cross-vault code replay", () => {
     const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
 
     const tokenRes = await handleToken(
-      makeRequest("https://vault.test/vaults/vault-a/oauth/token", {
+      makeRequest("https://vault.test/vault/vault-a/oauth/token", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: new URLSearchParams({

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -4,10 +4,10 @@
  * Implements the subset of OAuth 2.1 needed for MCP clients (Claude Web,
  * Claude Desktop, etc.) to connect via the standard browser-based flow:
  *
- *   1. Dynamic Client Registration (RFC 7591)  — POST /oauth/register
- *   2. Authorization endpoint (PKCE required)   — GET/POST /oauth/authorize
- *   3. Token endpoint (code exchange)           — POST /oauth/token
- *   4. Discovery endpoints                      — GET /.well-known/*
+ *   1. Dynamic Client Registration (RFC 7591)  — POST /vault/<name>/oauth/register
+ *   2. Authorization endpoint (PKCE required)   — GET/POST /vault/<name>/oauth/authorize
+ *   3. Token endpoint (code exchange)           — POST /vault/<name>/oauth/token
+ *   4. Discovery endpoints                      — GET /vault/<name>/.well-known/*
  *
  * The flow produces a standard `pvt_` token stored in the vault's tokens table.
  * After the OAuth handshake, all requests use the same Bearer token auth path.
@@ -74,36 +74,31 @@ function escapeHtml(s: string): string {
 /**
  * OAuth 2.0 Protected Resource Metadata (RFC 9728).
  *
- * @param mcpPath       — the resource URL (e.g. `/mcp` or `/vaults/X/mcp`).
- * @param authServerPrefix — path prefix for the authorization server issuer
- *                           (e.g. `""` for global, `/vaults/X` for scoped).
- *                           The client discovers the AS metadata at
- *                           `{base}{prefix}/.well-known/oauth-authorization-server`.
+ * @param vaultName — the vault whose MCP endpoint is the protected resource.
+ *                    The metadata advertises `resource: {base}/vault/{name}/mcp`
+ *                    and the vault's authorization server at
+ *                    `{base}/vault/{name}`. Clients discover the AS metadata
+ *                    at `{base}/vault/{name}/.well-known/oauth-authorization-server`.
  */
-export function handleProtectedResource(
-  req: Request,
-  mcpPath = "/mcp",
-  authServerPrefix = "",
-): Response {
+export function handleProtectedResource(req: Request, vaultName: string): Response {
   const base = getBaseUrl(req);
+  const prefix = `/vault/${vaultName}`;
   return Response.json({
-    resource: `${base}${mcpPath}`,
-    authorization_servers: [`${base}${authServerPrefix}`],
+    resource: `${base}${prefix}/mcp`,
+    authorization_servers: [`${base}${prefix}`],
     scopes_supported: ["full", "read"],
     bearer_methods_supported: ["header"],
   });
 }
 
 /**
- * OAuth 2.0 Authorization Server Metadata (RFC 8414).
- *
- * @param vaultName — when provided, returns vault-scoped endpoints
- *                    (`/vaults/<name>/oauth/*`) and issuer. Tokens minted
- *                    via these endpoints are scoped to the named vault's DB.
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414). The endpoints are
+ * vault-scoped under `/vault/<name>/oauth/*`; tokens minted via these
+ * endpoints are scoped to the named vault's DB.
  */
-export function handleAuthorizationServer(req: Request, vaultName?: string): Response {
+export function handleAuthorizationServer(req: Request, vaultName: string): Response {
   const base = getBaseUrl(req);
-  const prefix = vaultName ? `/vaults/${vaultName}` : "";
+  const prefix = `/vault/${vaultName}`;
   return Response.json({
     issuer: `${base}${prefix}`,
     authorization_endpoint: `${base}${prefix}/oauth/authorize`,
@@ -486,8 +481,8 @@ export async function handleToken(
   }
 
   // Validate the code was issued for the same vault this token endpoint
-  // serves. Without this, a code issued under /vaults/A/oauth/authorize
-  // could be presented to /vaults/B/oauth/token and the token would be
+  // serves. Without this, a code issued under /vault/A/oauth/authorize
+  // could be presented to /vault/B/oauth/token and the token would be
   // minted into B's DB — privilege escalation across vault boundaries.
   if (authCode.vault_name !== vaultName) {
     return Response.json({ error: "invalid_grant", error_description: "vault mismatch" }, { status: 400 });
@@ -708,7 +703,7 @@ function renderConsentPage(p: ConsentParams): string {
 <div class="card">
   <h1>Authorize access</h1>
   <p><span class="client">${escapeHtml(p.clientName)}</span> wants to access your <strong>${escapeHtml(p.vaultName)}</strong> vault.</p>
-  <form method="POST" action="/oauth/authorize">
+  <form method="POST" action="">
     <input type="hidden" name="client_id" value="${escapeHtml(p.clientId)}">
     <input type="hidden" name="redirect_uri" value="${escapeHtml(p.redirectUri)}">
     <input type="hidden" name="code_challenge" value="${escapeHtml(p.codeChallenge)}">

--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -25,8 +25,8 @@ describe("/public → /view redirect", () => {
   });
 
   it("works for vault-scoped paths", () => {
-    const url = buildRedirectUrl("http://localhost:1940/vaults/work/public/abc?key=pvk_x", "abc", "/vaults/work");
-    expect(url).toBe("http://localhost:1940/vaults/work/view/abc?key=pvk_x");
+    const url = buildRedirectUrl("http://localhost:1940/vault/work/public/abc?key=pvk_x", "abc", "/vault/work");
+    expect(url).toBe("http://localhost:1940/vault/work/view/abc?key=pvk_x");
   });
 });
 

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -1,19 +1,17 @@
 /**
  * Tests for the HTTP routing layer (src/routing.ts).
  *
- * Two surfaces under test here:
+ * The server exposes four root-level endpoints and everything else under
+ * `/vault/<name>/...`. These tests pin the dispatcher's behaviour:
  *
- *  1. `/vaults/list` — public, unauthenticated discovery endpoint.
- *     Intended for the Daily vault-picker dropdown pre-OAuth.
- *     Must never leak anything beyond vault names; must return 404 when
- *     the operator disables discovery in config.yaml.
+ *  1. `/vaults/list` — public, unauthenticated discovery. Returns vault
+ *     names only, 404 when operator disables discovery.
+ *  2. `/vaults` — authenticated metadata listing.
+ *  3. `/vault/<name>/...` — per-vault routing (OAuth, MCP, view, API).
+ *  4. The RFC 9728 WWW-Authenticate challenge that decorates MCP 401s.
  *
- *  2. Single-vault auto-default. A user with exactly one vault (named
- *     anything — not necessarily "default") should be able to hit unscoped
- *     routes (/mcp, /api/*, /oauth/*) and have them transparently target
- *     their sole vault. Previously `/mcp` tried to look up a vault literally
- *     named "default" and failed. The coherence invariant from PR #111 says
- *     `/mcp` and `/vaults/:name/mcp` must behave identically for that vault.
+ * No unscoped `/mcp`, `/api/*`, `/oauth/*` routes exist — every per-vault
+ * resource must name the vault it targets.
  *
  * Uses PARACHUTE_HOME override so each test's vaults live in a tmp dir and
  * never touch ~/.parachute.
@@ -71,7 +69,8 @@ afterAll(() => {
 });
 
 // ---------------------------------------------------------------------------
-// resolveDefaultVault — the function that powers every "unscoped" route.
+// resolveDefaultVault — used by the CLI to pick the vault to wire into
+// `~/.claude.json`, not on the request path (which is always scoped).
 // ---------------------------------------------------------------------------
 
 describe("resolveDefaultVault", () => {
@@ -84,13 +83,10 @@ describe("resolveDefaultVault", () => {
 
   test("returns the sole vault when default_vault is unset", () => {
     createVault("journal");
-    // No default_vault in global config.
     expect(resolveDefaultVault()).toBe("journal");
   });
 
   test("returns the sole vault even if default_vault points to a deleted one", () => {
-    // Simulates: user had two vaults, removed the one that was the default,
-    // but config.yaml still references the old name.
     createVault("journal");
     writeGlobalConfig({ port: 1940, default_vault: "deleted-vault" });
     expect(resolveDefaultVault()).toBe("journal");
@@ -107,19 +103,16 @@ describe("resolveDefaultVault", () => {
     expect(resolveDefaultVault()).toBeNull();
   });
 
-  test("does not special-case the name 'default' — a vault named 'journal' alone is the default", () => {
-    // This is the Aaron-acked bug: having to go to /vaults/journal/mcp
-    // when it's the only vault was confusing. Now the name doesn't matter.
+  test("does not special-case the name 'default'", () => {
     createVault("journal");
     expect(resolveDefaultVault()).toBe("journal");
     expect(listVaults()).toEqual(["journal"]);
-    // And explicitly: "default" is NOT synthesized when it doesn't exist.
     expect(resolveDefaultVault()).not.toBe("default");
   });
 });
 
 // ---------------------------------------------------------------------------
-// /vaults/list — Task 1: public discovery endpoint for the Daily picker.
+// /vaults/list — public discovery endpoint for the Daily picker.
 // ---------------------------------------------------------------------------
 
 describe("GET /vaults/list (public discovery)", () => {
@@ -183,8 +176,6 @@ describe("GET /vaults/list (public discovery)", () => {
   });
 
   test("ignores Authorization header (endpoint is public)", async () => {
-    // Even with an obviously-wrong token, the endpoint must still succeed.
-    // This catches a regression where we'd accidentally gate it behind auth.
     createVault("journal");
     const req = new Request("http://localhost:1940/vaults/list", {
       headers: { Authorization: "Bearer not-a-real-token" },
@@ -193,25 +184,16 @@ describe("GET /vaults/list (public discovery)", () => {
     expect(res.status).toBe(200);
   });
 
-  test("rejects non-GET methods (falls through to vault-scoped 404 path)", async () => {
-    // Non-GET methods on /vaults/list fall through to the /vaults/:name
-    // matcher with name="list". Since no vault named "list" can exist
-    // (reserved name), we get a 404. This is the expected behavior —
-    // the endpoint is GET-only.
+  test("rejects non-GET methods (falls through to 404)", async () => {
     createVault("journal");
     const req = new Request("http://localhost:1940/vaults/list", { method: "POST" });
     const res = await route(req, "/vaults/list");
     expect(res.status).toBe(404);
   });
 
-  test("discovery disabled still allows authenticated /vaults listing (they are separate concerns)", async () => {
-    // /vaults (authenticated, with metadata) is orthogonal to /vaults/list
-    // (public, names only). Disabling discovery hides the public endpoint
-    // but not the authenticated one.
+  test("discovery disabled still allows authenticated /vaults listing (separate concerns)", async () => {
     createVault("journal");
     writeGlobalConfig({ port: 1940, discovery: "disabled" });
-    // We can at least assert that /vaults still returns 401 (auth required)
-    // rather than 404 (disabled). Past that, auth is covered elsewhere.
     const req = new Request("http://localhost:1940/vaults");
     const res = await route(req, "/vaults");
     expect(res.status).toBe(401);
@@ -219,130 +201,68 @@ describe("GET /vaults/list (public discovery)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Single-vault auto-default — Task 2: /mcp, /api/*, /oauth/* target the
-// only vault regardless of its name.
+// Per-vault routing: /vault/<name>/... is the only URL shape for vault
+// resources. Unscoped routes (/mcp, /api/*, /oauth/*) no longer exist.
 // ---------------------------------------------------------------------------
 
-describe("single-vault auto-default", () => {
-  test("one vault named 'journal' → /mcp requires auth (would error if vault not resolvable)", async () => {
-    // With one vault named "journal" and no default_vault set, /mcp must
-    // still hit the MCP handler. The handler itself requires a valid
-    // Bearer token — we assert 401 (auth failure), proving the request
-    // reached the MCP layer and did NOT bail out with "Default vault not
-    // found". Before this fix, /mcp would error because the code
-    // hardcoded the fallback name "default".
+describe("per-vault routing under /vault/<name>/", () => {
+  test("/vault/<name>/mcp reaches the MCP handler (401 unauthenticated)", async () => {
     createVault("journal");
-    // Deliberately no default_vault — single-vault fallback should kick in.
-    const req = new Request("http://localhost:1940/mcp");
-    const res = await route(req, "/mcp");
+    const path = "/vault/journal/mcp";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
     expect(res.status).toBe(401);
   });
 
-  test("one vault named 'journal' → /api/notes reaches auth (not 404'd)", async () => {
+  test("/vault/<name>/api/notes reaches per-vault auth (401 unauthenticated)", async () => {
     createVault("journal");
-    const req = new Request("http://localhost:1940/api/notes");
-    const res = await route(req, "/api/notes");
-    // Unauthenticated: 401 from per-vault auth. Before the fix, it would
-    // have 404'd with "Default vault not found".
+    const path = "/vault/journal/api/notes";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
     expect(res.status).toBe(401);
   });
 
-  test("one vault named 'journal' → /oauth/register reaches the OAuth handler (not 500'd)", async () => {
+  test("/vault/<name>/oauth/register reaches the OAuth handler", async () => {
     createVault("journal");
-    const req = new Request("http://localhost:1940/oauth/register", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ client_name: "test", redirect_uris: ["https://x.example/cb"] }),
-    });
-    const res = await route(req, "/oauth/register");
-    // Successful registration (201) or 400 from a validation issue —
-    // either way, we're PAST the "Default vault not configured" path.
+    const path = "/vault/journal/oauth/register";
+    const res = await route(
+      new Request(`http://localhost:1940${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "test", redirect_uris: ["https://x.example/cb"] }),
+      }),
+      path,
+    );
     expect(res.status).not.toBe(500);
     expect([201, 400]).toContain(res.status);
   });
 
-  test("one vault named 'journal' → /vaults/journal/mcp still works identically (coherence invariant)", async () => {
-    // This is the invariant from PR #111: the scoped and unscoped MCP paths
-    // must behave identically for a single-vault deployment. Both should
-    // land on the MCP auth gate and return 401 unauthenticated.
+  test("unknown vault returns 404 before hitting auth", async () => {
     createVault("journal");
-    const unscopedReq = new Request("http://localhost:1940/mcp");
-    const unscopedRes = await route(unscopedReq, "/mcp");
-    const scopedReq = new Request("http://localhost:1940/vaults/journal/mcp");
-    const scopedRes = await route(scopedReq, "/vaults/journal/mcp");
-    expect(unscopedRes.status).toBe(scopedRes.status);
-    expect(unscopedRes.status).toBe(401);
+    for (const path of [
+      "/vault/nonexistent/mcp",
+      "/vault/nonexistent/api/notes",
+      "/vault/nonexistent/oauth/register",
+    ]) {
+      const res = await route(new Request(`http://localhost:1940${path}`), path);
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("Vault not found");
+    }
   });
 
-  test("multiple vaults, no default_vault → /mcp returns a clear error, not a silent guess", async () => {
+  test("no /mcp, /api, /oauth unscoped routes — all 404", async () => {
     createVault("journal");
-    createVault("work");
-    // No default_vault set.
-    const req = new Request("http://localhost:1940/mcp");
-    const res = await route(req, "/mcp");
-    // We refuse to guess when multiple vaults exist. Hitting /mcp here
-    // must NOT silently target one of them. We expect a non-200 status
-    // that is not the auth gate (since resolveDefaultVault returns null,
-    // we return 401 because auth runs first, but the underlying MCP
-    // handler never runs — the previous test guarantees that). For the
-    // /api/ path, which checks the vault before auth, we get 404.
-    const apiReq = new Request("http://localhost:1940/api/notes");
-    const apiRes = await route(apiReq, "/api/notes");
-    expect(apiRes.status).toBe(404);
+    for (const path of ["/mcp", "/api/notes", "/oauth/register", "/oauth/authorize"]) {
+      const res = await route(new Request(`http://localhost:1940${path}`), path);
+      expect(res.status).toBe(404);
+    }
   });
 
-  test("multiple vaults, default_vault='journal' → /api/notes targets journal", async () => {
-    createVault("journal");
-    createVault("work");
-    writeGlobalConfig({ port: 1940, default_vault: "journal" });
-    const req = new Request("http://localhost:1940/api/notes");
-    const res = await route(req, "/api/notes");
-    // Reaches auth (401) rather than "Default vault not found" (404).
+  test("bare /vault/<name> returns metadata for authenticated callers", async () => {
+    createVault("journal", "My journal vault");
+    const path = "/vault/journal";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
+    // No auth → 401 from per-vault auth gate.
     expect(res.status).toBe(401);
-  });
-
-  test("default_vault points to a deleted vault but one other exists → fall back to the survivor", async () => {
-    createVault("journal");
-    writeGlobalConfig({ port: 1940, default_vault: "deleted-vault" });
-    // resolveDefaultVault ignores the stale pointer and returns journal.
-    expect(resolveDefaultVault()).toBe("journal");
-    // And /api/notes now routes to it — 401 from per-vault auth, not 404.
-    const req = new Request("http://localhost:1940/api/notes");
-    const res = await route(req, "/api/notes");
-    expect(res.status).toBe(401);
-  });
-
-  test("default_vault points to a deleted vault and multiple others exist → error (no guessing)", async () => {
-    createVault("journal");
-    createVault("work");
-    writeGlobalConfig({ port: 1940, default_vault: "deleted-vault" });
-    expect(resolveDefaultVault()).toBeNull();
-    const req = new Request("http://localhost:1940/api/notes");
-    const res = await route(req, "/api/notes");
-    expect(res.status).toBe(404);
-  });
-
-  test("no vaults exist → /mcp returns auth error (MCP handler short-circuits on empty global config)", async () => {
-    // Edge case: /mcp runs global auth first. With no vaults and no keys,
-    // auth fails → 401. This is fine — the handler never sees the empty
-    // state. We assert we never return 500.
-    const req = new Request("http://localhost:1940/mcp");
-    const res = await route(req, "/mcp");
-    expect(res.status).not.toBe(500);
-  });
-
-  test("empty config file (no default_vault) with single vault — existing deployments keep working", async () => {
-    // Migration concern: users with a config.yaml that never had
-    // default_vault set (pre-#111 deployments) should not break.
-    // Drop a minimal config.yaml that only specifies port.
-    writeGlobalConfig({ port: 1940 });
-    createVault("my-only-vault");
-    const cfg = readGlobalConfig();
-    expect(cfg.default_vault).toBeUndefined();
-    // /api/notes still routes to my-only-vault via single-vault fallback.
-    const req = new Request("http://localhost:1940/api/notes");
-    const res = await route(req, "/api/notes");
-    expect(res.status).toBe(401); // reached per-vault auth
   });
 });
 
@@ -352,104 +272,60 @@ describe("single-vault auto-default", () => {
 // Claude Code's MCP SDK (and any other strict RFC 9728 client) requires the
 // server to emit `WWW-Authenticate: Bearer resource_metadata="..."` on 401
 // so the client knows which protected-resource metadata document applies to
-// the endpoint it just hit. Without it, clients fall back to probing the
-// root `/.well-known/oauth-protected-resource`, get `resource: <base>/mcp`,
-// and reject any connection to `/vaults/<name>/mcp` as a resource mismatch.
+// the endpoint it just hit.
 // ---------------------------------------------------------------------------
 
 describe("MCP 401 WWW-Authenticate challenge (RFC 9728)", () => {
-  test("unscoped /mcp 401 carries the root protected-resource pointer", async () => {
+  test("/vault/<name>/mcp 401 carries the vault-scoped pointer", async () => {
     createVault("journal");
-    const req = new Request("http://localhost:1940/mcp");
-    const res = await route(req, "/mcp");
+    const path = "/vault/journal/mcp";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
     expect(res.status).toBe(401);
     const header = res.headers.get("WWW-Authenticate");
     expect(header).toBe(
-      'Bearer resource_metadata="http://localhost:1940/.well-known/oauth-protected-resource"',
+      'Bearer resource_metadata="http://localhost:1940/vault/journal/.well-known/oauth-protected-resource"',
     );
   });
 
-  test("scoped /vaults/{name}/mcp 401 carries the vault-scoped pointer", async () => {
-    createVault("journal");
-    const req = new Request("http://localhost:1940/vaults/journal/mcp");
-    const res = await route(req, "/vaults/journal/mcp");
-    expect(res.status).toBe(401);
-    const header = res.headers.get("WWW-Authenticate");
-    expect(header).toBe(
-      'Bearer resource_metadata="http://localhost:1940/vaults/journal/.well-known/oauth-protected-resource"',
-    );
-  });
-
-  test("challenge points at the same PRM document the server actually serves", async () => {
+  test("challenge points at the PRM document the server actually serves", async () => {
     // Belt-and-braces: whatever we advertise in the header MUST line up with
     // what `/.well-known/oauth-protected-resource` actually returns. If these
     // drift, a conforming client will chase the pointer, fetch the PRM, then
-    // reject on resource mismatch anyway. Test both directions.
+    // reject on resource mismatch anyway.
     createVault("journal");
 
-    // Scoped: header points at /vaults/journal/.well-known/...
-    const scopedReq = new Request("http://localhost:1940/vaults/journal/mcp");
-    const scopedRes = await route(scopedReq, "/vaults/journal/mcp");
-    const scopedHeader = scopedRes.headers.get("WWW-Authenticate")!;
-    const scopedPrmUrl = scopedHeader.match(/resource_metadata="([^"]+)"/)![1];
-    // Fetch that PRM. Bypass the full URL by extracting the path.
-    const prmPath = new URL(scopedPrmUrl).pathname;
+    const mcpPath = "/vault/journal/mcp";
+    const mcpRes = await route(new Request(`http://localhost:1940${mcpPath}`), mcpPath);
+    const header = mcpRes.headers.get("WWW-Authenticate")!;
+    const prmUrl = header.match(/resource_metadata="([^"]+)"/)![1];
+    const prmPath = new URL(prmUrl).pathname;
     const prmRes = await route(new Request(`http://localhost:1940${prmPath}`), prmPath);
     expect(prmRes.status).toBe(200);
     const prm = (await prmRes.json()) as { resource: string };
-    expect(prm.resource).toBe("http://localhost:1940/vaults/journal/mcp");
-
-    // Unscoped: header points at root /.well-known/...
-    const unscopedReq = new Request("http://localhost:1940/mcp");
-    const unscopedRes = await route(unscopedReq, "/mcp");
-    const unscopedHeader = unscopedRes.headers.get("WWW-Authenticate")!;
-    const unscopedPrmUrl = unscopedHeader.match(/resource_metadata="([^"]+)"/)![1];
-    const unscopedPrmPath = new URL(unscopedPrmUrl).pathname;
-    const unscopedPrmRes = await route(
-      new Request(`http://localhost:1940${unscopedPrmPath}`),
-      unscopedPrmPath,
-    );
-    expect(unscopedPrmRes.status).toBe(200);
-    const unscopedPrm = (await unscopedPrmRes.json()) as { resource: string };
-    expect(unscopedPrm.resource).toBe("http://localhost:1940/mcp");
+    expect(prm.resource).toBe("http://localhost:1940/vault/journal/mcp");
   });
 
   test("MCP 401 with invalid token still carries the challenge", async () => {
-    // The no-token case is one 401 code path (extractApiKey returns null);
-    // the invalid-token case is another (extractApiKey returns a string but
-    // resolveToken / validateKey all fail). Both must emit the header.
     createVault("journal");
-    const req = new Request("http://localhost:1940/vaults/journal/mcp", {
+    const path = "/vault/journal/mcp";
+    const req = new Request(`http://localhost:1940${path}`, {
       headers: { Authorization: "Bearer pvt_not-a-real-token" },
     });
-    const res = await route(req, "/vaults/journal/mcp");
+    const res = await route(req, path);
     expect(res.status).toBe(401);
     expect(res.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost:1940/vaults/journal/.well-known/oauth-protected-resource"',
+      'Bearer resource_metadata="http://localhost:1940/vault/journal/.well-known/oauth-protected-resource"',
     );
   });
 
   test("non-MCP 401s do NOT carry the challenge (spec is MCP-only)", async () => {
-    // The RFC 9728 challenge header is specific to the MCP resource; plain
-    // REST endpoints are not OAuth resources in the same sense. A spurious
-    // challenge here could confuse non-MCP clients and makes the /api
-    // surface look OAuth-gated when it is not.
     createVault("journal");
 
-    // /api/notes (unscoped) — 401, no challenge.
-    const unscopedApi = await route(new Request("http://localhost:1940/api/notes"), "/api/notes");
-    expect(unscopedApi.status).toBe(401);
-    expect(unscopedApi.headers.get("WWW-Authenticate")).toBeNull();
-
-    // /vaults/journal/api/notes (scoped) — 401, no challenge. This is the
-    // code path that shares the auth check with the scoped MCP branch, so
-    // if we leak the header here the isScopedMcp gate has regressed.
-    const scopedApi = await route(
-      new Request("http://localhost:1940/vaults/journal/api/notes"),
-      "/vaults/journal/api/notes",
-    );
-    expect(scopedApi.status).toBe(401);
-    expect(scopedApi.headers.get("WWW-Authenticate")).toBeNull();
+    // /vault/journal/api/notes — 401, no challenge.
+    const apiPath = "/vault/journal/api/notes";
+    const apiRes = await route(new Request(`http://localhost:1940${apiPath}`), apiPath);
+    expect(apiRes.status).toBe(401);
+    expect(apiRes.headers.get("WWW-Authenticate")).toBeNull();
 
     // /vaults (authenticated listing) — 401, no challenge.
     const vaultsList = await route(new Request("http://localhost:1940/vaults"), "/vaults");
@@ -460,40 +336,37 @@ describe("MCP 401 WWW-Authenticate challenge (RFC 9728)", () => {
   test("x-forwarded-host and x-forwarded-proto shape the challenge URL", async () => {
     // Remote deployments behind Cloudflare Tunnel / Tailscale Funnel / any
     // reverse proxy need the challenge URL to match the external origin,
-    // not the 127.0.0.1:1940 the server actually binds. Parallels how the
-    // /.well-known/* endpoints already honor these headers.
+    // not the 127.0.0.1:1940 the server actually binds.
     createVault("journal");
-    const req = new Request("http://127.0.0.1:1940/vaults/journal/mcp", {
+    const path = "/vault/journal/mcp";
+    const req = new Request(`http://127.0.0.1:1940${path}`, {
       headers: {
         "x-forwarded-host": "vault.example.com",
         "x-forwarded-proto": "https",
       },
     });
-    const res = await route(req, "/vaults/journal/mcp");
+    const res = await route(req, path);
     expect(res.status).toBe(401);
     expect(res.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="https://vault.example.com/vaults/journal/.well-known/oauth-protected-resource"',
+      'Bearer resource_metadata="https://vault.example.com/vault/journal/.well-known/oauth-protected-resource"',
     );
   });
 });
 
 // ---------------------------------------------------------------------------
-// RFC 8414 §3.1 / RFC 9728 §3 path-insertion discovery.
+// Per-vault OAuth discovery (RFC 8414 / RFC 9728, path-append form).
 //
-// For a resource at `/vaults/<name>/mcp`, the spec-mandated metadata URLs are
-//   /.well-known/oauth-authorization-server/vaults/<name>[/mcp]
-//   /.well-known/oauth-protected-resource/vaults/<name>[/mcp]
-// rather than the path-append form
-//   /vaults/<name>/.well-known/<type>
-// that PR #111 also ships. Strict clients (including Claude Code's MCP OAuth
-// SDK) probe only the path-insertion form; lax clients try path-append. We
-// serve both so any conformant probe hits a live endpoint.
+// For a resource at `/vault/<name>/mcp`, clients fetch metadata from
+//   /vault/<name>/.well-known/oauth-protected-resource
+//   /vault/<name>/.well-known/oauth-authorization-server
+// All endpoints in the AS metadata are vault-scoped so a client that
+// discovers the AS at that URL can drive the full authorization flow.
 // ---------------------------------------------------------------------------
 
-describe("path-insertion OAuth discovery (RFC 8414 §3.1 / RFC 9728 §3)", () => {
-  test("/.well-known/oauth-authorization-server/vaults/<name> returns vault-scoped AS metadata", async () => {
+describe("per-vault OAuth discovery", () => {
+  test("/vault/<name>/.well-known/oauth-authorization-server returns vault-scoped AS metadata", async () => {
     createVault("journal");
-    const path = "/.well-known/oauth-authorization-server/vaults/journal";
+    const path = "/vault/journal/.well-known/oauth-authorization-server";
     const res = await route(new Request(`http://localhost:1940${path}`), path);
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -502,77 +375,27 @@ describe("path-insertion OAuth discovery (RFC 8414 §3.1 / RFC 9728 §3)", () =>
       token_endpoint: string;
       registration_endpoint: string;
     };
-    // All four endpoints must be vault-scoped — otherwise Claude Code's
-    // registration_endpoint falls back to root `/register` and cascades 404.
-    expect(body.issuer).toBe("http://localhost:1940/vaults/journal");
-    expect(body.authorization_endpoint).toBe("http://localhost:1940/vaults/journal/oauth/authorize");
-    expect(body.token_endpoint).toBe("http://localhost:1940/vaults/journal/oauth/token");
-    expect(body.registration_endpoint).toBe("http://localhost:1940/vaults/journal/oauth/register");
+    expect(body.issuer).toBe("http://localhost:1940/vault/journal");
+    expect(body.authorization_endpoint).toBe("http://localhost:1940/vault/journal/oauth/authorize");
+    expect(body.token_endpoint).toBe("http://localhost:1940/vault/journal/oauth/token");
+    expect(body.registration_endpoint).toBe("http://localhost:1940/vault/journal/oauth/register");
   });
 
-  test("/.well-known/oauth-authorization-server/vaults/<name>/mcp (longer form) also returns AS metadata", async () => {
-    // Aaron's log shows Claude Code probes this longer form too; cheap to
-    // support since it resolves to the same AS for the same vault.
+  test("/vault/<name>/.well-known/oauth-protected-resource returns vault-scoped PRM", async () => {
     createVault("journal");
-    const path = "/.well-known/oauth-authorization-server/vaults/journal/mcp";
-    const res = await route(new Request(`http://localhost:1940${path}`), path);
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { issuer: string; registration_endpoint: string };
-    expect(body.issuer).toBe("http://localhost:1940/vaults/journal");
-    expect(body.registration_endpoint).toBe("http://localhost:1940/vaults/journal/oauth/register");
-  });
-
-  test("/.well-known/oauth-protected-resource/vaults/<name> returns vault-scoped PRM", async () => {
-    createVault("journal");
-    const path = "/.well-known/oauth-protected-resource/vaults/journal";
+    const path = "/vault/journal/.well-known/oauth-protected-resource";
     const res = await route(new Request(`http://localhost:1940${path}`), path);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { resource: string; authorization_servers: string[] };
-    expect(body.resource).toBe("http://localhost:1940/vaults/journal/mcp");
-    expect(body.authorization_servers).toEqual(["http://localhost:1940/vaults/journal"]);
+    expect(body.resource).toBe("http://localhost:1940/vault/journal/mcp");
+    expect(body.authorization_servers).toEqual(["http://localhost:1940/vault/journal"]);
   });
 
-  test("/.well-known/oauth-protected-resource/vaults/<name>/mcp (longer form) also returns PRM", async () => {
-    createVault("journal");
-    const path = "/.well-known/oauth-protected-resource/vaults/journal/mcp";
-    const res = await route(new Request(`http://localhost:1940${path}`), path);
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { resource: string };
-    expect(body.resource).toBe("http://localhost:1940/vaults/journal/mcp");
-  });
-
-  test("path-insertion and path-append forms return identical metadata", async () => {
-    // The coherence guarantee: a client that follows either spec shape MUST
-    // land on the same AS config. If these drift, a mixed-toolchain deploy
-    // (CLI using one form, daemon using the other) would mint tokens
-    // against inconsistent endpoints.
-    createVault("journal");
-
-    // AS metadata
-    const insertAsPath = "/.well-known/oauth-authorization-server/vaults/journal";
-    const appendAsPath = "/vaults/journal/.well-known/oauth-authorization-server";
-    const insertAsRes = await route(new Request(`http://localhost:1940${insertAsPath}`), insertAsPath);
-    const appendAsRes = await route(new Request(`http://localhost:1940${appendAsPath}`), appendAsPath);
-    expect(await insertAsRes.json()).toEqual(await appendAsRes.json());
-
-    // PRM
-    const insertPrmPath = "/.well-known/oauth-protected-resource/vaults/journal";
-    const appendPrmPath = "/vaults/journal/.well-known/oauth-protected-resource";
-    const insertPrmRes = await route(new Request(`http://localhost:1940${insertPrmPath}`), insertPrmPath);
-    const appendPrmRes = await route(new Request(`http://localhost:1940${appendPrmPath}`), appendPrmPath);
-    expect(await insertPrmRes.json()).toEqual(await appendPrmRes.json());
-  });
-
-  test("unknown vault in path-insertion URL returns 404, not boilerplate metadata", async () => {
-    // Don't leak metadata for phantom vaults. The equivalent path-append
-    // route also 404s when the vault doesn't exist (`readVaultConfig` miss
-    // at the vault-scoped routes branch); path-insertion must match.
+  test("unknown vault returns 404 rather than boilerplate metadata", async () => {
     createVault("journal");
     for (const path of [
-      "/.well-known/oauth-authorization-server/vaults/nonexistent",
-      "/.well-known/oauth-authorization-server/vaults/nonexistent/mcp",
-      "/.well-known/oauth-protected-resource/vaults/nonexistent",
-      "/.well-known/oauth-protected-resource/vaults/nonexistent/mcp",
+      "/vault/nonexistent/.well-known/oauth-authorization-server",
+      "/vault/nonexistent/.well-known/oauth-protected-resource",
     ]) {
       const res = await route(new Request(`http://localhost:1940${path}`), path);
       expect(res.status).toBe(404);
@@ -580,12 +403,8 @@ describe("path-insertion OAuth discovery (RFC 8414 §3.1 / RFC 9728 §3)", () =>
   });
 
   test("x-forwarded-* headers propagate into the generated metadata URLs", async () => {
-    // Same contract as the WWW-Authenticate challenge and the root/append
-    // discovery endpoints: metadata must match the public-facing origin so
-    // a Cloudflare Tunnel / Tailscale Funnel deployment doesn't advertise
-    // internal localhost:1940 URLs.
     createVault("journal");
-    const path = "/.well-known/oauth-authorization-server/vaults/journal";
+    const path = "/vault/journal/.well-known/oauth-authorization-server";
     const res = await route(
       new Request(`http://127.0.0.1:1940${path}`, {
         headers: {
@@ -597,52 +416,40 @@ describe("path-insertion OAuth discovery (RFC 8414 §3.1 / RFC 9728 §3)", () =>
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { issuer: string; registration_endpoint: string };
-    expect(body.issuer).toBe("https://vault.example.com/vaults/journal");
+    expect(body.issuer).toBe("https://vault.example.com/vault/journal");
     expect(body.registration_endpoint).toBe(
-      "https://vault.example.com/vaults/journal/oauth/register",
+      "https://vault.example.com/vault/journal/oauth/register",
     );
   });
 
   test("end-to-end flow: WWW-Authenticate → PRM → AS metadata → registration_endpoint is live", async () => {
-    // The actual Claude-Code bug: on 401, follow the challenge to the PRM,
-    // then follow PRM.authorization_servers[0] to the AS metadata (via
-    // path-insertion), then hit the `registration_endpoint`. Every hop
-    // must resolve — before the fix, the AS-metadata-via-path-insertion
-    // step 404'd and the SDK fell back to `/register` which also 404'd.
+    // On 401, follow the challenge to the PRM, then follow
+    // PRM.authorization_servers[0] to the AS metadata, then hit the
+    // `registration_endpoint`. Every hop must resolve.
     createVault("journal");
 
     // Step 1: unauthenticated MCP → 401 + WWW-Authenticate.
-    const mcpRes = await route(
-      new Request("http://localhost:1940/vaults/journal/mcp"),
-      "/vaults/journal/mcp",
-    );
+    const mcpPath = "/vault/journal/mcp";
+    const mcpRes = await route(new Request(`http://localhost:1940${mcpPath}`), mcpPath);
     expect(mcpRes.status).toBe(401);
     const challenge = mcpRes.headers.get("WWW-Authenticate")!;
     const prmUrl = challenge.match(/resource_metadata="([^"]+)"/)![1];
 
-    // Step 2: fetch PRM. The challenge points at the path-append form, but
-    // a strict client might also try path-insertion — both must work.
-    // Follow the advertised URL (path-append in this case) and note the
-    // authorization_servers pointer.
+    // Step 2: fetch PRM.
     const prmPath = new URL(prmUrl).pathname;
     const prmRes = await route(new Request(`http://localhost:1940${prmPath}`), prmPath);
     expect(prmRes.status).toBe(200);
     const prm = (await prmRes.json()) as { authorization_servers: string[] };
-    const asBase = prm.authorization_servers[0]; // "http://localhost:1940/vaults/journal"
+    const asBase = prm.authorization_servers[0]; // "http://localhost:1940/vault/journal"
 
-    // Step 3: strict-client path-insertion probe for AS metadata.
-    const asBasePath = new URL(asBase).pathname; // "/vaults/journal"
-    const asInsertPath = `/.well-known/oauth-authorization-server${asBasePath}`;
-    const asRes = await route(
-      new Request(`http://localhost:1940${asInsertPath}`),
-      asInsertPath,
-    );
-    // This was the 404 before the fix — the reason Claude Code's SDK gave
-    // up and cascade-404'd on `/register`.
+    // Step 3: AS metadata lives at `{asBase}/.well-known/oauth-authorization-server`.
+    const asBasePath = new URL(asBase).pathname; // "/vault/journal"
+    const asMetaPath = `${asBasePath}/.well-known/oauth-authorization-server`;
+    const asRes = await route(new Request(`http://localhost:1940${asMetaPath}`), asMetaPath);
     expect(asRes.status).toBe(200);
     const asMeta = (await asRes.json()) as { registration_endpoint: string };
 
-    // Step 4: the advertised registration_endpoint must be live (POST-only).
+    // Step 4: the advertised registration_endpoint must be live.
     const regPath = new URL(asMeta.registration_endpoint).pathname;
     const regRes = await route(
       new Request(`http://localhost:1940${regPath}`, {
@@ -655,7 +462,6 @@ describe("path-insertion OAuth discovery (RFC 8414 §3.1 / RFC 9728 §3)", () =>
       }),
       regPath,
     );
-    // Successful DCR is 201; anything but 404 proves the endpoint is wired.
     expect(regRes.status).toBe(201);
   });
 });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,20 +1,31 @@
 /**
  * HTTP request router for the multi-vault server.
  *
- * Extracted from server.ts so routes are unit-testable without spinning up
- * Bun.serve(). server.ts imports this and wires it into the listener.
+ * All per-vault resources live under `/vault/<name>/...`. There is no
+ * unscoped fallback — a request must name the vault it targets. A fresh
+ * install creates a vault named `default`, so `/vault/default/...` is the
+ * baseline URL for single-vault deployments.
  *
- * Path dispatch order (skim):
- *   - /.well-known/oauth-*           — public OAuth discovery
- *   - /oauth/*                       — unscoped OAuth (targets default vault)
- *   - /health                        — lightweight ping
- *   - /mcp, /mcp/*                   — unified MCP (global auth)
- *   - /view/:id                      — default-vault HTML view
- *   - /public/:id                    — backward-compat redirect → /view
- *   - /vaults/list                   — PUBLIC vault names (no auth, no metadata)
- *   - /vaults                        — authenticated vault metadata listing
- *   - /api/*                         — default-vault REST API
- *   - /vaults/:name/*                — vault-scoped: view, oauth, mcp, api
+ * Dispatch shape:
+ *
+ *   /.well-known/parachute.json        — NOT served here (CLI owns it at
+ *                                        origin root; vault never handles it)
+ *   /health                            — liveness ping, vault names leaked
+ *                                        only to authenticated callers
+ *   /vaults/list                       — public vault-name discovery (can be
+ *                                        disabled globally via config)
+ *   /vaults                            — authenticated vault metadata list
+ *   /vault/<name>/.well-known/*        — per-vault OAuth discovery
+ *   /vault/<name>/oauth/{register,authorize,token}
+ *   /vault/<name>/mcp[/*]              — MCP endpoint (Bearer auth)
+ *   /vault/<name>/view/<idOrPath>      — auth-aware HTML view
+ *   /vault/<name>/public/<noteId>      — legacy alias → /view redirect
+ *   /vault/<name>                      — vault metadata + stats (auth)
+ *   /vault/<name>/api/...              — REST surface (auth)
+ *
+ * There is deliberately no compat for the old `/api/*`, `/mcp`, `/oauth/*`,
+ * `/view/*`, or `/vaults/<name>/*` prefixes. Clients must re-authenticate
+ * after the upgrade and point at the new URLs.
  */
 
 import type { VaultConfig } from "./config.ts";
@@ -23,7 +34,6 @@ import {
   readGlobalConfig,
   writeVaultConfig,
   listVaults,
-  resolveDefaultVault,
 } from "./config.ts";
 import {
   authenticateVaultRequest,
@@ -32,7 +42,7 @@ import {
   extractApiKey,
 } from "./auth.ts";
 import { getVaultStore } from "./vault-store.ts";
-import { handleUnifiedMcp, handleScopedMcp } from "./mcp-http.ts";
+import { handleScopedMcp } from "./mcp-http.ts";
 import {
   handleNotes,
   handleTags,
@@ -57,22 +67,12 @@ import {
  * header pointing at the matching protected-resource metadata document.
  *
  * An MCP-capable OAuth client that receives a plain 401 has no structured way
- * to discover which authorization server to use, and SDKs that follow RFC 9728
- * (including Claude Code's) default to probing the *root* `/.well-known/oauth-
- * protected-resource`. That document advertises `resource: <base>/mcp` — which
- * then fails the SDK's strict resource-URL match when the client is actually
- * connecting to `/vaults/{name}/mcp`. The `WWW-Authenticate` header tells the
- * client exactly which metadata document applies to the endpoint it just hit,
- * closing the mismatch.
- *
- * Scoped calls pass `vaultName`; unscoped omits it. Other 401-emitting
- * endpoints (`/api/*`, `/vaults`, `/health` when authenticated) are not MCP
- * resources and intentionally do not carry this header.
+ * to discover which authorization server to use; the `WWW-Authenticate`
+ * header names the metadata document for the exact endpoint they hit.
  */
-function mcpWwwAuthenticate(req: Request, vaultName?: string): string {
+function mcpWwwAuthenticate(req: Request, vaultName: string): string {
   const base = getBaseUrl(req);
-  const prefix = vaultName ? `/vaults/${vaultName}` : "";
-  return `Bearer resource_metadata="${base}${prefix}/.well-known/oauth-protected-resource"`;
+  return `Bearer resource_metadata="${base}/vault/${vaultName}/.well-known/oauth-protected-resource"`;
 }
 
 /**
@@ -83,7 +83,7 @@ function mcpWwwAuthenticate(req: Request, vaultName?: string): string {
 async function withMcpChallenge(
   res: Response,
   req: Request,
-  vaultName?: string,
+  vaultName: string,
 ): Promise<Response> {
   if (res.status !== 401) return res;
   const body = await res.text();
@@ -103,7 +103,6 @@ function isViewAuthenticated(
   vaultDb?: import("bun:sqlite").Database,
 ): boolean {
   if (!vaultConfig) return false;
-  // extractApiKey now checks headers AND ?key= query param
   const key = extractApiKey(req);
   if (!key) return false;
   const auth = authenticateVaultRequest(req, vaultConfig, vaultDb);
@@ -115,91 +114,10 @@ export async function route(
   path: string,
   clientIp?: string,
 ): Promise<Response> {
-  // OAuth discovery endpoints (no auth required).
-  //
-  // RFC 8414 §3.1 and RFC 9728 §3 specify the discovery URL shape when an
-  // authorization server (or protected resource) has a path component `/p`:
-  //
-  //   Path-insertion (spec-mandated):
-  //     <host>/.well-known/<metadata-type>/p
-  //   Path-append (widespread in the wild, shipped in PR #111):
-  //     <host>/p/.well-known/<metadata-type>
-  //
-  // Strict clients — including Claude Code's MCP OAuth SDK — probe only the
-  // path-insertion form. Lax clients try path-append. We serve both so any
-  // conformant probe hits a live endpoint. Unscoped root forms
-  // (`/.well-known/oauth-*`) are the third accepted shape, and the
-  // path-append branch for scoped discovery lives further down alongside the
-  // other `/vaults/{name}/*` routing.
-  const protectedResourceInsert = path.match(
-    /^\/\.well-known\/oauth-protected-resource\/vaults\/([^/]+)(?:\/mcp)?$/,
-  );
-  if (protectedResourceInsert) {
-    const vaultName = protectedResourceInsert[1];
-    if (!readVaultConfig(vaultName)) {
-      return Response.json({ error: "Vault not found", vault: vaultName }, { status: 404 });
-    }
-    return handleProtectedResource(req, `/vaults/${vaultName}/mcp`, `/vaults/${vaultName}`);
-  }
-  const authServerInsert = path.match(
-    /^\/\.well-known\/oauth-authorization-server\/vaults\/([^/]+)(?:\/mcp)?$/,
-  );
-  if (authServerInsert) {
-    const vaultName = authServerInsert[1];
-    if (!readVaultConfig(vaultName)) {
-      return Response.json({ error: "Vault not found", vault: vaultName }, { status: 404 });
-    }
-    return handleAuthorizationServer(req, vaultName);
-  }
+  // ---------------------------------------------------------------------
+  // Cross-vault / origin-root endpoints
+  // ---------------------------------------------------------------------
 
-  if (path === "/.well-known/oauth-protected-resource") {
-    return handleProtectedResource(req);
-  }
-  if (path === "/.well-known/oauth-authorization-server") {
-    return handleAuthorizationServer(req);
-  }
-
-  // OAuth flow endpoints (no auth — these ARE the auth)
-  if (path === "/oauth/register" || path === "/oauth/authorize" || path === "/oauth/token") {
-    const defaultVault = resolveDefaultVault();
-    const vaultConfig = defaultVault ? readVaultConfig(defaultVault) : null;
-    if (!defaultVault || !vaultConfig) {
-      return Response.json(
-        { error: "server_error", error_description: "Default vault not configured" },
-        { status: 500 },
-      );
-    }
-    const store = getVaultStore(defaultVault);
-
-    if (path === "/oauth/register") {
-      return handleRegister(req, store.db);
-    }
-    if (path === "/oauth/authorize") {
-      const gc = readGlobalConfig();
-      const ownerPasswordHash = gc.owner_password_hash ?? null;
-      const totpSecret = gc.totp_secret ?? null;
-      const totpEnrolled = typeof totpSecret === "string" && totpSecret.length > 0;
-      if (req.method === "GET") {
-        return handleAuthorizeGet(req, store.db, vaultConfig.name, ownerPasswordHash, totpEnrolled);
-      }
-      if (req.method === "POST") {
-        return handleAuthorizePost(req, store.db, {
-          vaultName: vaultConfig.name,
-          clientIp,
-          ownerPasswordHash,
-          totpSecret,
-        });
-      }
-      return Response.json({ error: "method_not_allowed" }, { status: 405 });
-    }
-    if (path === "/oauth/token") {
-      // PR #111: handleToken echoes the vault name back to the client so it
-      // knows which vault it just connected to.
-      return handleToken(req, store.db, defaultVault);
-    }
-  }
-
-  // Health check — vault names only for authenticated requests
   if (path === "/health") {
     const auth = authenticateGlobalRequest(req);
     if ("error" in auth) {
@@ -208,45 +126,10 @@ export async function route(
     return Response.json({ status: "ok", vaults: listVaults() });
   }
 
-  // Unified MCP (all vaults, global auth)
-  if (path === "/mcp" || path.startsWith("/mcp/")) {
-    const auth = authenticateGlobalRequest(req);
-    if ("error" in auth) return withMcpChallenge(auth.error, req);
-    return handleUnifiedMcp(req, auth);
-  }
-
-  // View endpoint — serves notes as HTML (auth-aware, supports ID or path)
-  const viewMatch = path.match(/^\/view\/(.+)$/);
-  if (viewMatch && req.method === "GET") {
-    const defaultVault = resolveDefaultVault();
-    const vaultConfig = defaultVault ? readVaultConfig(defaultVault) : null;
-    if (!defaultVault || !vaultConfig) {
-      return Response.json({ error: "Default vault not found" }, { status: 404 });
-    }
-    const store = getVaultStore(defaultVault);
-    const authenticated = isViewAuthenticated(req, vaultConfig, store.db);
-    return handleViewNote(store, decodeURIComponent(viewMatch[1]), {
-      authenticated,
-      publishedTag: vaultConfig.published_tag,
-    });
-  }
-
-  // Backward compat: /public/:noteId → /view/:noteId (preserving query params)
-  const publicMatch = path.match(/^\/public\/([^/]+)$/);
-  if (publicMatch && req.method === "GET") {
-    const dest = new URL(`/view/${publicMatch[1]}`, req.url);
-    dest.search = new URL(req.url).search;
-    return Response.redirect(dest.toString(), 301);
-  }
-
-  // Public vault names — no auth, no metadata. Lets unauthenticated clients
-  // (e.g. the Daily vault-picker dropdown before OAuth) know which vault to
-  // target. Only vault names are exposed; descriptions, counts, timestamps,
-  // and API keys are never returned from this endpoint.
-  //
-  // Operators who want to hide vault existence from anonymous callers can set
-  // `discovery: disabled` in ~/.parachute/config.yaml — the endpoint then
-  // returns 404 as if it didn't exist.
+  // Public vault-name discovery. Lets unauthenticated clients (e.g. the
+  // Daily vault-picker dropdown before OAuth) know which vault to target.
+  // Operators who want to hide vault existence can set `discovery: disabled`
+  // in ~/.parachute/config.yaml — the endpoint then returns 404.
   if (path === "/vaults/list" && req.method === "GET") {
     const globalConfig = readGlobalConfig();
     if (globalConfig.discovery === "disabled") {
@@ -255,7 +138,7 @@ export async function route(
     return Response.json({ vaults: listVaults() });
   }
 
-  // List vaults — requires auth
+  // Authenticated vault metadata list.
   if (path === "/vaults" && req.method === "GET") {
     const auth = authenticateGlobalRequest(req);
     if ("error" in auth) return auth.error;
@@ -271,38 +154,11 @@ export async function route(
     return Response.json({ vaults });
   }
 
-  // Backward-compatible: /api/* routes to default vault
-  if (path.startsWith("/api/")) {
-    const defaultVault = resolveDefaultVault();
-    const vaultConfig = defaultVault ? readVaultConfig(defaultVault) : null;
-    if (!defaultVault || !vaultConfig) {
-      return Response.json({ error: "Default vault not found" }, { status: 404 });
-    }
-    const store = getVaultStore(defaultVault);
-    const auth = authenticateVaultRequest(req, vaultConfig, store.db);
-    if ("error" in auth) return auth.error;
-    if (!isMethodAllowed(req.method, auth.permission)) {
-      return Response.json(
-        { error: "Forbidden", message: "Insufficient permissions" },
-        { status: 403 },
-      );
-    }
-    const apiPath = path.slice(4); // strip "/api"
-    if (apiPath.startsWith("/notes")) return handleNotes(req, store, apiPath.slice(6), defaultVault);
-    if (apiPath.startsWith("/tags")) return handleTags(req, store, apiPath.slice(5));
-    if (apiPath === "/find-path") return handleFindPath(req, store);
-    if (apiPath === "/vault") {
-      return handleVault(req, store, vaultConfig, () => {
-        writeVaultConfig(vaultConfig);
-      });
-    }
-    if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store);
-    if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), defaultVault);
-    if (apiPath === "/health") return Response.json({ status: "ok", vault: defaultVault });
-  }
+  // ---------------------------------------------------------------------
+  // Per-vault routing: /vault/<name>/...
+  // ---------------------------------------------------------------------
 
-  // Vault-scoped routes: /vaults/{name}/...
-  const vaultMatch = path.match(/^\/vaults\/([^/]+)(\/.*)?$/);
+  const vaultMatch = path.match(/^\/vault\/([^/]+)(\/.*)?$/);
   if (!vaultMatch) {
     return Response.json({ error: "Not found" }, { status: 404 });
   }
@@ -315,15 +171,18 @@ export async function route(
     return Response.json({ error: "Vault not found", vault: vaultName }, { status: 404 });
   }
 
-  // Backward compat: /vaults/{name}/public/:noteId → /view/:noteId
+  // Legacy-style /public/:noteId → /view/:noteId redirect (kept as a
+  // convenience for published-note URLs that predate the /view/ path).
   const vaultPublicMatch = subpath.match(/^\/public\/([^/]+)$/);
   if (vaultPublicMatch && req.method === "GET") {
-    const dest = new URL(`/vaults/${vaultName}/view/${vaultPublicMatch[1]}`, req.url);
+    const dest = new URL(`/vault/${vaultName}/view/${vaultPublicMatch[1]}`, req.url);
     dest.search = new URL(req.url).search;
     return Response.redirect(dest.toString(), 301);
   }
 
-  // View endpoint — serves notes as HTML (auth-aware, vault-scoped, supports ID or path)
+  // View endpoint — auth-aware HTML renderer. Unauthenticated requests
+  // still serve public notes; a valid API key via header or ?key= query
+  // parameter unlocks private notes.
   const vaultViewMatch = subpath.match(/^\/view\/(.+)$/);
   if (vaultViewMatch && req.method === "GET") {
     const store = getVaultStore(vaultName);
@@ -334,7 +193,7 @@ export async function route(
     });
   }
 
-  // Vault-scoped OAuth endpoints (no auth — these ARE the auth)
+  // OAuth flow endpoints (no auth — these ARE the auth).
   if (subpath === "/oauth/register" || subpath === "/oauth/authorize" || subpath === "/oauth/token") {
     const store = getVaultStore(vaultName);
     if (subpath === "/oauth/register") return handleRegister(req, store.db);
@@ -362,33 +221,27 @@ export async function route(
       }
       return Response.json({ error: "method_not_allowed" }, { status: 405 });
     }
-    // PR #111: handleToken now requires the vault name so it can (a) pin the
-    // OAuth code to the issuing vault (prevents cross-vault code replay) and
-    // (b) echo `vault: <name>` back to the client in the token response.
+    // handleToken pins the OAuth code to the issuing vault (prevents
+    // cross-vault code replay) and echoes `vault: <name>` in the response.
     if (subpath === "/oauth/token") return handleToken(req, store.db, vaultName);
   }
 
-  // Vault-scoped discovery endpoints. PR #111: the protected-resource
-  // advertises a vault-scoped authorization server (`${base}/vaults/${name}`),
-  // and the vault-scoped authorization-server metadata returns endpoints
-  // scoped to `/vaults/${name}/oauth/*` so tokens mint against this vault's
-  // DB. Keeps the RFC 9728 → RFC 8414 chain coherent end-to-end.
+  // OAuth discovery (no auth). The protected-resource metadata advertises
+  // this vault's MCP endpoint and names the vault's authorization server;
+  // the authorization-server metadata returns endpoints scoped to
+  // `/vault/<name>/oauth/*`. Together they keep RFC 9728 → RFC 8414
+  // discovery coherent for a single vault.
   if (subpath === "/.well-known/oauth-protected-resource") {
-    return handleProtectedResource(
-      req,
-      `/vaults/${vaultName}/mcp`,
-      `/vaults/${vaultName}`,
-    );
+    return handleProtectedResource(req, vaultName);
   }
   if (subpath === "/.well-known/oauth-authorization-server") {
     return handleAuthorizationServer(req, vaultName);
   }
 
-  // Auth: per-vault key OR global key.
-  // The auth check is shared between the scoped MCP branch and the scoped
-  // /api/* branches, so we can't unconditionally attach the MCP-only
-  // WWW-Authenticate challenge here — we pass the challenge back only when
-  // the failing request was actually targeting /vaults/{name}/mcp.
+  // ---------------------------------------------------------------------
+  // Authenticated surface
+  // ---------------------------------------------------------------------
+
   const store = getVaultStore(vaultName);
   const auth = authenticateVaultRequest(req, vaultConfig, store.db);
   const isScopedMcp = subpath === "/mcp" || subpath.startsWith("/mcp/");
@@ -396,12 +249,12 @@ export async function route(
     return isScopedMcp ? withMcpChallenge(auth.error, req, vaultName) : auth.error;
   }
 
-  // Per-vault scoped MCP
+  // MCP (per-vault, single-vault session).
   if (isScopedMcp) {
     return handleScopedMcp(req, vaultName, auth);
   }
 
-  // Bare /vaults/{name} — single-vault root. Returns name, description,
+  // Bare `/vault/<name>` — single-vault root. Returns name, description,
   // createdAt, and stats. One round trip for a viz landing page.
   if (subpath === "" || subpath === "/") {
     if (req.method !== "GET") {
@@ -416,7 +269,7 @@ export async function route(
     });
   }
 
-  // REST API — enforce permission level
+  // REST API — enforce permission level.
   if (!isMethodAllowed(req.method, auth.permission)) {
     return Response.json(
       { error: "Forbidden", message: "Insufficient permissions" },

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,11 +4,13 @@
  *
  * Routes:
  *   GET  /health                           — health check
- *   *    /mcp                              — unified MCP (all vaults, vault param)
- *   *    /vaults/{name}/mcp                — scoped MCP (single vault, no vault param)
  *   GET  /vaults                           — list vaults with metadata (authenticated)
  *   GET  /vaults/list                      — list vault names (public; disable via config.discovery)
- *   *    /vaults/{name}/api/...            — per-vault REST API
+ *   *    /vault/{name}/mcp                 — scoped MCP (per-vault session)
+ *   *    /vault/{name}/oauth/...           — per-vault OAuth flow
+ *   *    /vault/{name}/.well-known/...     — per-vault OAuth discovery
+ *   *    /vault/{name}/view/...            — auth-aware HTML note view
+ *   *    /vault/{name}/api/...             — per-vault REST API
  *
  * The request pipeline lives in ./routing.ts (exported for unit testing).
  */

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -528,30 +528,29 @@ describe("MCP tools", async () => {
   });
 });
 
-describe("unified MCP wrapper", async () => {
-  test("vault-info routes through vault param", async () => {
-    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+describe("scoped MCP wrapper", async () => {
+  test("vault-info returns the vault's stats", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
 
-    const vaultName = `unified-stats-${Date.now()}`;
+    const vaultName = `scoped-stats-${Date.now()}`;
     writeVaultConfig({
       name: vaultName,
       api_keys: [],
       created_at: new Date().toISOString(),
       description: "Test vault",
     });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
     await vaultStore.createNote("alpha", { tags: ["x", "y"] });
     await vaultStore.createNote("beta", { tags: ["x"] });
 
-    const tools = generateUnifiedMcpTools();
+    const tools = generateScopedMcpTools(vaultName);
     const vaultInfo = tools.find((t) => t.name === "vault-info");
     expect(vaultInfo).toBeTruthy();
 
-    const result = await vaultInfo!.execute({ vault: vaultName, include_stats: true }) as any;
+    const result = await vaultInfo!.execute({ include_stats: true }) as any;
     expect(result.name).toBe(vaultName);
     expect(result.description).toBe("Test vault");
     expect(result.stats.totalNotes).toBe(2);
@@ -560,9 +559,9 @@ describe("unified MCP wrapper", async () => {
     closeAllStores();
   });
 
-  test("list-tags with schema works through unified wrapper", async () => {
-    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+  test("list-tags with schema returns per-tag detail", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
 
     const vaultName = `tag-schema-${Date.now()}`;
@@ -571,7 +570,6 @@ describe("unified MCP wrapper", async () => {
       api_keys: [],
       created_at: new Date().toISOString(),
     });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
     await vaultStore.createNote("A", { tags: ["person"] });
@@ -580,11 +578,11 @@ describe("unified MCP wrapper", async () => {
       fields: { name: { type: "string", description: "Full name" } },
     });
 
-    const tools = generateUnifiedMcpTools();
+    const tools = generateScopedMcpTools(vaultName);
 
     // list-tags with tag param for single tag detail
     const listTags = tools.find((t) => t.name === "list-tags")!;
-    const detail = await listTags.execute({ vault: vaultName, tag: "person" }) as any;
+    const detail = await listTags.execute({ tag: "person" }) as any;
     expect(detail.name).toBe("person");
     expect(detail.count).toBe(1);
     expect(detail.description).toBe("A person");
@@ -594,8 +592,8 @@ describe("unified MCP wrapper", async () => {
   });
 
   test("create-note with schema tag auto-populates defaults", async () => {
-    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
 
     const vaultName = `schema-create-${Date.now()}`;
@@ -604,7 +602,6 @@ describe("unified MCP wrapper", async () => {
       api_keys: [],
       created_at: new Date().toISOString(),
     });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
     await vaultStore.upsertTagSchema("person", {
@@ -615,31 +612,29 @@ describe("unified MCP wrapper", async () => {
       },
     });
 
-    const tools = generateUnifiedMcpTools();
+    const tools = generateScopedMcpTools(vaultName);
     const createNote = tools.find((t) => t.name === "create-note")!;
     const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
     // Create a note tagged person with no metadata — defaults auto-populated
     const result = await createNote.execute({
-      vault: vaultName,
       content: "Alice",
       tags: ["person"],
     }) as any;
     expect(result.content).toBe("Alice");
 
     // Verify defaults were written
-    const fresh = await queryNotes.execute({ vault: vaultName, id: result.id }) as any;
+    const fresh = await queryNotes.execute({ id: result.id }) as any;
     expect(fresh.metadata.first_appeared).toBe("");
     expect(fresh.metadata.relationship).toBe("");
 
     // Create with explicit metadata — preserved
     const result2 = await createNote.execute({
-      vault: vaultName,
       content: "Bob",
       tags: ["person"],
       metadata: { first_appeared: "2024-01", relationship: "friend" },
     }) as any;
-    const fresh2 = await queryNotes.execute({ vault: vaultName, id: result2.id }) as any;
+    const fresh2 = await queryNotes.execute({ id: result2.id }) as any;
     expect(fresh2.metadata.first_appeared).toBe("2024-01");
     expect(fresh2.metadata.relationship).toBe("friend");
 
@@ -647,8 +642,8 @@ describe("unified MCP wrapper", async () => {
   });
 
   test("update-note tags.add with schema auto-populates defaults", async () => {
-    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores: close } = await import("./vault-store.ts");
 
     const vaultName = `schema-defaults-${Date.now()}`;
@@ -657,7 +652,6 @@ describe("unified MCP wrapper", async () => {
       api_keys: [],
       created_at: new Date().toISOString(),
     });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
     await vaultStore.upsertTagSchema("person", {
@@ -675,41 +669,40 @@ describe("unified MCP wrapper", async () => {
         priority: { type: "integer", description: "Priority level" },
       },
     });
-    const tools = generateUnifiedMcpTools();
+    const tools = generateScopedMcpTools(vaultName);
     const createNote = tools.find((t) => t.name === "create-note")!;
     const updateNote = tools.find((t) => t.name === "update-note")!;
     const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
     // Create a note, then add #person tag via update-note
-    const note = await createNote.execute({ vault: vaultName, content: "Alice" }) as any;
-    await updateNote.execute({ vault: vaultName, id: note.id, tags: { add: ["person"] } });
-    const after = await queryNotes.execute({ vault: vaultName, id: note.id }) as any;
+    const note = await createNote.execute({ content: "Alice" }) as any;
+    await updateNote.execute({ id: note.id, tags: { add: ["person"] } });
+    const after = await queryNotes.execute({ id: note.id }) as any;
     expect(after.metadata.first_appeared).toBe("");
     expect(after.metadata.relationship).toBe("");
 
     // Tag note that already has partial metadata — only missing fields populated
     const note2 = await createNote.execute({
-      vault: vaultName,
       content: "Bob",
       metadata: { first_appeared: "2023-11" },
     }) as any;
-    await updateNote.execute({ vault: vaultName, id: note2.id, tags: { add: ["person"] } });
-    const after2 = await queryNotes.execute({ vault: vaultName, id: note2.id }) as any;
+    await updateNote.execute({ id: note2.id, tags: { add: ["person"] } });
+    const after2 = await queryNotes.execute({ id: note2.id }) as any;
     expect(after2.metadata.first_appeared).toBe("2023-11"); // preserved
     expect(after2.metadata.relationship).toBe(""); // added
 
     // Tag with #project — enum defaults to first value, boolean to false, integer to 0
-    const note4 = await createNote.execute({ vault: vaultName, content: "My Project" }) as any;
-    await updateNote.execute({ vault: vaultName, id: note4.id, tags: { add: ["project"] } });
-    const after4 = await queryNotes.execute({ vault: vaultName, id: note4.id }) as any;
+    const note4 = await createNote.execute({ content: "My Project" }) as any;
+    await updateNote.execute({ id: note4.id, tags: { add: ["project"] } });
+    const after4 = await queryNotes.execute({ id: note4.id }) as any;
     expect(after4.metadata.status).toBe("active");
     expect(after4.metadata.active).toBe(false);
     expect(after4.metadata.priority).toBe(0);
 
     // Multiple schema tags at once — all defaults merged
-    const note5 = await createNote.execute({ vault: vaultName, content: "Multi" }) as any;
-    await updateNote.execute({ vault: vaultName, id: note5.id, tags: { add: ["person", "project"] } });
-    const after5 = await queryNotes.execute({ vault: vaultName, id: note5.id }) as any;
+    const note5 = await createNote.execute({ content: "Multi" }) as any;
+    await updateNote.execute({ id: note5.id, tags: { add: ["person", "project"] } });
+    const after5 = await queryNotes.execute({ id: note5.id }) as any;
     expect(after5.metadata.first_appeared).toBe("");
     expect(after5.metadata.relationship).toBe("");
     expect(after5.metadata.status).toBe("active");
@@ -719,8 +712,8 @@ describe("unified MCP wrapper", async () => {
   });
 
   test("update-note tags.add auto-populate does not bump updatedAt", async () => {
-    const { generateUnifiedMcpTools } = await import("./mcp-tools.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores: close } = await import("./vault-store.ts");
 
     const vaultName = `schema-noupdate-${Date.now()}`;
@@ -729,7 +722,6 @@ describe("unified MCP wrapper", async () => {
       api_keys: [],
       created_at: new Date().toISOString(),
     });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
     await vaultStore.upsertTagSchema("person", {
@@ -737,15 +729,15 @@ describe("unified MCP wrapper", async () => {
       fields: { name: { type: "string" } },
     });
 
-    const tools = generateUnifiedMcpTools();
+    const tools = generateScopedMcpTools(vaultName);
     const createNote = tools.find((t) => t.name === "create-note")!;
     const updateNote = tools.find((t) => t.name === "update-note")!;
     const queryNotes = tools.find((t) => t.name === "query-notes")!;
 
-    const note = await createNote.execute({ vault: vaultName, content: "Test" }) as any;
+    const note = await createNote.execute({ content: "Test" }) as any;
     const originalUpdatedAt = note.updatedAt;
-    await updateNote.execute({ vault: vaultName, id: note.id, tags: { add: ["person"] } });
-    const after = await queryNotes.execute({ vault: vaultName, id: note.id }) as any;
+    await updateNote.execute({ id: note.id, tags: { add: ["person"] } });
+    const after = await queryNotes.execute({ id: note.id }) as any;
     expect(after.updatedAt).toBe(originalUpdatedAt);
     expect(after.metadata.name).toBe("");
 
@@ -760,7 +752,6 @@ describe("auth permissions", () => {
     expect(isToolAllowed("list-tags", "read")).toBe(true);
     expect(isToolAllowed("find-path", "read")).toBe(true);
     expect(isToolAllowed("vault-info", "read")).toBe(true);
-    expect(isToolAllowed("list-vaults", "read")).toBe(true);
   });
 
   test("read permission blocks mutation tools", () => {
@@ -1513,8 +1504,8 @@ describe("HTTP /find-path", async () => {
 
 describe("stateless MCP transport", async () => {
   test("tools/call works without prior initialize handshake", async () => {
-    const { handleUnifiedMcp } = await import("./mcp-http.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { handleScopedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig } = await import("./config.ts");
     const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
 
     const vaultName = `stateless-mcp-${Date.now()}`;
@@ -1523,13 +1514,12 @@ describe("stateless MCP transport", async () => {
       api_keys: [],
       created_at: new Date().toISOString(),
     });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
     const vaultStore = getVaultStore(vaultName);
     await vaultStore.createNote("test note", { tags: ["daily"] });
 
     // Direct tools/call — no initialize, no session header
-    const req = new Request("http://localhost:1940/mcp", {
+    const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -1539,11 +1529,11 @@ describe("stateless MCP transport", async () => {
         jsonrpc: "2.0",
         id: 1,
         method: "tools/call",
-        params: { name: "vault-info", arguments: { vault: vaultName, include_stats: true } },
+        params: { name: "vault-info", arguments: { include_stats: true } },
       }),
     });
 
-    const res = await handleUnifiedMcp(req, "write");
+    const res = await handleScopedMcp(req, vaultName, { permission: "full" });
     expect(res.status).toBe(200);
 
     const body = await res.json() as any;
@@ -1555,8 +1545,8 @@ describe("stateless MCP transport", async () => {
   });
 
   test("tools/list works without prior initialize handshake", async () => {
-    const { handleUnifiedMcp } = await import("./mcp-http.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { handleScopedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig } = await import("./config.ts");
     const { closeAllStores } = await import("./vault-store.ts");
 
     const vaultName = `stateless-list-${Date.now()}`;
@@ -1565,9 +1555,8 @@ describe("stateless MCP transport", async () => {
       api_keys: [],
       created_at: new Date().toISOString(),
     });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
-    const req = new Request("http://localhost:1940/mcp", {
+    const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -1581,7 +1570,7 @@ describe("stateless MCP transport", async () => {
       }),
     });
 
-    const res = await handleUnifiedMcp(req, "write");
+    const res = await handleScopedMcp(req, vaultName, { permission: "full" });
     expect(res.status).toBe(200);
 
     const body = await res.json() as any;
@@ -1595,8 +1584,8 @@ describe("stateless MCP transport", async () => {
   });
 
   test("initialize still works for clients that send it", async () => {
-    const { handleUnifiedMcp } = await import("./mcp-http.ts");
-    const { writeVaultConfig, writeGlobalConfig } = await import("./config.ts");
+    const { handleScopedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig } = await import("./config.ts");
     const { closeAllStores } = await import("./vault-store.ts");
 
     const vaultName = `stateless-init-${Date.now()}`;
@@ -1605,9 +1594,8 @@ describe("stateless MCP transport", async () => {
       api_keys: [],
       created_at: new Date().toISOString(),
     });
-    writeGlobalConfig({ port: 1940, default_vault: vaultName });
 
-    const req = new Request("http://localhost:1940/mcp", {
+    const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -1625,12 +1613,12 @@ describe("stateless MCP transport", async () => {
       }),
     });
 
-    const res = await handleUnifiedMcp(req, "write");
+    const res = await handleScopedMcp(req, vaultName, { permission: "full" });
     expect(res.status).toBe(200);
 
     const body = await res.json() as any;
     expect(body.result.protocolVersion).toBe("2024-11-05");
-    expect(body.result.serverInfo.name).toBe("parachute-vault");
+    expect(body.result.serverInfo.name).toBe(`parachute-vault/${vaultName}`);
     expect(body.result.capabilities.tools).toBeDefined();
 
     closeAllStores();


### PR DESCRIPTION
## Summary

Collapses the old mix of unscoped (`/api`, `/mcp`, `/oauth`, `/view`) and legacy `/vaults/<name>/` paths into **one** per-vault base path. Every vault-touching route now lives under `/vault/<name>/...`. No backcompat layer — clients re-point their URL once and (for OAuth clients) re-auth once. Lands before the query-notes operator-object refactor so that PR rebases onto stable URLs.

- REST: `/vault/<name>/api/*`
- MCP: `/vault/<name>/mcp` (per-vault session; the unified `/mcp` that fanned tool calls via a `vault` param is removed)
- OAuth: `/vault/<name>/oauth/{register,authorize,token}`
- Discovery: `/vault/<name>/.well-known/oauth-*`
- View: `/vault/<name>/view/:id`
- Cross-vault endpoints unchanged: `GET /vaults`, `GET /vaults/list`, `GET /health`.

MCP 401s now carry a `WWW-Authenticate: Bearer resource_metadata="..."` header (RFC 9728) so OAuth-capable clients discover the authorization server straight from the challenge. The `list-vaults` tool is dropped — each MCP session pins to one vault by URL.

LOC: +452 / −932 across 16 files. Most of the reduction is from collapsing the previous "unscoped-default-vault" + "unified-MCP" + "/vaults/<name>" branches into a single regex.

## Test plan

- [x] `bun test src/` — 651 / 651 pass
- [x] `bun test core/src/` — 252 / 252 pass
- [x] `tsc --noEmit` — no net new errors (test-file errors dropped from 86 → 80)
- [x] CHANGELOG `[Unreleased]` has an "Upgrading from 0.2.x" section
- [ ] `parachute-vault mcp-install` smoke test after merge (rewrites `~/.claude.json` with `/vault/<name>/mcp`)
- [ ] Re-OAuth Claude Desktop / Parachute Daily after release
- [ ] Update downstream consumers (parachute-daily, parachute-lens, any notes-dashboard scripts) to the new URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)