### PR TITLE
feat: add /.parachute/info + icon.svg for CLI hub page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+### Added
+
+- **`GET /vault/<name>/.parachute/info` + `/.parachute/icon.svg` for the CLI hub page.** Two public (no auth), CORS-`*` endpoints so the ecosystem-root hub rendered by the CLI can aggregate service cards. `info` returns a locked card shape — `name`, `displayName`, `tagline`, `version` (from `package.json`), `iconUrl` — and `icon.svg` returns a small placeholder monogram inline. Zero PII, read-only. Non-GET methods return 405.
+
 ### Changed
 
 - **Vault state moved from `~/.parachute/` into `~/.parachute/vault/`.** The ecosystem root (`~/.parachute/`) now hosts multiple sibling services — `services.json` and `well-known/` stay at the root (CLI-owned), and everything vault owns (`.env`, `config.yaml`, `vault.log`, `vault.err`, `start.sh`, `server-path`, `vaults/`, `assets/`, `backup-last.json`, top-level `*.db` snapshots) has moved under `~/.parachute/vault/`. `PARACHUTE_HOME` still points at the ecosystem root; the vault subdir is derived as `${PARACHUTE_HOME}/vault`. On first post-upgrade run, any legacy paths still at the root are auto-migrated into `vault/` — the CLI logs each moved path to stderr and the migration is idempotent (double-runs are a no-op). If a legacy path and its new counterpart both exist, the new one wins and the legacy copy is left in place with a warning so users can inspect before removing. The launchd plist + systemd unit both point `WorkingDirectory` at the new `vault/` subdir, and the generated `start.sh` wrapper now sources `~/.parachute/vault/.env`. No user action is required — running any `parachute-vault` command (including `doctor` and `url`) triggers the migration.

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -465,3 +465,109 @@ describe("per-vault OAuth discovery", () => {
     expect(regRes.status).toBe(201);
   });
 });
+
+// ---------------------------------------------------------------------------
+// /.parachute/info + /.parachute/icon.svg — public service-info card for the
+// CLI hub page at the ecosystem root. The hub fetches these per service to
+// render tiles, so the endpoints are public (no auth), CORS `*`, and zero
+// PII. Shape is locked so all services line up in the aggregator UI.
+// ---------------------------------------------------------------------------
+
+describe("/.parachute/info + /.parachute/icon.svg", () => {
+  test("info returns the locked card shape with version from package.json", async () => {
+    createVault("journal");
+    const pkg = (await import("../package.json", { with: { type: "json" } })).default;
+    const path = "/vault/journal/.parachute/info";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    const body = (await res.json()) as {
+      name: string;
+      displayName: string;
+      tagline: string;
+      version: string;
+      iconUrl: string;
+    };
+    expect(body).toEqual({
+      name: "parachute-vault",
+      displayName: "Vault",
+      tagline: expect.stringContaining("knowledge graph"),
+      version: pkg.version,
+      iconUrl: "/vault/journal/.parachute/icon.svg",
+    });
+  });
+
+  test("info iconUrl is vault-scoped and points at a live icon handler", async () => {
+    createVault("work");
+    const infoPath = "/vault/work/.parachute/info";
+    const infoRes = await route(new Request(`http://localhost:1940${infoPath}`), infoPath);
+    const info = (await infoRes.json()) as { iconUrl: string };
+    expect(info.iconUrl).toBe("/vault/work/.parachute/icon.svg");
+
+    // Follow the pointer — the advertised iconUrl must resolve.
+    const iconRes = await route(
+      new Request(`http://localhost:1940${info.iconUrl}`),
+      info.iconUrl,
+    );
+    expect(iconRes.status).toBe(200);
+  });
+
+  test("icon.svg returns an SVG body with the right content-type + CORS", async () => {
+    createVault("journal");
+    const path = "/vault/journal/.parachute/icon.svg";
+    const res = await route(new Request(`http://localhost:1940${path}`), path);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    const body = await res.text();
+    expect(body).toContain("<svg");
+    expect(body).toContain("</svg>");
+  });
+
+  test("both endpoints are public — no auth header required, none honored", async () => {
+    createVault("journal");
+    for (const path of [
+      "/vault/journal/.parachute/info",
+      "/vault/journal/.parachute/icon.svg",
+    ]) {
+      // No Authorization header.
+      const resAnon = await route(new Request(`http://localhost:1940${path}`), path);
+      expect(resAnon.status).toBe(200);
+
+      // Bogus Authorization header — still 200, auth is not consulted.
+      const resWithHeader = await route(
+        new Request(`http://localhost:1940${path}`, {
+          headers: { Authorization: "Bearer pvt_nonsense" },
+        }),
+        path,
+      );
+      expect(resWithHeader.status).toBe(200);
+    }
+  });
+
+  test("unknown vault returns 404 before reaching the info/icon handlers", async () => {
+    createVault("journal");
+    for (const path of [
+      "/vault/nonexistent/.parachute/info",
+      "/vault/nonexistent/.parachute/icon.svg",
+    ]) {
+      const res = await route(new Request(`http://localhost:1940${path}`), path);
+      expect(res.status).toBe(404);
+    }
+  });
+
+  test("non-GET methods return 405 (and never trigger auth — stays public)", async () => {
+    createVault("journal");
+    for (const path of [
+      "/vault/journal/.parachute/info",
+      "/vault/journal/.parachute/icon.svg",
+    ]) {
+      const res = await route(
+        new Request(`http://localhost:1940${path}`, { method: "POST" }),
+        path,
+      );
+      expect(res.status).toBe(405);
+    }
+  });
+});

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -28,6 +28,7 @@
  * after the upgrade and point at the new URLs.
  */
 
+import pkg from "../package.json" with { type: "json" };
 import type { VaultConfig } from "./config.ts";
 import {
   readVaultConfig,
@@ -107,6 +108,42 @@ function isViewAuthenticated(
   if (!key) return false;
   const auth = authenticateVaultRequest(req, vaultConfig, vaultDb);
   return !("error" in auth);
+}
+
+/**
+ * Public service-info card for the CLI hub page. The CLI fetches this from
+ * every service registered in `~/.parachute/well-known/parachute.json` and
+ * renders each as a tile — services own their display story, CLI is a dumb
+ * aggregator. No auth, no PII, CORS `*` so the hub can call us cross-origin.
+ */
+function handleParachuteInfo(vaultName: string): Response {
+  const body = {
+    name: "parachute-vault",
+    displayName: "Vault",
+    tagline: "Agent-native knowledge graph — notes, tags, links, attachments over REST + MCP",
+    version: pkg.version,
+    iconUrl: `/vault/${vaultName}/.parachute/icon.svg`,
+  };
+  return Response.json(body, {
+    headers: { "Access-Control-Allow-Origin": "*" },
+  });
+}
+
+/**
+ * Placeholder monogram icon for the hub tile. Kept inline so the endpoint
+ * has zero filesystem dependency — the CLI can render a card even on a
+ * pristine install where no assets have been written out yet.
+ */
+const PARACHUTE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="30" fill="#879B7E"/><text x="32" y="43" text-anchor="middle" font-family="system-ui,sans-serif" font-size="32" font-weight="600" fill="#FAFAF7">V</text></svg>`;
+
+function handleParachuteIcon(): Response {
+  return new Response(PARACHUTE_ICON_SVG, {
+    headers: {
+      "Content-Type": "image/svg+xml",
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
 }
 
 export async function route(
@@ -224,6 +261,20 @@ export async function route(
     // handleToken pins the OAuth code to the issuing vault (prevents
     // cross-vault code replay) and echoes `vault: <name>` in the response.
     if (subpath === "/oauth/token") return handleToken(req, store.db, vaultName);
+  }
+
+  // Parachute service-info + icon (no auth, CORS *). The CLI hub page at
+  // the ecosystem root reads `~/.parachute/well-known/parachute.json`,
+  // fans out to each service's `/.parachute/info`, and renders a card per
+  // response. Keeping display copy here means the hub never needs a vault
+  // release to pick up wording changes.
+  if (subpath === "/.parachute/info" || subpath === "/.parachute/icon.svg") {
+    if (req.method !== "GET") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    return subpath === "/.parachute/info"
+      ? handleParachuteInfo(vaultName)
+      : handleParachuteIcon();
   }
 
   // OAuth discovery (no auth). The protected-resource metadata advertises


### PR DESCRIPTION
## Summary
- New public endpoint `GET /vault/<name>/.parachute/info` returns the locked card shape the CLI hub page expects: `name`, `displayName`, `tagline`, `version` (from `package.json`), `iconUrl`.
- Companion `GET /vault/<name>/.parachute/icon.svg` returns a small inline placeholder monogram (sage-green circle + "V"), `content-type: image/svg+xml`.
- Both are no-auth, CORS `*`, zero PII. Non-GET methods return 405 before auth runs so the surface stays public.

## Test plan
- [x] 686/686 vault tests pass (6 new, covering shape, content-type, no-auth behavior, cross-vault 404, 405 on non-GET, iconUrl → live handler round-trip)
- [x] Version field pulls from `package.json` at module load
- [x] Unknown vault still 404s (guard runs before info handler)

## Coordination
Pairs with lens static `public/.parachute/info.json` and the CLI hub PR 7 (task #84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)