### PR TITLE
refactor: filesystem hygiene inside ~/.parachute/vault/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+### Changed
+
+- **Filesystem hygiene inside `~/.parachute/vault/`: `vaults/` → `data/`, and logs moved into `logs/`.** Two internal moves with the same target-wins, idempotent, auto-migrating shape as the 0.3 ecosystem-root move. Per-vault SQLite state now lives at `~/.parachute/vault/data/<name>/` (was `vaults/<name>/`) — matches the Postgres/Redis convention and avoids the doubled "vault/vaults" path. Daemon logs now live at `~/.parachute/vault/logs/vault.log` and `~/.parachute/vault/logs/vault.err` (were flat in `~/.parachute/vault/`) — matches the `~/.parachute/<svc>/logs/<svc>.log` convention the CLI uses for every sibling service. On first post-upgrade run the vault auto-migrates `vault/vaults/` → `vault/data/` and `vault/vault.log`/`vault.err` → `vault/logs/`, logging each move to stderr. Target-wins on conflict: if both `vault/data/` and `vault/vaults/` exist (or both log locations), the new one is kept and the legacy copy is left in place with a warning. No user action required — any `parachute-vault` invocation triggers the migration. Note: vault does not use `~/.parachute/tokens.db` (no code references it), so it is not part of this move; the CLI will archive that file separately.
+
 ### Added
 
 - **`GET /vault/<name>/.parachute/info` + `/.parachute/icon.svg` for the CLI hub page.** Two public (no auth), CORS-`*` endpoints so the ecosystem-root hub rendered by the CLI can aggregate service cards. `info` returns a locked card shape — `name`, `displayName`, `tagline`, `version` (from `package.json`), `iconUrl` — and `icon.svg` returns a small placeholder monogram inline. Zero PII, read-only. Non-GET methods return 405.

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -33,7 +33,7 @@ let prevHome: string | undefined;
 
 beforeEach(() => {
   tmpHome = join(tmpdir(), `vault-auth-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  mkdirSync(join(tmpHome, "vault", "vaults"), { recursive: true });
+  mkdirSync(join(tmpHome, "vault", "data"), { recursive: true });
   prevHome = process.env.PARACHUTE_HOME;
   process.env.PARACHUTE_HOME = tmpHome;
   clearVaultStoreCache();

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -25,7 +25,7 @@ import { Database } from "bun:sqlite";
 import { $ } from "bun";
 import {
   VAULT_HOME,
-  VAULTS_DIR,
+  DATA_DIR,
   GLOBAL_CONFIG_PATH,
   listVaults,
   vaultDir,
@@ -126,7 +126,7 @@ export async function stageSnapshot(opts?: {
   stagingDir?: string;
 }): Promise<{ stagingDir: string; contents: TarballContents }> {
   const configDir = opts?.configDir ?? VAULT_HOME;
-  const vaultsDir = opts?.vaultsDir ?? VAULTS_DIR;
+  const vaultsDir = opts?.vaultsDir ?? DATA_DIR;
   const stagingDir = opts?.stagingDir ?? mkdtempSync(join(tmpdir(), "parachute-backup-"));
 
   const dbSnapshots: string[] = [];
@@ -211,7 +211,7 @@ function vacuumInto(srcDbPath: string, destPath: string): void {
 
 /**
  * Small internal helper so tests can point us at a vaults dir that isn't
- * the global VAULTS_DIR without plumbing the override through `listVaults()`.
+ * the global DATA_DIR without plumbing the override through `listVaults()`.
  */
 function listVaultsIn(dir: string): string[] {
   if (!existsSync(dir)) return [];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,7 @@ import {
   GLOBAL_CONFIG_PATH,
 } from "./config.ts";
 import type { VaultConfig } from "./config.ts";
-import { VAULTS_DIR } from "./config.ts";
+import { DATA_DIR } from "./config.ts";
 import { installAgent, uninstallAgent, isAgentLoaded, restartAgent } from "./launchd.ts";
 import {
   runBackup,
@@ -1078,7 +1078,7 @@ async function cmdUninstall(argsList: string[]) {
   // miss this; interactive users already see the prompts.
   if (skipPrompts && wipe) {
     const ts = new Date().toISOString();
-    const targets = [VAULTS_DIR, ENV_PATH, GLOBAL_CONFIG_PATH, LOG_PATH, ERR_PATH].join(", ");
+    const targets = [DATA_DIR, ENV_PATH, GLOBAL_CONFIG_PATH, LOG_PATH, ERR_PATH].join(", ");
     console.log(`[${ts}] scripted destructive wipe: ${targets}`);
   }
 
@@ -1122,7 +1122,7 @@ async function cmdUninstall(argsList: string[]) {
     // Inventory what's actually on disk. Paths that don't exist are a
     // silent no-op on removal, but we also skip listing them so the
     // "would be removed" summary doesn't lie to the user.
-    const vaultsExist = existsSync(VAULTS_DIR);
+    const vaultsExist = existsSync(DATA_DIR);
     const envExists = existsSync(ENV_PATH);
     const configExists = existsSync(GLOBAL_CONFIG_PATH);
     const logExists = existsSync(LOG_PATH);
@@ -1133,7 +1133,7 @@ async function cmdUninstall(argsList: string[]) {
       console.log("No user data to remove.");
     } else {
       console.log("\nUser data that would be removed:");
-      if (vaultsExist) console.log(`  ${VAULTS_DIR} (SQLite vaults)`);
+      if (vaultsExist) console.log(`  ${DATA_DIR} (per-vault SQLite data)`);
       if (envExists) console.log(`  ${ENV_PATH} (.env config + secrets)`);
       if (configExists) console.log(`  ${GLOBAL_CONFIG_PATH} (global config)`);
       if (logExists) console.log(`  ${LOG_PATH} (daemon log)`);
@@ -1147,7 +1147,7 @@ async function cmdUninstall(argsList: string[]) {
         doWipe = await confirm("Delete this data? (cannot be undone)", false);
       }
       if (doWipe) {
-        if (vaultsExist) rmSync(VAULTS_DIR, { recursive: true, force: true });
+        if (vaultsExist) rmSync(DATA_DIR, { recursive: true, force: true });
         if (envExists) rmSync(ENV_PATH, { force: true });
         if (configExists) rmSync(GLOBAL_CONFIG_PATH, { force: true });
         if (logExists) rmSync(LOG_PATH, { force: true });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -311,7 +311,7 @@ describe2("migrateFromLegacyLayout", () => {
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "parachute-migrate-")); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
-  test2("fresh install with no legacy files is a no-op", async () => {
+  test2("fresh install with no legacy files is a no-op and creates data/ + logs/", async () => {
     const script = `
       process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
       const fs = await import("fs");
@@ -321,7 +321,9 @@ describe2("migrateFromLegacyLayout", () => {
       const vaultHome = path.join(${JSON.stringify(dir)}, "vault");
       console.log(JSON.stringify({
         vaultHomeExists: fs.existsSync(vaultHome),
-        vaultsExists: fs.existsSync(path.join(vaultHome, "vaults")),
+        dataExists: fs.existsSync(path.join(vaultHome, "data")),
+        logsExists: fs.existsSync(path.join(vaultHome, "logs")),
+        legacyVaultsDirExists: fs.existsSync(path.join(vaultHome, "vaults")),
         rootEnvExists: fs.existsSync(path.join(${JSON.stringify(dir)}, ".env")),
       }));
     `;
@@ -330,11 +332,13 @@ describe2("migrateFromLegacyLayout", () => {
     expect2(proc.exitCode, stderr).toBe(0);
     const parsed = JSON.parse(new TextDecoder().decode(proc.stdout).trim());
     expect2(parsed.vaultHomeExists).toBe(true);
-    expect2(parsed.vaultsExists).toBe(true);
+    expect2(parsed.dataExists).toBe(true);
+    expect2(parsed.logsExists).toBe(true);
+    expect2(parsed.legacyVaultsDirExists).toBe(false);
     expect2(parsed.rootEnvExists).toBe(false);
   });
 
-  test2("moves legacy .env, config.yaml, vaults/, start.sh, server-path into vault/", async () => {
+  test2("moves legacy root files into vault/ (vaults → data/, logs → logs/)", async () => {
     const script = `
       process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
       const fs = await import("fs");
@@ -357,9 +361,13 @@ describe2("migrateFromLegacyLayout", () => {
         config: fs.readFileSync(path.join(vaultHome, "config.yaml"), "utf-8"),
         start: fs.readFileSync(path.join(vaultHome, "start.sh"), "utf-8"),
         serverPath: fs.readFileSync(path.join(vaultHome, "server-path"), "utf-8"),
-        vaultYaml: fs.readFileSync(path.join(vaultHome, "vaults", "default", "vault.yaml"), "utf-8"),
+        vaultYaml: fs.readFileSync(path.join(vaultHome, "data", "default", "vault.yaml"), "utf-8"),
+        log: fs.readFileSync(path.join(vaultHome, "logs", "vault.log"), "utf-8"),
+        err: fs.readFileSync(path.join(vaultHome, "logs", "vault.err"), "utf-8"),
         legacyEnv: fs.existsSync(path.join(root, ".env")),
         legacyVaults: fs.existsSync(path.join(root, "vaults")),
+        legacyVaultLog: fs.existsSync(path.join(root, "vault.log")),
+        legacyVaultErr: fs.existsSync(path.join(root, "vault.err")),
       }));
     `;
     const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
@@ -371,9 +379,13 @@ describe2("migrateFromLegacyLayout", () => {
     expect2(parsed.start).toContain("#!/bin/bash");
     expect2(parsed.serverPath).toContain("/repo/src/server.ts");
     expect2(parsed.vaultYaml).toContain("name: default");
+    expect2(parsed.log).toContain("log");
+    expect2(parsed.err).toContain("err");
     // Legacy paths should be gone after the move.
     expect2(parsed.legacyEnv).toBe(false);
     expect2(parsed.legacyVaults).toBe(false);
+    expect2(parsed.legacyVaultLog).toBe(false);
+    expect2(parsed.legacyVaultErr).toBe(false);
   });
 
   test2("double-migration is idempotent", async () => {
@@ -398,6 +410,98 @@ describe2("migrateFromLegacyLayout", () => {
     const parsed = JSON.parse(new TextDecoder().decode(proc.stdout).trim());
     expect2(parsed.envInVault).toContain("PORT=1940");
     expect2(parsed.rootEnv).toBe(false);
+  });
+
+  test2("0.3 install: vault/vaults/ → vault/data/, vault/{vault.log,vault.err} → vault/logs/", async () => {
+    // Users who installed on 0.3 (post-PR-8 but pre-filesystem-hygiene)
+    // have vault state under `vault/` with the old internal names.
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const fs = await import("fs");
+      const path = await import("path");
+      const vaultHome = path.join(${JSON.stringify(dir)}, "vault");
+      fs.mkdirSync(path.join(vaultHome, "vaults", "work"), { recursive: true });
+      fs.writeFileSync(path.join(vaultHome, "vaults", "work", "vault.yaml"), "name: work\\napi_keys: []\\n");
+      fs.writeFileSync(path.join(vaultHome, "vault.log"), "daemon-stdout\\n");
+      fs.writeFileSync(path.join(vaultHome, "vault.err"), "daemon-stderr\\n");
+      const { ensureConfigDirSync } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      ensureConfigDirSync();
+      console.log(JSON.stringify({
+        vaultYaml: fs.readFileSync(path.join(vaultHome, "data", "work", "vault.yaml"), "utf-8"),
+        log: fs.readFileSync(path.join(vaultHome, "logs", "vault.log"), "utf-8"),
+        err: fs.readFileSync(path.join(vaultHome, "logs", "vault.err"), "utf-8"),
+        legacyVaultsDir: fs.existsSync(path.join(vaultHome, "vaults")),
+        legacyLog: fs.existsSync(path.join(vaultHome, "vault.log")),
+        legacyErr: fs.existsSync(path.join(vaultHome, "vault.err")),
+      }));
+    `;
+    const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
+    const stderr = new TextDecoder().decode(proc.stderr);
+    expect2(proc.exitCode, stderr).toBe(0);
+    const parsed = JSON.parse(new TextDecoder().decode(proc.stdout).trim());
+    expect2(parsed.vaultYaml).toContain("name: work");
+    expect2(parsed.log).toContain("daemon-stdout");
+    expect2(parsed.err).toContain("daemon-stderr");
+    expect2(parsed.legacyVaultsDir).toBe(false);
+    expect2(parsed.legacyLog).toBe(false);
+    expect2(parsed.legacyErr).toBe(false);
+  });
+
+  test2("0.3 internal migration: both vault/vaults/ and vault/data/ exist — data/ wins, vaults/ preserved", async () => {
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const fs = await import("fs");
+      const path = await import("path");
+      const vaultHome = path.join(${JSON.stringify(dir)}, "vault");
+      // Both layouts present with distinct marker content — migration
+      // must NOT overwrite data/ (user may have manually staged it).
+      fs.mkdirSync(path.join(vaultHome, "vaults"), { recursive: true });
+      fs.writeFileSync(path.join(vaultHome, "vaults", "MARKER_LEGACY"), "legacy\\n");
+      fs.mkdirSync(path.join(vaultHome, "data"), { recursive: true });
+      fs.writeFileSync(path.join(vaultHome, "data", "MARKER_CURRENT"), "current\\n");
+      const { ensureConfigDirSync } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      ensureConfigDirSync();
+      console.log(JSON.stringify({
+        dataMarker: fs.existsSync(path.join(vaultHome, "data", "MARKER_CURRENT")),
+        legacyMarker: fs.existsSync(path.join(vaultHome, "vaults", "MARKER_LEGACY")),
+        dataOverwrittenByLegacy: fs.existsSync(path.join(vaultHome, "data", "MARKER_LEGACY")),
+      }));
+    `;
+    const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
+    const stderr = new TextDecoder().decode(proc.stderr);
+    expect2(proc.exitCode, stderr).toBe(0);
+    const parsed = JSON.parse(new TextDecoder().decode(proc.stdout).trim());
+    expect2(parsed.dataMarker).toBe(true); // data/ untouched
+    expect2(parsed.legacyMarker).toBe(true); // vaults/ untouched, for user to inspect
+    expect2(parsed.dataOverwrittenByLegacy).toBe(false);
+    // Warning surfaces on stderr so the user sees it.
+    expect2(stderr).toContain("both");
+    expect2(stderr).toContain("vaults");
+    expect2(stderr).toContain("data");
+  });
+
+  test2("0.3 internal migration: idempotent — second boot is a no-op", async () => {
+    const script = `
+      process.env.PARACHUTE_HOME = ${JSON.stringify(dir)};
+      const fs = await import("fs");
+      const path = await import("path");
+      const vaultHome = path.join(${JSON.stringify(dir)}, "vault");
+      fs.mkdirSync(path.join(vaultHome, "vaults", "journal"), { recursive: true });
+      fs.writeFileSync(path.join(vaultHome, "vaults", "journal", "vault.yaml"), "name: journal\\n");
+      const { ensureConfigDirSync } = await import(${JSON.stringify(join(import.meta.dir, "config.ts"))});
+      ensureConfigDirSync();
+      ensureConfigDirSync(); // second boot — no-op.
+      console.log(JSON.stringify({
+        vaultYaml: fs.readFileSync(path.join(vaultHome, "data", "journal", "vault.yaml"), "utf-8"),
+        legacyVaultsDir: fs.existsSync(path.join(vaultHome, "vaults")),
+      }));
+    `;
+    const proc = Bun.spawnSync({ cmd: ["bun", "-e", script], stdout: "pipe", stderr: "pipe" });
+    const stderr = new TextDecoder().decode(proc.stderr);
+    expect2(proc.exitCode, stderr).toBe(0);
+    const parsed = JSON.parse(new TextDecoder().decode(proc.stdout).trim());
+    expect2(parsed.vaultYaml).toContain("name: journal");
+    expect2(parsed.legacyVaultsDir).toBe(false);
   });
 
   test2("leaves legacy in place when target already exists (no overwrite)", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,9 +8,14 @@
  *     vault/                      — everything vault owns
  *       .env
  *       config.yaml               — global server config
- *       vault.log / vault.err     — daemon logs
  *       start.sh / server-path    — daemon wrapper + pointer (daemon.ts)
- *       vaults/
+ *       logs/
+ *         vault.log / vault.err   — daemon stdout/stderr (matches
+ *                                   `~/.parachute/<svc>/logs/<svc>.log` — the
+ *                                   CLI lifecycle convention from PR #83)
+ *       data/                     — per-vault SQLite data (Postgres-style:
+ *                                   named `data/` rather than `vaults/` so it
+ *                                   doesn't read as doubled)
  *         {name}/
  *           vault.db              — SQLite database
  *           vault.yaml            — per-vault config (description, api_keys, …)
@@ -18,6 +23,9 @@
  *
  * Pre-0.3 installs put vault state directly under `~/.parachute/`; on startup
  * we auto-migrate those paths into `vault/` (see `migrateFromLegacyLayout`).
+ * Pre-filesystem-hygiene 0.3 installs put per-vault state under
+ * `vault/vaults/` and daemon logs flat in `vault/`; those are moved into
+ * `data/` and `logs/` by `migrateVaultInternalLayout` on startup.
  */
 
 import { homedir } from "os";
@@ -29,7 +37,7 @@ import crypto from "node:crypto";
 // ---------------------------------------------------------------------------
 // Paths
 //
-// Historical note: the exported `CONFIG_DIR`, `VAULTS_DIR`, etc. used to be
+// Historical note: the exported `CONFIG_DIR`, `DATA_DIR`, etc. used to be
 // `const` captured at module load. That made tests flaky: anything setting
 // `process.env.PARACHUTE_HOME` after import would be ignored, and when `bun
 // test` shares one process across files, whichever test loaded first froze
@@ -52,8 +60,12 @@ function vaultHomePath(): string {
   return join(configDirPath(), "vault");
 }
 
-function vaultsDirPath(): string {
-  return join(vaultHomePath(), "vaults");
+function dataDirPath(): string {
+  return join(vaultHomePath(), "data");
+}
+
+function logsDirPath(): string {
+  return join(vaultHomePath(), "logs");
 }
 
 function globalConfigPath(): string {
@@ -66,16 +78,17 @@ function envFilePath(): string {
 
 export const CONFIG_DIR = configDirPath();
 export const VAULT_HOME = join(CONFIG_DIR, "vault");
-export const VAULTS_DIR = join(VAULT_HOME, "vaults");
+export const DATA_DIR = join(VAULT_HOME, "data");
+export const LOGS_DIR = join(VAULT_HOME, "logs");
 export const GLOBAL_CONFIG_PATH = join(VAULT_HOME, "config.yaml");
 export const ENV_PATH = join(VAULT_HOME, ".env");
-export const LOG_PATH = join(VAULT_HOME, "vault.log");
-export const ERR_PATH = join(VAULT_HOME, "vault.err");
+export const LOG_PATH = join(LOGS_DIR, "vault.log");
+export const ERR_PATH = join(LOGS_DIR, "vault.err");
 export const DEFAULT_PORT = 1940;
 export const ASSETS_DIR = join(VAULT_HOME, "assets");
 
 export function vaultDir(name: string): string {
-  return join(vaultsDirPath(), name);
+  return join(dataDirPath(), name);
 }
 
 export function vaultDbPath(name: string): string {
@@ -759,14 +772,16 @@ export async function ensureConfigDir(): Promise<void> {
   await mkdir(configDirPath(), { recursive: true });
   migrateFromLegacyLayout();
   await mkdir(vaultHomePath(), { recursive: true });
-  await mkdir(vaultsDirPath(), { recursive: true });
+  await mkdir(dataDirPath(), { recursive: true });
 }
 
 export function ensureConfigDirSync(): void {
   mkdirSync(configDirPath(), { recursive: true });
   migrateFromLegacyLayout();
   mkdirSync(vaultHomePath(), { recursive: true });
-  mkdirSync(vaultsDirPath(), { recursive: true });
+  migrateVaultInternalLayout();
+  mkdirSync(dataDirPath(), { recursive: true });
+  mkdirSync(logsDirPath(), { recursive: true });
 }
 
 /**
@@ -784,14 +799,18 @@ export function migrateFromLegacyLayout(): void {
   const root = configDirPath();
   const dest = vaultHomePath();
 
+  // Pre-0.3 installs targeted flat names at root (`vaults`, `vault.log`);
+  // we now land those directly under their current canonical subdirs
+  // (`data/`, `logs/`) so upgrading users skip the intermediate shape that
+  // `migrateVaultInternalLayout` would otherwise correct on a second pass.
   const candidates: Array<[string, string]> = [
     [".env", ".env"],
     ["config.yaml", "config.yaml"],
-    ["vault.log", "vault.log"],
-    ["vault.err", "vault.err"],
+    ["vault.log", "logs/vault.log"],
+    ["vault.err", "logs/vault.err"],
     ["start.sh", "start.sh"],
     ["server-path", "server-path"],
-    ["vaults", "vaults"],
+    ["vaults", "data"],
     ["assets", "assets"],
   ];
 
@@ -813,6 +832,10 @@ export function migrateFromLegacyLayout(): void {
       skipped.push(from);
       continue;
     }
+    // Target may live in a subdir (logs/, data/); ensure parent exists
+    // before renameSync, which is strict about target parent existence.
+    const parent = join(dst, "..");
+    mkdirSync(parent, { recursive: true });
     try {
       renameSync(src, dst);
       moved.push(from);
@@ -837,6 +860,80 @@ export function migrateFromLegacyLayout(): void {
   if (skipped.length > 0) {
     console.error(
       `[parachute-vault] left legacy paths in place (target already exists under vault/): ${skipped.map((p) => join(root, p)).join(", ")}. Remove the legacy copies once you've confirmed the vault/ copies are current.`,
+    );
+  }
+}
+
+/**
+ * Tidies the layout *inside* `vault/` for installs upgrading across the
+ * filesystem-hygiene refactor:
+ *
+ *   vault/vaults/   → vault/data/         (matches Postgres/Redis convention;
+ *                                          avoids the doubled "vault/vaults")
+ *   vault/vault.log → vault/logs/vault.log
+ *   vault/vault.err → vault/logs/vault.err
+ *
+ * Same target-wins, idempotent, rename-only policy as
+ * `migrateFromLegacyLayout`. Runs every boot — once the moves have
+ * happened, subsequent calls are pure existence checks that exit fast.
+ *
+ * If `vault/` doesn't exist yet (never booted before), this returns
+ * immediately — `ensureConfigDirSync` creates the fresh layout right after.
+ */
+export function migrateVaultInternalLayout(): void {
+  const vaultHome = vaultHomePath();
+  if (!existsSync(vaultHome)) return;
+
+  // vault/vaults/ → vault/data/
+  const legacyData = join(vaultHome, "vaults");
+  const newData = dataDirPath();
+  if (existsSync(legacyData)) {
+    if (existsSync(newData)) {
+      console.error(
+        `[parachute-vault] both ${legacyData}/ and ${newData}/ exist — using data/, leaving vaults/ in place. Remove the legacy copy once you've confirmed data/ is current.`,
+      );
+    } else {
+      try {
+        renameSync(legacyData, newData);
+        console.error(`[parachute-vault] migrated ${legacyData}/ → ${newData}/`);
+      } catch (err) {
+        console.warn(
+          `[parachute-vault] failed to migrate ${legacyData}/ → ${newData}/: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  // vault/{vault.log,vault.err} → vault/logs/{vault.log,vault.err}
+  const logsDir = logsDirPath();
+  const logsMoved: string[] = [];
+  const logsSkipped: string[] = [];
+  for (const name of ["vault.log", "vault.err"]) {
+    const src = join(vaultHome, name);
+    if (!existsSync(src)) continue;
+    const dst = join(logsDir, name);
+    if (existsSync(dst)) {
+      logsSkipped.push(name);
+      continue;
+    }
+    mkdirSync(logsDir, { recursive: true });
+    try {
+      renameSync(src, dst);
+      logsMoved.push(name);
+    } catch (err) {
+      console.warn(
+        `[parachute-vault] failed to migrate ${src} → ${dst}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  if (logsMoved.length > 0) {
+    console.error(
+      `[parachute-vault] migrated ${logsMoved.map((n) => join(vaultHome, n)).join(", ")} → ${logsDir}/`,
+    );
+  }
+  if (logsSkipped.length > 0) {
+    console.error(
+      `[parachute-vault] left legacy log files in place (target already exists under logs/): ${logsSkipped.map((n) => join(vaultHome, n)).join(", ")}.`,
     );
   }
 }
@@ -1119,7 +1216,7 @@ export function loadEnvFile(): void {
 
 export function listVaults(): string[] {
   try {
-    const dir = vaultsDirPath();
+    const dir = dataDirPath();
     if (!existsSync(dir)) return [];
     const entries = Bun.spawnSync(["ls", dir]).stdout.toString().trim();
     if (!entries) return [];

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -55,7 +55,7 @@ function reset(): void {
   clearVaultStoreCache();
   if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
   mkdirSync(testDir, { recursive: true });
-  mkdirSync(join(testDir, "vault", "vaults"), { recursive: true });
+  mkdirSync(join(testDir, "vault", "data"), { recursive: true });
   writeGlobalConfig({ port: 1940 });
 }
 


### PR DESCRIPTION
## Summary

Two internal moves inside the vault service directory, both with target-wins, idempotent auto-migration on boot. Same shape as the 0.3 ecosystem-root move — no user action required.

1. **`~/.parachute/vault/vaults/` → `~/.parachute/vault/data/`** — matches the Postgres/Redis convention (`data/` as the per-instance state dir) and avoids the doubled `vault/vaults` path.
2. **`~/.parachute/vault/vault.log` + `vault.err` → `~/.parachute/vault/logs/vault.{log,err}`** — matches the `~/.parachute/<svc>/logs/<svc>.log` convention the CLI uses for every sibling service (per PR #83).

### Migration

New `migrateVaultInternalLayout()` in `src/config.ts` runs alongside the existing `migrateFromLegacyLayout` on every `ensureConfigDirSync`. Both passes are idempotent.

**Conflict policy:** target-wins. If both `vault/data/` and `vault/vaults/` exist (or both log locations), the new path is kept and the legacy copy is left in place with a warning to stderr so the operator can inspect before removing.

### `~/.parachute/tokens.db` — not part of this PR

The original scope included moving `~/.parachute/tokens.db` into `~/.parachute/vault/`. A full `grep -r tokens.db src/ core/` turned up zero references — vault does not use this file. Per team-lead, the CLI's migrate PR will archive it separately.

### Backup layout

`src/backup.ts` was updated to use the renamed `DATA_DIR` constant, but the tarball layout inside the backup still uses the hardcoded `vaults/` subdir to preserve the on-disk → tarball contract. Backups created before or after this PR are interchangeable.

## Test plan

- [x] `bun test src/` — 689/689 pass, no migration noise in stderr
- [x] `migrateVaultInternalLayout` — 3 new tests covering: 0.3-era install (moves vaults/ → data/ and logs), both-exist conflict (data/ wins, vaults/ preserved, stderr warnings), idempotent second boot (no-op)
- [x] `migrateFromLegacyLayout` — updated to land pre-0.3 paths directly at the new names (skipping the intermediate vault/vaults step)
- [x] `ensureConfigDirSync` — fresh install now creates `data/` + `logs/`, never `vaults/`
- [x] Backup round-trip — `src/backup.ts` uses `DATA_DIR` constant; tarball layout unchanged
- [x] Uninstall `--wipe` — `cli.ts` references to `DATA_DIR`/`LOG_PATH`/`ERR_PATH` all point at the new locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)