### PR TITLE
Bump to 0.3.0 for launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Ready for `bun publish`. See commit for the material changes that warrant the minor bump.