### PR TITLE
chore: launch polish — async migrate, nosniff, EXDEV hint

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -532,3 +532,41 @@ describe2("migrateFromLegacyLayout", () => {
     expect2(parsed.legacyEnv).toBe("LEGACY\n");
   });
 });
+
+// ---------------------------------------------------------------------------
+// formatMigrationFailure: the warn-line the migration catches emit. EXDEV
+// (cross-device rename) is hard to simulate in a test — PARACHUTE_HOME
+// straddling a mount is the real trigger — but we can at least verify the
+// helper attaches the "mount boundary" hint when the error code matches,
+// so users debugging a Docker/multi-disk layout get a meaningful message
+// instead of "failed to migrate X → Y: EXDEV: cross-device link not permitted".
+// ---------------------------------------------------------------------------
+
+import { formatMigrationFailure } from "./config.ts";
+
+describe("formatMigrationFailure", () => {
+  test("EXDEV errors get a mount-boundary hint and note legacy fallback", () => {
+    const err = Object.assign(new Error("EXDEV: cross-device link not permitted"), {
+      code: "EXDEV",
+    });
+    const msg = formatMigrationFailure("/src/path", "/dst/path", err);
+    expect(msg).toContain("mount boundary");
+    expect(msg).toContain("EXDEV");
+    expect(msg).toContain("legacy layout");
+    expect(msg).toContain("/src/path");
+    expect(msg).toContain("/dst/path");
+  });
+
+  test("non-EXDEV errors fall back to the raw message", () => {
+    const err = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    const msg = formatMigrationFailure("/src/path", "/dst/path", err);
+    expect(msg).toContain("EACCES: permission denied");
+    expect(msg).not.toContain("mount boundary");
+  });
+
+  test("non-Error values are stringified safely", () => {
+    const msg = formatMigrationFailure("/src", "/dst", "weird string");
+    expect(msg).toContain("weird string");
+    expect(msg).not.toContain("mount boundary");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,6 @@
 
 import { homedir } from "os";
 import { join } from "path";
-import { mkdir, readFile, writeFile } from "fs/promises";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync, renameSync } from "fs";
 import crypto from "node:crypto";
 
@@ -768,13 +767,6 @@ function serializeBackup(backup: BackupConfig): string[] {
 // Directory management
 // ---------------------------------------------------------------------------
 
-export async function ensureConfigDir(): Promise<void> {
-  await mkdir(configDirPath(), { recursive: true });
-  migrateFromLegacyLayout();
-  await mkdir(vaultHomePath(), { recursive: true });
-  await mkdir(dataDirPath(), { recursive: true });
-}
-
 export function ensureConfigDirSync(): void {
   mkdirSync(configDirPath(), { recursive: true });
   migrateFromLegacyLayout();
@@ -840,12 +832,7 @@ export function migrateFromLegacyLayout(): void {
       renameSync(src, dst);
       moved.push(from);
     } catch (err) {
-      // Cross-device rename failures shouldn't be possible here (same
-      // filesystem), but surface them instead of silently leaving files in
-      // the legacy spot — users need to know their data didn't move.
-      console.warn(
-        `[parachute-vault] failed to migrate ${src} → ${dst}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      console.warn(formatMigrationFailure(src, dst, err));
     }
   }
 
@@ -862,6 +849,22 @@ export function migrateFromLegacyLayout(): void {
       `[parachute-vault] left legacy paths in place (target already exists under vault/): ${skipped.map((p) => join(root, p)).join(", ")}. Remove the legacy copies once you've confirmed the vault/ copies are current.`,
     );
   }
+}
+
+/**
+ * Format a migration-rename failure warning. If the underlying error is
+ * EXDEV (cross-device rename — `PARACHUTE_HOME` straddles a mount, a common
+ * shape in Docker with bind-mounts or multi-disk dev setups), the raw error
+ * message is opaque. Surface the likely cause and note that vault continues
+ * on the legacy layout rather than exiting.
+ */
+export function formatMigrationFailure(src: string, dst: string, err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  const code = err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
+  if (code === "EXDEV") {
+    return `[parachute-vault] migration failed for ${src} → ${dst}: likely because PARACHUTE_HOME crosses a mount boundary (EXDEV). Vault will continue on the legacy layout; move the file manually to complete the upgrade.`;
+  }
+  return `[parachute-vault] failed to migrate ${src} → ${dst}: ${msg}`;
 }
 
 /**
@@ -897,9 +900,7 @@ export function migrateVaultInternalLayout(): void {
         renameSync(legacyData, newData);
         console.error(`[parachute-vault] migrated ${legacyData}/ → ${newData}/`);
       } catch (err) {
-        console.warn(
-          `[parachute-vault] failed to migrate ${legacyData}/ → ${newData}/: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        console.warn(formatMigrationFailure(`${legacyData}/`, `${newData}/`, err));
       }
     }
   }
@@ -921,9 +922,7 @@ export function migrateVaultInternalLayout(): void {
       renameSync(src, dst);
       logsMoved.push(name);
     } catch (err) {
-      console.warn(
-        `[parachute-vault] failed to migrate ${src} → ${dst}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      console.warn(formatMigrationFailure(src, dst, err));
     }
   }
   if (logsMoved.length > 0) {

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -520,6 +520,8 @@ describe("/.parachute/info + /.parachute/icon.svg", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    // Pin nosniff so older Edge/IE can't sniff the inline SVG as HTML.
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
     const body = await res.text();
     expect(body).toContain("<svg");
     expect(body).toContain("</svg>");

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -140,6 +140,11 @@ function handleParachuteIcon(): Response {
   return new Response(PARACHUTE_ICON_SVG, {
     headers: {
       "Content-Type": "image/svg+xml",
+      // Defense-in-depth: the payload is a static inline SVG with no
+      // script/foreignObject, but older Edge/IE have been known to sniff
+      // image/svg+xml as HTML under certain conditions. nosniff pins the
+      // declared type and takes the sniff path off the table entirely.
+      "X-Content-Type-Options": "nosniff",
       "Access-Control-Allow-Origin": "*",
       "Cache-Control": "public, max-age=3600",
     },


### PR DESCRIPTION
## Summary

Three review nits from PR #144, bundled for Wednesday launch. No launch-blocking items; all defensive cleanup.

1. **Delete unused async `ensureConfigDir`.** Had zero callers in the codebase — all real entrypoints use `ensureConfigDirSync`. It was also missing the `migrateVaultInternalLayout` call that shipped in #144, which would have quietly misled anyone who picked it up. Dropped along with the now-unused `fs/promises` import.

2. **Add `X-Content-Type-Options: nosniff` to `/.parachute/icon.svg`.** The payload is a static inline SVG with no `<script>` or `<foreignObject>`, but older Edge/IE versions can sniff `image/svg+xml` as HTML in certain contexts. One-line header addition, defense-in-depth.

3. **Extract `formatMigrationFailure()` for the three `renameSync` catch sites.** When the underlying error is EXDEV — `PARACHUTE_HOME` straddling a mount, a common shape in Docker bind-mounts and multi-disk dev setups — the raw error ("EXDEV: cross-device link not permitted") is opaque. The helper now surfaces a "mount boundary" hint and notes that vault continues on the legacy layout. Non-EXDEV errors still fall through to the raw message.

No copy-then-delete fallback for EXDEV itself (explicitly out of scope per assignment); just a clearer warn.

## Test plan

- [x] `bun test src/` — 692/692 pass (+3 for `formatMigrationFailure`, +1 nosniff assertion)
- [x] `formatMigrationFailure`: EXDEV → includes "mount boundary" and "legacy layout"; non-EXDEV → raw message; non-Error value → stringified without the hint
- [x] `/.parachute/icon.svg` now asserts `X-Content-Type-Options: nosniff`
- [x] `grep -r ensureConfigDir src/ core/` shows only `ensureConfigDirSync` call sites — deletion clean
- [x] Biome clean on the four touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)