### PR TITLE
chore(cli): demote `serve`/`status` to Advanced section in --help

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2018,9 +2018,15 @@ function usage() {
   console.log(`
 Parachute Vault — self-hosted knowledge graph
 
+If you installed via the Parachute CLI, prefer the wrapper commands for
+lifecycle — \`parachute start vault\`, \`parachute stop vault\`,
+\`parachute status\` — and use the vault-direct commands below for setup,
+data, and debugging.
+
+── Standard use ───────────────────────────────────────────────────────
+
 Setup:
   parachute-vault init                     Set up everything (one command, idempotent)
-  parachute-vault status                   Check what's running
   parachute-vault doctor                   Diagnose install/config issues
   parachute-vault uninstall [--wipe] [--yes]
                                            Remove daemon + MCP entry; --wipe also removes vaults, .env,
@@ -2067,8 +2073,16 @@ Import/Export:
   parachute-vault import <path> --dry-run  Preview import without writing
   parachute-vault export <path>            Export vault as Obsidian markdown
 
-Server:
-  parachute-vault serve                    Run server (foreground)
+── Advanced / standalone ──────────────────────────────────────────────
+
+Direct daemon controls. For normal use, prefer the Parachute CLI wrappers
+— they add PID tracking, log rotation, and cross-service \`parachute status\`
+visibility. Use these when running vault without the CLI or when debugging.
+
+  parachute-vault serve                    Run server in the foreground (no PID tracking).
+                                           Prefer \`parachute start vault\` for managed lifecycle.
+  parachute-vault status                   Vault-only daemon status.
+                                           Prefer \`parachute status\` for a cross-service view.
   parachute-vault logs                     Stream server logs
   parachute-vault restart                  Restart the daemon
 `);


### PR DESCRIPTION
## Problem

For users who installed via `parachute install vault`, the lifecycle path is the Parachute CLI wrapper (`parachute start vault`, `parachute stop vault`, `parachute status`) — it adds PID tracking, log rotation, and cross-service status. But `parachute-vault --help` previously listed `serve` and `status` as top-level Setup commands with no hint that the wrapped forms are preferred. Users saw both in docs/help and couldn't tell which to use.

## Fix

Two visual sections in the usage output:

```
── Standard use ───────────────────────────────────────────────────────
Setup / Vaults / Tokens / OAuth / Config / Backup / Import/Export
(everything you normally reach for)

── Advanced / standalone ──────────────────────────────────────────────
serve, status, logs, restart — direct daemon controls with a short
explainer, each pointing at its CLI wrapper.
```

A header note at the top tells CLI users to prefer the wrappers for lifecycle. `serve` and `status` each carry a one-liner pointing at `parachute start vault` / `parachute status` respectively.

## Scope

- `src/cli.ts` only — `usage()` function restructured (+17 / -3).
- **No deprecation.** Both commands remain fully functional for standalone / debugging use.
- **No behaviour changes.** No tests assert on the usage text; suite 697/697 pass.
- No bin-name or subcommand changes; no touches to `mcp-install`, `init`, or any command's behaviour.

## Before / after

`parachute-vault serve` was under `Setup:` alongside `init`, `status`, `doctor`. Now it sits under `── Advanced / standalone ──` with:

> `parachute-vault serve    Run server in the foreground (no PID tracking). Prefer \`parachute start vault\` for managed lifecycle.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)