### PR TITLE
chore(cli): demote `set-password`/`2fa` to Advanced/Identity in --help

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2018,10 +2018,10 @@ function usage() {
   console.log(`
 Parachute Vault — self-hosted knowledge graph
 
-If you installed via the Parachute CLI, prefer the wrapper commands for
-lifecycle — \`parachute start vault\`, \`parachute stop vault\`,
-\`parachute status\` — and use the vault-direct commands below for setup,
-data, and debugging.
+If you installed via the Parachute CLI, prefer the wrapper commands — lifecycle
+(\`parachute start vault\`, \`parachute stop vault\`, \`parachute status\`) and
+identity (\`parachute auth *\`) both dispatch into this binary. Reach for the
+vault-direct commands below for setup, data, and debugging.
 
 ── Standard use ───────────────────────────────────────────────────────
 
@@ -2050,14 +2050,6 @@ Tokens:
   parachute-vault tokens create --expires 30d     Expiring token
   parachute-vault tokens revoke <token-id>        Revoke a token (default vault)
 
-OAuth:
-  parachute-vault set-password             Set/change the owner password (for consent page)
-  parachute-vault set-password --clear     Remove the owner password
-  parachute-vault 2fa status               Show 2FA state
-  parachute-vault 2fa enroll               Enable TOTP 2FA (QR + backup codes)
-  parachute-vault 2fa disable              Disable 2FA (requires password)
-  parachute-vault 2fa backup-codes         Regenerate backup codes
-
 Config:
   parachute-vault config                   Show current configuration
   parachute-vault config set <key> <val>   Set a config value
@@ -2075,15 +2067,30 @@ Import/Export:
 
 ── Advanced / standalone ──────────────────────────────────────────────
 
-Direct daemon controls. For normal use, prefer the Parachute CLI wrappers
-— they add PID tracking, log rotation, and cross-service \`parachute status\`
-visibility. Use these when running vault without the CLI or when debugging.
+Vault-direct implementation commands. For normal use, prefer the Parachute
+CLI wrappers: lifecycle (\`parachute start/stop/status\`) and identity
+(\`parachute auth *\`) both dispatch into these. Reach for them directly when
+running vault standalone or when debugging.
 
+Daemon:
   parachute-vault serve                    Run server in the foreground (no PID tracking).
                                            Prefer \`parachute start vault\` for managed lifecycle.
   parachute-vault status                   Vault-only daemon status.
                                            Prefer \`parachute status\` for a cross-service view.
   parachute-vault logs                     Stream server logs
   parachute-vault restart                  Restart the daemon
+
+Identity:
+  parachute-vault set-password             Set/change the owner password (for consent page).
+                                           Prefer \`parachute auth set-password\`.
+  parachute-vault set-password --clear     Remove the owner password.
+  parachute-vault 2fa status               Show 2FA state.
+                                           Prefer \`parachute auth 2fa status\`.
+  parachute-vault 2fa enroll               Enable TOTP 2FA (QR + backup codes).
+                                           Prefer \`parachute auth 2fa enroll\`.
+  parachute-vault 2fa disable              Disable 2FA (requires password).
+                                           Prefer \`parachute auth 2fa disable\`.
+  parachute-vault 2fa backup-codes         Regenerate backup codes.
+                                           Prefer \`parachute auth 2fa backup-codes\`.
 `);
 }


### PR DESCRIPTION
## Context

Companion to #150. Identity is moving to the ecosystem CLI — `parachute auth set-password` and `parachute auth 2fa *` are landing there and dispatch into this binary. Vault's commands stay as the implementation surface; the wrapper becomes the preferred entry point. Same model as the `serve` demotion.

## Changes

`usage()` in `src/cli.ts`:

- **Drop** the standalone `OAuth:` section under Standard use.
- **Add** `Identity:` under `── Advanced / standalone ──`, parallel to the existing `Daemon:` subsection. Each command keeps its description and carries a one-line `Prefer \`parachute auth ...\`` pointer — the same two-line pattern `serve` / `status` adopted in #150.
- **Update** the top-of-help note + Advanced blurb to call out `parachute auth *` alongside the lifecycle wrappers.

## Out of scope

- **No deprecation** — commands remain fully functional; `parachute auth` dispatches here.
- **No backend logic changes** — strictly help-text reorganization.
- **No new modules.**

## Tests

No tests assert on the usage text. Suite 697/697 pass.

## Stacking

Stacked on #150 (`cli-help-demote-serve`) so the two help-text edits don't conflict. Either merge order works — if #150 lands first, this rebases clean; if this lands first, #150 rebases clean. Base is `cli-help-demote-serve`; flip to `main` once #150 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)