### PR TITLE
Bump to 0.3.0-rc.1 for pre-launch RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.0",
+  "version": "0.3.0-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Publish with `bun publish --tag rc`. Existing 0.2.4 on `latest` stays intact.