### PR TITLE
hotfix: load .env before SCRIBE_URL checks (transcription worker never started from .env)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -59,6 +59,12 @@ function safeHost(url: string): string | null {
   try { return new URL(url).host; } catch { return null; }
 }
 
+// Load .env before anything reads process.env — otherwise SCRIBE_URL and
+// friends configured in ~/.parachute/vault/.env are invisible to the
+// transcription-worker check and the trigger double-fire warning below.
+ensureConfigDirSync();
+loadEnvFile();
+
 registerConfiguredTriggers();
 
 /**
@@ -82,9 +88,6 @@ if (process.env.SCRIBE_URL) {
 } else {
   console.log("[transcribe] worker disabled (set SCRIBE_URL to enable)");
 }
-
-ensureConfigDirSync();
-loadEnvFile();
 
 // Auto-init: create a default vault if none exist (first run in Docker)
 if (listVaults().length === 0) {


### PR DESCRIPTION
## Summary

- **Bug (prod, 2026-04-21)**: transcription worker never started when `SCRIBE_URL` was set in `~/.parachute/vault/.env` — only worked when exported in shell env.
- **Cause**: `src/server.ts` ran `if (process.env.SCRIBE_URL) { startTranscriptionWorker(...) }` (and the double-fire warning in `registerConfiguredTriggers()`) **before** `loadEnvFile()`. So the `.env`-sourced value hadn't landed in `process.env` yet when the gate was checked.
- **Fix**: move `ensureConfigDirSync()` + `loadEnvFile()` to the top of module execution, above `registerConfiguredTriggers()` and the worker block.

Minimal 6-line diff. No refactor of the duplicate `process.env.SCRIBE_URL` checks on lines 44 and 71 — that smell is out of scope; separate PR if we want it.

Launch is 2026-04-23; this affects anyone following the documented `.env`-based config path.

## Test plan

- [x] `bunx tsc --noEmit` — 383 errors on main, 383 after this change (zero new; `server.ts` clean for the edited range)
- [x] `bun test src/` — 790 pass / 0 fail
- [ ] Manual: set `SCRIBE_URL=http://127.0.0.1:1943` in `~/.parachute/vault/.env`, restart vault, confirm logs show `[transcribe] worker started → http://127.0.0.1:1943` (left for reviewer / Aaron's machine)

No automated test was added for the `.env → worker starts` path: the check lives at module top-level and exercising it would require resetting Bun's module cache or spawning a subprocess per case. Given launch timing and the minimality of the fix, a manual smoke is the right gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)