### PR TITLE
feat: bind loopback by default + --scope flag for tokens create

### DIFF
--- a/docs/auth-model.md
+++ b/docs/auth-model.md
@@ -98,18 +98,25 @@ today (per-vault narrowing is a future phase).
 **CLI:**
 
 ```
-parachute vault tokens create                  # full-access token, default vault
-parachute vault tokens create --read           # vault:read only
-parachute vault tokens create --vault <name>   # target a specific vault
-parachute vault tokens create --label <label>  # label for the `tokens list` output
-parachute vault tokens create --expires 30d    # optional TTL (h/d/w/m/y)
-parachute vault tokens list                    # list across all vaults (shows t_<prefix> IDs, never the plaintext)
-parachute vault tokens revoke <t_…>            # delete by display ID or full hash
+parachute vault tokens create                         # full-access token, default vault
+parachute vault tokens create --read                  # vault:read only (shorthand for --scope vault:read)
+parachute vault tokens create --scope vault:write     # narrow to a specific scope
+parachute vault tokens create --scope vault:read,vault:write
+                                                      # comma-separated or repeated --scope
+parachute vault tokens create --vault <name>          # target a specific vault
+parachute vault tokens create --label <label>         # label for the `tokens list` output
+parachute vault tokens create --expires 30d           # optional TTL (h/d/w/m/y)
+parachute vault tokens list                           # list across all vaults (shows t_<prefix> IDs, never the plaintext)
+parachute vault tokens revoke <t_…>                   # delete by display ID or full hash
 ```
 
-A CLI-created token without `--read` gets the full scope set
-(`vault:read vault:write vault:admin`). There is no finer-grained
-`--scope` flag today.
+With no narrowing flag, a CLI-created token gets the full scope set
+(`vault:read vault:write vault:admin`) — unchanged for back-compat.
+`--scope` accepts any combination of `vault:read`, `vault:write`, and
+`vault:admin`; unrecognized scopes are rejected up front so a token is
+never minted with a scope the server can't enforce. `--scope` and
+`--read` cannot be combined (that ambiguity fails loudly rather than
+silently picking one).
 
 ### Legacy: YAML `api_keys` and `X-API-Key`
 
@@ -223,72 +230,77 @@ Then, in the client:
 ### Path B: "I want a script or agent to use this"
 
 ```
-parachute vault tokens create                   # full-access token in default vault
-parachute vault tokens create --read            # read-only
-parachute vault tokens create --vault <name>    # specific vault
-parachute vault tokens create --expires 30d     # with TTL
+parachute vault tokens create                            # full-access token in default vault
+parachute vault tokens create --read                     # read-only (shorthand for --scope vault:read)
+parachute vault tokens create --scope vault:write        # write-only token
+parachute vault tokens create --scope vault:read,vault:admin
+                                                         # combine scopes with a comma
+parachute vault tokens create --vault <name>             # specific vault
+parachute vault tokens create --expires 30d              # with TTL
 ```
 
 The command prints the plaintext `pvt_…` once. Put it in the client's
 `Authorization: Bearer <token>` header (or `X-API-Key`, or `?key=`).
 Revoke with `parachute vault tokens revoke <t_…>`.
 
-There is no `--scope vault:write` flag today — the choice is
-`--read` (→ `vault:read`) or default (→ `vault:read vault:write vault:admin`).
-Finer scoping is a future addition.
+The default (no narrowing flag) still mints a full-scope token. Pick a
+`--scope` to reduce blast radius; combining `--scope` with `--read` is
+an error (see §1 "API tokens").
 
 ## 4. Default exposure posture
 
-The Bun server is started with `hostname: "0.0.0.0"`
-(`src/server.ts`) — it accepts connections on every interface the host
-exposes. In practice on a laptop that means:
+The Bun server binds **`127.0.0.1`** by default (`src/server.ts`,
+resolved via `src/bind.ts`). The socket itself only accepts connections
+arriving on the loopback interface — LAN and public interfaces are not
+reachable unless the operator opts in. The startup log echoes the
+resolved hostname (`Parachute Vault server listening on
+http://127.0.0.1:1940`) so the bind is always visible.
 
-- **Loopback (`127.0.0.1:1940`)** always reachable — this is what the
-  CLI, MCP clients, and local scripts hit.
-- **LAN interfaces** — reachable from the local network unless the OS
-  firewall blocks inbound on port 1940. macOS prompts the first time an
-  unsigned binary accepts incoming connections; Linux is open by default.
-- **Public interfaces** — reachable from the internet if the host has a
-  public IP and nothing filters it.
+**Overriding the default**: set `VAULT_BIND` to bind a different
+interface. The two common reasons to override:
 
-The CLI copy ("Listening on http://0.0.0.0:1940") reflects this; it is
-not hardened to loopback at the socket level.
+- `VAULT_BIND=0.0.0.0` — accept traffic from every interface. Required
+  for **Docker bridge networking** (the container's virtual interface
+  isn't loopback from the server's perspective) and for intentional
+  **LAN setups** where another machine on the local network needs to
+  reach vault directly.
+- `VAULT_BIND=10.0.0.5` (or similar) — bind one specific interface IP
+  on a multi-homed host.
 
-**The auth model does not change when you run `parachute expose
-tailnet` or `parachute expose public`** (Tailscale, Cloudflare Tunnel,
-etc.). Those commands don't rewrite auth rules — they just change *which
-networks can attempt to reach* an already auth-gated server. Everything
-in §2 still applies: the bearer gate, the scope gate, the OAuth flow,
-the public-by-design endpoints. When you expose, the
-public-by-design endpoints (`/health`, `/vaults/list`,
+Empty or whitespace-only `VAULT_BIND` is treated as unset.
+
+**Supported remote-access paths are unaffected by the loopback
+default.** `parachute expose tailnet` (Tailscale Serve) and `parachute
+expose public` (Cloudflare Tunnel) both proxy *from* loopback — they
+connect to `127.0.0.1:1940` on the local host and forward the decrypted
+traffic in. Neither needs `VAULT_BIND` set. The auth model does not
+change when you expose: those commands don't rewrite auth rules, they
+just change *which networks can attempt to reach* an already
+auth-gated server. Everything in §2 still applies — the bearer gate,
+the scope gate, the OAuth flow, the public-by-design endpoints. When
+you expose, the public-by-design endpoints (`/health`, `/vaults/list`,
 `/.well-known/*`, OAuth discovery, `/.parachute/info`,
-`/.parachute/icon.svg`, `/.parachute/config/schema`,
-published notes at `/view/…`) become reachable from wherever you
-exposed to. Treat that as part of the threat model, not as a bug.
-
-If a deployment truly needs loopback-only, bind the daemon to
-`127.0.0.1` at the process manager level (a reverse proxy, a
-`127.0.0.1`-bound socket on a host that doesn't run Bun with
-`hostname`), or run behind a firewall.
+`/.parachute/icon.svg`, `/.parachute/config/schema`, published notes
+at `/view/…`) become reachable from wherever you exposed to. Treat
+that as part of the threat model, not as a bug.
 
 ## 5. Known rough edges
 
 Honest list. Things a user might trip over, or that the launch copy
 should be careful about.
 
-- **Server binds `0.0.0.0`, not `127.0.0.1`.** See §4. The
-  auth gate protects the data regardless, but don't describe vault as
-  "loopback-only" in marketing copy — it isn't at the socket level.
 - **OAuth does not strictly require an owner password.** If none is set,
   the consent page falls back to asking for a `pvt_…` vault token as
   proof of ownership. This works, but means the "launch flow" is still
   operable without ever running `set-password`. Recommended: require the
   password in docs, even though the server doesn't enforce it.
-- **CLI-created tokens default to full scope.** `parachute vault tokens
-  create` with no flags produces a token with
-  `vault:read vault:write vault:admin`. There is no middle ground today
-  (`--read` is the only narrowing flag). A user who wants a write-only
-  script token has to accept admin-level access.
+- **CLI-created tokens still default to full scope.** `parachute vault
+  tokens create` with no flags produces a token with
+  `vault:read vault:write vault:admin`, unchanged for back-compat.
+  Narrowing is now available via `--scope vault:read`, `--scope
+  vault:read,vault:write`, etc. (see §1 "API tokens") — the scriptwriter
+  who only wants write can now mint exactly that. The *default* is still
+  a footgun for users who don't know to narrow it.
 - **Tokens are per-vault, not vault-wide.** A token lives in one vault's
   SQLite DB. Exception: when presented to the unified `/mcp` endpoint
   (no vault in the URL), auth scans every vault's token table, so an

--- a/src/bind.test.ts
+++ b/src/bind.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "bun:test";
+import { resolveBindHostname } from "./bind.ts";
+
+describe("resolveBindHostname", () => {
+  test("defaults to 127.0.0.1 when VAULT_BIND is unset", () => {
+    expect(resolveBindHostname({})).toBe("127.0.0.1");
+  });
+
+  test("honors VAULT_BIND=0.0.0.0 for Docker / LAN", () => {
+    expect(resolveBindHostname({ VAULT_BIND: "0.0.0.0" })).toBe("0.0.0.0");
+  });
+
+  test("honors a specific interface IP in VAULT_BIND", () => {
+    expect(resolveBindHostname({ VAULT_BIND: "10.0.0.5" })).toBe("10.0.0.5");
+  });
+
+  test("treats empty VAULT_BIND as unset", () => {
+    expect(resolveBindHostname({ VAULT_BIND: "" })).toBe("127.0.0.1");
+  });
+
+  test("treats whitespace-only VAULT_BIND as unset", () => {
+    expect(resolveBindHostname({ VAULT_BIND: "   " })).toBe("127.0.0.1");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(resolveBindHostname({ VAULT_BIND: "  127.0.0.1  " })).toBe("127.0.0.1");
+  });
+});

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -1,0 +1,19 @@
+/**
+ * Resolve the hostname the HTTP server binds to.
+ *
+ * Default is `127.0.0.1` — loopback-only at the socket level. The auth gate
+ * protects vault data regardless, but listening only on loopback is a
+ * defense-in-depth default that matches the threat model in
+ * `docs/auth-model.md` §4. Supported remote-access paths (Tailscale Serve,
+ * Cloudflare Tunnel) proxy from loopback, so the default does not break any
+ * documented exposure path.
+ *
+ * Escape hatch: `VAULT_BIND`. Set to `0.0.0.0` for Docker bridge networking
+ * or an intentional LAN setup; set to a specific interface IP for
+ * multi-homed hosts. Empty/whitespace values are treated as unset.
+ */
+export function resolveBindHostname(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.VAULT_BIND?.trim();
+  if (override) return override;
+  return "127.0.0.1";
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,7 @@ import {
 import { confirm, ask, askPassword, choose } from "./prompt.ts";
 import { generateToken, createToken, listTokens, revokeToken, migrateVaultKeys } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
+import { parseScopeFlags, SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN } from "./scopes.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { upsertService, ServicesManifestError } from "./services-manifest.ts";
 import {
@@ -844,7 +845,8 @@ function cmdTokens(args: string[]) {
     return;
   }
 
-  // parachute-vault tokens create --vault <name> [--permission full|read]
+  // parachute-vault tokens create --vault <name>
+  //   [--scope vault:read,vault:write | --read | --permission full|read]
   //   [--expires <duration>] [--label <label>]
   if (subcmd === "create") {
     const vaultFlag = args.indexOf("--vault");
@@ -856,14 +858,34 @@ function cmdTokens(args: string[]) {
       process.exit(1);
     }
 
-    // --read shorthand or --permission full|read
+    // Precedence: --scope (most explicit) > --read shorthand > --permission (legacy) > default full.
+    // All three narrow from full; omit every flag to get the historical default.
+    const scopeResult = parseScopeFlags(args);
+    if (scopeResult.error) {
+      console.error(scopeResult.error);
+      process.exit(1);
+    }
     const isReadShorthand = args.includes("--read");
     const permFlag = args.indexOf("--permission");
-    const rawPerm = isReadShorthand ? "read" : (permFlag !== -1 ? args[permFlag + 1] : "full");
-    const permission: TokenPermission = rawPerm === "read" ? "read" : "full";
-    if (!["full", "read", "admin", "write"].includes(rawPerm)) {
+    const rawPerm = permFlag !== -1 ? args[permFlag + 1] : null;
+    if (rawPerm !== null && !["full", "read", "admin", "write"].includes(rawPerm)) {
       console.error(`Invalid permission: ${rawPerm}. Must be full or read.`);
       process.exit(1);
+    }
+
+    let scopes: string[] | undefined;
+    let permission: TokenPermission;
+    if (scopeResult.scopes) {
+      scopes = scopeResult.scopes;
+      // Map scopes → permission column for legacy readers. Any write/admin
+      // surface means the token can mutate, which is what "full" encodes.
+      permission = scopes.includes(SCOPE_WRITE) || scopes.includes(SCOPE_ADMIN) ? "full" : "read";
+    } else if (isReadShorthand) {
+      permission = "read";
+      scopes = [SCOPE_READ];
+    } else {
+      permission = rawPerm === "read" ? "read" : "full";
+      scopes = undefined; // token-store derives from permission
     }
 
     const expiresFlag = args.indexOf("--expires");
@@ -885,12 +907,15 @@ function cmdTokens(args: string[]) {
     createToken(store.db, fullToken, {
       label,
       permission,
+      scopes,
       expires_at: expiresAt,
     });
 
+    const displayScopes = scopes ?? [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN];
     console.log(`Created token for vault "${vaultName}":`);
     console.log(`  Token:      ${fullToken}`);
     console.log(`  Permission: ${permission}`);
+    console.log(`  Scopes:     ${displayScopes.join(" ")}`);
     if (expiresAt) console.log(`  Expires:    ${expiresAt}`);
     console.log(`  Label:      ${label}`);
     console.log();
@@ -2076,7 +2101,11 @@ Tokens:
   parachute-vault tokens                          List all tokens
   parachute-vault tokens create                   Create a full-access token in the default vault
   parachute-vault tokens create --vault <name>    Create a token in a specific vault
-  parachute-vault tokens create --read            Read-only token
+  parachute-vault tokens create --read            Read-only token (shorthand for --scope vault:read)
+  parachute-vault tokens create --scope vault:write
+                                                  Narrow the token's scopes. Accepts a comma-separated
+                                                  list or repeated --scope flags. Valid scopes:
+                                                  vault:read, vault:write, vault:admin.
   parachute-vault tokens create --label x         Set a label
   parachute-vault tokens create --expires 30d     Expiring token
   parachute-vault tokens revoke <token-id>        Revoke a token (default vault)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,7 +79,7 @@ import {
 import { confirm, ask, askPassword, choose } from "./prompt.ts";
 import { generateToken, createToken, listTokens, revokeToken, migrateVaultKeys } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
-import { parseScopeFlags, SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN } from "./scopes.ts";
+import { resolveCreateTokenFlags, VAULT_SCOPES } from "./scopes.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { upsertService, ServicesManifestError } from "./services-manifest.ts";
 import {
@@ -858,35 +858,17 @@ function cmdTokens(args: string[]) {
       process.exit(1);
     }
 
-    // Precedence: --scope (most explicit) > --read shorthand > --permission (legacy) > default full.
-    // All three narrow from full; omit every flag to get the historical default.
-    const scopeResult = parseScopeFlags(args);
-    if (scopeResult.error) {
-      console.error(scopeResult.error);
+    // Combining --scope / --read / --permission is always an error: a
+    // user minting a token expects exactly one narrowing signal, and
+    // silently picking one would mint the opposite of what the other
+    // reading intended. See resolveCreateTokenFlags.
+    const resolved = resolveCreateTokenFlags(args);
+    if (resolved.error) {
+      console.error(resolved.error);
       process.exit(1);
     }
-    const isReadShorthand = args.includes("--read");
-    const permFlag = args.indexOf("--permission");
-    const rawPerm = permFlag !== -1 ? args[permFlag + 1] : null;
-    if (rawPerm !== null && !["full", "read", "admin", "write"].includes(rawPerm)) {
-      console.error(`Invalid permission: ${rawPerm}. Must be full or read.`);
-      process.exit(1);
-    }
-
-    let scopes: string[] | undefined;
-    let permission: TokenPermission;
-    if (scopeResult.scopes) {
-      scopes = scopeResult.scopes;
-      // Map scopes → permission column for legacy readers. Any write/admin
-      // surface means the token can mutate, which is what "full" encodes.
-      permission = scopes.includes(SCOPE_WRITE) || scopes.includes(SCOPE_ADMIN) ? "full" : "read";
-    } else if (isReadShorthand) {
-      permission = "read";
-      scopes = [SCOPE_READ];
-    } else {
-      permission = rawPerm === "read" ? "read" : "full";
-      scopes = undefined; // token-store derives from permission
-    }
+    const scopes = resolved.scopes;
+    const permission: TokenPermission = resolved.permission;
 
     const expiresFlag = args.indexOf("--expires");
     let expiresAt: string | null = null;
@@ -911,7 +893,7 @@ function cmdTokens(args: string[]) {
       expires_at: expiresAt,
     });
 
-    const displayScopes = scopes ?? [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN];
+    const displayScopes = scopes ?? [...VAULT_SCOPES];
     console.log(`Created token for vault "${vaultName}":`);
     console.log(`  Token:      ${fullToken}`);
     console.log(`  Permission: ${permission}`);

--- a/src/scopes.test.ts
+++ b/src/scopes.test.ts
@@ -11,6 +11,7 @@ import {
   SCOPE_ADMIN,
   parseScopes,
   parseScopeFlags,
+  resolveCreateTokenFlags,
   hasScope,
   scopeForMethod,
   legacyPermissionToScopes,
@@ -192,6 +193,91 @@ describe("parseScopeFlags", () => {
     const result = parseScopeFlags(["--scope", ",,"]);
     expect(result.scopes).toBeNull();
     expect(result.error).toContain("empty");
+  });
+});
+
+describe("resolveCreateTokenFlags", () => {
+  test("no flags → full scope, full permission (historical default)", () => {
+    expect(resolveCreateTokenFlags([]))
+      .toEqual({ scopes: undefined, permission: "full", error: null });
+  });
+
+  test("--read alone → [vault:read], read permission", () => {
+    expect(resolveCreateTokenFlags(["--read"]))
+      .toEqual({ scopes: [SCOPE_READ], permission: "read", error: null });
+  });
+
+  test("--scope vault:read alone → read permission", () => {
+    expect(resolveCreateTokenFlags(["--scope", "vault:read"]))
+      .toEqual({ scopes: [SCOPE_READ], permission: "read", error: null });
+  });
+
+  test("--scope vault:write,vault:read → full permission (any write surface → full)", () => {
+    expect(resolveCreateTokenFlags(["--scope", "vault:write,vault:read"]))
+      .toEqual({ scopes: [SCOPE_WRITE, SCOPE_READ], permission: "full", error: null });
+  });
+
+  test("--scope vault:admin alone → full permission", () => {
+    expect(resolveCreateTokenFlags(["--scope", "vault:admin"]))
+      .toEqual({ scopes: [SCOPE_ADMIN], permission: "full", error: null });
+  });
+
+  test("--permission read → no scopes (token-store default), read permission", () => {
+    expect(resolveCreateTokenFlags(["--permission", "read"]))
+      .toEqual({ scopes: undefined, permission: "read", error: null });
+  });
+
+  test("--permission full → no scopes, full permission", () => {
+    expect(resolveCreateTokenFlags(["--permission", "full"]))
+      .toEqual({ scopes: undefined, permission: "full", error: null });
+  });
+
+  test("--scope + --read errors and mentions both flags", () => {
+    const result = resolveCreateTokenFlags(["--scope", "vault:write", "--read"]);
+    expect(result.scopes).toBeUndefined();
+    expect(result.error).toContain("--scope");
+    expect(result.error).toContain("--read");
+    expect(result.error).toContain("cannot be combined");
+  });
+
+  test("--scope + --permission errors", () => {
+    const result = resolveCreateTokenFlags(["--scope", "vault:read", "--permission", "full"]);
+    expect(result.scopes).toBeUndefined();
+    expect(result.error).toContain("--scope");
+    expect(result.error).toContain("--permission");
+    expect(result.error).toContain("cannot be combined");
+  });
+
+  test("--read + --permission errors", () => {
+    const result = resolveCreateTokenFlags(["--read", "--permission", "full"]);
+    expect(result.scopes).toBeUndefined();
+    expect(result.error).toContain("--read");
+    expect(result.error).toContain("--permission");
+    expect(result.error).toContain("cannot be combined");
+  });
+
+  test("invalid --permission value errors with prefer-scope hint", () => {
+    const result = resolveCreateTokenFlags(["--permission", "admin"]);
+    expect(result.scopes).toBeUndefined();
+    expect(result.error).toContain("admin");
+    expect(result.error).toContain("full");
+    expect(result.error).toContain("read");
+    expect(result.error).toContain("--scope");
+  });
+
+  test("--permission with no value errors", () => {
+    expect(resolveCreateTokenFlags(["--permission"]).error).toContain("requires a value");
+    expect(resolveCreateTokenFlags(["--permission", "--label", "x"]).error).toContain("requires a value");
+  });
+
+  test("surfaces parseScopeFlags errors unchanged", () => {
+    const result = resolveCreateTokenFlags(["--scope", "vault:frob"]);
+    expect(result.error).toContain("Unknown scope");
+  });
+
+  test("ignores unrelated flags", () => {
+    const result = resolveCreateTokenFlags(["--vault", "journal", "--label", "r", "--read"]);
+    expect(result).toEqual({ scopes: [SCOPE_READ], permission: "read", error: null });
   });
 });
 

--- a/src/scopes.test.ts
+++ b/src/scopes.test.ts
@@ -10,6 +10,7 @@ import {
   SCOPE_WRITE,
   SCOPE_ADMIN,
   parseScopes,
+  parseScopeFlags,
   hasScope,
   scopeForMethod,
   legacyPermissionToScopes,
@@ -120,6 +121,77 @@ describe("legacyPermissionToScopes", () => {
     expect(legacyPermissionToScopes("full")).toEqual([SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN]);
     expect(legacyPermissionToScopes("admin")).toEqual([SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN]);
     expect(legacyPermissionToScopes("write")).toEqual([SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN]);
+  });
+});
+
+describe("parseScopeFlags", () => {
+  test("returns null scopes when --scope is absent", () => {
+    expect(parseScopeFlags([])).toEqual({ scopes: null, error: null });
+    expect(parseScopeFlags(["--vault", "default", "--label", "x"]))
+      .toEqual({ scopes: null, error: null });
+  });
+
+  test("single --scope with one value", () => {
+    expect(parseScopeFlags(["--scope", "vault:read"]))
+      .toEqual({ scopes: [SCOPE_READ], error: null });
+  });
+
+  test("single --scope with comma-separated values", () => {
+    expect(parseScopeFlags(["--scope", "vault:read,vault:write"]))
+      .toEqual({ scopes: [SCOPE_READ, SCOPE_WRITE], error: null });
+  });
+
+  test("repeated --scope flags", () => {
+    expect(parseScopeFlags(["--scope", "vault:read", "--scope", "vault:write"]))
+      .toEqual({ scopes: [SCOPE_READ, SCOPE_WRITE], error: null });
+  });
+
+  test("dedupes while preserving first-occurrence order", () => {
+    expect(parseScopeFlags(["--scope", "vault:write,vault:read,vault:write"]))
+      .toEqual({ scopes: [SCOPE_WRITE, SCOPE_READ], error: null });
+  });
+
+  test("trims whitespace around each scope", () => {
+    expect(parseScopeFlags(["--scope", "  vault:read ,  vault:write  "]))
+      .toEqual({ scopes: [SCOPE_READ, SCOPE_WRITE], error: null });
+  });
+
+  test("rejects unknown scopes with a helpful error", () => {
+    const result = parseScopeFlags(["--scope", "vault:frob"]);
+    expect(result.scopes).toBeNull();
+    expect(result.error).toContain("Unknown scope");
+    expect(result.error).toContain("vault:frob");
+    expect(result.error).toContain("vault:read, vault:write, vault:admin");
+  });
+
+  test("rejects a mixed list with one invalid scope", () => {
+    const result = parseScopeFlags(["--scope", "vault:read,admin"]);
+    expect(result.scopes).toBeNull();
+    expect(result.error).toContain("admin");
+  });
+
+  test("rejects --scope with no value (end of argv)", () => {
+    const result = parseScopeFlags(["--scope"]);
+    expect(result.scopes).toBeNull();
+    expect(result.error).toContain("--scope requires a value");
+  });
+
+  test("rejects --scope followed by another flag", () => {
+    const result = parseScopeFlags(["--scope", "--label", "x"]);
+    expect(result.scopes).toBeNull();
+    expect(result.error).toContain("--scope requires a value");
+  });
+
+  test("rejects --scope with an empty value", () => {
+    const result = parseScopeFlags(["--scope", ""]);
+    expect(result.scopes).toBeNull();
+    expect(result.error).toContain("empty");
+  });
+
+  test("rejects --scope with only commas", () => {
+    const result = parseScopeFlags(["--scope", ",,"]);
+    expect(result.scopes).toBeNull();
+    expect(result.error).toContain("empty");
   });
 });
 

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -160,3 +160,94 @@ export function parseScopeFlags(
   }
   return { scopes: deduped, error: null };
 }
+
+/**
+ * Resolve `parachute vault tokens create` argv into a concrete scope set +
+ * legacy `permission` column value, or an actionable error.
+ *
+ * Precedence is **exclusive**: `--scope`, `--read`, and `--permission` all
+ * narrow the token, but combining them is always an error — a user who
+ * writes `--scope vault:write --read` almost certainly expects one of the
+ * two to win, and silently picking would mint the opposite of what at
+ * least one reading intended. Fail loud for anything token-minting.
+ *
+ * With no narrowing flag, falls back to a full-scope token for back-compat.
+ */
+export function resolveCreateTokenFlags(args: string[]): {
+  scopes: string[] | undefined;
+  permission: "full" | "read";
+  error: string | null;
+} {
+  const scopeResult = parseScopeFlags(args);
+  if (scopeResult.error) {
+    return { scopes: undefined, permission: "full", error: scopeResult.error };
+  }
+  const hasScopeFlag = scopeResult.scopes !== null;
+  const hasReadFlag = args.includes("--read");
+  const permIdx = args.indexOf("--permission");
+  const hasPermFlag = permIdx !== -1;
+
+  if (hasScopeFlag && hasReadFlag) {
+    return {
+      scopes: undefined,
+      permission: "full",
+      error:
+        "--scope and --read cannot be combined. Pick one:\n" +
+        "  --read                     # shorthand for --scope vault:read\n" +
+        "  --scope vault:read         # equivalent, explicit\n" +
+        "  --scope vault:write        # write scope",
+    };
+  }
+  if (hasScopeFlag && hasPermFlag) {
+    return {
+      scopes: undefined,
+      permission: "full",
+      error:
+        "--scope and --permission cannot be combined. --scope is the canonical way to narrow a token; --permission is legacy.",
+    };
+  }
+  if (hasReadFlag && hasPermFlag) {
+    return {
+      scopes: undefined,
+      permission: "full",
+      error: "--read and --permission cannot be combined. --read is a shorthand for --permission read.",
+    };
+  }
+
+  if (hasPermFlag) {
+    const rawPerm = args[permIdx + 1];
+    if (!rawPerm || rawPerm.startsWith("--")) {
+      return {
+        scopes: undefined,
+        permission: "full",
+        error: `--permission requires a value ("full" or "read"). Prefer --scope for new scripts.`,
+      };
+    }
+    if (!["full", "read"].includes(rawPerm)) {
+      return {
+        scopes: undefined,
+        permission: "full",
+        error: `Invalid --permission: ${rawPerm}. Must be "full" or "read". Prefer --scope for new scripts.`,
+      };
+    }
+  }
+
+  if (scopeResult.scopes) {
+    const scopes = scopeResult.scopes;
+    const permission: "full" | "read" =
+      scopes.includes(SCOPE_WRITE) || scopes.includes(SCOPE_ADMIN) ? "full" : "read";
+    return { scopes, permission, error: null };
+  }
+  if (hasReadFlag) {
+    return { scopes: [SCOPE_READ], permission: "read", error: null };
+  }
+  if (hasPermFlag) {
+    const rawPerm = args[permIdx + 1];
+    return {
+      scopes: undefined,
+      permission: rawPerm === "read" ? "read" : "full",
+      error: null,
+    };
+  }
+  return { scopes: undefined, permission: "full", error: null };
+}

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -103,3 +103,60 @@ export function legacyPermissionToScopes(permission: string): string[] {
 export function serializeScopes(scopes: string[]): string {
   return scopes.join(" ");
 }
+
+/**
+ * Parse `--scope` flag values from an argv list into a validated scope list.
+ *
+ * Accepts repeatable `--scope vault:read --scope vault:write` and
+ * comma-separated `--scope vault:read,vault:write` (and a mix of the two).
+ * Scopes are validated against `VAULT_SCOPES` — we refuse to mint a token
+ * with a scope the server has no way to enforce.
+ *
+ * Return shape: `{scopes}` is `null` when no `--scope` appears anywhere, so
+ * the caller can distinguish "flag not set" from "flag set to empty." On
+ * validation failure, `error` is a human-readable message suitable for
+ * `console.error` + `process.exit(1)`.
+ */
+export function parseScopeFlags(
+  args: string[],
+): { scopes: string[] | null; error: string | null } {
+  const validList = VAULT_SCOPES.join(", ");
+  const raw: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== "--scope") continue;
+    const val = args[i + 1];
+    if (val === undefined || val.startsWith("--")) {
+      return { scopes: null, error: `--scope requires a value. Valid scopes: ${validList}` };
+    }
+    raw.push(val);
+    i++;
+  }
+  if (raw.length === 0) return { scopes: null, error: null };
+
+  const expanded = raw
+    .flatMap((v) => v.split(","))
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (expanded.length === 0) {
+    return { scopes: null, error: `--scope value was empty. Valid scopes: ${validList}` };
+  }
+
+  const validSet = new Set<string>(VAULT_SCOPES);
+  const invalid = expanded.filter((s) => !validSet.has(s));
+  if (invalid.length > 0) {
+    return {
+      scopes: null,
+      error: `Unknown scope(s): ${invalid.join(", ")}. Valid scopes: ${validList}`,
+    };
+  }
+
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const s of expanded) {
+    if (!seen.has(s)) {
+      seen.add(s);
+      deduped.push(s);
+    }
+  }
+  return { scopes: deduped, error: null };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import { route } from "./routing.ts";
 import { startTranscriptionWorker, registerTranscriptionHook, type TranscriptionWorker } from "./transcription-worker.ts";
 import { assetsDir } from "./routes.ts";
 import { resolveScribeAuthToken } from "./scribe-env.ts";
+import { resolveBindHostname } from "./bind.ts";
 
 // Register webhook triggers from global config. Replaces the old hardcoded
 // tts-hook and transcription-hook with config-driven webhooks.
@@ -169,10 +170,11 @@ for (const vaultName of listVaults()) {
 
 const globalConfig = readGlobalConfig();
 const port = parseInt(process.env.PORT ?? "") || globalConfig.port || DEFAULT_PORT;
+const hostname = resolveBindHostname();
 
 const server = Bun.serve({
   port,
-  hostname: "0.0.0.0",
+  hostname,
   idleTimeout: 120, // seconds — webhook triggers can take a while
   async fetch(req, server) {
     const url = new URL(req.url);
@@ -218,7 +220,7 @@ const server = Bun.serve({
   },
 });
 
-console.log(`Parachute Vault server listening on http://0.0.0.0:${server.port}`);
+console.log(`Parachute Vault server listening on http://${hostname}:${server.port}`);
 
 // Graceful shutdown — best-effort drain of in-flight note-mutation hooks.
 async function shutdown(signal: string): Promise<void> {


### PR DESCRIPTION
Two narrow fixes from the recent auth-model audit (see [`docs/auth-model.md`](../blob/main/docs/auth-model.md) §5, landed as #161). One PR, two commits for bisectability.

## Summary

- **Default bind to `127.0.0.1`** — honest loopback-only at the socket level, with `VAULT_BIND` as an escape hatch for Docker / LAN setups. Log line echoes the resolved hostname.
- **`--scope` flag on `tokens create`** — accept `vault:read`, `vault:write`, `vault:admin` (comma-separated or repeated). Reject unknown scopes up front. `--read` kept as a shorthand; default (no flag) unchanged.

## Why

Both items were listed in `docs/auth-model.md` §5 as rough edges the launch copy had to work around:

> **Server binds `0.0.0.0`, not `127.0.0.1`.** The auth gate protects the data regardless, but don't describe vault as "loopback-only" in marketing copy — it isn't at the socket level.

> **CLI-created tokens default to full scope.** There is no middle ground today (`--read` is the only narrowing flag). A user who wants a write-only script token has to accept admin-level access.

The historical reason for binding `0.0.0.0` (exposing vault via Tailscale by letting it listen on every interface) is obsolete — `parachute expose` uses Tailscale Serve / Cloudflare Tunnel, and both proxy *from* loopback. `127.0.0.1` breaks no supported exposure path.

## Migration

Users running vault on a non-Tailscale, non-Tunnel LAN setup — e.g. pointing nginx / Caddy at `localhost:1940` *from another machine* — will see their setup stop working until they set `VAULT_BIND=0.0.0.0`. This is a behavior change on the bind side; mention in release notes.

OAuth-minted tokens are unchanged (consent page still mints the full set, or read-only per the radio button). This PR only adds a new knob to `parachute vault tokens create`.

## Test plan

- [x] `bun test src/` — 814 pass, 0 fail
- [x] `bunx tsc --noEmit` — no new errors (384 total, same as main)
- [x] Manual smoke test of each `tokens create` flag combination (no flag / `--read` / `--scope vault:read` / `--scope vault:read,vault:write` / `--scope invalid`) against a sandbox `PARACHUTE_HOME` — all behave correctly
- [ ] Reviewer: verify the bind-change note lands in release notes / migration docs before the next release cut

## Out of scope

- Changing the default token scope (stays "full" for back-compat; this PR only adds narrowing)
- Rate-limiting on bearer-token endpoints (auth-model finding #3, parked)
- Requiring owner password before OAuth (auth-model finding #2, parked)