### PR TITLE
fix(cli): honor VAULT_BIND in init/status display strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,7 @@ import {
   resolveServerPath,
 } from "./daemon.ts";
 import { confirm, ask, askPassword, choose } from "./prompt.ts";
+import { resolveBindHostname } from "./bind.ts";
 import { generateToken, createToken, listTokens, revokeToken, migrateVaultKeys } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
 import { resolveCreateTokenFlags, VAULT_SCOPES } from "./scopes.ts";
@@ -347,7 +348,8 @@ async function cmdInit(args: string[] = []) {
     console.log(`  Server path:  ${serverPath}`);
     console.log(`  Wrapper:      ~/.parachute/vault/start.sh`);
   }
-  console.log(`  Listening on http://0.0.0.0:${globalConfig.port || DEFAULT_PORT}`);
+  const bindHost = resolveBindHostname(process.env);
+  console.log(`  Listening on http://${bindHost}:${globalConfig.port || DEFAULT_PORT}`);
 
   // 7. Install MCP for Claude Code (with token for auth) — user confirms
   // unless --mcp / --no-mcp explicitly passed. Writing to ~/.claude.json
@@ -384,7 +386,7 @@ async function cmdInit(args: string[] = []) {
   }
 
   console.log(`\nConfig:   ${CONFIG_DIR}`);
-  console.log(`Server:   http://0.0.0.0:${port}`);
+  console.log(`Server:   http://${bindHost}:${port}`);
 
   console.log(`\nUsage examples:`);
   console.log(`  curl http://localhost:${port}/health`);


### PR DESCRIPTION
## Summary

PR #162 flipped the actual bind default to `127.0.0.1`, but two hardcoded `http://0.0.0.0:` strings in `cmdInit` output remained — users running \`parachute install vault\` saw \`Listening on http://0.0.0.0:1940\` even though the server was bound to loopback. That directly contradicts the install guide's loopback-by-default security claim.

Launching today; fixing the display lie before users eyeball it.

## Changes

- Import \`resolveBindHostname\` in \`src/cli.ts\` (same helper \`src/server.ts\` uses)
- Compute \`bindHost\` once at the top of the post-install block, reuse in both log lines
- Users who set \`VAULT_BIND=0.0.0.0\` (Docker bridge, intentional LAN) still see a correct string
- Patch bump: \`package.json\` \`0.3.0\` → \`0.3.1\` (display-only fix, no behavior change)

## Before / after

Default (no \`VAULT_BIND\`):

```
# before
  Listening on http://0.0.0.0:1940
Server:   http://0.0.0.0:1940

# after
  Listening on http://127.0.0.1:1940
Server:   http://127.0.0.1:1940
```

With \`VAULT_BIND=0.0.0.0\` set:

```
# after
  Listening on http://0.0.0.0:1940
Server:   http://0.0.0.0:1940
```

## Test plan

- [x] \`bun test src/bind.test.ts\` — 6 pass, resolver contract intact
- [x] \`grep -n '0\.0\.0\.0' src/\` — only remaining hits are the \`bind.ts\` doc comment and the \`bind.test.ts\` test case (both correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)