### PR TITLE
chore(launch): README reshape + no-password-on-init + MCP-client-aware summary + password echo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Parachute Vault is a self-hosted knowledge graph that any AI can read and write, over the open [MCP](https://modelcontextprotocol.io) protocol.** Your notes, tags, links, and attachments live on your machine — in plain SQLite databases under `~/.parachute/`, not in a vendor's cloud.
 
-Works with Claude, ChatGPT, Gemini, or any future MCP-capable AI. Switch tools without losing your knowledge. No vendor lock-in, no re-import step when the next model lands. One command to install; one OAuth consent to connect each AI client.
+Today it works with **Claude Code, Codex, Goose, OpenCode, and any other local MCP client** — same endpoint, your vault. Claude Code auto-wires on install; for the rest, point them at `http://127.0.0.1:1940/vault/default/mcp`.
+
+Web AI connectors — **claude.ai**, **ChatGPT**, and **Gemini** — are coming in the next few weeks. Switch tools, keep your knowledge. No vendor lock-in, no re-import step when the next model lands.
 
 ## Quick start
 
@@ -20,7 +22,7 @@ bun install
 bun src/cli.ts vault init
 ```
 
-`vault init` creates a vault, generates an API key, starts a background daemon (launchd on Mac, systemd on Linux), and configures Claude Code's MCP — all in one command. Your API key is printed once at init; save it for connecting from other tools.
+`vault init` creates a vault, generates an API key, starts a background daemon (launchd on Mac, systemd on Linux), and configures Claude Code's MCP — all in one command. Start a new Claude Code session and your vault's tools show up. For other local MCP clients (Codex, Goose, OpenCode, Cursor, Zed, Cline, your own agent), point them at `http://127.0.0.1:1940/vault/default/mcp` — the API key is printed once at init; save it for anything that isn't Claude Code.
 
 For remote access from Claude Desktop or mobile apps, see [Deployment](#deployment) below.
 
@@ -90,9 +92,9 @@ The daemon binds `0.0.0.0:1940` (or whatever you set in `PORT`) and serves REST,
 
 The `pvt_...` token printed at init is the one baked into `~/.claude.json`. It's not stored anywhere retrievable — save it if you need it for `curl`, cron, or any other script. Lost it? Just mint a new one: `parachute-vault tokens create`. Tokens are SHA-256 hashed at rest in each vault's `vault.db`.
 
-### Owner password prompt
+### Owner password (for OAuth, coming soon)
 
-Init pauses for one interactive prompt: "Set an owner password for OAuth consent?" The password is what the consent page asks for when Claude Desktop / Parachute Daily / any browser-OAuth client connects. You can skip it and set it later with `parachute-vault set-password`; without it, the consent page falls back to pasting a vault token. See [Connecting a client → Owner password](#owner-password-needed-for-oauth).
+`vault init` doesn't prompt for an owner password — the password is only needed for OAuth consent, which is what browser-based clients (claude.ai, ChatGPT, Claude Desktop) use, and those paths are coming in the next few weeks. When you're ready to expose the vault publicly, set one with `parachute-vault set-password` (and optionally `parachute-vault 2fa enroll`). See [Connecting a client → Owner password](#owner-password-needed-for-oauth).
 
 ## Connecting a client
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -325,9 +325,16 @@ async function cmdInit(args: string[] = []) {
     console.log();
   }
 
-  // 5b. Offer to set an owner password for OAuth consent, unless one is already set.
+  // 5b. Owner password is only needed for OAuth consent (browser-based
+  // clients like claude.ai / ChatGPT / Claude Desktop). Those paths are
+  // coming in the next few weeks; until then, skip the prompt. Users who
+  // want to expose the vault publicly today can set one manually via
+  // `parachute-vault set-password`.
   if (!hasOwnerPassword()) {
-    await promptForOwnerPassword("Set an owner password for OAuth consent?");
+    console.log();
+    console.log("Public exposure + web-AI connectors (claude.ai, ChatGPT, etc.) are coming soon.");
+    console.log("  When you're ready to expose this vault publicly, run:");
+    console.log("    parachute-vault set-password    # required for OAuth consent");
   }
 
   // 6. Install daemon (platform-aware). Idempotent — safe to re-run after
@@ -394,9 +401,23 @@ async function cmdInit(args: string[] = []) {
     console.log(`  curl -H "Authorization: Bearer ${apiKey}" http://localhost:${port}/api/notes`);
   }
 
+  const defaultVault = globalConfig.default_vault ?? "default";
+  const mcpUrl = `http://127.0.0.1:${port}/vault/${defaultVault}/mcp`;
   console.log(`\nNext steps:`);
-  console.log(`  parachute-vault status            check everything is running`);
-  console.log(`  parachute-vault config             view/edit configuration`);
+  if (addMcp) {
+    console.log(`  - Start a new Claude Code session — your Vault is already wired in. Try:`);
+    console.log(`      claude "Help me set up my parachute vault"`);
+    console.log(`  - Or point any other local MCP client (Codex, Goose, OpenCode, Cursor,`);
+    console.log(`    Zed, Cline, your own agent) at:`);
+    console.log(`      ${mcpUrl}`);
+  } else {
+    console.log(`  - Point any local MCP client (Codex, Goose, OpenCode, Cursor, Zed,`);
+    console.log(`    Cline, your own agent) at:`);
+    console.log(`      ${mcpUrl}`);
+    console.log(`  - Or add Claude Code back anytime:  parachute-vault mcp-install`);
+  }
+  console.log(`  - Check status:     parachute-vault status`);
+  console.log(`  - Edit config:      parachute-vault config`);
 }
 
 async function promptForOwnerPassword(purpose: string): Promise<boolean> {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -74,35 +74,51 @@ export async function askPassword(question: string): Promise<string> {
       }
     };
 
+    // Batch visible output per data event. On Bun 1.2.x, per-char writes
+    // can appear in bursts (keystrokes echoing late or out of order);
+    // coalescing to a single write per data event keeps the visible
+    // stream in lock-step with the captured input.
     const onData = (data: string) => {
       try {
+        let toWrite = "";
+        let done = false;
+        let aborted = false;
         for (const ch of data) {
           // Enter — done
           if (ch === "\r" || ch === "\n") {
-            process.stdout.write("\n");
-            cleanup();
-            resolve(buf);
-            return;
+            done = true;
+            break;
           }
           // Ctrl-C — abort
           if (ch === "\u0003") {
-            process.stdout.write("\n");
-            cleanup();
-            process.exit(130);
+            aborted = true;
+            break;
           }
           // Backspace / DEL
           if (ch === "\u0008" || ch === "\u007f") {
             if (buf.length > 0) {
               buf = buf.slice(0, -1);
-              process.stdout.write("\b \b");
+              toWrite += "\b \b";
             }
             continue;
           }
           // Printable
           if (ch >= " ") {
             buf += ch;
-            process.stdout.write("*");
+            toWrite += "*";
           }
+        }
+        if (toWrite) process.stdout.write(toWrite);
+        if (done) {
+          process.stdout.write("\n");
+          cleanup();
+          resolve(buf);
+          return;
+        }
+        if (aborted) {
+          process.stdout.write("\n");
+          cleanup();
+          process.exit(130);
         }
       } catch (err) {
         cleanup();


### PR DESCRIPTION
## Why

Launch positioning has shifted: **Claude Code is today's hero, other local MCP clients (Codex, Goose, OpenCode, Cursor, Zed, Cline) are first-class alongside it, and claude.ai / ChatGPT / Gemini web connectors are coming in the next few weeks**. Vault's install UX still reads like the old world — README promises "one OAuth consent to connect each AI client," init prompts for an OAuth password users don't need yet, and the end-of-init summary doesn't name the endpoint a launch user's non-Claude-Code agent should talk to. Four small, coupled fixes in one PR so 0.3.2 ships launch-aligned.

## What

- **README hero reshape (surgical).** Keeps the thesis (open knowledge graph, any MCP-capable AI, self-hosted, your data). Today's featured path is Claude Code + any other local MCP client at the same endpoint. claude.ai / ChatGPT / Gemini moved to "coming in the next few weeks" — matches site's `install.njk` "What comes next" section. Drops the over-promising "one OAuth consent" line. "Owner password prompt" subsection rewritten now that init no longer prompts.
- **`init`: skip the interactive owner-password prompt.** OAuth consent (the only thing the password is for) is what the coming-soon browser clients use; a launch user running Claude Code locally doesn't need it and doesn't know what OAuth consent is. Replaced with a short one-block nudge pointing at `parachute-vault set-password` for anyone who wants to expose publicly today. `cmdSetPassword` (the escape hatch) is unchanged.
- **`init` summary: Claude-Code-first / local-MCP-client-aware.** The old "Next steps" was two lines of zero help. New version steers the user at Claude Code if they said yes to MCP install, and at the `http://127.0.0.1:<port>/vault/<name>/mcp` URL + `mcp-install` hint if they said no — plus names the concrete other clients (Codex, Goose, OpenCode, Cursor, Zed, Cline) inline so nobody wonders what "local MCP client" means.
- **`askPassword`: batch the stdout writes per data event.** On Bun 1.2.x the old per-char `process.stdout.write("*")` / `"\b \b"` could appear in bursts, making users think keystrokes were being dropped (Aaron hit this today — capture was correct, echo was visually inconsistent). Coalesced to one write per `data` event; capture semantics for enter / ctrl-C / backspace / printable are preserved.

## Out of scope

- OAuth subsystem, vault API, MCP tools — untouched.
- No config-writing for third-party clients (Codex/Goose/OpenCode/etc.); PR only mentions them as "point your client at this URL." Writing third-party configs is an overreach we'll revisit when those clients' configs stabilize.
- No full README rewrite; hero + quick-start + one subsection only.

## Test plan

- [x] `bun test` — 828 pass, 3 skip, 0 fail
- [x] `bunx tsc --noEmit` — no new type errors introduced (383 pre-existing → 383)
- [x] Diff reviewed
- [ ] Smoke on a real `parachute-vault init` after merge to confirm the new summary renders clean in both yes-to-MCP and no-to-MCP branches
- [ ] Smoke the password prompt under Bun 1.2.x to confirm the echo is steady per keystroke

## Context

- Launch site's phrasing: [`parachute.computer/install.njk`](https://github.com/ParachuteComputer/parachute.computer/blob/main/install.njk) — "What comes next" section ("coming in the next couple of weeks of stabilization").
- Version bump: `0.3.1` → `0.3.2` — patch; UX polish + a terminal-echo fix, no API changes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)