### PR TITLE
feat(init): prompt for vault name (closes #167)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,7 @@ import { resolveBindHostname } from "./bind.ts";
 import { generateToken, createToken, listTokens, revokeToken, migrateVaultKeys } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
 import { resolveCreateTokenFlags, VAULT_SCOPES } from "./scopes.ts";
+import { validateVaultName, decideInitVaultName } from "./vault-name.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { upsertService, ServicesManifestError } from "./services-manifest.ts";
 import {
@@ -230,10 +231,25 @@ async function cmdInit(args: string[] = []) {
   // --token / --no-token follow the same pattern for whether the API
   // token is surfaced to the user at the end of init (for pasting into
   // other MCP clients, scripts, or curl).
+  //
+  // --vault-name <name> skips the name prompt for non-interactive installs
+  // (validated up front; exits non-zero on invalid input).
   const flagMcpOn = args.includes("--mcp");
   const flagMcpOff = args.includes("--no-mcp");
   const flagTokenOn = args.includes("--token");
   const flagTokenOff = args.includes("--no-token");
+
+  const nameDecision = decideInitVaultName(args, {
+    isTTY: !!process.stdin.isTTY,
+  });
+  if (nameDecision.kind === "error") {
+    console.error(nameDecision.message);
+    process.exit(1);
+  }
+  // Whether the user explicitly supplied --vault-name. We use this both to
+  // pick the chosen name on first init AND to print a friendly notice if
+  // they pass --vault-name on a re-run where vaults already exist.
+  const vaultNameFlagSupplied = args.indexOf("--vault-name") !== -1;
 
   const isMac = process.platform === "darwin";
   const isLinux = process.platform === "linux";
@@ -241,14 +257,23 @@ async function cmdInit(args: string[] = []) {
 
   console.log("Parachute Vault — self-hosted knowledge graph\n");
 
-  // 1. Create default vault if none exist
+  // 1. Create the vault if none exist. The name is decided here — flag wins,
+  // else prompt in a TTY (default "default"), else fall back to "default" so
+  // piped installs keep working unchanged.
   const vaults = listVaults();
   let apiKey: string | undefined;
   if (vaults.length === 0) {
-    console.log("Creating default vault...");
-    apiKey = createVault("default");
-    console.log("  Created vault: default");
+    const chosenName =
+      nameDecision.kind === "name" ? nameDecision.name : await promptVaultName();
+    console.log(`Creating vault "${chosenName}"...`);
+    apiKey = createVault(chosenName);
+    console.log(`  Created vault: ${chosenName}`);
   } else {
+    if (vaultNameFlagSupplied) {
+      console.log(
+        `  --vault-name ignored: ${vaults.length} vault(s) already exist. Use \`parachute-vault create\` to add another.`,
+      );
+    }
     console.log(`Found ${vaults.length} existing vault(s)`);
   }
 
@@ -433,6 +458,16 @@ async function cmdInit(args: string[] = []) {
     mcpUrl,
   });
   for (const line of lines) console.log(line);
+}
+
+
+async function promptVaultName(): Promise<string> {
+  while (true) {
+    const answer = await ask("What would you like to call this vault?", "default");
+    const v = validateVaultName(answer);
+    if (v.ok) return v.name;
+    console.log(`  ${v.error}`);
+  }
 }
 
 
@@ -2103,11 +2138,14 @@ data, and debugging.
 ── Standard use ───────────────────────────────────────────────────────
 
 Setup:
-  parachute-vault init [--mcp|--no-mcp] [--token|--no-token]
+  parachute-vault init [--mcp|--no-mcp] [--token|--no-token] [--vault-name <name>]
                                            Set up everything (one command, idempotent).
                                            --mcp/--no-mcp controls the Claude Code MCP entry;
                                            --token/--no-token controls whether an API token is
                                            printed for pasting into other MCP clients / scripts.
+                                           --vault-name skips the prompt and names the vault
+                                           (lowercase alphanumeric, hyphens, underscores;
+                                           omit to be prompted interactively, default "default").
   parachute-vault doctor                   Diagnose install/config issues
   parachute-vault uninstall [--wipe] [--yes]
                                            Remove daemon + MCP entry; --wipe also removes vaults, .env,

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration tests for `parachute-vault init` flag plumbing — the cases
+ * where init exits early without touching the daemon, ~/.claude.json, or
+ * the vault filesystem. The full happy-path of init isn't run here because
+ * it would install a launchd agent on macOS and write into the developer's
+ * real ~/Library/LaunchAgents — out of scope for unit tests. The vault-name
+ * decision logic is fully covered by `vault-name.test.ts`.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+
+const CLI = resolve(import.meta.dir, "cli.ts");
+
+function runCli(args: string[]): {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+} {
+  const proc = Bun.spawnSync({
+    cmd: ["bun", CLI, ...args],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+describe("vault init — --vault-name validation", () => {
+  test("rejects --vault-name with uppercase + space and exits non-zero", () => {
+    const { exitCode, stderr } = runCli(["init", "--vault-name", "My Vault"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--vault-name:");
+    expect(stderr).toContain("lowercase alphanumeric");
+  });
+
+  test("rejects --vault-name with a slash and exits non-zero", () => {
+    const { exitCode, stderr } = runCli(["init", "--vault-name", "team/work"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("lowercase alphanumeric");
+  });
+
+  test("rejects --vault-name with no value and exits non-zero", () => {
+    // `--vault-name` is the last arg → no value follows.
+    const { exitCode, stderr } = runCli(["init", "--vault-name"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("requires a value");
+  });
+
+  test("rejects reserved name 'list' and exits non-zero", () => {
+    const { exitCode, stderr } = runCli(["init", "--vault-name", "list"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("reserved");
+  });
+});
+
+describe("vault init — --help mentions --vault-name", () => {
+  test("usage text documents the new flag", () => {
+    const { exitCode, stdout } = runCli(["--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--vault-name");
+  });
+});

--- a/src/vault-name.test.ts
+++ b/src/vault-name.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for `validateVaultName` — the rule enforced by the `init`
+ * prompt and the `--vault-name` flag. Covers each rejection branch plus
+ * the happy paths the prompt has to accept (default, hyphens, underscores).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { validateVaultName, decideInitVaultName } from "./vault-name.ts";
+
+describe("validateVaultName", () => {
+  describe("accepts", () => {
+    test.each([
+      "default",
+      "aaron",
+      "personal",
+      "work",
+      "a",
+      "vault-1",
+      "my_vault",
+      "a-b_c-1",
+      "abc123",
+    ])("%s", (name) => {
+      const result = validateVaultName(name);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.name).toBe(name);
+    });
+
+    test("trims surrounding whitespace before validating", () => {
+      const result = validateVaultName("  aaron  ");
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.name).toBe("aaron");
+    });
+  });
+
+  describe("rejects", () => {
+    test("empty string", () => {
+      const result = validateVaultName("");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("empty");
+    });
+
+    test("whitespace-only", () => {
+      const result = validateVaultName("   ");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("empty");
+    });
+
+    test.each([
+      ["uppercase", "Aaron"],
+      ["mixed case", "MyVault"],
+      ["space inside", "my vault"],
+      ["slash", "team/work"],
+      ["dot", "vault.1"],
+      ["backslash", "team\\work"],
+      ["question mark", "vault?"],
+      ["hash", "vault#1"],
+      ["leading symbol disallowed by regex", "@aaron"],
+      ["unicode", "café"],
+    ])("%s (%s)", (_label, name) => {
+      const result = validateVaultName(name);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain(
+          "lowercase alphanumeric with hyphens or underscores",
+        );
+      }
+    });
+
+    test("reserved name 'list'", () => {
+      const result = validateVaultName("list");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("reserved");
+    });
+  });
+});
+
+describe("decideInitVaultName", () => {
+  test("--vault-name=aaron resolves to name 'aaron'", () => {
+    const d = decideInitVaultName(["--vault-name", "aaron"], { isTTY: true });
+    expect(d).toEqual({ kind: "name", name: "aaron" });
+  });
+
+  test("--vault-name=default preserves the existing default", () => {
+    const d = decideInitVaultName(["--vault-name", "default"], { isTTY: false });
+    expect(d).toEqual({ kind: "name", name: "default" });
+  });
+
+  test("--vault-name with no value errors out", () => {
+    const d = decideInitVaultName(["--vault-name"], { isTTY: true });
+    expect(d.kind).toBe("error");
+    if (d.kind === "error") expect(d.message).toContain("requires a value");
+  });
+
+  test("--vault-name=My Vault errors out (uppercase + space)", () => {
+    const d = decideInitVaultName(["--vault-name", "My Vault"], { isTTY: true });
+    expect(d.kind).toBe("error");
+    if (d.kind === "error") {
+      expect(d.message).toContain("--vault-name:");
+      expect(d.message).toContain("lowercase alphanumeric");
+    }
+  });
+
+  test("--vault-name=list errors out (reserved)", () => {
+    const d = decideInitVaultName(["--vault-name", "list"], { isTTY: true });
+    expect(d.kind).toBe("error");
+    if (d.kind === "error") expect(d.message).toContain("reserved");
+  });
+
+  test("no flag + non-TTY falls back to 'default' (piped install)", () => {
+    const d = decideInitVaultName(["--no-mcp"], { isTTY: false });
+    expect(d).toEqual({ kind: "name", name: "default" });
+  });
+
+  test("no flag + TTY signals the caller to prompt", () => {
+    const d = decideInitVaultName([], { isTTY: true });
+    expect(d).toEqual({ kind: "prompt" });
+  });
+
+  test("--vault-name with leading whitespace is trimmed and accepted", () => {
+    const d = decideInitVaultName(["--vault-name", "  aaron  "], { isTTY: true });
+    expect(d).toEqual({ kind: "name", name: "aaron" });
+  });
+});

--- a/src/vault-name.ts
+++ b/src/vault-name.ts
@@ -1,0 +1,80 @@
+/**
+ * Validation for vault names.
+ *
+ * Vault names appear in URLs (`/vault/<name>/mcp`, `/vault/<name>/api/*`),
+ * the SQLite filename, and the OAuth consent page — anything that breaks
+ * URL routing or filesystem assumptions has to be rejected up front.
+ *
+ * Used by the `init` prompt and the `--vault-name` flag. `cmdCreate` keeps
+ * its own (slightly more permissive, legacy) regex for backward compat —
+ * tightening it would reject names existing users may already have minted.
+ */
+
+const VAULT_NAME_RE = /^[a-z0-9_-]+$/;
+
+const RESERVED_NAMES = new Set([
+  // Collides with the `/vaults/list` discovery endpoint historically; the
+  // routes have since moved under `/vault/<name>/`, but `cmdCreate` still
+  // rejects "list" and consistency is cheap.
+  "list",
+]);
+
+export type VaultNameValidation =
+  | { ok: true; name: string }
+  | { ok: false; error: string };
+
+export function validateVaultName(raw: string): VaultNameValidation {
+  const name = raw.trim();
+  if (!name) {
+    return { ok: false, error: "vault name cannot be empty." };
+  }
+  if (!VAULT_NAME_RE.test(name)) {
+    return {
+      ok: false,
+      error:
+        "vault names must be lowercase alphanumeric with hyphens or underscores. Try again.",
+    };
+  }
+  if (RESERVED_NAMES.has(name)) {
+    return { ok: false, error: `"${name}" is a reserved vault name.` };
+  }
+  return { ok: true, name };
+}
+
+/**
+ * Decide what vault name `init` should use, based on `--vault-name` and
+ * whether we're attached to a TTY. Pure: extracted so the flag/TTY matrix
+ * can be unit-tested without spawning the CLI or touching the filesystem.
+ *
+ *   - flag present + valid → `{ kind: "name", name }`
+ *   - flag present + invalid (or missing value) → `{ kind: "error", message }`
+ *   - no flag, non-TTY → `{ kind: "name", name: "default" }` (piped install)
+ *   - no flag, TTY → `{ kind: "prompt" }` (caller runs an interactive prompt)
+ */
+export type VaultNameDecision =
+  | { kind: "name"; name: string }
+  | { kind: "prompt" }
+  | { kind: "error"; message: string };
+
+export function decideInitVaultName(
+  args: string[],
+  opts: { isTTY: boolean },
+): VaultNameDecision {
+  const idx = args.indexOf("--vault-name");
+  if (idx !== -1) {
+    const raw = args[idx + 1];
+    if (raw === undefined) {
+      return {
+        kind: "error",
+        message: "--vault-name requires a value, e.g. --vault-name aaron",
+      };
+    }
+    const v = validateVaultName(raw);
+    if (!v.ok) return { kind: "error", message: `--vault-name: ${v.error}` };
+    return { kind: "name", name: v.name };
+  }
+  if (!opts.isTTY) {
+    return { kind: "name", name: "default" };
+  }
+  return { kind: "prompt" };
+}


### PR DESCRIPTION
## Summary

Bumps to **0.3.4** — patch, additive UX, fully backward-compatible.

Today every fresh install gets a vault named `default`. The name shows up in the MCP URL (`/vault/default/mcp`), the SQLite filename, the OAuth consent page, and anywhere a vault is referenced by name in clients. A user with a vault named `aaron`, `personal`, or `work` reads as much more legible than `default` forever.

## Behavior

- **First-run TTY**: prompts `What would you like to call this vault? [default]`. Pressing enter keeps `default`; typing a name uses that name.
- **`--vault-name <name>`**: non-interactive override (validated up front; exits non-zero on invalid input or missing value). Mirrors `--mcp` / `--token`'s pattern.
- **Non-TTY, no flag**: uses `default`. Preserves existing piped-install behavior unchanged.
- **Re-init with existing vaults + `--vault-name`**: flag is ignored with a friendly notice. Renaming an existing vault is out of scope (involves migrating tokens, claude.json entries, etc.).

## Validation

New `src/vault-name.ts`:

- `validateVaultName` enforces lowercase alphanumeric + `-` + `_` (URL-safe).
- Empty after trim is rejected (with re-prompt at the prompt).
- Reserved names (today: `list`) are rejected.
- `decideInitVaultName(args, { isTTY })` is a pure helper that resolves the (flag, TTY) matrix into one of `{ kind: "name" | "prompt" | "error" }` — extracted so the matrix can be unit-tested without spawning the CLI.

`cmdCreate`'s legacy regex (which allows uppercase) is left alone for backward compatibility — tightening it would surprise users who minted mixed-case names before this PR.

## Threading

The chosen name flows through:

- `createVault(chosenName)` → SQLite filename + initial token.
- `globalConfig.default_vault` (set immediately after creation when only one vault exists).
- The services-manifest mount path (`/vault/<name>`).
- `installMcpConfig` (reads `default_vault` to compose the MCP URL written into `~/.claude.json`).
- `buildInitSummaryLines`'s `mcpUrl` (composed from `default_vault`).

No call sites had `"default"` hardcoded outside the bootstrap branch this PR replaces.

## Tests

- 23 unit tests for `validateVaultName` (accepts `default`/`aaron`/hyphens/underscores; rejects empty, uppercase, slashes, dots, unicode, `list`).
- 8 unit tests for `decideInitVaultName` (flag-supplied, missing value, invalid value, reserved name, no-flag-non-TTY default, no-flag-TTY prompt, whitespace trim).
- 5 spawn-based integration tests in `src/init.test.ts` for init's early-exit error paths (uppercase + space, slash, missing value, reserved name) and help-text documentation. Full happy-path init isn't run in tests because it installs a launchd agent on macOS.
- All previously-passing 848 tests still pass (+36 new = **884 / 884**).

## Test plan

- [x] `bun test` — 884 pass, 3 skip, 0 fail
- [x] `bunx tsc --noEmit` — no new errors introduced (pre-existing test-file errors unchanged)
- [x] `parachute-vault --help` shows `--vault-name` documentation
- [ ] Manual smoke (reviewer): fresh install with `--vault-name aaron` produces `/vault/aaron/mcp` in `~/.claude.json` and `~/.parachute/vault/aaron/`
- [ ] Manual smoke (reviewer): piped install (`curl … | sh` style, non-TTY) with no flag still produces `/vault/default/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)