### PR TITLE
feat(auth): dual-validate hub-issued JWTs alongside pvt_* tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
-## [0.3.5] — 2026-04-26
+## [0.3.6-rc.1] — 2026-04-26
+
+Vault becomes a pure OAuth resource server: hub-issued JWTs are now accepted alongside legacy `pvt_*` opaque tokens. RC track — promotion to `@latest` follows validation against a real hub.
+
+### Added
+
+- **Hub-issued JWT validation alongside `pvt_*` tokens.** Vault now dual-validates bearer tokens. Tokens whose first three characters are `eyJ` (the base64url encoding of a JWT header's `{"`) route through the new `src/hub-jwt.ts` validator: `jose.createRemoteJWKSet` fetches the hub's `/.well-known/jwks.json` (cached 5min, with a 30s cooldown between failed fetches), `jwtVerify` checks the RS256 signature and claims, and the `iss` claim MUST equal the configured hub origin — the load-bearing trust check that prevents anyone from minting a token against any RSA key. The hub origin comes from `PARACHUTE_HUB_ORIGIN` (set by the hub's `expose` / `start` flow when vault runs behind it) with a `http://127.0.0.1:1939` loopback fallback for dev. The JWT's `scope` claim becomes the granted scopes; `permission` is derived for back-compat with code paths that still branch on `permission` (MCP tool gating, view auth). Audience is parsed but accepted broadly today — the hub issues `aud="operator"` for operator tokens and `aud=<client_id>` for user OAuth tokens, both legitimate vault callers; tightening to a strict allow-list is reserved for the post-cli#59 scope-guard work. Existing `pvt_*` callers (CLI-created tokens, OAuth-minted access tokens, legacy YAML keys) continue to work unchanged — JWT-shaped tokens commit to JWT validation (no fallthrough to `pvt_*` lookup on failure, since a malformed JWT was never going to be a valid local token), and non-JWT tokens follow the existing per-vault DB → vault.yaml → config.yaml resolution chain. `legacyDerived` is `false` for JWT-issued scopes — they're explicit, never inferred. Companion to the hub's Phase B JWKS plumbing; together they make hub-as-issuer Phase B2 functional end-to-end.
+
+
 
 The rename-aware release. The upstream hub repo was renamed `parachute-cli` → `parachute-hub` and its npm package `@openparachute/cli` → `@openparachute/hub` on 2026-04-26; this release refreshes vault's docs and inline comments to match. No functional changes — `parachute-vault` binary, schemas, source code, and on-disk layout are unchanged. Promoted directly to `@latest` so new installs land on docs that match the current ecosystem naming.
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "parachute-vault",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode-terminal": "^0.12.0",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.5",
+  "version": "0.3.6-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode-terminal": "^0.12.0"
   },

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -83,7 +83,7 @@ function bearer(token: string): Request {
 }
 
 describe("auth — per-vault routing", () => {
-  test("token minted in a vault authenticates at its own /vault/<name>/* endpoints", () => {
+  test("token minted in a vault authenticates at its own /vault/<name>/* endpoints", async () => {
     seedVault("journal");
     const token = mintTokenInVault("journal");
     const journalConfig = readVaultConfig("journal")!;
@@ -91,44 +91,44 @@ describe("auth — per-vault routing", () => {
 
     // /vault/journal/api/* and /vault/journal/mcp both funnel into
     // authenticateVaultRequest with journal's config + DB.
-    const vaultAuth = authenticateVaultRequest(bearer(token), journalConfig, journalStore.db);
+    const vaultAuth = await authenticateVaultRequest(bearer(token), journalConfig, journalStore.db);
     expect("error" in vaultAuth).toBe(false);
     if (!("error" in vaultAuth)) expect(vaultAuth.permission).toBe("full");
 
     // /vaults (global metadata listing) uses authenticateGlobalRequest which
     // scans every vault's DB. Since the token is in journal's DB, it must resolve.
-    const global = authenticateGlobalRequest(bearer(token));
+    const global = await authenticateGlobalRequest(bearer(token));
     expect("error" in global).toBe(false);
   });
 
   // HTTP-level routing stand-in. Mirrors routing.ts: every vault-scoped path
   // matches `/vault/<name>/...`, we look the vault up, then authenticate the
   // request against that vault's DB.
-  function dispatchAuthFromPath(path: string, req: Request): {
+  async function dispatchAuthFromPath(path: string, req: Request): Promise<{
     status: number;
     permission?: string;
-  } {
+  }> {
     const match = path.match(/^\/vault\/([^/]+)(\/.*)?$/);
     if (!match) return { status: 404 };
-    const vaultName = match[1];
+    const vaultName = match[1]!;
     const vaultConfig = readVaultConfig(vaultName);
     if (!vaultConfig) return { status: 404 };
     const store = getVaultStore(vaultName);
-    const res = authenticateVaultRequest(req, vaultConfig, store.db);
+    const res = await authenticateVaultRequest(req, vaultConfig, store.db);
     if ("error" in res) return { status: res.error.status };
     return { status: 200, permission: res.permission };
   }
 
-  test("routing: /vault/<name>/api/health accepts a token minted in that vault", () => {
+  test("routing: /vault/<name>/api/health accepts a token minted in that vault", async () => {
     seedVault("journal");
     const token = mintTokenInVault("journal");
 
-    const result = dispatchAuthFromPath("/vault/journal/api/health", bearer(token));
+    const result = await dispatchAuthFromPath("/vault/journal/api/health", bearer(token));
     expect(result.status).toBe(200);
     expect(result.permission).toBe("full");
   });
 
-  test("routing: /vault/A/api/* rejects a token issued for vault B", () => {
+  test("routing: /vault/A/api/* rejects a token issued for vault B", async () => {
     // The privilege-escalation barrier: a valid token for vault A must not
     // authenticate at vault B's endpoint, even though the token is valid
     // for some vault. This is the point of per-vault DBs.
@@ -136,42 +136,42 @@ describe("auth — per-vault routing", () => {
     seedVault("work");
     const workToken = mintTokenInVault("work");
 
-    const crossVault = dispatchAuthFromPath("/vault/journal/api/health", bearer(workToken));
+    const crossVault = await dispatchAuthFromPath("/vault/journal/api/health", bearer(workToken));
     expect(crossVault.status).toBe(401);
   });
 
-  test("routing: /vault/<unknown> returns 404 (not 401)", () => {
+  test("routing: /vault/<unknown> returns 404 (not 401)", async () => {
     seedVault("journal");
     const token = mintTokenInVault("journal");
-    const result = dispatchAuthFromPath("/vault/nonexistent/api/health", bearer(token));
+    const result = await dispatchAuthFromPath("/vault/nonexistent/api/health", bearer(token));
     expect(result.status).toBe(404);
   });
 });
 
 describe("auth — cross-vault isolation", () => {
-  test("token minted in a non-default vault authenticates via scoped and global paths", () => {
+  test("token minted in a non-default vault authenticates via scoped and global paths", async () => {
     seedVault("journal", { isDefault: true });
     seedVault("work");
     const workToken = mintTokenInVault("work");
     const workConfig = readVaultConfig("work")!;
     const workStore = getVaultStore("work");
 
-    const scoped = authenticateVaultRequest(bearer(workToken), workConfig, workStore.db);
+    const scoped = await authenticateVaultRequest(bearer(workToken), workConfig, workStore.db);
     expect("error" in scoped).toBe(false);
 
     // Global auth scans every vault, must find the token in work's DB.
-    const global = authenticateGlobalRequest(bearer(workToken));
+    const global = await authenticateGlobalRequest(bearer(workToken));
     expect("error" in global).toBe(false);
   });
 
-  test("a work-vault token does NOT authenticate against the journal vault", () => {
+  test("a work-vault token does NOT authenticate against the journal vault", async () => {
     seedVault("journal", { isDefault: true });
     seedVault("work");
     const workToken = mintTokenInVault("work");
     const journalConfig = readVaultConfig("journal")!;
     const journalStore = getVaultStore("journal");
 
-    const res = authenticateVaultRequest(bearer(workToken), journalConfig, journalStore.db);
+    const res = await authenticateVaultRequest(bearer(workToken), journalConfig, journalStore.db);
     expect("error" in res).toBe(true);
   });
 });
@@ -256,11 +256,11 @@ describe("OAuth-minted tokens — per-vault coherence", () => {
     const store = getVaultStore("journal");
 
     // /vault/journal/api/* and /vault/journal/mcp both reach this auth call.
-    const vaultAuth = authenticateVaultRequest(bearer(token), cfg, store.db);
+    const vaultAuth = await authenticateVaultRequest(bearer(token), cfg, store.db);
     expect("error" in vaultAuth).toBe(false);
 
     // /vaults (authenticated listing) uses authenticateGlobalRequest.
-    const global = authenticateGlobalRequest(bearer(token));
+    const global = await authenticateGlobalRequest(bearer(token));
     expect("error" in global).toBe(false);
   });
 
@@ -272,17 +272,17 @@ describe("OAuth-minted tokens — per-vault coherence", () => {
     const workStore = getVaultStore("work");
 
     // Valid at work's own endpoints.
-    const scoped = authenticateVaultRequest(bearer(token), workCfg, workStore.db);
+    const scoped = await authenticateVaultRequest(bearer(token), workCfg, workStore.db);
     expect("error" in scoped).toBe(false);
 
     // Global auth finds the token in work's DB.
-    const global = authenticateGlobalRequest(bearer(token));
+    const global = await authenticateGlobalRequest(bearer(token));
     expect("error" in global).toBe(false);
 
     // Isolation: the token is NOT usable against the journal vault.
     const journalCfg = readVaultConfig("journal")!;
     const journalStore = getVaultStore("journal");
-    const crossCheck = authenticateVaultRequest(bearer(token), journalCfg, journalStore.db);
+    const crossCheck = await authenticateVaultRequest(bearer(token), journalCfg, journalStore.db);
     expect("error" in crossCheck).toBe(true);
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -22,6 +22,7 @@ import type { TokenPermission } from "./token-store.ts";
 import type { Database } from "bun:sqlite";
 import { getVaultStore } from "./vault-store.ts";
 import { hasScope, legacyPermissionToScopes, SCOPE_ADMIN, SCOPE_READ, SCOPE_WRITE } from "./scopes.ts";
+import { HubJwtError, looksLikeJwt, validateHubJwt } from "./hub-jwt.ts";
 
 /** Result of a successful auth check. */
 export interface AuthResult {
@@ -128,16 +129,32 @@ function validateKey(keys: StoredKey[], providedKey: string): StoredKey | null {
 
 /**
  * Authenticate for a specific vault.
- * Checks the vault's token DB first, then falls back to legacy YAML keys.
+ *
+ * Token shape decides the path:
+ *   - JWT-shaped (`eyJ…`) → validate against the hub's JWKS. JWT-shaped tokens
+ *     commit to JWT validation; we don't fall through to `pvt_*` lookup on
+ *     failure, since a malformed JWT was never going to be a valid local
+ *     token anyway.
+ *   - Anything else → try the vault's token DB, then legacy YAML keys.
+ *
+ * Dual-validate window: both paths are live during this release cycle so
+ * existing `pvt_*` callers continue to work. A follow-up issue retires the
+ * legacy path.
  */
-export function authenticateVaultRequest(
+export async function authenticateVaultRequest(
   req: Request,
   vaultConfig: VaultConfig,
   vaultDb?: Database,
-): { error: Response } | AuthResult {
+): Promise<{ error: Response } | AuthResult> {
   const key = extractApiKey(req);
   if (!key) {
     return { error: Response.json({ error: "Unauthorized", message: "API key required" }, { status: 401 }) };
+  }
+
+  // JWT path: hub-issued tokens. Trust pinned to the hub origin via `iss`
+  // verification inside validateHubJwt; signature checked against hub's JWKS.
+  if (looksLikeJwt(key)) {
+    return await authenticateHubJwt(key);
   }
 
   // Try vault's token DB first
@@ -182,17 +199,47 @@ export function authenticateVaultRequest(
 }
 
 /**
+ * Validate a JWT-shaped bearer and convert the result into an `AuthResult`.
+ * The token's scope claim becomes the granted scopes; permission is derived
+ * for back-compat with code paths that still branch on `permission` (MCP
+ * tool gating, view auth). `legacyDerived` is `false` — JWT-issued scopes
+ * are explicit, never inferred.
+ */
+async function authenticateHubJwt(token: string): Promise<{ error: Response } | AuthResult> {
+  try {
+    const claims = await validateHubJwt(token);
+    const permission: TokenPermission =
+      hasScope(claims.scopes, SCOPE_WRITE) || hasScope(claims.scopes, SCOPE_ADMIN)
+        ? "full"
+        : "read";
+    return { permission, scopes: claims.scopes, legacyDerived: false };
+  } catch (err) {
+    if (err instanceof HubJwtError) {
+      return { error: Response.json({ error: "Unauthorized", message: err.message }, { status: 401 }) };
+    }
+    // Unknown failure shape — surface the message but stay 401.
+    const msg = err instanceof Error ? err.message : "JWT validation failed";
+    return { error: Response.json({ error: "Unauthorized", message: msg }, { status: 401 }) };
+  }
+}
+
+/**
  * Authenticate for the unified /mcp endpoint.
  * Checks legacy global config.yaml keys first, then falls back to checking
  * each vault's token DB. This allows OAuth-minted pvt_ tokens to work on
  * the unified endpoint.
  */
-export function authenticateGlobalRequest(
+export async function authenticateGlobalRequest(
   req: Request,
-): { error: Response } | AuthResult {
+): Promise<{ error: Response } | AuthResult> {
   const key = extractApiKey(req);
   if (!key) {
     return { error: Response.json({ error: "Unauthorized", message: "API key required" }, { status: 401 }) };
+  }
+
+  // JWT path: hub-issued tokens validate without a per-vault DB lookup.
+  if (looksLikeJwt(key)) {
+    return await authenticateHubJwt(key);
   }
 
   // Legacy: check global keys from config.yaml

--- a/src/hub-jwt.test.ts
+++ b/src/hub-jwt.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Hub-issued JWT validation — vault as resource server.
+ *
+ * Spins up a fake JWKS endpoint (Bun.serve) with a known RSA keypair, signs
+ * JWTs locally with `jose.SignJWT`, and asserts `validateHubJwt` accepts the
+ * good ones and rejects every failure mode the spec cares about: bad
+ * signature, wrong issuer, expired, missing kid, unknown kid, JWKS
+ * unreachable. Audience permissiveness is exercised — both `aud="operator"`
+ * and `aud="<client_id>"` shapes pass.
+ *
+ * Each test resets the JWKS cache so the origin/keys can change between
+ * cases. The cache is module-scoped; without `resetJwksCache()` we'd reuse
+ * the previous origin's getter and miss test rotations.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { generateKeyPair, exportJWK, SignJWT } from "jose";
+import { resetJwksCache, validateHubJwt, looksLikeJwt } from "./hub-jwt.ts";
+
+interface Keypair {
+  privateKey: CryptoKey;
+  publicJwk: { kty: string; n: string; e: string; kid: string; alg: string; use: string };
+  kid: string;
+}
+
+async function makeKeypair(kid: string): Promise<Keypair> {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  const jwk = await exportJWK(publicKey);
+  return {
+    privateKey,
+    publicJwk: {
+      kty: "RSA",
+      n: jwk.n!,
+      e: jwk.e!,
+      kid,
+      alg: "RS256",
+      use: "sig",
+    },
+    kid,
+  };
+}
+
+interface JwksFixture {
+  origin: string;
+  stop: () => void;
+  setKeys: (keys: Keypair[]) => void;
+  setUnreachable: (down: boolean) => void;
+}
+
+function startJwksFixture(): JwksFixture {
+  let keys: Keypair[] = [];
+  let down = false;
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/.well-known/jwks.json") {
+        return new Response("not found", { status: 404 });
+      }
+      if (down) return new Response("upstream down", { status: 503 });
+      return Response.json({ keys: keys.map((k) => k.publicJwk) });
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    stop: () => server.stop(true),
+    setKeys: (next) => { keys = next; },
+    setUnreachable: (v) => { down = v; },
+  };
+}
+
+interface SignOpts {
+  iss?: string;
+  aud?: string;
+  sub?: string;
+  scope?: string;
+  jti?: string;
+  clientId?: string;
+  ttlSeconds?: number;
+  expiresAtSeconds?: number;
+  omitKid?: boolean;
+  kid?: string;
+}
+
+async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = opts.expiresAtSeconds ?? iat + (opts.ttlSeconds ?? 60);
+  const builder = new SignJWT({
+    scope: opts.scope ?? "vault:read vault:write",
+    client_id: opts.clientId ?? "test-client",
+  })
+    .setProtectedHeader(opts.omitKid ? { alg: "RS256" } : { alg: "RS256", kid: opts.kid ?? kp.kid })
+    .setIssuer(opts.iss ?? "http://issuer.invalid")
+    .setSubject(opts.sub ?? "user-1")
+    .setAudience(opts.aud ?? "operator")
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .setJti(opts.jti ?? "jti-1");
+  return await builder.sign(kp.privateKey);
+}
+
+let fixture: JwksFixture;
+let kp: Keypair;
+let prevHubOrigin: string | undefined;
+
+beforeAll(async () => {
+  fixture = startJwksFixture();
+  kp = await makeKeypair("k1");
+  fixture.setKeys([kp]);
+});
+
+afterAll(() => {
+  fixture.stop();
+  if (prevHubOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = prevHubOrigin;
+});
+
+beforeEach(() => {
+  // Each test sets its own origin for clarity.
+  prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+  process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
+  fixture.setUnreachable(false);
+  fixture.setKeys([kp]);
+  resetJwksCache();
+});
+
+describe("looksLikeJwt", () => {
+  test("`eyJ` prefix → true", () => {
+    expect(looksLikeJwt("eyJhbGciOiJSUzI1NiJ9.x.y")).toBe(true);
+  });
+
+  test("pvt_ token → false", () => {
+    expect(looksLikeJwt("pvt_abcdef0123456789")).toBe(false);
+  });
+
+  test("empty / random → false", () => {
+    expect(looksLikeJwt("")).toBe(false);
+    expect(looksLikeJwt("hello-world")).toBe(false);
+  });
+});
+
+describe("validateHubJwt — happy path", () => {
+  test("valid JWT with correct iss → claims surface", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, scope: "vault:read vault:write" });
+    const claims = await validateHubJwt(token);
+    expect(claims.sub).toBe("user-1");
+    expect(claims.scopes).toEqual(["vault:read", "vault:write"]);
+    expect(claims.aud).toBe("operator");
+    expect(claims.jti).toBe("jti-1");
+    expect(claims.clientId).toBe("test-client");
+  });
+
+  test("aud=operator accepted", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, aud: "operator" });
+    const claims = await validateHubJwt(token);
+    expect(claims.aud).toBe("operator");
+  });
+
+  test("aud=<client_id> accepted (no strict aud match)", async () => {
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "did:plc:randomclientid",
+      clientId: "did:plc:randomclientid",
+    });
+    const claims = await validateHubJwt(token);
+    expect(claims.aud).toBe("did:plc:randomclientid");
+  });
+
+  test("empty scope claim → empty scopes array", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, scope: "" });
+    const claims = await validateHubJwt(token);
+    expect(claims.scopes).toEqual([]);
+  });
+});
+
+describe("validateHubJwt — failure modes", () => {
+  test("wrong issuer → throws", async () => {
+    const token = await signJwt(kp, { iss: "http://attacker.example" });
+    await expect(validateHubJwt(token)).rejects.toThrow(/verification failed/);
+  });
+
+  test("expired token → throws", async () => {
+    const past = Math.floor(Date.now() / 1000) - 10;
+    const token = await signJwt(kp, { iss: fixture.origin, expiresAtSeconds: past });
+    await expect(validateHubJwt(token)).rejects.toThrow(/verification failed/);
+  });
+
+  test("bad signature (token signed by an unpublished key) → throws", async () => {
+    const otherKp = await makeKeypair("k1"); // same kid, different key
+    const token = await signJwt(otherKp, { iss: fixture.origin });
+    await expect(validateHubJwt(token)).rejects.toThrow(/verification failed/);
+  });
+
+  test("unknown kid → throws", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, kid: "does-not-exist" });
+    await expect(validateHubJwt(token)).rejects.toThrow(/verification failed/);
+  });
+
+  test("missing kid header → throws when JWKS has multiple keys", async () => {
+    // jose's createRemoteJWKSet falls back to the only key when JWKS has just
+    // one — so to exercise the "no kid" failure path we need ≥2 keys.
+    const kp2 = await makeKeypair("k2");
+    fixture.setKeys([kp, kp2]);
+    resetJwksCache();
+    const token = await signJwt(kp, { iss: fixture.origin, omitKid: true });
+    await expect(validateHubJwt(token)).rejects.toThrow(/verification failed/);
+  });
+
+  test("JWKS endpoint unreachable → throws (fail closed)", async () => {
+    fixture.setUnreachable(true);
+    const token = await signJwt(kp, { iss: fixture.origin });
+    await expect(validateHubJwt(token)).rejects.toThrow(/verification failed/);
+  });
+
+  test("missing `sub` claim → throws", async () => {
+    // SignJWT requires .setSubject; build the token manually-ish: pass empty sub.
+    const iat = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ scope: "vault:read" })
+      .setProtectedHeader({ alg: "RS256", kid: kp.kid })
+      .setIssuer(fixture.origin)
+      .setAudience("operator")
+      .setIssuedAt(iat)
+      .setExpirationTime(iat + 60)
+      .setJti("jti-no-sub")
+      .sign(kp.privateKey);
+    await expect(validateHubJwt(token)).rejects.toThrow(/missing required `sub`/);
+  });
+});
+
+describe("validateHubJwt — JWKS rotation", () => {
+  test("rotated key (new kid published) verifies after cache reset", async () => {
+    const kp2 = await makeKeypair("k2");
+    fixture.setKeys([kp, kp2]);
+    resetJwksCache();
+    const token = await signJwt(kp2, { iss: fixture.origin });
+    const claims = await validateHubJwt(token);
+    expect(claims.sub).toBe("user-1");
+  });
+});

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -1,0 +1,147 @@
+/**
+ * Hub-issued JWT validation. Vault as resource server: trusts tokens that the
+ * hub signs against keys we fetch from the hub's `/.well-known/jwks.json`.
+ *
+ * Two halves:
+ *   - Origin resolution. The hub's URL comes from `PARACHUTE_HUB_ORIGIN` (set
+ *     by the hub's `expose` / `start` flow when vault runs behind it). Falls
+ *     back to `http://127.0.0.1:1939` for loopback dev. We only resolve once
+ *     per process — a server restart picks up an env change.
+ *   - JWKS fetch + verify. `jose.createRemoteJWKSet` does the fetching, kid
+ *     lookup, and rotation handling. Tokens MUST have `iss = <hub origin>` —
+ *     the load-bearing trust check; without it, anyone could forge tokens
+ *     against any RSA key. Audience is parsed but accepted broadly (TODO).
+ *
+ * Vault#169 / hub-as-issuer Phase B2.
+ */
+import { type JWTPayload, createRemoteJWKSet, jwtVerify } from "jose";
+import { parseScopes } from "./scopes.ts";
+
+const DEFAULT_HUB_LOOPBACK = "http://127.0.0.1:1939";
+
+/**
+ * Resolve the hub origin used to fetch JWKS and validate `iss`. Strips a
+ * trailing slash so we get a single canonical form.
+ *
+ * Order: env var → loopback fallback. We deliberately don't read
+ * `~/.parachute/services.json` — the hub is the dispatcher, not a registered
+ * service in that file. If a deployment exposes the hub on a non-default
+ * origin, the env var is the contract.
+ */
+export function getHubOrigin(): string {
+  const env = process.env.PARACHUTE_HUB_ORIGIN?.replace(/\/$/, "");
+  if (env && env.length > 0) return env;
+  return DEFAULT_HUB_LOOPBACK;
+}
+
+/**
+ * A presented bearer token is JWT-shaped iff it begins with `eyJ` — the
+ * base64url encoding of `{"` from a `{"alg":...}` JSON header. Cheap
+ * pre-check so we don't try to verify `pvt_` tokens as JWTs.
+ */
+export function looksLikeJwt(token: string): boolean {
+  return token.startsWith("eyJ");
+}
+
+/** Subset of claims we surface to callers. Everything else is dropped. */
+export interface HubJwtClaims {
+  sub: string;
+  /** Parsed `scope` claim (whitespace-separated → array, normalized). */
+  scopes: string[];
+  /** Audience — operator | client_id | module-name. Surfaced for logging. */
+  aud: string | undefined;
+  /** Token id. Surfaced for logging / future revocation lookups. */
+  jti: string | undefined;
+  /** Client id from the `client_id` claim, if present. */
+  clientId: string | undefined;
+}
+
+export class HubJwtError extends Error {
+  override name = "HubJwtError";
+}
+
+// jose's createRemoteJWKSet returns a getter that internally caches keys with
+// a configurable TTL. One getter per origin — recreated only on origin change
+// (rare; survives across requests). Module-scoped so retries / kid lookups
+// reuse the same in-flight fetches.
+type JwksGetter = ReturnType<typeof createRemoteJWKSet>;
+let cachedGetter: JwksGetter | null = null;
+let cachedOrigin: string | null = null;
+
+function getJwksGetter(origin: string): JwksGetter {
+  if (cachedGetter && cachedOrigin === origin) return cachedGetter;
+  cachedGetter = createRemoteJWKSet(new URL(`${origin}/.well-known/jwks.json`), {
+    // 5min cache — keys rarely rotate but DO rotate. Matches hub's signing-key
+    // overlap window expectation.
+    cacheMaxAge: 5 * 60 * 1000,
+    // 30s cooldown between failed fetches. Prevents thundering-herd if the
+    // hub is briefly down: we serve cached keys when possible, and the
+    // cooldown bounds the retry rate.
+    cooldownDuration: 30 * 1000,
+  });
+  cachedOrigin = origin;
+  return cachedGetter;
+}
+
+/**
+ * Reset the cached JWKS getter. Tests use this to switch origins between
+ * cases; production callers shouldn't need it (origin is process-stable).
+ */
+export function resetJwksCache(): void {
+  cachedGetter = null;
+  cachedOrigin = null;
+}
+
+/**
+ * Verify a presented JWT against the hub's JWKS. Throws `HubJwtError` on any
+ * failure (bad signature, wrong issuer, expired, missing kid, JWKS
+ * unreachable). On success returns the surfaced claims plus the parsed scope
+ * list.
+ *
+ * The `iss` claim MUST equal the configured hub origin — this is the
+ * load-bearing trust check. Without it, anyone could mint a token against
+ * any RSA key and pass verification.
+ *
+ * Audience: parsed and returned but not strict-checked. Today's hub-issued
+ * tokens carry `aud="operator"` (operator token) or `aud=<client_id>` (user
+ * OAuth); both are legitimate vault callers.
+ *
+ * TODO(post-cli#59): tighten audience validation to accept only
+ * {operator, vault, registered-client-ids}. Reject service-specific
+ * aud values meant for siblings (e.g. aud="scribe-webhook"). Today
+ * the hub doesn't issue narrow service tokens so any aud is safe;
+ * once cli#59 scope-guard lib exists and service-to-service moves
+ * off shared-secret onto JWTs, tighten this.
+ */
+export async function validateHubJwt(token: string): Promise<HubJwtClaims> {
+  const origin = getHubOrigin();
+  const getter = getJwksGetter(origin);
+
+  let payload: JWTPayload;
+  try {
+    const verified = await jwtVerify(token, getter, {
+      issuer: origin,
+      // Don't pass `audience` — jose enforces strict match if set, and we
+      // accept multiple audiences (see TODO above).
+    });
+    payload = verified.payload;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new HubJwtError(`hub JWT verification failed: ${msg}`);
+  }
+
+  if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+    throw new HubJwtError("hub JWT missing required `sub` claim");
+  }
+
+  const scopeRaw = (payload as { scope?: unknown }).scope;
+  const scopes =
+    typeof scopeRaw === "string" ? parseScopes(scopeRaw) : [];
+
+  const aud = typeof payload.aud === "string" ? payload.aud : undefined;
+  const jti = typeof payload.jti === "string" ? payload.jti : undefined;
+  const clientIdRaw = (payload as { client_id?: unknown }).client_id;
+  const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
+
+  return { sub: payload.sub, scopes, aud, jti, clientId };
+}

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -100,15 +100,15 @@ async function withMcpChallenge(
  * Returns true if authenticated, false if not. Never rejects — unauthenticated
  * requests still get public notes.
  */
-function isViewAuthenticated(
+async function isViewAuthenticated(
   req: Request,
   vaultConfig: VaultConfig | null,
   vaultDb?: import("bun:sqlite").Database,
-): boolean {
+): Promise<boolean> {
   if (!vaultConfig) return false;
   const key = extractApiKey(req);
   if (!key) return false;
-  const auth = authenticateVaultRequest(req, vaultConfig, vaultDb);
+  const auth = await authenticateVaultRequest(req, vaultConfig, vaultDb);
   return !("error" in auth);
 }
 
@@ -210,7 +210,7 @@ export async function route(
   // ---------------------------------------------------------------------
 
   if (path === "/health") {
-    const auth = authenticateGlobalRequest(req);
+    const auth = await authenticateGlobalRequest(req);
     if ("error" in auth) {
       return Response.json({ status: "ok" });
     }
@@ -231,7 +231,7 @@ export async function route(
 
   // Authenticated vault metadata list.
   if (path === "/vaults" && req.method === "GET") {
-    const auth = authenticateGlobalRequest(req);
+    const auth = await authenticateGlobalRequest(req);
     if ("error" in auth) return auth.error;
     const names = listVaults();
     const vaults = names.map((name) => {
@@ -277,7 +277,7 @@ export async function route(
   const vaultViewMatch = subpath.match(/^\/view\/(.+)$/);
   if (vaultViewMatch && req.method === "GET") {
     const store = getVaultStore(vaultName);
-    const authenticated = isViewAuthenticated(req, vaultConfig, store.db);
+    const authenticated = await isViewAuthenticated(req, vaultConfig, store.db);
     return handleViewNote(store, decodeURIComponent(vaultViewMatch[1]), {
       authenticated,
       publishedTag: vaultConfig.published_tag,
@@ -350,7 +350,7 @@ export async function route(
     // (worker intervals, TTLs, retention policy) but are still configuration
     // an attacker could use to map the deployment. `vault:admin` keeps the
     // hub's loopback workflow intact while locking out read-only tokens.
-    const configAuth = authenticateVaultRequest(req, vaultConfig, getVaultStore(vaultName).db);
+    const configAuth = await authenticateVaultRequest(req, vaultConfig, getVaultStore(vaultName).db);
     if ("error" in configAuth) return configAuth.error;
     if (!requireScope(configAuth, SCOPE_ADMIN)) {
       return Response.json(
@@ -385,7 +385,7 @@ export async function route(
   // ---------------------------------------------------------------------
 
   const store = getVaultStore(vaultName);
-  const auth = authenticateVaultRequest(req, vaultConfig, store.db);
+  const auth = await authenticateVaultRequest(req, vaultConfig, store.db);
   const isScopedMcp = subpath === "/mcp" || subpath.startsWith("/mcp/");
   if ("error" in auth) {
     return isScopedMcp ? withMcpChallenge(auth.error, req, vaultName) : auth.error;


### PR DESCRIPTION
## Summary

- Vault becomes a pure OAuth resource server: JWT-shaped bearer tokens (`eyJ…`) now route through a new `src/hub-jwt.ts` validator that fetches the hub's `/.well-known/jwks.json` via `jose.createRemoteJWKSet`, verifies the RS256 signature, and strict-checks `iss = $PARACHUTE_HUB_ORIGIN` (loopback fallback `http://127.0.0.1:1939`). Audience is parsed but accepted broadly today — hub still issues `aud="operator"` and `aud=<client_id>`; tightening is reserved for the post-cli#59 scope-guard work.
- Existing `pvt_*` callers continue to work unchanged. JWT-shaped tokens commit to JWT validation (no fallthrough on failure, since a malformed JWT was never going to be a valid local token). `legacyDerived` is `false` for JWT-issued scopes — they're explicit, never inferred.
- `authenticateVaultRequest` and `authenticateGlobalRequest` are now async; the await ripples through 5 `routing.ts` call sites + `isViewAuthenticated`. Bumps 0.3.5 → 0.3.6-rc.1.

## Test plan

- [x] `bun test src/` — 899 pass, 0 fail (15 new in `src/hub-jwt.test.ts`)
- [x] `bunx biome check` clean on modified files
- [x] `bunx tsc --noEmit` — error count down from 509 → 505 (no new errors in `src/hub-jwt.ts` / `src/auth.ts` / `src/routing.ts`; the strict-mode pre-existing errors in `src/vault.test.ts` etc. are unrelated)
- [ ] End-to-end against a real hub once the hub's Phase B2 ships — currently stubbed via fake JWKS endpoint in `hub-jwt.test.ts`

## Patterns

- `parachute-patterns/patterns/hub-as-issuer.md` — vault as resource server, JWT iss/aud trust pinning
- `parachute-patterns/patterns/oauth-scopes.md` — `vault:read` / `vault:write` / `vault:admin` from JWT `scope` claim
- `parachute-patterns/patterns/service-to-service-auth.md` — companion to the hub's Phase B JWKS plumbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)