### PR TITLE
feat(scopes): narrow vault scopes for hub JWTs + per-vault aud enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.1",
+  "version": "0.3.6-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -21,7 +21,15 @@ import { resolveToken } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
 import type { Database } from "bun:sqlite";
 import { getVaultStore } from "./vault-store.ts";
-import { hasScope, legacyPermissionToScopes, SCOPE_ADMIN, SCOPE_READ, SCOPE_WRITE } from "./scopes.ts";
+import {
+  findBroadVaultScopes,
+  hasScope,
+  hasScopeForVault,
+  legacyPermissionToScopes,
+  SCOPE_ADMIN,
+  SCOPE_READ,
+  SCOPE_WRITE,
+} from "./scopes.ts";
 import { HubJwtError, looksLikeJwt, validateHubJwt } from "./hub-jwt.ts";
 
 /** Result of a successful auth check. */
@@ -48,14 +56,6 @@ function legacyAuthResult(permission: TokenPermission): AuthResult {
     scopes: legacyPermissionToScopes(permission),
     legacyDerived: true,
   };
-}
-
-/**
- * Guard: does the authenticated request carry the required scope?
- * Uses `hasScope` inheritance: admin ⊇ write ⊇ read.
- */
-export function requireScope(auth: AuthResult, required: string): boolean {
-  return hasScope(auth.scopes, required);
 }
 
 // One-shot deprecation warning tracker, keyed by token hash / legacy label so
@@ -153,8 +153,10 @@ export async function authenticateVaultRequest(
 
   // JWT path: hub-issued tokens. Trust pinned to the hub origin via `iss`
   // verification inside validateHubJwt; signature checked against hub's JWKS.
+  // Audience strict-checked against `vault.<name>` so a token stamped for
+  // one vault can't reach another.
   if (looksLikeJwt(key)) {
-    return await authenticateHubJwt(key);
+    return await authenticateHubJwt(key, { expectedAudience: `vault.${vaultConfig.name}` });
   }
 
   // Try vault's token DB first
@@ -204,10 +206,31 @@ export async function authenticateVaultRequest(
  * for back-compat with code paths that still branch on `permission` (MCP
  * tool gating, view auth). `legacyDerived` is `false` — JWT-issued scopes
  * are explicit, never inferred.
+ *
+ * Scope-shape policy: hub-issued tokens MUST carry resource-narrowed
+ * `vault:<name>:<verb>` scopes. Broad `vault:<verb>` scopes are rejected
+ * here — Phase B2 settled that hub tokens always name the resource. Per-
+ * vault audience enforcement happens inside `validateHubJwt` via
+ * `opts.expectedAudience`.
  */
-async function authenticateHubJwt(token: string): Promise<{ error: Response } | AuthResult> {
+async function authenticateHubJwt(
+  token: string,
+  opts: { expectedAudience: string | null },
+): Promise<{ error: Response } | AuthResult> {
   try {
-    const claims = await validateHubJwt(token);
+    const claims = await validateHubJwt(token, { expectedAudience: opts.expectedAudience });
+    const broad = findBroadVaultScopes(claims.scopes);
+    if (broad.length > 0) {
+      return {
+        error: Response.json(
+          {
+            error: "Unauthorized",
+            message: `hub JWT carries broad vault scope(s): ${broad.join(" ")}. Hub-issued tokens must use resource-narrowed scopes (vault:<name>:<verb>).`,
+          },
+          { status: 401 },
+        ),
+      };
+    }
     const permission: TokenPermission =
       hasScope(claims.scopes, SCOPE_WRITE) || hasScope(claims.scopes, SCOPE_ADMIN)
         ? "full"
@@ -237,9 +260,24 @@ export async function authenticateGlobalRequest(
     return { error: Response.json({ error: "Unauthorized", message: "API key required" }, { status: 401 }) };
   }
 
-  // JWT path: hub-issued tokens validate without a per-vault DB lookup.
+  // Hub-issued JWTs are always vault-bound (aud=vault.<name>). The unified
+  // /vaults / /health surface spans every vault and has no single audience to
+  // strict-check against, so JWTs aren't accepted here. Cross-vault listing
+  // for hub-authenticated callers will land alongside the `parachute:host:*`
+  // scope namespace; until then, callers wanting `/vaults` from a JWT
+  // context use a per-vault token at `/vault/<name>` and rely on services.json
+  // for the broader catalog.
   if (looksLikeJwt(key)) {
-    return await authenticateHubJwt(key);
+    return {
+      error: Response.json(
+        {
+          error: "Unauthorized",
+          message:
+            "Hub-issued JWTs are vault-bound; use /vault/<name>/* endpoints. Cross-vault routes accept legacy config.yaml keys or per-vault tokens.",
+        },
+        { status: 401 },
+      ),
+    };
   }
 
   // Legacy: check global keys from config.yaml

--- a/src/hub-jwt.test.ts
+++ b/src/hub-jwt.test.ts
@@ -140,22 +140,22 @@ describe("looksLikeJwt", () => {
 
 describe("validateHubJwt — happy path", () => {
   test("valid JWT with correct iss → claims surface", async () => {
-    const token = await signJwt(kp, { iss: fixture.origin, scope: "vault:read vault:write" });
+    const token = await signJwt(kp, { iss: fixture.origin, scope: "vault:work:read vault:work:write" });
     const claims = await validateHubJwt(token);
     expect(claims.sub).toBe("user-1");
-    expect(claims.scopes).toEqual(["vault:read", "vault:write"]);
+    expect(claims.scopes).toEqual(["vault:work:read", "vault:work:write"]);
     expect(claims.aud).toBe("operator");
     expect(claims.jti).toBe("jti-1");
     expect(claims.clientId).toBe("test-client");
   });
 
-  test("aud=operator accepted", async () => {
+  test("aud=operator accepted when expectedAudience not set", async () => {
     const token = await signJwt(kp, { iss: fixture.origin, aud: "operator" });
     const claims = await validateHubJwt(token);
     expect(claims.aud).toBe("operator");
   });
 
-  test("aud=<client_id> accepted (no strict aud match)", async () => {
+  test("aud=<client_id> accepted when expectedAudience not set", async () => {
     const token = await signJwt(kp, {
       iss: fixture.origin,
       aud: "did:plc:randomclientid",
@@ -169,6 +169,36 @@ describe("validateHubJwt — happy path", () => {
     const token = await signJwt(kp, { iss: fixture.origin, scope: "" });
     const claims = await validateHubJwt(token);
     expect(claims.scopes).toEqual([]);
+  });
+
+  test("audience strict-check passes when expected matches", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, aud: "vault.work" });
+    const claims = await validateHubJwt(token, { expectedAudience: "vault.work" });
+    expect(claims.aud).toBe("vault.work");
+  });
+});
+
+describe("validateHubJwt — audience strict-check", () => {
+  test("mismatched audience throws with the expected vs got values", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, aud: "vault.personal" });
+    await expect(
+      validateHubJwt(token, { expectedAudience: "vault.work" }),
+    ).rejects.toThrow(/audience mismatch.*vault\.work.*vault\.personal/);
+  });
+
+  test("missing audience claim throws when expected is set", async () => {
+    // jose's SignJWT requires .setAudience() — provide an unrelated value to
+    // exercise "not the expected one" rather than a literal missing claim.
+    const token = await signJwt(kp, { iss: fixture.origin, aud: "operator" });
+    await expect(
+      validateHubJwt(token, { expectedAudience: "vault.work" }),
+    ).rejects.toThrow(/audience mismatch/);
+  });
+
+  test("expectedAudience: null skips the check (cross-vault path)", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, aud: "vault.anything" });
+    const claims = await validateHubJwt(token, { expectedAudience: null });
+    expect(claims.aud).toBe("vault.anything");
   });
 });
 

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -92,28 +92,41 @@ export function resetJwksCache(): void {
   cachedOrigin = null;
 }
 
+export interface ValidateHubJwtOptions {
+  /**
+   * If set, strict-check the JWT `aud` claim against this exact value. Used
+   * by the per-vault auth path: each request derives the expected audience
+   * from the URL (`vault.<name>`) and rejects tokens stamped for a different
+   * vault. Pass `null` (or omit) to skip — only callers that lack a single
+   * resource binding (e.g. cross-vault routes) should skip.
+   *
+   * The `aud` strict-check is the resource-server backstop. Even if scope
+   * narrowing slips somewhere upstream, `aud=vault.work` cannot reach
+   * `/vault/personal/*` because the audience-mismatch reject fires first.
+   */
+  expectedAudience?: string | null;
+}
+
 /**
  * Verify a presented JWT against the hub's JWKS. Throws `HubJwtError` on any
  * failure (bad signature, wrong issuer, expired, missing kid, JWKS
- * unreachable). On success returns the surfaced claims plus the parsed scope
- * list.
+ * unreachable, audience mismatch). On success returns the surfaced claims
+ * plus the parsed scope list.
  *
- * The `iss` claim MUST equal the configured hub origin — this is the
- * load-bearing trust check. Without it, anyone could mint a token against
- * any RSA key and pass verification.
+ * Trust model:
+ *   - `iss` MUST equal the configured hub origin. Without this, anyone could
+ *     mint a token against any RSA key and pass verification.
+ *   - `aud` is strict-checked against `opts.expectedAudience` when provided
+ *     — the resource-server backstop for per-vault binding.
  *
- * Audience: parsed and returned but not strict-checked. Today's hub-issued
- * tokens carry `aud="operator"` (operator token) or `aud=<client_id>` (user
- * OAuth); both are legitimate vault callers.
- *
- * TODO(post-cli#59): tighten audience validation to accept only
- * {operator, vault, registered-client-ids}. Reject service-specific
- * aud values meant for siblings (e.g. aud="scribe-webhook"). Today
- * the hub doesn't issue narrow service tokens so any aud is safe;
- * once cli#59 scope-guard lib exists and service-to-service moves
- * off shared-secret onto JWTs, tighten this.
+ * Scope-shape policy (e.g. "hub-issued tokens may not carry broad
+ * `vault:<verb>` scopes") is enforced one layer up in `authenticateHubJwt`,
+ * not here — this function stays focused on JWT-level concerns.
  */
-export async function validateHubJwt(token: string): Promise<HubJwtClaims> {
+export async function validateHubJwt(
+  token: string,
+  opts: ValidateHubJwtOptions = {},
+): Promise<HubJwtClaims> {
   const origin = getHubOrigin();
   const getter = getJwksGetter(origin);
 
@@ -121,8 +134,10 @@ export async function validateHubJwt(token: string): Promise<HubJwtClaims> {
   try {
     const verified = await jwtVerify(token, getter, {
       issuer: origin,
-      // Don't pass `audience` — jose enforces strict match if set, and we
-      // accept multiple audiences (see TODO above).
+      // We strict-check audience ourselves below when `expectedAudience` is
+      // provided. Letting jose do it would also work, but keeping the check
+      // local lets us shape a clearer error message and centralize the
+      // "vault.<name>" derivation rule in one place.
     });
     payload = verified.payload;
   } catch (err) {
@@ -134,11 +149,19 @@ export async function validateHubJwt(token: string): Promise<HubJwtClaims> {
     throw new HubJwtError("hub JWT missing required `sub` claim");
   }
 
+  const aud = typeof payload.aud === "string" ? payload.aud : undefined;
+  if (opts.expectedAudience != null) {
+    if (aud !== opts.expectedAudience) {
+      throw new HubJwtError(
+        `hub JWT audience mismatch: expected "${opts.expectedAudience}", got "${aud ?? "(missing)"}"`,
+      );
+    }
+  }
+
   const scopeRaw = (payload as { scope?: unknown }).scope;
   const scopes =
     typeof scopeRaw === "string" ? parseScopes(scopeRaw) : [];
 
-  const aud = typeof payload.aud === "string" ? payload.aud : undefined;
   const jti = typeof payload.jti === "string" ? payload.jti : undefined;
   const clientIdRaw = (payload as { client_id?: unknown }).client_id;
   const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -24,47 +24,48 @@ import {
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 import { generateScopedMcpTools, getServerInstruction } from "./mcp-tools.ts";
-import { requireScope } from "./auth.ts";
 import type { AuthResult } from "./auth.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
-import { SCOPE_READ, SCOPE_WRITE } from "./scopes.ts";
+import { hasScopeForVault } from "./scopes.ts";
+import type { VaultVerb } from "./scopes.ts";
 
 /**
- * Required scope for each MCP tool. Tools that mutate note/tag state require
- * `vault:write`; pure query tools need `vault:read`. `vault-info` is listed as
- * read because read-only callers can fetch stats — the description-update
- * branch inside vault-info performs its own secondary `vault:write` check
- * (see `overrideVaultInfo` in mcp-tools.ts). Do not assume the outer gate
- * alone protects the inner branch.
+ * Required verb for each MCP tool. Tools that mutate note/tag state require
+ * write; pure query tools need read. `vault-info` is listed as read because
+ * read-only callers can fetch stats — the description-update branch inside
+ * vault-info performs its own secondary write check (see `overrideVaultInfo`
+ * in mcp-tools.ts). Do not assume the outer gate alone protects the inner
+ * branch.
  */
-const TOOL_REQUIRED_SCOPE: Record<string, string> = {
-  "query-notes": SCOPE_READ,
-  "list-tags": SCOPE_READ,
-  "find-path": SCOPE_READ,
-  "vault-info": SCOPE_READ,
-  "create-note": SCOPE_WRITE,
-  "update-note": SCOPE_WRITE,
-  "delete-note": SCOPE_WRITE,
-  "update-tag": SCOPE_WRITE,
-  "delete-tag": SCOPE_WRITE,
+const TOOL_REQUIRED_VERB: Record<string, VaultVerb> = {
+  "query-notes": "read",
+  "list-tags": "read",
+  "find-path": "read",
+  "vault-info": "read",
+  "create-note": "write",
+  "update-note": "write",
+  "delete-note": "write",
+  "update-tag": "write",
+  "delete-tag": "write",
 };
 
-function requiredScopeForTool(toolName: string): string {
+function requiredVerbForTool(toolName: string): VaultVerb {
   // Default-deny: unknown tools require write. Keeps accidental reads of
   // a not-yet-mapped mutation tool from slipping past.
-  return TOOL_REQUIRED_SCOPE[toolName] ?? SCOPE_WRITE;
+  return TOOL_REQUIRED_VERB[toolName] ?? "write";
 }
 
 /** Handle scoped MCP at /vault/{name}/mcp (single vault). */
 export async function handleScopedMcp(req: Request, vaultName: string, auth: AuthResult): Promise<Response> {
   const instruction = getServerInstruction(vaultName);
-  return handleMcp(req, () => generateScopedMcpTools(vaultName, auth), `parachute-vault/${vaultName}`, auth, instruction);
+  return handleMcp(req, () => generateScopedMcpTools(vaultName, auth), `parachute-vault/${vaultName}`, vaultName, auth, instruction);
 }
 
 async function handleMcp(
   req: Request,
   getTools: () => McpToolDef[],
   serverName: string,
+  vaultName: string,
   auth: AuthResult,
   instruction: string,
 ): Promise<Response> {
@@ -84,11 +85,11 @@ async function handleMcp(
   const mcpTools = getTools();
 
   // Filter the advertised tool list to what the caller's scopes actually
-  // permit. Callers without `vault:write` don't see mutation tools at all —
-  // matches the prior behavior of the read/full permission model but is now
-  // driven by scope inheritance.
+  // permit for THIS vault. Callers without write don't see mutation tools at
+  // all — matches the prior behavior of the read/full permission model but
+  // now driven by per-vault scope inheritance.
   const visibleTools = mcpTools.filter((t) =>
-    requireScope(auth, requiredScopeForTool(t.name)),
+    hasScopeForVault(auth.scopes, vaultName, requiredVerbForTool(t.name)),
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -102,12 +103,12 @@ async function handleMcp(
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
-    const neededScope = requiredScopeForTool(name);
-    if (!requireScope(auth, neededScope)) {
+    const neededVerb = requiredVerbForTool(name);
+    if (!hasScopeForVault(auth.scopes, vaultName, neededVerb)) {
       return {
         content: [{
           type: "text" as const,
-          text: `Forbidden: tool '${name}' requires the '${neededScope}' scope. Granted scopes: ${auth.scopes.join(" ") || "(none)"}.`,
+          text: `Forbidden: tool '${name}' requires the 'vault:${neededVerb}' scope (or 'vault:${vaultName}:${neededVerb}'). Granted scopes: ${auth.scopes.join(" ") || "(none)"}.`,
         }],
         isError: true,
       };

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -9,7 +9,7 @@ import { generateMcpTools } from "../core/src/mcp.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
 import { readVaultConfig, writeVaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
-import { hasScope, SCOPE_WRITE } from "./scopes.ts";
+import { hasScopeForVault } from "./scopes.ts";
 import type { AuthResult } from "./auth.ts";
 
 /**
@@ -64,12 +64,13 @@ function overrideVaultInfo(
 
     if (params.description !== undefined) {
       // Secondary scope check: vault-info is read-gated so read-only callers
-      // can fetch stats, but mutating the vault description requires write.
-      // Without this, a vault:read token could bypass the outer gate by
-      // passing `description` to a tool the outer gate considers read-only.
-      if (!auth || !hasScope(auth.scopes, SCOPE_WRITE)) {
+      // can fetch stats, but mutating the vault description requires write
+      // for THIS vault. Without this, a vault:read token could bypass the
+      // outer gate by passing `description` to a tool the outer gate
+      // considers read-only.
+      if (!auth || !hasScopeForVault(auth.scopes, vaultName, "write")) {
         throw new Error(
-          `Forbidden: updating the vault description requires the '${SCOPE_WRITE}' scope. Granted scopes: ${auth?.scopes.join(" ") || "(none)"}.`,
+          `Forbidden: updating the vault description requires the 'vault:write' scope (or 'vault:${vaultName}:write'). Granted scopes: ${auth?.scopes.join(" ") || "(none)"}.`,
         );
       }
       config.description = params.description as string;

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -40,9 +40,8 @@ import {
   authenticateVaultRequest,
   authenticateGlobalRequest,
   extractApiKey,
-  requireScope,
 } from "./auth.ts";
-import { SCOPE_ADMIN, scopeForMethod } from "./scopes.ts";
+import { hasScopeForVault, SCOPE_ADMIN, scopeForMethod, verbForMethod } from "./scopes.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleScopedMcp } from "./mcp-http.ts";
 import {
@@ -352,12 +351,12 @@ export async function route(
     // hub's loopback workflow intact while locking out read-only tokens.
     const configAuth = await authenticateVaultRequest(req, vaultConfig, getVaultStore(vaultName).db);
     if ("error" in configAuth) return configAuth.error;
-    if (!requireScope(configAuth, SCOPE_ADMIN)) {
+    if (!hasScopeForVault(configAuth.scopes, vaultName, "admin")) {
       return Response.json(
         {
           error: "Forbidden",
           error_type: "insufficient_scope",
-          message: `This endpoint requires the '${SCOPE_ADMIN}' scope.`,
+          message: `This endpoint requires the '${SCOPE_ADMIN}' scope (or '${SCOPE_ADMIN.replace("vault:", `vault:${vaultName}:`)}').`,
           required_scope: SCOPE_ADMIN,
           granted_scopes: configAuth.scopes,
         },
@@ -418,14 +417,17 @@ export async function route(
 
   // REST API — scope gate. GET/HEAD/OPTIONS → vault:read,
   // POST/PATCH/PUT/DELETE → vault:write. Inheritance (admin ⊇ write ⊇ read)
-  // is handled inside `requireScope`.
-  const requiredApiScope = scopeForMethod(req.method);
-  if (!requireScope(auth, requiredApiScope)) {
+  // and the broad-vs-narrowed shape (`vault:<verb>` from pvt_*, or
+  // `vault:<vaultName>:<verb>` from hub JWTs) are handled by
+  // `hasScopeForVault`.
+  const requiredVerb = verbForMethod(req.method);
+  if (!hasScopeForVault(auth.scopes, vaultName, requiredVerb)) {
+    const requiredApiScope = scopeForMethod(req.method);
     return Response.json(
       {
         error: "Forbidden",
         error_type: "insufficient_scope",
-        message: `This endpoint requires the '${requiredApiScope}' scope.`,
+        message: `This endpoint requires the '${requiredApiScope}' scope (or '${requiredApiScope.replace("vault:", `vault:${vaultName}:`)}').`,
         required_scope: requiredApiScope,
         granted_scopes: auth.scopes,
       },

--- a/src/scopes.test.ts
+++ b/src/scopes.test.ts
@@ -13,7 +13,10 @@ import {
   parseScopeFlags,
   resolveCreateTokenFlags,
   hasScope,
+  hasScopeForVault,
+  findBroadVaultScopes,
   scopeForMethod,
+  verbForMethod,
   legacyPermissionToScopes,
   serializeScopes,
 } from "./scopes.ts";
@@ -34,10 +37,10 @@ describe("parseScopes", () => {
     ]);
   });
 
-  test("collapses vault:<name>:<verb> synonym to vault:<verb>", () => {
-    expect(parseScopes("vault:journal:read")).toEqual([SCOPE_READ]);
+  test("preserves vault:<name>:<verb> narrowed shape verbatim", () => {
+    expect(parseScopes("vault:journal:read")).toEqual(["vault:journal:read"]);
     expect(parseScopes("vault:journal:write vault:work:admin")).toEqual([
-      SCOPE_WRITE, SCOPE_ADMIN,
+      "vault:journal:write", "vault:work:admin",
     ]);
   });
 
@@ -46,12 +49,13 @@ describe("parseScopes", () => {
     expect(parseScopes("vault:unknown:frob")).toEqual(["vault:unknown:frob"]);
   });
 
-  test("empty name segment does NOT collapse (vault::read stays literal)", () => {
+  test("empty name segment is treated as unrecognized (vault::read stays literal)", () => {
     // Guard against a hand-crafted DB row with `vault::read` satisfying a
     // `vault:read` check by accident. Only reachable via direct DB write,
     // not API input, but the parser stays honest.
     expect(parseScopes("vault::read")).toEqual(["vault::read"]);
     expect(hasScope(parseScopes("vault::read"), SCOPE_READ)).toBe(false);
+    expect(hasScopeForVault(parseScopes("vault::read"), "", "read")).toBe(false);
   });
 });
 
@@ -91,25 +95,79 @@ describe("hasScope — inheritance admin ⊇ write ⊇ read", () => {
     expect(hasScope(["profile"], "email")).toBe(false);
     expect(hasScope([SCOPE_ADMIN], "profile")).toBe(false);
   });
+
+  test("narrowed grant satisfies broad query (more-specific is at-least-as-strong)", () => {
+    expect(hasScope(["vault:work:write"], SCOPE_READ)).toBe(true);
+    expect(hasScope(["vault:work:write"], SCOPE_WRITE)).toBe(true);
+    expect(hasScope(["vault:work:write"], SCOPE_ADMIN)).toBe(false);
+    expect(hasScope(["vault:work:admin"], SCOPE_ADMIN)).toBe(true);
+  });
+
+  test("broad query against narrowed query returns false (use hasScopeForVault for that)", () => {
+    // hasScope refuses to answer narrowed queries — they need a vault context.
+    expect(hasScope([SCOPE_ADMIN], "vault:work:read")).toBe(false);
+    expect(hasScope(["vault:work:write"], "vault:work:read")).toBe(false);
+  });
 });
 
-describe("scopeForMethod", () => {
-  test("read methods → vault:read", () => {
+describe("hasScopeForVault — per-vault matching with inheritance", () => {
+  test("broad grant satisfies any vault (caller pins via DB lookup / aud check)", () => {
+    expect(hasScopeForVault([SCOPE_READ], "work", "read")).toBe(true);
+    expect(hasScopeForVault([SCOPE_WRITE], "work", "read")).toBe(true);
+    expect(hasScopeForVault([SCOPE_WRITE], "work", "write")).toBe(true);
+    expect(hasScopeForVault([SCOPE_ADMIN], "anything", "admin")).toBe(true);
+  });
+
+  test("narrowed grant satisfies only the matching vault", () => {
+    expect(hasScopeForVault(["vault:work:read"], "work", "read")).toBe(true);
+    expect(hasScopeForVault(["vault:work:read"], "personal", "read")).toBe(false);
+    expect(hasScopeForVault(["vault:work:write"], "work", "read")).toBe(true);
+    expect(hasScopeForVault(["vault:work:admin"], "work", "write")).toBe(true);
+  });
+
+  test("narrowed grant does NOT satisfy a higher verb on its vault", () => {
+    expect(hasScopeForVault(["vault:work:read"], "work", "write")).toBe(false);
+    expect(hasScopeForVault(["vault:work:write"], "work", "admin")).toBe(false);
+  });
+
+  test("mixed grant — narrowed for one vault, broad fallback nowhere", () => {
+    expect(hasScopeForVault(["vault:work:write"], "personal", "read")).toBe(false);
+  });
+
+  test("empty grant fails everywhere", () => {
+    expect(hasScopeForVault([], "any", "read")).toBe(false);
+  });
+});
+
+describe("findBroadVaultScopes", () => {
+  test("returns broad vault scopes only", () => {
+    expect(findBroadVaultScopes([SCOPE_READ, SCOPE_WRITE])).toEqual([SCOPE_READ, SCOPE_WRITE]);
+    expect(findBroadVaultScopes(["vault:work:read"])).toEqual([]);
+    expect(findBroadVaultScopes([SCOPE_READ, "vault:work:write", "profile"])).toEqual([SCOPE_READ]);
+    expect(findBroadVaultScopes([])).toEqual([]);
+  });
+});
+
+describe("scopeForMethod / verbForMethod", () => {
+  test("read methods → vault:read / read", () => {
     expect(scopeForMethod("GET")).toBe(SCOPE_READ);
     expect(scopeForMethod("HEAD")).toBe(SCOPE_READ);
     expect(scopeForMethod("OPTIONS")).toBe(SCOPE_READ);
     expect(scopeForMethod("get")).toBe(SCOPE_READ); // case-insensitive
+    expect(verbForMethod("GET")).toBe("read");
   });
 
-  test("write methods → vault:write", () => {
+  test("write methods → vault:write / write", () => {
     expect(scopeForMethod("POST")).toBe(SCOPE_WRITE);
     expect(scopeForMethod("PATCH")).toBe(SCOPE_WRITE);
     expect(scopeForMethod("PUT")).toBe(SCOPE_WRITE);
     expect(scopeForMethod("DELETE")).toBe(SCOPE_WRITE);
+    expect(verbForMethod("POST")).toBe("write");
   });
 
-  test("unknown method falls back to vault:write (default-deny)", () => {
+  test("unknown method falls back to write (default-deny)", () => {
     expect(scopeForMethod("TRACE")).toBe(SCOPE_WRITE);
+    expect(verbForMethod("TRACE")).toBe("write");
   });
 });
 

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -1,11 +1,20 @@
 /**
- * Scope primitives for Phase 2 enforcement.
+ * Scope primitives for vault enforcement.
  *
- * Tokens carry OAuth-standard whitespace-separated scopes. This module parses,
- * normalizes, and matches them — including the `admin ⊇ write ⊇ read`
- * inheritance rule and the `vault:<name>:<verb>` future-shape synonym
- * (narrowed per-vault scopes are Phase 2+; today we treat them as equivalent
- * to `vault:<verb>`).
+ * Tokens carry OAuth-standard whitespace-separated scopes. Two shapes coexist:
+ *
+ *   - **Broad** `vault:<verb>` — used by `pvt_*` tokens, which are vault-pinned
+ *     by storage (each vault has its own tokens DB; a token only resolves
+ *     against the vault that minted it).
+ *   - **Narrowed** `vault:<name>:<verb>` — used by hub-issued JWTs, which are
+ *     not pinned by storage and so MUST name the resource they grant access
+ *     to. Hub JWTs carrying broad `vault:<verb>` are rejected at validation
+ *     (see `authenticateHubJwt`).
+ *
+ * Inheritance is `admin ⊇ write ⊇ read` for both shapes. `hasScopeForVault`
+ * resolves a (vault, verb) request: broad grants satisfy any vault (the
+ * caller has already pinned the vault via DB lookup), narrowed grants
+ * satisfy only the matching vault.
  *
  * Legacy back-compat: tokens without any `vault:*` scope — but with a
  * 0.2.x-era `permission = "full" | "read"` — are mapped to the appropriate
@@ -21,14 +30,40 @@ export const SCOPE_ADMIN = "vault:admin" as const;
 export const VAULT_SCOPES = [SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN] as const;
 export type VaultScope = (typeof VAULT_SCOPES)[number];
 
+/** The verb component of a vault scope — `read`, `write`, or `admin`. */
+export type VaultVerb = "read" | "write" | "admin";
+
+const VERB_RANK: Record<VaultVerb, number> = { read: 0, write: 1, admin: 2 };
+
+function isVerb(s: string): s is VaultVerb {
+  return s === "read" || s === "write" || s === "admin";
+}
+
 /**
- * Parse a whitespace-separated scope string into a normalized scope list.
+ * Decompose a scope string into `{ vault?, verb }` if it's a recognized vault
+ * scope; return `null` otherwise. Recognizes both broad (`vault:<verb>`) and
+ * narrowed (`vault:<name>:<verb>`) shapes. The empty-name case
+ * (`vault::read`) is rejected — a hand-crafted DB row with that shape must
+ * not satisfy any vault scope check.
+ */
+function decomposeVaultScope(scope: string): { vault: string | null; verb: VaultVerb } | null {
+  const parts = scope.split(":");
+  if (parts.length === 2 && parts[0] === "vault" && isVerb(parts[1])) {
+    return { vault: null, verb: parts[1] };
+  }
+  if (parts.length === 3 && parts[0] === "vault" && parts[1].length > 0 && isVerb(parts[2])) {
+    return { vault: parts[1], verb: parts[2] };
+  }
+  return null;
+}
+
+/**
+ * Parse a whitespace-separated scope string into a scope list.
  *
- * Normalization:
  *   - Empty / null → []
  *   - Trim + split on any whitespace
- *   - `vault:<name>:<verb>` collapses to `vault:<verb>` (per-vault narrowing
- *     is Phase 2+; today it's treated as a synonym)
+ *   - Both `vault:<verb>` and `vault:<name>:<verb>` shapes are preserved
+ *     verbatim; `hasScope` / `hasScopeForVault` decide what each satisfies.
  *   - Unrecognized scopes are preserved as-is (they just won't match anything)
  */
 export function parseScopes(raw: string | null | undefined): string[] {
@@ -36,38 +71,65 @@ export function parseScopes(raw: string | null | undefined): string[] {
   return raw
     .split(/\s+/)
     .map((s) => s.trim())
-    .filter(Boolean)
-    .map((s) => normalizeScope(s));
-}
-
-function normalizeScope(scope: string): string {
-  // `vault:<name>:<verb>` → `vault:<verb>` (synonym collapse). Reject an empty
-  // name segment (`vault::read`) — preserve it as-is so it can't accidentally
-  // satisfy a `vault:read` check. Only reachable via direct DB write, but the
-  // one-liner keeps the parser honest.
-  const parts = scope.split(":");
-  if (parts.length === 3 && parts[0] === "vault" && parts[1].length > 0) {
-    const verb = parts[2];
-    if (verb === "read" || verb === "write" || verb === "admin") {
-      return `vault:${verb}`;
-    }
-  }
-  return scope;
+    .filter(Boolean);
 }
 
 /**
- * Return true iff `granted` satisfies `required` under the inheritance rule
- * `admin ⊇ write ⊇ read`. Exact-match required for non-vault scopes.
+ * Broad-query check: does `granted` satisfy `required` (e.g. `vault:read`)?
+ *
+ * Used by code paths that don't have a specific vault in hand — JWT claim
+ * inspection, MCP tool list filtering inside a session that's already pinned
+ * to one vault, the legacy permission-derivation path. For per-request
+ * routing where the URL names a vault, prefer `hasScopeForVault`.
+ *
+ * A `vault:<name>:<verb>` grant DOES satisfy a broad `vault:<verb>` query —
+ * narrowed scopes are strictly more specific. The reverse is not true; broad
+ * grants do not satisfy narrowed queries via this function.
+ *
+ * Inheritance `admin ⊇ write ⊇ read` applies in both forms. Non-vault scopes
+ * require exact match.
  */
 export function hasScope(granted: string[], required: string): boolean {
   if (granted.includes(required)) return true;
 
-  // Inheritance: admin ⊇ write ⊇ read
-  if (required === SCOPE_READ) {
-    return granted.includes(SCOPE_WRITE) || granted.includes(SCOPE_ADMIN);
+  const requiredDecomposed = decomposeVaultScope(required);
+  if (!requiredDecomposed || requiredDecomposed.vault !== null) {
+    // Non-vault scope or narrowed query — exact match only via hasScope.
+    // (Narrowed queries belong on hasScopeForVault.)
+    return false;
   }
-  if (required === SCOPE_WRITE) {
-    return granted.includes(SCOPE_ADMIN);
+  const reqRank = VERB_RANK[requiredDecomposed.verb];
+  for (const s of granted) {
+    const d = decomposeVaultScope(s);
+    if (d && VERB_RANK[d.verb] >= reqRank) return true;
+  }
+  return false;
+}
+
+/**
+ * Per-vault check: does `granted` satisfy a (vault, verb) request? Use this
+ * at request-routing time — the URL names the vault and the method picks
+ * the verb.
+ *
+ * Match rules:
+ *   - Broad `vault:<verb>` in granted satisfies any vault (the broad scope
+ *     has no resource constraint; the caller pins the vault upstream — pvt_*
+ *     resolves only against its issuing vault's DB, hub JWTs reject broad
+ *     scopes at validation).
+ *   - Narrowed `vault:<name>:<verb>` satisfies only the matching `vaultName`.
+ *   - Verb inheritance `admin ⊇ write ⊇ read` applies in both forms.
+ */
+export function hasScopeForVault(
+  granted: string[],
+  vaultName: string,
+  requiredVerb: VaultVerb,
+): boolean {
+  const reqRank = VERB_RANK[requiredVerb];
+  for (const s of granted) {
+    const d = decomposeVaultScope(s);
+    if (!d) continue;
+    if (d.vault !== null && d.vault !== vaultName) continue;
+    if (VERB_RANK[d.verb] >= reqRank) return true;
   }
   return false;
 }
@@ -78,12 +140,33 @@ export function hasScope(granted: string[], required: string): boolean {
  *   - POST/PATCH/PUT/DELETE → write
  *
  * Admin-gated endpoints (like `/.parachute/config`) don't go through this
- * helper — they call `hasScope(auth.scopes, SCOPE_ADMIN)` directly.
+ * helper — they call `hasScopeForVault(auth.scopes, vaultName, "admin")`
+ * directly.
  */
 export function scopeForMethod(method: string): VaultScope {
+  return verbForMethod(method) === "read" ? SCOPE_READ : SCOPE_WRITE;
+}
+
+/** Verb-only variant of `scopeForMethod`, for use with `hasScopeForVault`. */
+export function verbForMethod(method: string): VaultVerb {
   const m = method.toUpperCase();
-  if (m === "GET" || m === "HEAD" || m === "OPTIONS") return SCOPE_READ;
-  return SCOPE_WRITE;
+  if (m === "GET" || m === "HEAD" || m === "OPTIONS") return "read";
+  return "write";
+}
+
+/**
+ * Detect a broad `vault:<verb>` scope in a granted list. Hub-issued JWTs
+ * must NOT carry broad vault scopes — the hub mints `vault:<name>:<verb>` so
+ * the resource is named on the wire. `authenticateHubJwt` calls this to
+ * reject tokens that slipped through with the old shape.
+ */
+export function findBroadVaultScopes(granted: string[]): string[] {
+  const out: string[] = [];
+  for (const s of granted) {
+    const d = decomposeVaultScope(s);
+    if (d && d.vault === null) out.push(s);
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 1 of the vault config + scope semantics design ([PR #179](https://github.com/ParachuteComputer/parachute-vault/pull/179), merged as `0d18414`). Hub-issued JWTs are now required to carry resource-narrowed scopes, and every authenticated request strict-checks the JWT audience against the requested vault.

- **Scope narrowing**: hub-issued JWTs MUST carry `vault:<name>:<verb>` scopes. Broad `vault:<verb>` scopes from a hub JWT are rejected at the JWT validation layer (`authenticateHubJwt`) — forces picker semantics so the hub never mints "all vaults" tokens.
- **Per-vault audience enforcement**: `validateHubJwt` accepts an `expectedAudience` option; `authenticateVaultRequest` passes `vault.<name>`. Mismatch → 401 with a clear "audience mismatch: expected X, got Y" message.
- **pvt_\* tokens unaffected**: they remain vault-pinned by DB lookup and may keep broad `vault:<verb>` scopes. The narrowing rule only applies to hub-issued JWTs.
- **Verb inheritance preserved**: `admin ⊇ write ⊇ read` for both broad and narrowed shapes. New `hasScopeForVault(scopes, vault, verb)` helper centralizes the per-vault check; `findBroadVaultScopes` is what the JWT path uses to detect violations.
- **MCP per-vault tool gating**: `mcp-http.ts` now uses `hasScopeForVault(auth.scopes, vaultName, verbForTool(name))` for both list-filtering and call-time gating. `vault-info`'s description-update inner gate uses the same.
- **Cross-vault routes reject hub JWTs**: `/vaults`, `/health`, `/mcp` (unified) — there's no single audience to strict-check against. Cross-vault listing for hub-authenticated callers waits for the `parachute:host:*` namespace; until then, callers use per-vault `/vault/<name>/*` endpoints.

Bumps `0.3.6-rc.1` → `0.3.6-rc.2` per RC governance.

## Test plan

- [x] `bun test src/scopes.test.ts src/hub-jwt.test.ts src/auth.test.ts src/routing.test.ts src/oauth.test.ts src/vault.test.ts` — 333 pass / 0 fail
- [x] New tests cover: narrowed scope round-trip; broad-grant satisfies any vault via `hasScopeForVault`; narrowed-grant matches only its named vault; verb inheritance; `findBroadVaultScopes` detection; JWT audience strict-check pass/fail/null-skip
- [x] `pvt_*` token paths still pass with broad scopes (existing routing.test.ts coverage)
- [ ] Reviewer-friendly: paraclaw-reviewer will run

🤖 Generated with [Claude Code](https://claude.com/claude-code)