### PR TITLE
feat(cli): add --json flag to vault create for orchestrator integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.2",
+  "version": "0.3.6-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,8 @@ import {
   loadEnvFile,
   listVaults,
   vaultDir,
+  vaultDbPath,
+  vaultConfigPath,
   DEFAULT_PORT,
   CONFIG_DIR,
   ASSETS_DIR,
@@ -700,9 +702,15 @@ async function cmd2fa(args: string[]) {
 }
 
 function cmdCreate(args: string[]) {
-  const name = args[0];
+  // --json: emit a single machine-readable object on stdout instead of the
+  // human-friendly multi-line print. Designed for orchestrators (the hub's
+  // POST /vaults shells out to this CLI and parses stdout). Errors still go
+  // to stderr as plain text and exit nonzero — callers branch on exit code.
+  const jsonMode = args.includes("--json");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const name = positional[0];
   if (!name) {
-    console.error("Usage: parachute-vault create <name>");
+    console.error("Usage: parachute-vault create <name> [--json]");
     process.exit(1);
   }
 
@@ -735,12 +743,29 @@ function cmdCreate(args: string[]) {
   const needsDefault = !globalConfig.default_vault
     || !listVaults().includes(globalConfig.default_vault);
   let defaultNote: string | null = null;
+  let setAsDefault = false;
   if (needsDefault) {
     globalConfig.default_vault = name;
     writeGlobalConfig(globalConfig);
+    setAsDefault = true;
     defaultNote = wasFirst
       ? `Set as default vault (unscoped routes will target "${name}")`
       : `Set as default vault (previous default was missing)`;
+  }
+
+  if (jsonMode) {
+    const payload = {
+      name,
+      token: key,
+      paths: {
+        vault_dir: vaultDir(name),
+        vault_db: vaultDbPath(name),
+        vault_config: vaultConfigPath(name),
+      },
+      set_as_default: setAsDefault,
+    };
+    console.log(JSON.stringify(payload));
+    return;
   }
 
   console.log(`Vault "${name}" created.`);
@@ -2155,7 +2180,7 @@ Setup:
   parachute --version                      Print the installed version (alias: -v, version)
 
 Vaults:
-  parachute-vault create <name>            Create a new vault
+  parachute-vault create <name> [--json]   Create a new vault (--json: emit { name, token, paths, set_as_default })
   parachute-vault list                     List all vaults
   parachute-vault remove <name> [--yes]    Remove a vault
   parachute-vault mcp-install              Add vault MCP to Claude

--- a/src/vault-create.test.ts
+++ b/src/vault-create.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration tests for `parachute-vault create <name> [--json]`.
+ *
+ * The `--json` mode is the contract the hub orchestrator parses: stdout
+ * carries a single JSON object with name/token/paths/set_as_default. These
+ * tests spawn the CLI in a temp `PARACHUTE_HOME` so the create lands on a
+ * fresh, isolated vault tree and we can assert the on-disk artifacts the
+ * payload claims to have written.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { resolve } from "path";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = resolve(import.meta.dir, "cli.ts");
+
+function runCli(
+  args: string[],
+  env: Record<string, string>,
+): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync({
+    cmd: ["bun", CLI, ...args],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "vault-create-test-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("vault create --json", () => {
+  test("emits parseable JSON with name, token, paths, set_as_default=true on first vault", () => {
+    const { exitCode, stdout, stderr } = runCli(
+      ["create", "myvault", "--json"],
+      { PARACHUTE_HOME: home },
+    );
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+
+    // stdout must be exactly one JSON object — single-line, parseable.
+    const payload = JSON.parse(stdout.trim());
+    expect(payload.name).toBe("myvault");
+    expect(payload.token).toMatch(/^pvt_/);
+    expect(payload.set_as_default).toBe(true);
+    expect(payload.paths.vault_dir).toBe(join(home, "vault", "data", "myvault"));
+    expect(payload.paths.vault_db).toBe(join(home, "vault", "data", "myvault", "vault.db"));
+    expect(payload.paths.vault_config).toBe(join(home, "vault", "data", "myvault", "vault.yaml"));
+
+    // Sanity: the on-disk artifacts the payload describes actually exist.
+    expect(existsSync(payload.paths.vault_dir)).toBe(true);
+    expect(existsSync(payload.paths.vault_db)).toBe(true);
+    expect(existsSync(payload.paths.vault_config)).toBe(true);
+  });
+
+  test("set_as_default=false when another vault already holds the default slot", () => {
+    runCli(["create", "first", "--json"], { PARACHUTE_HOME: home });
+    const { exitCode, stdout } = runCli(
+      ["create", "second", "--json"],
+      { PARACHUTE_HOME: home },
+    );
+    expect(exitCode).toBe(0);
+    const payload = JSON.parse(stdout.trim());
+    expect(payload.name).toBe("second");
+    expect(payload.set_as_default).toBe(false);
+  });
+
+  test("--json works regardless of flag position (before or after name)", () => {
+    const { exitCode, stdout } = runCli(
+      ["create", "--json", "before"],
+      { PARACHUTE_HOME: home },
+    );
+    expect(exitCode).toBe(0);
+    const payload = JSON.parse(stdout.trim());
+    expect(payload.name).toBe("before");
+  });
+
+  test("invalid name in --json mode still errors on stderr (not stdout) and exits non-zero", () => {
+    const { exitCode, stdout, stderr } = runCli(
+      ["create", "Bad Name", "--json"],
+      { PARACHUTE_HOME: home },
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("letters, numbers");
+  });
+
+  test("duplicate name in --json mode errors on stderr and exits non-zero", () => {
+    runCli(["create", "dup", "--json"], { PARACHUTE_HOME: home });
+    const { exitCode, stdout, stderr } = runCli(
+      ["create", "dup", "--json"],
+      { PARACHUTE_HOME: home },
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("already exists");
+  });
+});
+
+describe("vault create (human mode unchanged)", () => {
+  test("prints multi-line human output without --json", () => {
+    const { exitCode, stdout } = runCli(
+      ["create", "human"],
+      { PARACHUTE_HOME: home },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Vault "human" created.');
+    expect(stdout).toContain("API token:");
+    expect(stdout).toContain("Save this");
+    // Human output should NOT be valid JSON.
+    expect(() => JSON.parse(stdout.trim())).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Hub-side Phase 1 (POST /vaults) needs machine-readable output from `parachute-vault create`. `--json` adds a single-line JSON contract on stdout.

- `parachute-vault create <name> --json` emits `{ name, token, paths: { vault_dir, vault_db, vault_config }, set_as_default }` on stdout — single line, parseable.
- Errors continue to go to stderr as plain text with non-zero exit; callers branch on exit code rather than parsing error JSON.
- Human output unchanged when `--json` is absent.
- Flag-position-independent (`create --json foo` and `create foo --json` both work).

Pairs with hub Phase 1 (#235 in-progress) — coordinator brief was: "Hub is proceeding under the assumption that --json will exist when their integration commit lands."

Bumps `0.3.6-rc.2` → `0.3.6-rc.3` (rc.2 is reserved by [PR #180](https://github.com/ParachuteComputer/parachute-vault/pull/180); this PR sequences after it).

## Test plan

- [x] New `src/vault-create.test.ts` (6 tests): JSON shape, on-disk artifacts match payload paths, `set_as_default` flag, flag-position independence, invalid name errors on stderr (not stdout), duplicate name errors on stderr, human mode unchanged
- [x] `bun test src/` — 905/905 green
- [x] Reviewer-friendly: paraclaw-reviewer pattern applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)