### PR TITLE
Phase 1 cleanup bundle: #181-#186

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.3",
+  "version": "0.3.6-rc.4",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -1,0 +1,231 @@
+/**
+ * End-to-end auth tests for the hub-JWT path.
+ *
+ * `hub-jwt.test.ts` covers `validateHubJwt` in isolation. This file exercises
+ * the full request path: a JWT bearer arrives at `authenticateVaultRequest`,
+ * goes through `authenticateHubJwt`, and the result either resolves into an
+ * `AuthResult` or surfaces as a 401 Response. The cases that matter most:
+ *
+ *   - happy path with narrowed scopes
+ *   - broad `vault:<verb>` scope rejected (forced narrowing per #180)
+ *   - `aud=vault.<other>` rejected (audience mismatch)
+ *   - JWT path rejected at the global (cross-vault) entrypoint
+ *
+ * Each test owns a fresh `PARACHUTE_HOME` and JWKS fixture, like the auth.test
+ * peer file. The JWKS fixture mirrors the one in hub-jwt.test.ts; duplicating
+ * ~30 lines is cheaper than introducing a shared test-helper module.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { generateKeyPair, exportJWK, SignJWT } from "jose";
+import { writeVaultConfig, readVaultConfig } from "./config.ts";
+import { getVaultStore, clearVaultStoreCache } from "./vault-store.ts";
+import { authenticateVaultRequest, authenticateGlobalRequest } from "./auth.ts";
+import { resetJwksCache } from "./hub-jwt.ts";
+
+interface Keypair {
+  privateKey: CryptoKey;
+  publicJwk: { kty: string; n: string; e: string; kid: string; alg: string; use: string };
+  kid: string;
+}
+
+async function makeKeypair(kid: string): Promise<Keypair> {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  const jwk = await exportJWK(publicKey);
+  return {
+    privateKey,
+    publicJwk: { kty: "RSA", n: jwk.n!, e: jwk.e!, kid, alg: "RS256", use: "sig" },
+    kid,
+  };
+}
+
+interface JwksFixture {
+  origin: string;
+  stop: () => void;
+}
+
+function startJwksFixture(keys: Keypair[]): JwksFixture {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/.well-known/jwks.json") {
+        return new Response("not found", { status: 404 });
+      }
+      return Response.json({ keys: keys.map((k) => k.publicJwk) });
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    stop: () => server.stop(true),
+  };
+}
+
+interface SignOpts {
+  iss: string;
+  aud: string;
+  scope: string;
+  sub?: string;
+  ttlSeconds?: number;
+}
+
+async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + (opts.ttlSeconds ?? 60);
+  return await new SignJWT({ scope: opts.scope, client_id: "test-client" })
+    .setProtectedHeader({ alg: "RS256", kid: kp.kid })
+    .setIssuer(opts.iss)
+    .setSubject(opts.sub ?? "user-1")
+    .setAudience(opts.aud)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .setJti(`jti-${Math.random().toString(36).slice(2)}`)
+    .sign(kp.privateKey);
+}
+
+function bearer(token: string): Request {
+  return new Request("https://vault.test/x", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+let tmpHome: string;
+let prevHome: string | undefined;
+let prevHubOrigin: string | undefined;
+let fixture: JwksFixture;
+let kp: Keypair;
+
+beforeEach(async () => {
+  tmpHome = join(
+    tmpdir(),
+    `vault-auth-jwt-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(join(tmpHome, "vault", "data"), { recursive: true });
+  prevHome = process.env.PARACHUTE_HOME;
+  process.env.PARACHUTE_HOME = tmpHome;
+  clearVaultStoreCache();
+
+  kp = await makeKeypair("k1");
+  fixture = startJwksFixture([kp]);
+  prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+  process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
+  resetJwksCache();
+});
+
+afterEach(() => {
+  fixture.stop();
+  clearVaultStoreCache();
+  if (prevHome === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = prevHome;
+  if (prevHubOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = prevHubOrigin;
+  if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function seedVault(name: string): void {
+  writeVaultConfig({ name, api_keys: [], created_at: new Date().toISOString() });
+  // Touch the store so the DB file exists (matches the routing path's expectation).
+  getVaultStore(name);
+}
+
+describe("authenticateVaultRequest — hub JWT integration", () => {
+  test("narrowed scope + matching aud → AuthResult with permission derived from verb", async () => {
+    seedVault("journal");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:write",
+    });
+    const config = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("full");
+      expect(result.scopes).toEqual(["vault:journal:write"]);
+      expect(result.legacyDerived).toBe(false);
+    }
+  });
+
+  test("narrowed read scope → permission='read'", async () => {
+    seedVault("journal");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:read",
+    });
+    const config = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) expect(result.permission).toBe("read");
+  });
+
+  test("broad vault:write scope from a JWT → 401 with explanatory message", async () => {
+    seedVault("journal");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:write",
+    });
+    const config = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+      const body = (await result.error.json()) as { error: string; message: string };
+      expect(body.error).toBe("Unauthorized");
+      expect(body.message).toContain("broad vault scope");
+      expect(body.message).toContain("vault:write");
+    }
+  });
+
+  test("aud=vault.work cannot reach /vault/journal/* → 401 audience mismatch", async () => {
+    seedVault("journal");
+    seedVault("work");
+    // Token is correctly stamped for work, but presented at journal's endpoint.
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.work",
+      scope: "vault:work:write",
+    });
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(
+      bearer(token),
+      journalConfig,
+      journalStore.db,
+    );
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+      const body = (await result.error.json()) as { error: string; message: string };
+      expect(body.message).toMatch(/audience mismatch.*vault\.journal.*vault\.work/);
+    }
+  });
+
+  test("hub JWT at the global (cross-vault) entrypoint → 401 with vault-bound hint", async () => {
+    seedVault("journal");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:read",
+    });
+    const result = await authenticateGlobalRequest(bearer(token));
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+      const body = (await result.error.json()) as { error: string; message: string };
+      expect(body.message).toContain("vault-bound");
+      expect(body.message).toContain("/vault/<name>");
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -707,6 +707,11 @@ function cmdCreate(args: string[]) {
   // POST /vaults shells out to this CLI and parses stdout). Errors still go
   // to stderr as plain text and exit nonzero — callers branch on exit code.
   const jsonMode = args.includes("--json");
+  // Greedy strip of any `--*` token to recover the positional vault name.
+  // Today only `--json` is recognized; any other `--foo` is silently dropped.
+  // If a future flag (e.g. `--force`, `--dry-run`) is added, the parsing
+  // here needs to whitelist it — otherwise an invalid flag becomes a silent
+  // no-op rather than a usage error.
   const positional = args.filter((a) => !a.startsWith("--"));
   const name = positional[0];
   if (!name) {

--- a/src/hub-jwt.test.ts
+++ b/src/hub-jwt.test.ts
@@ -70,7 +70,7 @@ function startJwksFixture(): JwksFixture {
 
 interface SignOpts {
   iss?: string;
-  aud?: string;
+  aud?: string | string[];
   sub?: string;
   scope?: string;
   jti?: string;
@@ -199,6 +199,34 @@ describe("validateHubJwt — audience strict-check", () => {
     const token = await signJwt(kp, { iss: fixture.origin, aud: "vault.anything" });
     const claims = await validateHubJwt(token, { expectedAudience: null });
     expect(claims.aud).toBe("vault.anything");
+  });
+
+  test("array aud: passes when expected is one of the entries", async () => {
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: ["vault.work", "vault.personal", "operator"],
+    });
+    const claims = await validateHubJwt(token, { expectedAudience: "vault.personal" });
+    expect(claims.aud).toBe("vault.personal");
+  });
+
+  test("array aud: rejects when expected is not in the entries", async () => {
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: ["vault.work", "operator"],
+    });
+    await expect(
+      validateHubJwt(token, { expectedAudience: "vault.personal" }),
+    ).rejects.toThrow(/audience mismatch.*vault\.personal.*vault\.work.*operator/);
+  });
+
+  test("array aud: surfaces the first entry when no expectation is set", async () => {
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: ["vault.first", "vault.second"],
+    });
+    const claims = await validateHubJwt(token, { expectedAudience: null });
+    expect(claims.aud).toBe("vault.first");
   });
 });
 

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -10,7 +10,9 @@
  *   - JWKS fetch + verify. `jose.createRemoteJWKSet` does the fetching, kid
  *     lookup, and rotation handling. Tokens MUST have `iss = <hub origin>` —
  *     the load-bearing trust check; without it, anyone could forge tokens
- *     against any RSA key. Audience is parsed but accepted broadly (TODO).
+ *     against any RSA key. `aud` is strict-checked against
+ *     `opts.expectedAudience` when provided (per-vault binding); RFC 7519
+ *     `aud` may be a string or string[], and either shape is supported.
  *
  * Vault#169 / hub-as-issuer Phase B2.
  */
@@ -149,14 +151,28 @@ export async function validateHubJwt(
     throw new HubJwtError("hub JWT missing required `sub` claim");
   }
 
-  const aud = typeof payload.aud === "string" ? payload.aud : undefined;
+  // RFC 7519 §4.1.3: `aud` may be a string OR an array of strings. We unify
+  // into an array internally and check membership; surfacing back to callers
+  // collapses to a single representative value (the matched one when an
+  // expectation was supplied, else the first array element).
+  const audRaw = payload.aud;
+  const auds: string[] =
+    typeof audRaw === "string"
+      ? [audRaw]
+      : Array.isArray(audRaw)
+        ? audRaw.filter((a): a is string => typeof a === "string")
+        : [];
+
   if (opts.expectedAudience != null) {
-    if (aud !== opts.expectedAudience) {
+    if (!auds.includes(opts.expectedAudience)) {
+      const got = auds.length === 0 ? "(missing)" : auds.join(", ");
       throw new HubJwtError(
-        `hub JWT audience mismatch: expected "${opts.expectedAudience}", got "${aud ?? "(missing)"}"`,
+        `hub JWT audience mismatch: expected "${opts.expectedAudience}", got "${got}"`,
       );
     }
   }
+  const aud: string | undefined =
+    opts.expectedAudience != null ? opts.expectedAudience : auds[0];
 
   const scopeRaw = (payload as { scope?: unknown }).scope;
   const scopes =

--- a/src/vault-create.test.ts
+++ b/src/vault-create.test.ts
@@ -53,7 +53,12 @@ describe("vault create --json", () => {
     expect(stderr).toBe("");
 
     // stdout must be exactly one JSON object — single-line, parseable.
-    const payload = JSON.parse(stdout.trim());
+    // Asserting line count first so a regression that prints a banner above
+    // the JSON fails with "expected 1 line, got 2" rather than the much
+    // less actionable "JSON parse error".
+    const lines = stdout.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const payload = JSON.parse(lines[0]!);
     expect(payload.name).toBe("myvault");
     expect(payload.token).toMatch(/^pvt_/);
     expect(payload.set_as_default).toBe(true);


### PR DESCRIPTION
## Summary

Five Phase 1 follow-up nits filed against PRs #180 / #184, bundled into one PR per the bundle-cohesive-PRs pattern. All small, mechanical, in adjacent areas (auth + tests + CLI). Per-issue commits.

| Issue | Commit | What changed |
|---|---|---|
| **#181** | [`6e923e1`](../commit/6e923e1) | `validateHubJwt` now accepts `aud: string[]` per RFC 7519 §4.1.3 — was silently dropping arrays to `(missing)`. Mismatch error lists every aud entry. |
| **#183** | [`6e923e1`](../commit/6e923e1) | Module-level doc comment on `hub-jwt.ts` no longer claims audience handling is "TODO" — refreshed to describe the post-#180 behaviour. |
| **#182** | [`28914d1`](../commit/28914d1) | New `src/auth-hub-jwt.test.ts` covers the full request path: JWT bearer → `authenticateVaultRequest` / `authenticateGlobalRequest` → AuthResult or 401 Response. 5 cases (narrowed happy path read+write, broad-scope reject, audience mismatch, JWT at cross-vault entrypoint). |
| **#185** | [`73dfd97`](../commit/73dfd97) | `vault-create.test.ts` now asserts `stdout.trim().split('\n').length === 1` before parsing JSON — turns a "JSON parse error" regression into "expected 1 line, got 2". |
| **#186** | [`73dfd97`](../commit/73dfd97) | Comment on `cmdCreate`'s `args.filter(a => !a.startsWith('--'))` flagging that future flags must be whitelisted to avoid silent no-op behaviour. |

Bumps `0.3.6-rc.3` → `0.3.6-rc.4` per RC governance.

## Test plan

- [x] `bun test src/hub-jwt.test.ts` — 22 pass (3 new array-aud cases)
- [x] `bun test src/auth-hub-jwt.test.ts` — 5 pass (all new)
- [x] `bun test src/vault-create.test.ts` — 6 pass (single-line assertion folded in)
- [x] `bun test src/` — 925/925 green

## Notes for reviewer

- Array-aud rejection error message intentionally lists *every* aud entry, not just the first. A token with `aud: ["operator", "vault.work"]` presented at `/vault/personal/*` should make it obvious the token was minted for a different vault.
- The 5-line `aud` parsing block is the load-bearing change in #181 — everything else is comment polish, single-line guards, or test scaffolding.
- The integration tests in `auth-hub-jwt.test.ts` duplicate ~30 lines of JWKS fixture from `hub-jwt.test.ts`. Cheaper than introducing a `_test-helpers/jwks.ts` module for two callers; revisit if a third caller appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)