### PR TITLE
chore: cleanup batch 2 — module.json + services-manifest merge fix

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -1,0 +1,14 @@
+{
+  "name": "vault",
+  "manifestName": "parachute-vault",
+  "displayName": "Vault",
+  "tagline": "Your owner-authenticated MCP knowledge store.",
+  "kind": "api",
+  "port": 1940,
+  "paths": ["/vault/default"],
+  "health": "/vault/default/health",
+  "startCmd": ["parachute-vault", "serve"],
+  "scopes": {
+    "defines": ["vault:read", "vault:write", "vault:admin"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.4",
+  "version": "0.3.6-rc.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/services-manifest.test.ts
+++ b/src/services-manifest.test.ts
@@ -123,6 +123,26 @@ describe("services-manifest", () => {
     }
   });
 
+  test("preserves hub-stamped fields on the row (e.g. installDir from parachute-hub#84)", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      // Pre-existing row carries `installDir` — a field the hub stamps onto
+      // the entry post-install. Vault's self-registration pass must not drop
+      // it, even though `installDir` isn't part of the typed ServiceEntry.
+      const stamped = { ...vault, installDir: "/Users/test/.parachute/vault" };
+      writeFileSync(path, `${JSON.stringify({ services: [stamped] }, null, 2)}\n`);
+      const updated = { ...vault, version: "0.4.0" };
+      upsertService(updated, path);
+      const m = readManifest(path);
+      expect(m.services).toHaveLength(1);
+      const row = m.services[0] as ServiceEntry & { installDir?: string };
+      expect(row.version).toBe("0.4.0"); // vault's field wins
+      expect(row.installDir).toBe("/Users/test/.parachute/vault"); // hub's field survives
+    } finally {
+      cleanup();
+    }
+  });
+
   test("default path honors PARACHUTE_HOME set at runtime", () => {
     const dir = mkdtempSync(join(tmpdir(), "pvault-home-"));
     const prior = process.env.PARACHUTE_HOME;

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -46,7 +46,10 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
   if (typeof version !== "string") {
     throw new ServicesManifestError(`${where}: "version" must be a string`);
   }
-  return { name, port, paths: paths as string[], health, version };
+  // Spread the raw object first so hub-stamped fields (e.g. `installDir` from
+  // parachute-hub#84) ride through the read. The strict fields below pin the
+  // typed shape we promise callers; anything extra survives untouched.
+  return { ...e, name, port, paths: paths as string[], health, version } as ServiceEntry;
 }
 
 function validateManifest(raw: unknown, where: string): ServicesManifest {
@@ -90,7 +93,11 @@ export function upsertService(
   const current = readManifest(path);
   const idx = current.services.findIndex((s) => s.name === entry.name);
   if (idx >= 0) {
-    current.services[idx] = entry;
+    // Merge rather than replace so fields the hub stamps onto the row
+    // (`installDir` from parachute-hub#84, etc.) survive a self-registration
+    // pass. Vault still wins for the fields it owns — port, paths, version,
+    // health — because `entry` spreads last.
+    current.services[idx] = { ...current.services[idx], ...entry };
   } else {
     current.services.push(entry);
   }


### PR DESCRIPTION
## Summary

Bundles two related cleanup items in the config/manifest area, plus the verdict on a third.

- **#178** — `fix(services-manifest):` merge upsert preserves hub-stamped fields (e.g. `installDir` from parachute-hub#84). Mirrors paraclaw#17 / scribe#28. Also fixes a stricter-than-paraclaw bug: vault's `validateEntry` was stripping unknown fields on read, so `installDir` would have been dropped even before upsert.
- **#175** — `feat(module):` ship `.parachute/module.json` so hub's `FIRST_PARTY_FALLBACKS` entry for vault can retire. Shape mirrors hub's existing `VAULT_FALLBACK` (parachute-hub/src/service-spec.ts:254) so the swap is a no-op at runtime. Verified `.parachute/module.json` ships in `bun pm pack`.
- **#129** — investigated, not actionable on vault side. Vault has no unscoped OAuth route (`routing.ts:1–29` documents this explicitly). The empty-`vault` field in the unscoped flow must come from hub. Recommend closing #129 here with a pointer to hub. **No code change in this PR.**

## Phase 1 obsoleted-issue sweep

Scanned open issues for items now done by Phase 1 (PR #180). Two candidates examined:

- **#94** (server-side scope binding on `/oauth/authorize`) — still applies. It's about vault's *native* `pvt_*` OAuth flow, not the hub-issued JWT path Phase 1 narrowed.
- **#93** (rate limiter per-vault scoping) — still applies. Phase 1 didn't touch rate limiting.

No clear obsoletes from this scan.

## After-this-lands

A follow-up PR on the hub repo can delete `VAULT_FALLBACK` (parachute-hub/src/service-spec.ts:252–275) — the `FALLBACK: Delete when @openparachute/vault ships .parachute/module.json` marker names this exact follow-up.

## Version

`0.3.6-rc.4` → `0.3.6-rc.5`.

## Test plan

- [x] `bun test src/` — 926 pass / 0 fail (includes new `services-manifest.test.ts` case for hub-stamped field preservation)
- [x] `bun test core/src/` — 279 pass / 0 fail
- [x] `bun pm pack --dry-run` — confirms `.parachute/module.json` is in the tarball
- [ ] Smoke: `parachute install @openparachute/vault` from rc tarball — defer until hub-side `VAULT_FALLBACK` removal PR is also green; the in-repo gates above are sufficient signal for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)