### PR TITLE
chore: cleanup batch 3 — #130 query-notes near, #163 /auth/status

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -1529,6 +1529,35 @@ describe("MCP tools", async () => {
     expect(result[0].id).toBe("near");
   });
 
+  it("query-notes near returns neighborhood even when limit is small and unrelated notes were created first (#130)", async () => {
+    // Repro of #130: anchor + linked notes get crowded out by unrelated notes
+    // when the query runs ORDER BY created_at LIMIT 5 BEFORE the
+    // neighborhood filter. With the SQL-pushed ids filter, LIMIT applies to
+    // the neighborhood, not the whole notes table.
+    //
+    // Seed: 10 unrelated notes created first, THEN the anchor + 2 linked
+    // notes. With limit=5 and ORDER BY created_at ASC, the unrelated ten
+    // would fill the slate and the in-neighborhood notes would never appear.
+    for (let i = 0; i < 10; i++) {
+      await store.createNote(`Unrelated ${i}`, { id: `unrelated-${i}` });
+    }
+    await store.createNote("Anchor", { id: "anchor" });
+    await store.createNote("Outbound target", { id: "outbound" });
+    await store.createNote("Inbound source", { id: "inbound" });
+    await store.createLink("anchor", "outbound", "wikilink");
+    await store.createLink("inbound", "anchor", "wikilink");
+
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = await query.execute({
+      near: { note_id: "anchor", depth: 2 },
+      limit: 5,
+    }) as any[];
+
+    const ids = result.map((n: any) => n.id).sort();
+    expect(ids).toEqual(["anchor", "inbound", "outbound"]);
+  });
+
   it("delete-note accepts path", async () => {
     await store.createNote("To delete", { path: "Temp/note" });
     const tools = generateMcpTools(store);

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -213,6 +213,12 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             hasLinks: params.has_links as boolean | undefined,
             path: params.path as string | undefined,
             pathPrefix: params.path_prefix as string | undefined,
+            // Push the near-scope into the SQL WHERE so that LIMIT and ORDER
+            // BY apply to the neighborhood. Without this, queryNotes would
+            // fetch the first `limit` notes by created_at and then post-
+            // filter to the few in-scope ones — which silently empties the
+            // result whenever the neighborhood lies outside that prefix.
+            ids: nearScope ? [...nearScope] : undefined,
             metadata: params.metadata as Record<string, unknown> | undefined,
             dateFrom: params.date_from as string | undefined,
             dateTo: params.date_to as string | undefined,
@@ -223,8 +229,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           });
         }
 
-        // --- Apply near-scope filter ---
-        if (nearScope) {
+        // For full-text search the post-filter is still the right shape — FTS
+        // owns its own ranked LIMIT and we just narrow to the neighborhood
+        // afterwards. Structured queries already pushed `ids` into SQL above.
+        if (nearScope && params.search) {
           results = results.filter((n) => nearScope!.has(n.id));
         }
 

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -259,6 +259,20 @@ export function queryNotes(db: Database, opts: QueryOpts): Note[] {
     );
   }
 
+  // ID set filter — used by `near` to push neighborhood scoping into SQL so
+  // that LIMIT applies to the neighborhood, not the whole notes table.
+  if (opts.ids !== undefined) {
+    if (opts.ids.length === 0) {
+      // Caller asked for "in this empty set" — no rows match. Short-circuit
+      // with an always-false condition; building `IN ()` would be a SQL error.
+      conditions.push("0 = 1");
+    } else {
+      const placeholders = opts.ids.map(() => "?").join(", ");
+      conditions.push(`n.id IN (${placeholders})`);
+      params.push(...opts.ids);
+    }
+  }
+
   // Exact path match (case-insensitive)
   if (opts.path) {
     conditions.push("n.path = ? COLLATE NOCASE");

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -57,6 +57,11 @@ export interface QueryOpts {
   hasLinks?: boolean;
   path?: string;        // exact path match (case-insensitive)
   pathPrefix?: string;  // e.g., "Projects/Parachute" matches "Projects/Parachute/README"
+  // Restrict results to a specific set of note IDs. The MCP `near` query uses
+  // this to push graph-neighborhood scoping into the SQL WHERE clause so that
+  // LIMIT and ORDER BY apply to the filtered set, not the whole notes table.
+  // Empty array → no rows match (avoids `IN ()` syntax error).
+  ids?: string[];
   // Per-field metadata filter. Each value is either a primitive (exact
   // match, today's behavior) or an operator object — `{ eq, ne, gt, gte, lt,
   // lte, in, not_in, exists }` — which routes through the generated column

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.5",
+  "version": "0.3.6-rc.6",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/auth-status.ts
+++ b/src/auth-status.ts
@@ -1,0 +1,84 @@
+/**
+ * Public auth-state probe — read-only summary that lets a first-contact
+ * client decide which token to mint before doing anything authenticated.
+ *
+ * Mirrors the consumer shape that `parachute-hub/src/vault/auth-status.ts`
+ * already computes by snooping vault's filesystem; this endpoint replaces
+ * that out-of-process coupling with an in-process read.
+ *
+ * What gets exposed:
+ *   - `initialized` — at least one vault exists
+ *   - `auth_modes`  — accepted bearer formats (pvt_*, hub-issued JWT)
+ *   - `vaults`      — list of `{ name, url }` for client-side dispatch
+ *   - `hasOwnerPassword`, `hasTotp` — OAuth consent prerequisites
+ *   - `hasTokens`   — boolean | null. `null` ≈ "we couldn't read all DBs,
+ *     don't trust this answer"; `true`/`false` are honest yes/no signals.
+ *
+ * What is deliberately NOT exposed: token counts, hashes, descriptions,
+ * timestamps, owner-password hash, totp secret, backup codes. The endpoint
+ * is unauthenticated — anything sensitive belongs behind /vaults or
+ * /vault/<name>/.
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync } from "fs";
+import { listVaults, readGlobalConfig, vaultDbPath } from "./config.ts";
+
+export interface AuthStatusResponse {
+  initialized: boolean;
+  auth_modes: ("pvt_token" | "hub_jwt")[];
+  vaults: { name: string; url: string }[];
+  hasOwnerPassword: boolean;
+  hasTotp: boolean;
+  hasTokens: boolean | null;
+}
+
+/**
+ * Probe a single vault's `tokens` table for *existence* (not count). We open
+ * the DB read-only and `LIMIT 1` so we never block a writer or fight for a
+ * lock. Any failure (missing DB, schema drift, lock contention) is the
+ * caller's signal to degrade `hasTokens` to `null`.
+ */
+function vaultHasTokens(dbPath: string): boolean {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db.prepare("SELECT 1 FROM tokens LIMIT 1").get();
+    return row !== null && row !== undefined;
+  } finally {
+    db.close();
+  }
+}
+
+function readTokenPresence(vaultNames: string[]): boolean | null {
+  if (vaultNames.length === 0) return false;
+  let any = false;
+  for (const name of vaultNames) {
+    const dbPath = vaultDbPath(name);
+    if (!existsSync(dbPath)) continue;
+    try {
+      if (vaultHasTokens(dbPath)) {
+        any = true;
+        // Don't early-return — keep probing so a later locked DB still
+        // surfaces as `null` rather than a misleading `true`.
+      }
+    } catch {
+      return null;
+    }
+  }
+  return any;
+}
+
+export function buildAuthStatus(): AuthStatusResponse {
+  const globalConfig = readGlobalConfig();
+  const vaultNames = listVaults();
+  return {
+    initialized: vaultNames.length > 0,
+    auth_modes: ["pvt_token", "hub_jwt"],
+    vaults: vaultNames.map((name) => ({ name, url: `/vault/${name}` })),
+    hasOwnerPassword: typeof globalConfig.owner_password_hash === "string"
+      && globalConfig.owner_password_hash.length > 0,
+    hasTotp: typeof globalConfig.totp_secret === "string"
+      && globalConfig.totp_secret.length > 0,
+    hasTokens: readTokenPresence(vaultNames),
+  };
+}

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -217,6 +217,129 @@ describe("GET /vaults/list (public discovery)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// /auth/status — public preflight discovery (issue #163). Tells first-contact
+// clients which bearer format to use and surfaces auth-state bits the hub's
+// post-exposure flow needs without locking us into any auth check.
+// ---------------------------------------------------------------------------
+
+describe("GET /auth/status (public auth preflight)", () => {
+  test("empty server: initialized=false, no vaults, no auth bits", async () => {
+    const res = await route(new Request("http://localhost:1940/auth/status"), "/auth/status");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      initialized: boolean;
+      auth_modes: string[];
+      vaults: { name: string; url: string }[];
+      hasOwnerPassword: boolean;
+      hasTotp: boolean;
+      hasTokens: boolean | null;
+    };
+    expect(body.initialized).toBe(false);
+    expect(body.vaults).toEqual([]);
+    expect(body.auth_modes).toEqual(["pvt_token", "hub_jwt"]);
+    expect(body.hasOwnerPassword).toBe(false);
+    expect(body.hasTotp).toBe(false);
+    // No vaults means hasTokens collapses to false (not null), since there's
+    // no DB to fail on.
+    expect(body.hasTokens).toBe(false);
+  });
+
+  test("vault with no tokens: initialized=true, hasTokens=false", async () => {
+    createVault("journal");
+    // getVaultStore opens (and creates) the SQLite file with the tokens
+    // table — without it, the probe falls into the "DB missing" branch and
+    // hasTokens stays false anyway, but we want the table to exist for the
+    // realistic case.
+    getVaultStore("journal");
+    const res = await route(new Request("http://localhost:1940/auth/status"), "/auth/status");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      initialized: boolean;
+      vaults: { name: string; url: string }[];
+      hasTokens: boolean | null;
+    };
+    expect(body.initialized).toBe(true);
+    expect(body.vaults).toEqual([{ name: "journal", url: "/vault/journal" }]);
+    expect(body.hasTokens).toBe(false);
+  });
+
+  test("vault with a token: hasTokens=true", async () => {
+    createVault("journal");
+    createAdminToken("journal");
+    const res = await route(new Request("http://localhost:1940/auth/status"), "/auth/status");
+    const body = (await res.json()) as { hasTokens: boolean | null };
+    expect(body.hasTokens).toBe(true);
+  });
+
+  test("multiple vaults are all listed; hasTokens=true if any has tokens", async () => {
+    createVault("journal");
+    createVault("work");
+    getVaultStore("journal");
+    createAdminToken("work");
+    const res = await route(new Request("http://localhost:1940/auth/status"), "/auth/status");
+    const body = (await res.json()) as {
+      vaults: { name: string; url: string }[];
+      hasTokens: boolean | null;
+    };
+    expect(new Set(body.vaults.map((v) => v.name))).toEqual(new Set(["journal", "work"]));
+    expect(body.hasTokens).toBe(true);
+  });
+
+  test("owner password / TOTP set in global config surface as true", async () => {
+    createVault("journal");
+    writeGlobalConfig({
+      port: 1940,
+      owner_password_hash: "$2b$10$abcdefghijklmnopqrstuv",
+      totp_secret: "JBSWY3DPEHPK3PXP",
+    });
+    const res = await route(new Request("http://localhost:1940/auth/status"), "/auth/status");
+    const body = (await res.json()) as { hasOwnerPassword: boolean; hasTotp: boolean };
+    expect(body.hasOwnerPassword).toBe(true);
+    expect(body.hasTotp).toBe(true);
+  });
+
+  test("response never leaks secrets, hashes, descriptions, or token counts", async () => {
+    createVault("journal", "Private journal — must not appear in /auth/status");
+    createAdminToken("journal");
+    writeGlobalConfig({
+      port: 1940,
+      owner_password_hash: "$2b$10$verysecretpasswordhash",
+      totp_secret: "JBSWY3DPEHPK3PXP",
+      backup_codes: ["$2b$10$backup1", "$2b$10$backup2"],
+    });
+    const res = await route(new Request("http://localhost:1940/auth/status"), "/auth/status");
+    const dump = JSON.stringify(await res.json());
+    expect(dump).not.toContain("Private journal");
+    expect(dump).not.toContain("$2b$10$verysecretpasswordhash");
+    expect(dump).not.toContain("JBSWY3DPEHPK3PXP");
+    expect(dump).not.toContain("backup");
+    // Token-count guard: even with one token created above, no integer count
+    // appears in the dump. `hasTokens` is the only token-derived field.
+    expect(dump).not.toMatch(/"tokenCount"/);
+    expect(dump).not.toMatch(/"token_count"/);
+  });
+
+  test("ignores Authorization header (endpoint is public)", async () => {
+    const req = new Request("http://localhost:1940/auth/status", {
+      headers: { Authorization: "Bearer not-a-real-token" },
+    });
+    const res = await route(req, "/auth/status");
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects non-GET methods (falls through to 404)", async () => {
+    const req = new Request("http://localhost:1940/auth/status", { method: "POST" });
+    const res = await route(req, "/auth/status");
+    expect(res.status).toBe(404);
+  });
+
+  test("response includes CORS allow-origin so first-contact browser clients can read it", async () => {
+    const res = await route(new Request("http://localhost:1940/auth/status"), "/auth/status");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Per-vault routing: /vault/<name>/... is the only URL shape for vault
 // resources. Unscoped routes (/mcp, /api/*, /oauth/*) no longer exist.
 // ---------------------------------------------------------------------------

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -63,6 +63,7 @@ import {
   getBaseUrl,
 } from "./oauth.ts";
 import { handleConfigSchema, handleConfig } from "./module-config.ts";
+import { buildAuthStatus } from "./auth-status.ts";
 
 /**
  * Decorate a 401 response from the MCP endpoint with the RFC 9728 challenge
@@ -226,6 +227,18 @@ export async function route(
       return Response.json({ error: "Not found" }, { status: 404 });
     }
     return Response.json({ vaults: listVaults() });
+  }
+
+  // Public auth-state probe. Tells a first-contact client whether the
+  // server has any vaults yet, which bearer formats it accepts, and
+  // whether owner-password / TOTP / tokens are configured. Replaces
+  // hub's out-of-process filesystem snoop (parachute-hub#86 follow-up).
+  // No auth, GET-only, no token counts — `hasTokens` is a yes/no signal
+  // only, with `null` for "DB read failed."
+  if (path === "/auth/status" && req.method === "GET") {
+    return Response.json(buildAuthStatus(), {
+      headers: { "Access-Control-Allow-Origin": "*" },
+    });
   }
 
   // Authenticated vault metadata list.


### PR DESCRIPTION
## Summary

Cleanup batch 3, two issues bundled per team-lead's brief.

### #130 — query-notes `near` returns empty for anchor with known links

**Root cause:** `mcp.ts` collected the anchor + neighborhood via BFS, then handed the *whole* options bag to `queryNotes` and post-filtered the JS array. SQL's `ORDER BY created_at + LIMIT` ran over the entire notes table, so when the anchor's neighborhood wasn't in the first N notes by creation order, the post-filter dropped every row and `near` returned `[]` — even though the graph was correct.

**Fix:** push neighborhood scoping into the SQL `WHERE`:
- `QueryOpts` gets optional `ids: string[]`.
- `notes.ts` emits `n.id IN (?, ?, ...)`. Empty `ids` becomes `0 = 1` (avoids `IN ()` syntax error).
- `mcp.ts` passes `ids: [...nearScope]` for the structured-query path. The FTS path keeps its post-filter because FTS owns its own ranked LIMIT and would re-rank if narrowed upstream.

**Regression test** seeds 10 unrelated notes before the anchor + 2 linked, queries `near: anchor` with `limit: 5`, asserts `[anchor, inbound, outbound]` returned. Pre-fix: empty.

### #163 — public GET `/auth/status` endpoint

First-contact discovery for clients that need to choose between `pvt_*` and hub-issued JWT before authenticating. Also replaces parachute-hub's filesystem snoop in `src/vault/auth-status.ts` (its module doc already flagged this as a future endpoint to drop the coupling).

**Path:** `/auth/status`, not `/api/auth/status` — vault deliberately has no unscoped `/api/*` surface (see `routing.ts` header). Matches the existing `/health`, `/vaults/list` cross-vault root convention.

**Response shape:**
\`\`\`json
{
  "initialized": true,
  "auth_modes": ["pvt_token", "hub_jwt"],
  "vaults": [{ "name": "default", "url": "/vault/default" }],
  "hasOwnerPassword": false,
  "hasTotp": false,
  "hasTokens": true
}
\`\`\`

Per team-lead's "no token counts" policy, `hasTokens` is a yes/no signal (`boolean | null`, where `null` = DB read failed). The consumer's "is the vault wide open?" check needs the bit, not the integer; shipping a count would expose token cardinality to anyone on the network.

CORS `*` so first-contact browser clients can read cross-origin.

**Tests** cover empty server, vault without tokens, vault with token, multi-vault, password+totp set, secret-leak guard (description / hashes / totp / backup codes / token-count keys), Authorization header ignored, non-GET → 404, CORS header present.

## Per-issue commits

- \`fix(query-notes): push near-scope into SQL so LIMIT respects neighborhood\` — closes #130
- \`feat(routing): public GET /auth/status\` — closes #163
- \`chore(release): 0.3.6-rc.6\`

## Gates

- \`bun test src/\` → 936 pass / 0 fail
- \`bun test core/src/\` → 280 pass / 0 fail (now includes #130 regression test)
- \`bunx tsc --noEmit\` → 386 errors, identical to main (no delta from this PR)

## Test plan

- [ ] CI green
- [ ] Verify `GET /auth/status` against a running vault returns the expected shape
- [ ] Verify `query-notes` with `near: <anchor>` returns the anchor's neighborhood even when many unrelated notes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)