### PR TITLE
Cleanup batch 4 — graceful stop, path_conflict 409, PDF+mp4 allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,11 +97,16 @@ PORT=1940
 bun src/cli.ts vault init          # setup everything
 bun src/cli.ts vault status        # check status
 bun src/cli.ts vault config        # view/edit config
+bun src/cli.ts vault stop          # graceful shutdown via filesystem sentinel
 bun src/cli.ts vault import <path> # import Obsidian vault
 bun src/cli.ts vault export <path> # export as Obsidian markdown
 bun test src/                      # run server tests
 bun test core/src/                 # run core tests
 ```
+
+### Graceful shutdown
+
+`parachute-vault stop` writes a sentinel file at `~/.parachute/vault/stop.signal`. The running server polls for it every 500ms and, when it finds one, deletes it and runs the same drain-and-exit shutdown path used for SIGINT/SIGTERM. Stale sentinels are removed at server startup, so a `stop` written while no server was listening can't pre-empt the next boot. This exists for environments where signals are awkward (Docker exec, foreground runs without a managed PID) — when you have a PID, `kill -TERM` still works and is the more direct path.
 
 ## Deployment
 

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -136,6 +136,57 @@ describe("notes", async () => {
     await store.deleteNote("a");
     expect(await store.getLinks("b")).toHaveLength(0);
   });
+
+  // ---- PathConflictError: typed 409 on duplicate path (#126) ----
+
+  it("createNote throws PathConflictError when path is taken (#126)", async () => {
+    await store.createNote("First", { path: "Inbox/note" });
+    let caught: any;
+    try {
+      await store.createNote("Second", { path: "Inbox/note" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeTruthy();
+    expect(caught.code).toBe("PATH_CONFLICT");
+    expect(caught.path).toBe("Inbox/note");
+  });
+
+  it("createNote on path collision does not insert the second note (#126)", async () => {
+    await store.createNote("First", { id: "a", path: "Inbox/note" });
+    try {
+      await store.createNote("Second", { id: "b", path: "Inbox/note" });
+    } catch {}
+    expect(await store.getNote("b")).toBeNull();
+  });
+
+  it("updateNote throws PathConflictError when renaming onto an existing path (#126)", async () => {
+    const a = await store.createNote("First", { path: "a" });
+    await store.createNote("Second", { path: "b" });
+    let caught: any;
+    try {
+      await store.updateNote(a.id, { path: "b", if_updated_at: a.createdAt });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeTruthy();
+    expect(caught.code).toBe("PATH_CONFLICT");
+    expect(caught.path).toBe("b");
+  });
+
+  it("updateNote with no path collision still succeeds (#126 — no false positives)", async () => {
+    const a = await store.createNote("First", { path: "a" });
+    await store.createNote("Second", { path: "b" });
+    const updated = await store.updateNote(a.id, { path: "c", if_updated_at: a.createdAt });
+    expect(updated.path).toBe("c");
+  });
+
+  it("updateNote with no path field is unaffected by the path-conflict guard (#126)", async () => {
+    const a = await store.createNote("First", { path: "a" });
+    const updated = await store.updateNote(a.id, { content: "edited", if_updated_at: a.createdAt });
+    expect(updated.content).toBe("edited");
+    expect(updated.path).toBe("a");
+  });
 });
 
 // ---- Backfill migration: legacy rows with NULL updated_at ----

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -838,7 +838,7 @@ function normalizeTags(tag: unknown): string[] | undefined {
 
 // Re-exported for backward compat; defined in notes.ts alongside the
 // conditional-UPDATE implementation that raises it.
-export { ConflictError } from "./notes.js";
+export { ConflictError, PathConflictError } from "./notes.js";
 
 /**
  * Thrown by the `update-note` MCP tool (and the REST PATCH handler) when a

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -41,9 +41,16 @@ export function createNote(
   // value. Hook-style writes with `skipUpdatedAt` preserve this; real user
   // edits bump it strictly upward, so `updated_at > created_at` still means
   // "user-touched since creation."
-  db.prepare(
-    `INSERT INTO notes (id, content, path, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
-  ).run(id, content, path, metadata, createdAt, createdAt);
+  try {
+    db.prepare(
+      `INSERT INTO notes (id, content, path, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, content, path, metadata, createdAt, createdAt);
+  } catch (err) {
+    if (path !== null && isPathUniqueError(err)) {
+      throw new PathConflictError(path);
+    }
+    throw err;
+  }
 
   if (opts?.tags && opts.tags.length > 0) {
     tagNote(db, id, opts.tags);
@@ -106,6 +113,38 @@ export class ConflictError extends Error {
     this.current_updated_at = current;
     this.expected_updated_at = expected;
   }
+}
+
+/**
+ * Thrown by `createNote` / `updateNote` when the requested path is already
+ * taken by another note. Surfaces as 409 at the HTTP layer so clients can
+ * distinguish "path taken — pick another" from a generic 500.
+ *
+ * Detected by catching SQLite's UNIQUE-constraint error on the
+ * `idx_notes_path_unique` partial index (schema v5+). Matches the tag
+ * "UNIQUE constraint failed: notes.path" rather than a numeric code so
+ * we keep working if bun:sqlite changes its error class hierarchy.
+ */
+export class PathConflictError extends Error {
+  code = "PATH_CONFLICT" as const;
+  path: string;
+
+  constructor(path: string) {
+    super(`path_conflict: another note already uses path "${path}"`);
+    this.name = "PathConflictError";
+    this.path = path;
+  }
+}
+
+/**
+ * Match bun:sqlite's UNIQUE-constraint error on the notes.path index. The
+ * error class is `SQLiteError` but matching on the message is sufficient
+ * here — the index name and column are stable parts of the schema, and
+ * bun:sqlite has carried this exact message text since 1.0.
+ */
+function isPathUniqueError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.message.includes("UNIQUE constraint failed: notes.path");
 }
 
 export function updateNote(
@@ -187,7 +226,15 @@ export function updateNote(
     values.push(updates.if_updated_at);
   }
 
-  const res = db.prepare(sql).run(...values);
+  let res;
+  try {
+    res = db.prepare(sql).run(...values);
+  } catch (err) {
+    if (updates.path !== undefined && isPathUniqueError(err)) {
+      throw new PathConflictError(normalizePath(updates.path) ?? updates.path);
+    }
+    throw err;
+  }
 
   if (updates.if_updated_at !== undefined && res.changes === 0) {
     throwConflictOrMissing(db, id, updates.if_updated_at);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.6",
+  "version": "0.3.6-rc.7",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ import {
   LOG_PATH,
   ERR_PATH,
   GLOBAL_CONFIG_PATH,
+  stopSignalPath,
 } from "./config.ts";
 import type { VaultConfig } from "./config.ts";
 import { DATA_DIR } from "./config.ts";
@@ -180,6 +181,9 @@ switch (command) {
     break;
   case "restart":
     await cmdRestart();
+    break;
+  case "stop":
+    await cmdStop();
     break;
   case "uninstall":
     await cmdUninstall(cmdArgs);
@@ -1100,6 +1104,41 @@ async function cmdRestart() {
 
   console.error(`Vault did not come up within 10s — status: ${health.status}${health.error ? ` (${health.error})` : ""}`);
   printErrLogTail(20);
+  process.exit(1);
+}
+
+async function cmdStop() {
+  loadEnvFile();
+  const port = readGlobalConfig().port || DEFAULT_PORT;
+  const sentinel = stopSignalPath();
+
+  // Health check first: avoid leaving a stale sentinel that would kill the
+  // *next* server boot. The server clears any pre-existing sentinel on
+  // startup, but only after it loads — a sentinel written between launch
+  // and the first poll could still win the race. Skipping the write when
+  // nothing is listening is the cheap, obvious guard.
+  const health = await checkHealth(port);
+  if (health.status === "not-listening" || health.status === "error") {
+    console.log(`Vault is not running (${health.status}${health.error ? `: ${health.error}` : ""}).`);
+    return;
+  }
+
+  ensureConfigDirSync();
+  writeFileSync(sentinel, `${new Date().toISOString()}\n`);
+  console.log(`Stop signal written: ${sentinel}`);
+
+  // Wait briefly for the server to pick up the sentinel and stop responding.
+  // Polls match the server's 500ms cadence; give it ~5s before giving up.
+  const start = Date.now();
+  while (Date.now() - start < 5_000) {
+    await new Promise((r) => setTimeout(r, 600));
+    const h = await checkHealth(port);
+    if (h.status === "not-listening" || h.status === "error") {
+      console.log(`Vault stopped (${Math.round((Date.now() - start) / 100) / 10}s).`);
+      return;
+    }
+  }
+  console.error("Vault did not stop within 5s. Check vault logs or `parachute-vault status`.");
   process.exit(1);
 }
 
@@ -2238,5 +2277,9 @@ visibility. Use these when running vault without the hub or when debugging.
                                            Prefer \`parachute status\` for a cross-service view.
   parachute-vault logs                     Stream server logs
   parachute-vault restart                  Restart the daemon
+  parachute-vault stop                     Signal a graceful shutdown of the running server
+                                           (writes \`~/.parachute/vault/stop.signal\` — useful
+                                           when no signal channel is available, e.g. Docker
+                                           exec or unmanaged foreground runs).
 `);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,14 @@ export const ERR_PATH = join(LOGS_DIR, "vault.err");
 export const DEFAULT_PORT = 1940;
 export const ASSETS_DIR = join(VAULT_HOME, "assets");
 
+// Filesystem sentinel for graceful shutdown. `parachute-vault stop` writes
+// this file; the running server polls for it and exits cleanly when it
+// appears. Resolved per-call so PARACHUTE_HOME overrides (tests, Docker)
+// match between writer and reader.
+export function stopSignalPath(): string {
+  return join(vaultHomePath(), "stop.signal");
+}
+
 export function vaultDir(name: string): string {
   return join(dataDirPath(), name);
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -286,24 +286,35 @@ export async function handleNotes(
       const items: any[] = body.notes ?? [body];
 
       const created: Note[] = [];
-      for (const item of items) {
-        const note = await store.createNote(item.content ?? "", {
-          id: item.id,
-          path: item.path,
-          tags: item.tags,
-          metadata: item.metadata,
-          created_at: item.createdAt ?? item.created_at,
-        });
+      try {
+        for (const item of items) {
+          const note = await store.createNote(item.content ?? "", {
+            id: item.id,
+            path: item.path,
+            tags: item.tags,
+            metadata: item.metadata,
+            created_at: item.createdAt ?? item.created_at,
+          });
 
-        // Create explicit links
-        if (item.links) {
-          for (const link of item.links as { target: string; relationship: string }[]) {
-            const target = await resolveNote(store, link.target);
-            if (target) await store.createLink(note.id, target.id, link.relationship);
+          // Create explicit links
+          if (item.links) {
+            for (const link of item.links as { target: string; relationship: string }[]) {
+              const target = await resolveNote(store, link.target);
+              if (target) await store.createLink(note.id, target.id, link.relationship);
+            }
           }
-        }
 
-        created.push((await store.getNote(note.id)) ?? note);
+          created.push((await store.getNote(note.id)) ?? note);
+        }
+      } catch (e: any) {
+        // Duck-type for module-boundary robustness (matches the PATCH branch).
+        if (e && e.code === "PATH_CONFLICT") {
+          return json(
+            { error_type: "path_conflict", error: "path_conflict", path: e.path, message: e.message },
+            409,
+          );
+        }
+        throw e;
       }
 
       // Apply tag schema defaults
@@ -518,6 +529,13 @@ export async function handleNotes(
             error: "conflict",
             expected_updated_at: e.expected_updated_at,
           },
+          409,
+        );
+      }
+      // Path-rename collision — schema's UNIQUE(path) tripped. Issue #126.
+      if (e && e.code === "PATH_CONFLICT") {
+        return json(
+          { error_type: "path_conflict", error: "path_conflict", path: e.path, message: e.message },
           409,
         );
       }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -949,9 +949,17 @@ export function assetsDir(vault: string): string {
 }
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024; // 100MB
 
+// Storage allowlist policy:
+//   - audio + image + .pdf (knowledge-vault content: papers, scans, receipts)
+//     + .mp4 (mobile capture default; iOS records mp4, not webm).
+//   - .svg and .html are deliberately excluded — both can embed `<script>`
+//     tags, which would turn an upload into a same-origin XSS vector when
+//     the asset is served back from /storage/. If a future use case needs
+//     SVG, sanitize on read (strip <script>/<foreignObject>) and revisit.
 const ALLOWED_EXTENSIONS = new Set([
   ".wav", ".mp3", ".m4a", ".ogg", ".webm",
   ".png", ".jpg", ".jpeg", ".gif", ".webp",
+  ".pdf", ".mp4",
 ]);
 
 const MIME_TYPES: Record<string, string> = {
@@ -965,6 +973,8 @@ const MIME_TYPES: Record<string, string> = {
   ".jpeg": "image/jpeg",
   ".gif": "image/gif",
   ".webp": "image/webp",
+  ".pdf": "application/pdf",
+  ".mp4": "video/mp4",
 };
 
 export async function handleStorage(req: Request, path: string, vault: string): Promise<Response> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,8 @@
  * The request pipeline lives in ./routing.ts (exported for unit testing).
  */
 
-import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile, generateApiKey, hashKey } from "./config.ts";
+import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile, generateApiKey, hashKey, stopSignalPath } from "./config.ts";
+import { existsSync, rmSync } from "fs";
 import { migrateVaultKeys } from "./token-store.ts";
 import { getVaultStore, getVaultNameForStore } from "./vault-store.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
@@ -240,4 +241,25 @@ async function shutdown(signal: string): Promise<void> {
 }
 process.on("SIGINT", () => void shutdown("SIGINT"));
 process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+// Filesystem-sentinel shutdown: `parachute-vault stop` writes
+// `~/.parachute/vault/stop.signal`; we poll for it and exit cleanly when it
+// appears. Useful when no signal channel is available — Docker exec, foreground
+// runs without a TTY, scripts that can't manage PIDs. Any stale sentinel is
+// removed before we start polling so a previous `stop` can't pre-empt this boot.
+const STOP_POLL_MS = 500;
+try {
+  if (existsSync(stopSignalPath())) rmSync(stopSignalPath(), { force: true });
+} catch (err) {
+  console.warn("[stop-signal] could not clear stale sentinel:", err);
+}
+setInterval(() => {
+  if (!existsSync(stopSignalPath())) return;
+  try {
+    rmSync(stopSignalPath(), { force: true });
+  } catch (err) {
+    console.warn("[stop-signal] could not remove sentinel:", err);
+  }
+  void shutdown("STOP_SIGNAL");
+}, STOP_POLL_MS).unref();
 

--- a/src/stop-signal.test.ts
+++ b/src/stop-signal.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Integration test for `parachute-vault stop` — exercises the filesystem
+ * sentinel handshake end-to-end: spawn server → write sentinel → confirm
+ * the server exits cleanly. Closes #100.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, existsSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { stopSignalPath } from "./config.ts";
+import { waitForHealthy, checkHealth } from "./health.ts";
+
+const SERVER_PATH = resolve(import.meta.dir, "server.ts");
+
+// Pick a port unlikely to clash with the developer's running daemon (1940)
+// or the typical hub/scribe range.
+const TEST_PORT = 19_404;
+
+let tmpHome: string;
+let originalHome: string | undefined;
+
+beforeAll(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "vault-stop-test-"));
+  mkdirSync(join(tmpHome, "vault"), { recursive: true });
+  originalHome = process.env.PARACHUTE_HOME;
+  process.env.PARACHUTE_HOME = tmpHome;
+});
+
+afterAll(() => {
+  if (originalHome === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = originalHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("graceful shutdown via stop.signal (#100)", () => {
+  test("stopSignalPath resolves under PARACHUTE_HOME", () => {
+    expect(stopSignalPath()).toBe(join(tmpHome, "vault", "stop.signal"));
+  });
+
+  test("server clears a stale sentinel at startup, then exits when one is written", async () => {
+    // Pre-populate a stale sentinel — the server should clear it on boot
+    // rather than treating it as a fresh shutdown request.
+    writeFileSync(stopSignalPath(), "stale\n");
+    expect(existsSync(stopSignalPath())).toBe(true);
+
+    const proc = Bun.spawn({
+      cmd: ["bun", SERVER_PATH],
+      env: {
+        ...process.env,
+        PARACHUTE_HOME: tmpHome,
+        PORT: String(TEST_PORT),
+        // Avoid the transcription worker spinning up + adding shutdown latency.
+        SCRIBE_URL: "",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    try {
+      const health = await waitForHealthy(TEST_PORT, { totalMs: 10_000 });
+      expect(health.status).toBe("healthy");
+      expect(existsSync(stopSignalPath())).toBe(false); // stale cleared
+
+      writeFileSync(stopSignalPath(), `${new Date().toISOString()}\n`);
+
+      const exitCode = await Promise.race([
+        proc.exited,
+        new Promise<number>((_, reject) =>
+          setTimeout(() => reject(new Error("server did not exit within 5s")), 5_000),
+        ),
+      ]);
+      expect(exitCode).toBe(0);
+
+      // Server should also have removed the sentinel as it processed it.
+      expect(existsSync(stopSignalPath())).toBe(false);
+
+      // And the port is no longer accepting connections.
+      const after = await checkHealth(TEST_PORT);
+      expect(["not-listening", "error"]).toContain(after.status);
+    } finally {
+      if (!proc.killed) proc.kill();
+    }
+  }, 20_000);
+});

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Storage upload allowlist tests (issue #127).
+ *
+ * The allowlist guards `POST /api/storage/upload` against turning user
+ * uploads into XSS vectors when the asset is later served back from
+ * `/storage/`. We pin both the accepted set and the deliberate exclusions
+ * so a future widening doesn't quietly let SVG/HTML in.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { rmSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const testDir = join(
+  tmpdir(),
+  `vault-storage-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+);
+process.env.PARACHUTE_HOME = testDir;
+process.env.ASSETS_DIR = join(testDir, "assets");
+
+const { handleStorage } = await import("./routes.ts");
+
+function uploadRequest(filename: string, mimeType: string): Request {
+  const form = new FormData();
+  const file = new File([new Uint8Array([0x00, 0x01, 0x02])], filename, {
+    type: mimeType,
+  });
+  form.set("file", file);
+  return new Request("http://localhost:1940/storage/upload", {
+    method: "POST",
+    body: form,
+  });
+}
+
+beforeAll(() => {
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(testDir, "assets"), { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("storage upload allowlist", () => {
+  test("accepts .pdf — knowledge-vault content (#127)", async () => {
+    const res = await handleStorage(uploadRequest("paper.pdf", "application/pdf"), "/upload", "default");
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { mimeType: string; path: string };
+    expect(body.mimeType).toBe("application/pdf");
+    expect(body.path).toMatch(/\.pdf$/);
+  });
+
+  test("accepts .mp4 — mobile capture default (#127)", async () => {
+    const res = await handleStorage(uploadRequest("clip.mp4", "video/mp4"), "/upload", "default");
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { mimeType: string };
+    expect(body.mimeType).toBe("video/mp4");
+  });
+
+  test("still accepts the existing audio + image set", async () => {
+    for (const [name, mime] of [
+      ["clip.wav", "audio/wav"],
+      ["clip.mp3", "audio/mpeg"],
+      ["photo.png", "image/png"],
+      ["photo.jpg", "image/jpeg"],
+      ["clip.webm", "audio/webm"],
+    ] as const) {
+      const res = await handleStorage(uploadRequest(name, mime), "/upload", "default");
+      expect(res.status).toBe(201);
+    }
+  });
+
+  test("rejects .svg — XSS vector via inline <script> (#127)", async () => {
+    const res = await handleStorage(uploadRequest("evil.svg", "image/svg+xml"), "/upload", "default");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain(".svg");
+  });
+
+  test("rejects .html — same XSS surface as SVG (#127)", async () => {
+    const res = await handleStorage(uploadRequest("evil.html", "text/html"), "/upload", "default");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain(".html");
+  });
+
+  test("rejects unknown extensions (default-deny)", async () => {
+    const res = await handleStorage(uploadRequest("payload.exe", "application/octet-stream"), "/upload", "default");
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1363,6 +1363,47 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect(body.deleted).toBe(true);
     expect(await store.getNoteByPath("Temp/note")).toBeNull();
   });
+
+  test("POST /notes returns 409 path_conflict when path already exists (#126)", async () => {
+    await store.createNote("first", { path: "Inbox/note" });
+    const res = await handleNotes(
+      mkReq("POST", "/notes", { content: "second", path: "Inbox/note" }),
+      store,
+      "",
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("path_conflict");
+    expect(body.error).toBe("path_conflict");
+    expect(body.path).toBe("Inbox/note");
+  });
+
+  test("POST /notes path_conflict — second note never lands in DB (#126)", async () => {
+    await store.createNote("first", { path: "Inbox/note" });
+    const before = (await store.queryNotes({})).length;
+    await handleNotes(
+      mkReq("POST", "/notes", { content: "second", path: "Inbox/note" }),
+      store,
+      "",
+    );
+    expect((await store.queryNotes({})).length).toBe(before);
+  });
+
+  test("PATCH /notes returns 409 path_conflict when renaming onto existing path (#126)", async () => {
+    const a = await store.createNote("first", { id: "a", path: "alpha" });
+    await store.createNote("second", { id: "b", path: "beta" });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/a", { path: "beta", if_updated_at: a.createdAt }),
+      store,
+      "/a",
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("path_conflict");
+    expect(body.path).toBe("beta");
+    // Source note unchanged
+    expect((await store.getNote("a"))!.path).toBe("alpha");
+  });
 });
 
 describe("HTTP /tags", async () => {


### PR DESCRIPTION
## Summary

Three small mechanical items off main, each in its own commit. Closes #100, #126, #127.

## Changes

### #127 — Storage allowlist: add .pdf + .mp4 (3656c1d)
Knowledge-vault content (papers, scans, receipts) and mobile capture (iOS records mp4 by default) are first-class. SVG/HTML stay excluded — both can embed `<script>` tags and serving an untrusted upload back from `/storage/` would be a same-origin XSS vector. Policy is documented inline so future "please add SVG" PRs land on the rationale.

### #126 — Typed 409 path_conflict on duplicate path (e9913b6)
`POST /notes` and `PATCH /notes/:id` now return:
```json
{ "error_type": "path_conflict", "error": "path_conflict", "path": "<conflicting>", "message": "…" }
```
Mirrors the existing `if_updated_at` 409 convention (error_type + offending value). Detection: a `PathConflictError` (`code: "PATH_CONFLICT"`) thrown by `core/src/notes.ts` when SQLite's UNIQUE constraint on `notes.path` fires. Routes branch on the `code` (duck-typed) rather than `instanceof`, matching the existing `ConflictError` pattern across module boundaries.

### #100 — `parachute-vault stop` via filesystem sentinel (17c8ca4)
`parachute-vault stop` writes `~/.parachute/vault/stop.signal`; the running server polls every 500ms, deletes the sentinel, and runs the existing drain-and-exit shutdown path used for SIGINT/SIGTERM.

Why filesystem-sentinel instead of an HTTP endpoint:
- Smaller blast radius — no auth surface to mis-scope.
- Works in environments where signals are awkward (Docker exec, unmanaged foreground runs, scripts without PID tracking).
- An HTTP endpoint can be added later under `parachute:host:admin` if a network-side need emerges; the sentinel handles the local-operator case.

Stale-sentinel guard: the server clears any pre-existing sentinel on startup, so a `stop` written while no server was listening can't pre-empt the next boot. `cmdStop` also health-checks first and skips the write when nothing is listening.

Documented under Running in CLAUDE.md.

### Release (4c0e756)
Bumps `0.3.6-rc.6 → 0.3.6-rc.7` per pre-1.0 governance.

## Test plan

- [x] `bun test src/` — 952 pass (38 files; +3 path_conflict HTTP tests, +6 storage allowlist tests, +2 stop-sentinel integration tests)
- [x] `bun test core/src/` — 285 pass (+5 path_conflict unit tests)
- [x] `bunx tsc --noEmit` — 386 errors (vs 387 on main; no new regressions, net -1)
- [x] Manual: spawned the new test server, `bun src/cli.ts stop` exits the process within ~600ms, sentinel cleaned up
- [x] Manual: pre-existing stale sentinel cleared on next boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)