### PR TITLE
chore: cleanup batch 5 — OAuth rate limiter scoping/cap (#93) + scope binding (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.7",
+  "version": "0.3.6-rc.8",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -1864,3 +1864,222 @@ describe("OAuth consent — per-vault rate limiting (#93)", () => {
     expect(limiter.check("10.0.0.4").allowed).toBe(true); // still under threshold
   });
 });
+
+// ---------------------------------------------------------------------------
+// Server-bound scope at /authorize, subset enforcement at /token (#94)
+// ---------------------------------------------------------------------------
+
+describe("OAuth scope binding (#94, RFC 6749 §3.3 / §6)", () => {
+  test("/authorize floors selected scope to requested — form cannot smuggle a broader scope", async () => {
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "read",            // requested = read
+          selected_scope: "full",   // smuggled broader value
+          owner_token: ownerToken,
+        }),
+      }),
+      db,
+      { vaultName: "default" },
+    );
+    expect(authRes.status).toBe(302);
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+
+    // The bound scope on the issued auth code must be the narrower of the two.
+    const row = db
+      .prepare("SELECT scope FROM oauth_codes WHERE code = ?")
+      .get(code) as { scope: string };
+    expect(row.scope).toBe("read");
+  });
+
+  test("/token rejects requested scope broader than bound (read → full)", async () => {
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "read",
+          owner_token: ownerToken,
+        }),
+      }),
+      db,
+      { vaultName: "default" },
+    );
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      makeRequest("https://vault.test/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          scope: "full", // attempt to broaden
+        }).toString(),
+      }),
+      db,
+      "default",
+    );
+    expect(tokenRes.status).toBe(400);
+    const body = (await tokenRes.json()) as { error?: string };
+    expect(body.error).toBe("invalid_scope");
+  });
+
+  test("/token accepts a narrower requested scope (full → read) and reflects it on the token", async () => {
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",
+          owner_token: ownerToken,
+        }),
+      }),
+      db,
+      { vaultName: "default" },
+    );
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      makeRequest("https://vault.test/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          scope: "read", // narrower than bound
+        }).toString(),
+      }),
+      db,
+      "default",
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as { scope?: string };
+    expect(body.scope).toBe("vault:read");
+  });
+
+  test("/token rejects unknown scope strings even when the bound scope is broad", async () => {
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "full",
+          owner_token: ownerToken,
+        }),
+      }),
+      db,
+      { vaultName: "default" },
+    );
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      makeRequest("https://vault.test/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          scope: "vault:admin", // not in the consent vocabulary
+        }).toString(),
+      }),
+      db,
+      "default",
+    );
+    expect(tokenRes.status).toBe(400);
+    const body = (await tokenRes.json()) as { error?: string };
+    expect(body.error).toBe("invalid_scope");
+  });
+
+  test("/token uses the bound scope when no scope param is sent (regression)", async () => {
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "read",
+          owner_token: ownerToken,
+        }),
+      }),
+      db,
+      { vaultName: "default" },
+    );
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      makeRequest("https://vault.test/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          // no scope param
+        }).toString(),
+      }),
+      db,
+      "default",
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as { scope?: string };
+    expect(body.scope).toBe("vault:read");
+  });
+});

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -1809,3 +1809,58 @@ describe("OAuth Phase 0: PARACHUTE_HUB_ORIGIN", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Per-vault rate limiter + memory cap (#93)
+// ---------------------------------------------------------------------------
+
+describe("OAuth consent — per-vault rate limiting (#93)", () => {
+  test("getAuthorizeRateLimiter returns the same instance for the same vault name", async () => {
+    const { getAuthorizeRateLimiter, resetVaultAuthorizeRateLimiters } =
+      await import("./owner-auth.ts");
+    resetVaultAuthorizeRateLimiters();
+    const a1 = getAuthorizeRateLimiter("alpha");
+    const a2 = getAuthorizeRateLimiter("alpha");
+    expect(a1).toBe(a2);
+  });
+
+  test("getAuthorizeRateLimiter returns distinct instances per vault", async () => {
+    const { getAuthorizeRateLimiter, resetVaultAuthorizeRateLimiters } =
+      await import("./owner-auth.ts");
+    resetVaultAuthorizeRateLimiters();
+    const work = getAuthorizeRateLimiter("work");
+    const personal = getAuthorizeRateLimiter("personal");
+    expect(work).not.toBe(personal);
+  });
+
+  test("a lockout on one vault's limiter does not lock the same IP on another vault's limiter", async () => {
+    const { getAuthorizeRateLimiter, resetVaultAuthorizeRateLimiters } =
+      await import("./owner-auth.ts");
+    resetVaultAuthorizeRateLimiters();
+    const ip = "192.0.2.55";
+    const work = getAuthorizeRateLimiter("work");
+    // Pump enough failures on `work` to trip the default 10-failure threshold.
+    for (let i = 0; i < 10; i++) work.recordFailure(ip);
+    expect(work.check(ip).allowed).toBe(false);
+    // The unrelated vault's limiter should still allow this IP.
+    const personal = getAuthorizeRateLimiter("personal");
+    expect(personal.check(ip).allowed).toBe(true);
+  });
+
+  test("entry count is hard-capped — oldest IP is evicted FIFO when full", async () => {
+    const { RateLimiter } = await import("./owner-auth.ts");
+    // Tiny cap (3) so we don't have to hammer the limiter to prove eviction.
+    const limiter = new RateLimiter(10, 60_000, 60_000, 3);
+    limiter.recordFailure("10.0.0.1");
+    limiter.recordFailure("10.0.0.2");
+    limiter.recordFailure("10.0.0.3");
+    expect(limiter.size()).toBe(3);
+    // Adding a 4th IP must evict the oldest (10.0.0.1) to stay at the cap.
+    limiter.recordFailure("10.0.0.4");
+    expect(limiter.size()).toBe(3);
+    // The evicted IP is treated as untracked → fresh check is allowed.
+    expect(limiter.check("10.0.0.1").allowed).toBe(true);
+    // Newer entries remain locked into their failure state.
+    expect(limiter.check("10.0.0.4").allowed).toBe(true); // still under threshold
+  });
+});

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -47,6 +47,37 @@ export interface AuthorizePostOptions {
 // ---------------------------------------------------------------------------
 
 /**
+ * Today the consent page binds one of two scope strings — "read" or "full" —
+ * with `read ⊂ full`. `narrowerScope` picks the more-restrictive of two
+ * inputs (used to floor `selected` by `requested` at /oauth/authorize),
+ * `isScopeSubset` checks an inbound /oauth/token scope against the bound
+ * scope. Both default to "full" only if **both** inputs allow "full",
+ * otherwise narrow to "read". When the consent vocabulary expands beyond
+ * read/full, both helpers should switch to vault:read|write|admin and the
+ * inheritance rules in scopes.ts (`hasScope`).
+ */
+function normalizeConsentScope(s: string | null | undefined): "read" | "full" {
+  return s === "read" ? "read" : "full";
+}
+
+function narrowerScope(a: string, b: string): "read" | "full" {
+  return normalizeConsentScope(a) === "read" || normalizeConsentScope(b) === "read"
+    ? "read"
+    : "full";
+}
+
+function isScopeSubset(requested: string, bound: string): boolean {
+  // Strict: only "read" / "full" are acceptable on the wire today. Unknown
+  // scope strings are rejected as out-of-bounds rather than silently
+  // normalized — otherwise `scope=vault:admin` would coast through when
+  // bound is "full".
+  if (requested !== "read" && requested !== "full") return false;
+  const bnd = normalizeConsentScope(bound);
+  if (bnd === "full") return requested === "read" || requested === "full";
+  return requested === "read";
+}
+
+/**
  * Public-facing base URL of the server. Honors `x-forwarded-*` headers so a
  * Cloudflare Tunnel / Tailscale Funnel / reverse-proxied deployment advertises
  * the right external origin in discovery documents (RFC 8414, RFC 9728).
@@ -483,7 +514,13 @@ export async function handleAuthorizePost(
 
   if (clientIp) rateLimiter.recordSuccess(clientIp);
 
-  // Generate auth code — persist the user-selected scope (not the requested one)
+  // Generate auth code — bind the NARROWER of (requested, selected). The
+  // user can shrink the requested scope at consent time (e.g. flip "full"
+  // to "read"); they cannot broaden it. Without this floor, a malicious
+  // form could smuggle `selected_scope=full` even when /authorize?scope=read
+  // was the original ask, escalating beyond what the client requested at
+  // authorize time (#94, RFC 6749 §3.3).
+  const boundScope = narrowerScope(requestedScope, selectedScope);
   const code = crypto.randomBytes(32).toString("base64url");
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString(); // 10 minutes
 
@@ -492,7 +529,7 @@ export async function handleAuthorizePost(
   db.prepare(`
     INSERT INTO oauth_codes (code, client_id, code_challenge, code_challenge_method, scope, redirect_uri, expires_at, created_at, vault_name)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(code, clientId, codeChallenge, codeChallengeMethod, selectedScope, redirectUri, expiresAt, new Date().toISOString(), vaultName ?? null);
+  `).run(code, clientId, codeChallenge, codeChallengeMethod, boundScope, redirectUri, expiresAt, new Date().toISOString(), vaultName ?? null);
 
   redirect.searchParams.set("code", code);
   return Response.redirect(redirect.toString(), 302);
@@ -607,14 +644,35 @@ export async function handleToken(
     return Response.json({ error: "invalid_grant", error_description: "PKCE verification failed" }, { status: 400 });
   }
 
+  // RFC 6749 §3.3 / §6: a `scope` parameter at /oauth/token, if present,
+  // must equal or be a subset of the scope bound to the auth code at
+  // /oauth/authorize. Reject expansion attempts as `invalid_scope` rather
+  // than silently honoring the bound scope (#94). Absent param → use bound.
+  const requestedTokenScopeRaw = params.get("scope");
+  let effectiveScope = authCode.scope;
+  if (requestedTokenScopeRaw !== null && requestedTokenScopeRaw.trim().length > 0) {
+    const requested = requestedTokenScopeRaw.trim();
+    if (!isScopeSubset(requested, authCode.scope)) {
+      return Response.json(
+        {
+          error: "invalid_scope",
+          error_description:
+            "Requested scope exceeds the scope bound at authorization time.",
+        },
+        { status: 400 },
+      );
+    }
+    effectiveScope = requested;
+  }
+
   // Mark code as used
   db.prepare("UPDATE oauth_codes SET used = 1 WHERE code = ?").run(code);
 
-  // Translate the consent-time selected scope into both the legacy permission
-  // column and the OAuth-standard scope list we now persist on the token row.
-  // The consent page only offers read vs full today; full becomes the
-  // admin-inheriting scope set so hub admin operations keep working.
-  const permission: TokenPermission = authCode.scope === "read" ? "read" : "full";
+  // Translate the (possibly-narrowed) effective scope into both the legacy
+  // permission column and the OAuth-standard scope list we persist on the
+  // token row. The consent page only offers read vs full today; full becomes
+  // the admin-inheriting scope set so hub admin operations keep working.
+  const permission: TokenPermission = effectiveScope === "read" ? "read" : "full";
   const scopes = legacyPermissionToScopes(permission);
   const scopeString = serializeScopes(scopes);
 

--- a/src/owner-auth.ts
+++ b/src/owner-auth.ts
@@ -88,6 +88,9 @@ interface RateLimitEntry {
  *   - Up to MAX_FAILURES failed attempts within WINDOW_MS → lockout
  *   - Lockout lasts LOCKOUT_MS
  *   - A successful attempt clears the IP's counter
+ *   - Hard cap on entry count — when full, the oldest insertion is evicted
+ *     before a new one is recorded. Prevents memory exhaustion via IP /
+ *     client_id enumeration (#93).
  */
 export class RateLimiter {
   private entries = new Map<string, RateLimitEntry>();
@@ -96,6 +99,7 @@ export class RateLimiter {
     private readonly maxFailures = 10,
     private readonly windowMs = 60_000,
     private readonly lockoutMs = 15 * 60_000,
+    private readonly maxEntries = 10_000,
   ) {}
 
   /**
@@ -130,6 +134,7 @@ export class RateLimiter {
     const entry = this.entries.get(ip);
 
     if (!entry || now - entry.firstFailureAt > this.windowMs) {
+      this.evictIfFull();
       this.entries.set(ip, {
         failures: 1,
         firstFailureAt: now,
@@ -153,7 +158,54 @@ export class RateLimiter {
   reset(): void {
     this.entries.clear();
   }
+
+  /** Current entry count — exposed for tests + observability. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Evict the oldest insertion(s) until size < maxEntries. Map preserves
+   * insertion order, so `keys().next().value` is the oldest. We re-insert
+   * on window-rollover (delete + new set), so insertion order tracks
+   * recency-of-failure closely enough for FIFO eviction.
+   */
+  private evictIfFull(): void {
+    while (this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
 }
 
-/** Singleton rate limiter for the OAuth consent endpoint. */
+/**
+ * Singleton rate limiter — kept for back-compat with callers that don't pass
+ * through per-vault routing. Fresh callers should prefer
+ * `getAuthorizeRateLimiter(vaultName)` so traffic on one vault's consent flow
+ * doesn't lock out IPs on another vault's consent flow (#93).
+ */
 export const authorizeRateLimit = new RateLimiter();
+
+/**
+ * Per-vault rate limiter registry. The vault count is admin-bounded (vaults
+ * are created via CLI, not by clients) so this Map can grow only with operator
+ * action — no attacker-driven growth path. Each instance carries the
+ * default 10,000-entry IP cap, scoped to its vault (#93).
+ */
+const vaultAuthorizeRateLimiters = new Map<string, RateLimiter>();
+
+/** Lazily get-or-create the rate limiter for a given vault. */
+export function getAuthorizeRateLimiter(vaultName: string): RateLimiter {
+  let limiter = vaultAuthorizeRateLimiters.get(vaultName);
+  if (!limiter) {
+    limiter = new RateLimiter();
+    vaultAuthorizeRateLimiters.set(vaultName, limiter);
+  }
+  return limiter;
+}
+
+/** For tests: drop all per-vault limiters. */
+export function resetVaultAuthorizeRateLimiters(): void {
+  vaultAuthorizeRateLimiters.clear();
+}

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -64,6 +64,7 @@ import {
 } from "./oauth.ts";
 import { handleConfigSchema, handleConfig } from "./module-config.ts";
 import { buildAuthStatus } from "./auth-status.ts";
+import { getAuthorizeRateLimiter } from "./owner-auth.ts";
 
 /**
  * Decorate a 401 response from the MCP endpoint with the RFC 9728 challenge
@@ -320,6 +321,10 @@ export async function route(
           clientIp,
           ownerPasswordHash,
           totpSecret,
+          // Per-vault rate-limit instance — prevents brute-force traffic on
+          // one vault's consent flow from locking out IPs trying to authorize
+          // against an unrelated vault (#93).
+          rateLimiter: getAuthorizeRateLimiter(vaultConfig.name),
         });
       }
       return Response.json({ error: "method_not_allowed" }, { status: 405 });


### PR DESCRIPTION
## Summary

Pre-launch OAuth security hardening, bundled per the team-lead brief.

- **#93 — per-vault rate limiter + memory cap.** The consent-page rate
  limiter is now keyed per vault, so brute-force traffic on one vault's
  `/oauth/authorize` cannot lock out IPs from another vault's flow. Each
  per-vault limiter carries a hard cap (default 10,000 entries) and
  evicts the oldest insertion FIFO when full — closes the IP /
  client_id memory-exhaustion path.

- **#94 — server-side scope binding.** The auth code's bound scope at
  `/oauth/authorize` is now the *narrower* of (URL-requested,
  form-selected); a malicious form cannot smuggle a broader
  `selected_scope`. At `/oauth/token`, an inbound `scope` parameter must
  equal or be a subset of the bound scope — broader values return `400
  invalid_scope`. Unknown scope strings (e.g. `vault:admin`, outside the
  consent vocabulary) are rejected strictly rather than silently
  normalized. Aligns with RFC 6749 §3.3 / §6.

Released as **0.3.6-rc.8**.

## Commits (per-issue)

- `8dd2715` — fix(oauth): per-vault rate limiter + memory cap — closes #93
- `26d6556` — fix(oauth): bind requested scope at /authorize, enforce subset at /token — closes #94
- `b45325c` — chore(release): 0.3.6-rc.8 — cleanup batch 5

## Gates

- `bun test src/`  → 961 pass / 0 fail
- `bun test core/src/`  → 285 pass / 0 fail
- `bunx tsc --noEmit`  → 386 errors (flat to baseline)

## Test plan

- [x] same vault name → same `RateLimiter` instance
- [x] distinct vault names → distinct instances
- [x] lockout on vault A's limiter does not lock the same IP on vault B's limiter
- [x] FIFO eviction at cap — 4th IP after a 3-cap pushes oldest out
- [x] `/authorize` floors `selected_scope=full` to `read` when URL `scope=read`
- [x] `/token` rejects `scope=full` with bound `read` → 400 `invalid_scope`
- [x] `/token` accepts `scope=read` with bound `full` and reflects narrower
- [x] `/token` rejects `scope=vault:admin` even when bound is `full`
- [x] `/token` with no `scope` param honors the bound scope (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)