### PR TITLE
feat(mcp): synthesize-notes — graph-aware neighborhood for an agent (#18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,13 +45,13 @@ Metadata is a JSON column on notes, links, and attachments. Queryable via `json_
 
 Path is unique (when set), normalized (no .md, no trailing slashes), and used for wikilink resolution.
 
-### MCP Tools (9)
+### MCP Tools (10)
 
 Notes: `query-notes` (single by ID/path, filter, search, graph neighborhood), `create-note` (single or batch), `update-note` (single or batch — content, tags, links, metadata merge), `delete-note`
 
 Tags: `list-tags` (with optional schema detail), `update-tag` (upsert schema), `delete-tag`
 
-Graph: `find-path` (BFS shortest path)
+Graph: `find-path` (BFS shortest path), `synthesize-notes` (anchor + neighbors + search → ranked neighborhood, connections, tag distribution, timeline; agent writes the narrative)
 
 Vault: `vault-info` (get/update description + stats)
 

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -958,7 +958,7 @@ describe("attachments", async () => {
 // ---- MCP Tools ----
 
 describe("MCP tools", async () => {
-  it("generates all 9 consolidated tools", () => {
+  it("generates all 10 consolidated tools", () => {
     const tools = generateMcpTools(store);
     const names = tools.map((t) => t.name);
 
@@ -970,8 +970,9 @@ describe("MCP tools", async () => {
     expect(names).toContain("update-tag");
     expect(names).toContain("delete-tag");
     expect(names).toContain("find-path");
+    expect(names).toContain("synthesize-notes");
     expect(names).toContain("vault-info");
-    expect(tools).toHaveLength(9);
+    expect(tools).toHaveLength(10);
   });
 
   it("create-note tool works", async () => {
@@ -1734,6 +1735,183 @@ describe("MCP tools", async () => {
     expect(result).not.toBeNull();
     expect(result.path).toEqual(["a", "b", "c"]);
     expect(result.relationships).toEqual(["mentions", "related-to"]);
+  });
+
+  // ---- synthesize-notes ----
+
+  it("synthesize-notes rejects when neither anchor nor query is supplied", async () => {
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({}) as any;
+    expect(result.error).toMatch(/at least one of `anchor` or `query`/);
+  });
+
+  it("synthesize-notes rejects an unknown anchor", async () => {
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ anchor: "does-not-exist" }) as any;
+    expect(result.error).toMatch(/Anchor note not found/);
+  });
+
+  it("synthesize-notes returns anchor + linked neighbors ranked", async () => {
+    await store.createNote("Hub note", { id: "hub", tags: ["topic"] });
+    await store.createNote("Direct neighbor", { id: "n1" });
+    await store.createNote("Two-hop neighbor", { id: "n2" });
+    await store.createNote("Unrelated", { id: "u1" });
+    await store.createLink("hub", "n1", "mentions");
+    await store.createLink("n1", "n2", "mentions");
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ anchor: "hub", depth: 2 }) as any;
+
+    const ids = result.notes.map((n: any) => n.id);
+    expect(ids).toContain("hub");
+    expect(ids).toContain("n1");
+    expect(ids).toContain("n2");
+    expect(ids).not.toContain("u1");
+    // Anchor ranks first; one-hop beats two-hop.
+    expect(ids[0]).toBe("hub");
+    expect(ids.indexOf("n1")).toBeLessThan(ids.indexOf("n2"));
+    expect(result.notes[0].sources).toContain("anchor");
+    expect(result.notes[0].distance).toBe(0);
+    expect(result.topic.anchor).toEqual({ id: "hub", path: null });
+  });
+
+  it("synthesize-notes returns FTS hits when only query is supplied", async () => {
+    await store.createNote("Octopus thoughts: ink and color", { id: "o1" });
+    await store.createNote("Squid thoughts: deep blue", { id: "s1" });
+    await store.createNote("Recipe for octopus salad", { id: "o2" });
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ query: "octopus" }) as any;
+
+    const ids = result.notes.map((n: any) => n.id);
+    expect(ids).toContain("o1");
+    expect(ids).toContain("o2");
+    expect(ids).not.toContain("s1");
+    expect(result.notes[0].sources).toContain("search");
+    expect(result.notes[0]).toHaveProperty("fts_rank");
+    expect(result.topic.query).toBe("octopus");
+  });
+
+  it("synthesize-notes applies scope.tags filter (any-match)", async () => {
+    await store.createNote("Anchor", { id: "a" });
+    await store.createNote("Tagged neighbor", { id: "t1", tags: ["alpha"] });
+    await store.createNote("Other neighbor", { id: "t2", tags: ["beta"] });
+    await store.createLink("a", "t1", "mentions");
+    await store.createLink("a", "t2", "mentions");
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ anchor: "a", scope: { tags: ["alpha"] } }) as any;
+
+    const ids = result.notes.map((n: any) => n.id);
+    expect(ids).toContain("t1");
+    expect(ids).not.toContain("t2");
+    expect(ids).not.toContain("a"); // anchor itself has no tags
+  });
+
+  it("synthesize-notes applies scope.path prefix filter", async () => {
+    await store.createNote("Anchor", { id: "a" });
+    await store.createNote("In scope", { id: "p1", path: "Projects/Alpha/notes" });
+    await store.createNote("Out of scope", { id: "p2", path: "People/Bob" });
+    await store.createLink("a", "p1", "mentions");
+    await store.createLink("a", "p2", "mentions");
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ anchor: "a", scope: { path: "projects/" } }) as any;
+
+    const ids = result.notes.map((n: any) => n.id);
+    expect(ids).toContain("p1");
+    expect(ids).not.toContain("p2");
+  });
+
+  it("synthesize-notes respects limit and sets truncated flag", async () => {
+    await store.createNote("Anchor", { id: "anchor" });
+    for (let i = 0; i < 5; i++) {
+      await store.createNote(`Neighbor ${i}`, { id: `n${i}` });
+      await store.createLink("anchor", `n${i}`, "mentions");
+    }
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ anchor: "anchor", limit: 3 }) as any;
+
+    expect(result.notes).toHaveLength(3);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("synthesize-notes connections include only links between returned notes", async () => {
+    await store.createNote("Anchor", { id: "a" });
+    await store.createNote("In set", { id: "b" });
+    await store.createNote("Excluded", { id: "c" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("a", "c", "mentions");
+    await store.createLink("b", "c", "related-to");
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ anchor: "a", depth: 1, limit: 2 }) as any;
+
+    const ids = new Set(result.notes.map((n: any) => n.id));
+    for (const c of result.connections) {
+      expect(ids.has(c.source)).toBe(true);
+      expect(ids.has(c.target)).toBe(true);
+    }
+    expect(result.connections.some((c: any) => c.target === "c")).toBe(false);
+  });
+
+  it("synthesize-notes timeline orders oldest → newest", async () => {
+    await store.createNote("Old", { id: "old", created_at: "2024-01-01T00:00:00.000Z" });
+    await store.createNote("Mid", { id: "mid", created_at: "2025-01-01T00:00:00.000Z" });
+    await store.createNote("New", { id: "new", created_at: "2026-01-01T00:00:00.000Z" });
+    await store.createLink("new", "mid", "mentions");
+    await store.createLink("mid", "old", "mentions");
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ anchor: "new", depth: 2 }) as any;
+
+    const ids = result.timeline.map((t: any) => t.id);
+    expect(ids).toEqual(["old", "mid", "new"]);
+  });
+
+  it("synthesize-notes tag distribution counts tags across results", async () => {
+    await store.createNote("Anchor", { id: "a", tags: ["alpha", "beta"] });
+    await store.createNote("N1", { id: "n1", tags: ["alpha"] });
+    await store.createNote("N2", { id: "n2", tags: ["alpha", "gamma"] });
+    await store.createLink("a", "n1", "mentions");
+    await store.createLink("a", "n2", "mentions");
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+    const result = await synth.execute({ anchor: "a" }) as any;
+
+    const tagMap = new Map(result.tags.map((t: any) => [t.name, t.count]));
+    expect(tagMap.get("alpha")).toBe(3);
+    expect(tagMap.get("beta")).toBe(1);
+    expect(tagMap.get("gamma")).toBe(1);
+    expect(result.tags[0].name).toBe("alpha");
+  });
+
+  it("synthesize-notes include_content controls snippet vs full body", async () => {
+    const longBody = "x".repeat(500);
+    await store.createNote(longBody, { id: "long", path: "Long" });
+
+    const tools = generateMcpTools(store);
+    const synth = tools.find((t) => t.name === "synthesize-notes")!;
+
+    const snippetResult = await synth.execute({ anchor: "long" }) as any;
+    expect(snippetResult.notes[0]).toHaveProperty("snippet");
+    expect(snippetResult.notes[0]).not.toHaveProperty("content");
+    expect(snippetResult.notes[0].snippet.length).toBeLessThanOrEqual(200);
+
+    const fullResult = await synth.execute({ anchor: "long", include_content: true }) as any;
+    expect(fullResult.notes[0].content).toBe(longBody);
+    expect(fullResult.notes[0]).not.toHaveProperty("snippet");
   });
 
   it("create-note via store triggers wikilink sync", async () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -68,7 +68,7 @@ function removeWikilinkBrackets(content: string, targetPath: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Generate the 9 consolidated MCP tools for a vault.
+ * Generate the 10 consolidated MCP tools for a vault.
  */
 export function generateMcpTools(store: Store): McpToolDef[] {
   const db: Database = (store as any).db;
@@ -756,7 +756,233 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     },
 
     // =====================================================================
-    // 9. vault-info — get/update vault description + stats
+    // 9. synthesize-notes — gather a coherent neighborhood for a topic
+    // =====================================================================
+    {
+      name: "synthesize-notes",
+      description: `Gather the notes that, taken together, tell the story of a topic — for the agent to read and synthesize.
+
+This is the graph-aware sibling of \`query-notes\`. Where \`query-notes\` returns flat matches, \`synthesize-notes\` pulls a *neighborhood*: anchor + linked notes + search hits + tag distribution + an oldest-first timeline, so the agent can write a coherent narrative without needing 4 separate calls.
+
+**Inputs.** Pass at least one of \`anchor\` (note ID/path to seed graph traversal) or \`query\` (FTS search string). Optionally narrow with \`scope.tags\` / \`scope.path\` (path prefix). \`depth\` (1–3, default 2) caps anchor traversal hops. \`limit\` (default 25, max 50) caps the returned note count.
+
+**What you get back.**
+  - \`notes\`: ranked candidates with \`sources\` (which seed brought them in: \`anchor\` / \`neighbor\` / \`search\`), \`distance\` (hops from anchor), and a short \`snippet\`. Pass \`include_content: true\` to inline the full note body.
+  - \`connections\`: direct links between notes in the result set — the edge structure of the neighborhood.
+  - \`tags\`: tag distribution across the result set (count desc) — quickly shows the conceptual axes.
+  - \`timeline\`: the same notes sorted oldest → newest by \`created_at\` — surfaces evolution of the topic.
+  - \`truncated\`: true when more candidates were available than \`limit\` allowed.
+
+**Synthesis is the caller's job.** The vault returns *what to read*; the agent writes the narrative. No LLM call is made server-side.`,
+      inputSchema: {
+        type: "object",
+        properties: {
+          anchor: { type: "string", description: "Note ID or path to seed graph traversal. Optional if `query` is set." },
+          query: { type: "string", description: "Full-text search query. Optional if `anchor` is set." },
+          scope: {
+            type: "object",
+            properties: {
+              tags: { type: "array", items: { type: "string" }, description: "Restrict to notes carrying any of these tags." },
+              path: { type: "string", description: "Restrict to notes whose path starts with this prefix (case-insensitive)." },
+            },
+            description: "Optional filters applied after seeding.",
+          },
+          depth: { type: "number", description: "Max graph hops from anchor (1–3, default 2). Ignored when no anchor is set." },
+          limit: { type: "number", description: "Max notes returned (default 25, hard cap 50)." },
+          include_content: { type: "boolean", description: "Inline full note content (default false — only a short snippet is included)." },
+        },
+      },
+      execute: async (params) => {
+        const anchorParam = typeof params.anchor === "string" && params.anchor.trim() ? params.anchor.trim() : null;
+        const queryParam = typeof params.query === "string" && params.query.trim() ? params.query.trim() : null;
+        if (!anchorParam && !queryParam) {
+          return { error: "synthesize-notes requires at least one of `anchor` or `query`." };
+        }
+
+        const depth = Math.max(1, Math.min((params.depth as number | undefined) ?? 2, 3));
+        const limit = Math.max(1, Math.min((params.limit as number | undefined) ?? 25, 50));
+        const includeContent = params.include_content === true;
+        const scope = (params.scope as { tags?: string[]; path?: string } | undefined) ?? {};
+        const scopeTags = Array.isArray(scope.tags) && scope.tags.length > 0 ? scope.tags : null;
+        const scopePathPrefix = typeof scope.path === "string" && scope.path.trim() ? scope.path.trim().toLowerCase() : null;
+
+        // Pre-resolve the anchor so a bad ID/path errors out cheaply.
+        let anchorNote: Note | null = null;
+        if (anchorParam) {
+          anchorNote = resolveNote(db, anchorParam);
+          if (!anchorNote) {
+            return { error: "Anchor note not found", anchor: anchorParam };
+          }
+        }
+
+        // ----- Candidate seeding -----
+        // Each candidate tracks every signal that surfaced it (so the agent
+        // can see whether a note came from the search hit, the graph, or
+        // both) plus enough provenance to score it.
+        type Candidate = {
+          sources: Set<"anchor" | "neighbor" | "search">;
+          distance: number | null;       // hops from anchor; null if not on the graph
+          ftsRank: number | null;        // 0 = best FTS hit; null if not a search hit
+        };
+        const candidates = new Map<string, Candidate>();
+
+        const upsert = (id: string, patch: Partial<Candidate> & { source: "anchor" | "neighbor" | "search" }): void => {
+          const existing = candidates.get(id);
+          if (!existing) {
+            candidates.set(id, {
+              sources: new Set([patch.source]),
+              distance: patch.distance ?? null,
+              ftsRank: patch.ftsRank ?? null,
+            });
+            return;
+          }
+          existing.sources.add(patch.source);
+          if (patch.distance !== undefined && patch.distance !== null) {
+            existing.distance = existing.distance === null ? patch.distance : Math.min(existing.distance, patch.distance);
+          }
+          if (patch.ftsRank !== undefined && patch.ftsRank !== null) {
+            existing.ftsRank = existing.ftsRank === null ? patch.ftsRank : Math.min(existing.ftsRank, patch.ftsRank);
+          }
+        };
+
+        if (anchorNote) {
+          upsert(anchorNote.id, { source: "anchor", distance: 0 });
+          const traversed = linkOps.traverseLinks(db, anchorNote.id, { max_depth: depth });
+          for (const t of traversed) upsert(t.noteId, { source: "neighbor", distance: t.depth });
+        }
+
+        if (queryParam) {
+          // Cap the FTS pull at 2× limit so the post-scope filter still leaves
+          // enough headroom to fill the result set with real hits.
+          const searchHits = noteOps.searchNotes(db, queryParam, { limit: Math.min(limit * 2, 100) });
+          searchHits.forEach((n, idx) => upsert(n.id, { source: "search", ftsRank: idx }));
+        }
+
+        // ----- Hydrate + scope filter -----
+        const ids = [...candidates.keys()];
+        const noteMap = new Map<string, Note>();
+        for (const id of ids) {
+          const n = noteOps.getNote(db, id);
+          if (n) noteMap.set(id, n);
+        }
+
+        const passesScope = (note: Note): boolean => {
+          if (scopeTags) {
+            const tags = note.tags ?? [];
+            if (!scopeTags.some((t) => tags.includes(t))) return false;
+          }
+          if (scopePathPrefix) {
+            const p = (note.path ?? "").toLowerCase();
+            if (!p.startsWith(scopePathPrefix)) return false;
+          }
+          return true;
+        };
+
+        const inScope: { id: string; note: Note; cand: Candidate }[] = [];
+        for (const [id, cand] of candidates) {
+          const note = noteMap.get(id);
+          if (!note) continue;
+          if (!passesScope(note)) continue;
+          inScope.push({ id, note, cand });
+        }
+
+        // ----- Score + rank -----
+        // Heuristic: anchor wins outright (5), search hits decay with FTS rank
+        // toward 0 (max ≈ 3), graph proximity contributes 0–3 (1 hop = 2,
+        // 2 hops = 1). Multi-source notes naturally rise — both axes add up.
+        const scoreOf = (c: Candidate): number => {
+          let s = 0;
+          if (c.sources.has("anchor")) s += 5;
+          if (c.sources.has("search") && c.ftsRank !== null) {
+            const decay = Math.max(0, 1 - c.ftsRank / 50);
+            s += 3 * decay;
+          }
+          if (c.sources.has("neighbor") && c.distance !== null) {
+            s += Math.max(0, 3 - c.distance);
+          }
+          return s;
+        };
+
+        inScope.sort((a, b) => {
+          const sa = scoreOf(a.cand);
+          const sb = scoreOf(b.cand);
+          if (sb !== sa) return sb - sa;
+          // Tie-break on recency so the agent surfaces the freshest take.
+          return (b.note.updatedAt ?? b.note.createdAt).localeCompare(a.note.updatedAt ?? a.note.createdAt);
+        });
+
+        const truncated = inScope.length > limit;
+        const top = inScope.slice(0, limit);
+
+        // ----- Snippet (cheap: first ~200 chars of content, single-line) -----
+        const snippetOf = (content: string): string => {
+          const flat = content.replace(/\s+/g, " ").trim();
+          return flat.length > 200 ? `${flat.slice(0, 197)}...` : flat;
+        };
+
+        const notesOut = top.map(({ id, note, cand }) => {
+          const out: Record<string, unknown> = {
+            id,
+            path: note.path ?? null,
+            tags: note.tags ?? [],
+            created_at: note.createdAt,
+            updated_at: note.updatedAt ?? null,
+            sources: [...cand.sources],
+            score: Number(scoreOf(cand).toFixed(3)),
+          };
+          if (cand.distance !== null) out.distance = cand.distance;
+          if (cand.ftsRank !== null) out.fts_rank = cand.ftsRank;
+          if (includeContent) {
+            out.content = note.content;
+          } else {
+            out.snippet = snippetOf(note.content);
+          }
+          return out;
+        });
+
+        // ----- Connections (direct links among returned notes only) -----
+        const idSet = new Set(top.map((t) => t.id));
+        const connections: { source: string; target: string; relationship: string }[] = [];
+        if (idSet.size > 1) {
+          const placeholders = [...idSet].map(() => "?").join(",");
+          const rows = db.prepare(
+            `SELECT source_id, target_id, relationship FROM links
+             WHERE source_id IN (${placeholders}) AND target_id IN (${placeholders})`,
+          ).all(...idSet, ...idSet) as { source_id: string; target_id: string; relationship: string }[];
+          for (const r of rows) {
+            connections.push({ source: r.source_id, target: r.target_id, relationship: r.relationship });
+          }
+        }
+
+        // ----- Tag distribution + timeline -----
+        const tagCounts = new Map<string, number>();
+        for (const { note } of top) {
+          for (const t of note.tags ?? []) tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+        }
+        const tags = [...tagCounts.entries()]
+          .map(([name, count]) => ({ name, count }))
+          .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+
+        const timeline = [...top]
+          .sort((a, b) => a.note.createdAt.localeCompare(b.note.createdAt))
+          .map(({ id, note }) => ({ id, created_at: note.createdAt }));
+
+        return {
+          topic: {
+            ...(anchorNote ? { anchor: { id: anchorNote.id, path: anchorNote.path ?? null } } : {}),
+            ...(queryParam ? { query: queryParam } : {}),
+          },
+          notes: notesOut,
+          connections,
+          tags,
+          timeline,
+          truncated,
+        };
+      },
+    },
+
+    // =====================================================================
+    // 10. vault-info — get/update vault description + stats
     // =====================================================================
     {
       name: "vault-info",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.8",
+  "version": "0.3.6-rc.9",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -41,6 +41,7 @@ const TOOL_REQUIRED_VERB: Record<string, VaultVerb> = {
   "query-notes": "read",
   "list-tags": "read",
   "find-path": "read",
+  "synthesize-notes": "read",
   "vault-info": "read",
   "create-note": "write",
   "update-note": "write",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,11 +1,12 @@
 /**
  * REST API route handlers for the multi-vault server.
  *
- * Mirrors the 9 MCP tools:
+ * Mirrors the MCP tools:
  *   /api/notes          — query-notes, create-note, update-note, delete-note
  *   /api/tags           — list-tags, update-tag, delete-tag
  *   /api/find-path      — find-path
  *   /api/vault          — vault-info
+ * (synthesize-notes is MCP-only; agents call it through the MCP transport.)
  *
  * Each handler receives a Store instance (already resolved for the vault)
  * and the Request, and returns a Response.

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -476,9 +476,9 @@ describe("deeper link queries", async () => {
 });
 
 describe("MCP tools", async () => {
-  test("generates all 9 core tools", () => {
+  test("generates all 10 core tools", () => {
     const tools = generateMcpTools(store);
-    expect(tools.length).toBe(9);
+    expect(tools.length).toBe(10);
 
     const names = tools.map((t) => t.name);
     expect(names).toContain("query-notes");
@@ -489,6 +489,7 @@ describe("MCP tools", async () => {
     expect(names).toContain("update-tag");
     expect(names).toContain("delete-tag");
     expect(names).toContain("find-path");
+    expect(names).toContain("synthesize-notes");
     expect(names).toContain("vault-info");
   });
 


### PR DESCRIPTION
## Summary

Adds a new MCP tool, `synthesize-notes`, that gathers the notes that — taken together — tell the story of a topic. Closes #18.

Where `query-notes` returns flat matches, `synthesize-notes` pulls a **neighborhood** keyed on anchor + linked neighbors + FTS hits, and returns it as a structured shape the agent can read and synthesize a narrative from. No LLM call inside vault.

## Surface

```ts
synthesize-notes({
  anchor?: string,        // id or path; seeds graph traversal
  query?: string,         // FTS string; seeds search hits
  scope?: { tags?: string[]; path?: string },
  depth?: 1|2|3,          // graph hops (default 2)
  limit?: number,         // ≤ 50, default 25
  include_content?: boolean,
})
```

At least one of `anchor` / `query` is required.

Returns:

- `notes` — ranked candidates with `sources` (`anchor` / `neighbor` / `search`), `distance`, `fts_rank`, `score`, and `snippet` (or full `content`).
- `connections` — direct links among the returned notes only.
- `tags` — tag distribution across the result set, count desc.
- `timeline` — same notes oldest → newest.
- `truncated` — true when more candidates were available than `limit`.

## Implementation

- Built on existing primitives only — `linkOps.traverseLinks` for graph BFS, `noteOps.searchNotes` for FTS — no embedding requirement.
- Multi-source candidates aggregate; scoring sums anchor (5) + search-decay (3 × `1 − rank/50`) + graph-proximity (max 0, 3 − distance). Ties break on recency.
- Wired into `TOOL_REQUIRED_VERB` as `"read"`, so `vault:<name>:read` scopes can call it through OAuth-gated MCP.
- REST not extended — synthesize-notes is MCP-only; the value is in the agent loop.

## Versioning

Bumped to `0.3.6-rc.9`.

## Test plan

- [x] `bun test core/src/` — 176 pass (10 new synthesize-notes cases)
- [x] `bun test src/` — 972 pass
- [x] `bunx tsc --noEmit` — 386 errors (baseline unchanged)
- [ ] Try a real anchor + query call from an MCP client and confirm the narrative composes nicely

🤖 Generated with [Claude Code](https://claude.com/claude-code)