### PR TITLE
feat(mcp): update-note operations bundle — append/prepend (#79) + content_edit (#80) + if_updated_at baseline (#81)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -1368,6 +1368,43 @@ describe("MCP tools", async () => {
     expect(err?.message).toMatch(/mutually exclusive/);
   });
 
+  it("update-note rejects content + content_edit in same call", async () => {
+    const note = await store.createNote("hello world", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: note.id,
+        content: "replace",
+        content_edit: { old_text: "hello", new_text: "hi" },
+        force: true,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toMatch(/mutually exclusive/);
+  });
+
+  it("update-note rejects append + content_edit in same call", async () => {
+    const note = await store.createNote("hello world", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: note.id,
+        append: " more",
+        content_edit: { old_text: "hello", new_text: "hi" },
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toMatch(/mutually exclusive/);
+  });
+
   it("update-note append still requires precondition when combined with other fields", async () => {
     const note = await store.createNote("body", { id: "n1" });
     const tools = generateMcpTools(store);
@@ -1434,6 +1471,98 @@ describe("MCP tools", async () => {
 
     const links = await store.getLinks(source.id, { direction: "outbound" });
     expect(links.some((l) => l.targetId === target.id && l.relationship === "wikilink")).toBe(true);
+  });
+
+  it("update-note content_edit replaces a single occurrence", async () => {
+    const note = await store.createNote("hello world", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const result = await updateNote.execute({
+      id: note.id,
+      content_edit: { old_text: "hello", new_text: "hi" },
+      if_updated_at: note.updatedAt,
+    }) as any;
+    expect(result.content).toBe("hi world");
+  });
+
+  it("update-note content_edit errors when old_text is not found", async () => {
+    const note = await store.createNote("hello world", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: note.id,
+        content_edit: { old_text: "missing", new_text: "x" },
+        if_updated_at: note.updatedAt,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toMatch(/not found/);
+    // Note must be untouched.
+    const persisted = await store.getNote(note.id);
+    expect(persisted!.content).toBe("hello world");
+  });
+
+  it("update-note content_edit errors when old_text matches multiple times", async () => {
+    const note = await store.createNote("hello hello", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: note.id,
+        content_edit: { old_text: "hello", new_text: "hi" },
+        if_updated_at: note.updatedAt,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toMatch(/matches multiple times|exactly once/);
+    const persisted = await store.getNote(note.id);
+    expect(persisted!.content).toBe("hello hello");
+  });
+
+  it("update-note content_edit requires precondition by default", async () => {
+    const note = await store.createNote("hello world", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: note.id,
+        content_edit: { old_text: "hello", new_text: "hi" },
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("PRECONDITION_REQUIRED");
+  });
+
+  it("update-note content_edit conflicts when if_updated_at is stale", async () => {
+    const note = await store.createNote("hello world", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // Bump the note so a stale token will conflict at the SQL layer.
+    await updateNote.execute({ id: note.id, content: "hello world", force: true });
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        id: note.id,
+        content_edit: { old_text: "hello", new_text: "hi" },
+        if_updated_at: "2020-01-01T00:00:00.000Z",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("CONFLICT");
   });
 
   it("query-notes single note by id", async () => {

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -1319,6 +1319,123 @@ describe("MCP tools", async () => {
     expect((await store.getNote("source"))!.content).toBe("See [[People/Alice]] for details");
   });
 
+  it("update-note append concatenates to end without precondition", async () => {
+    const note = await store.createNote("first line\n", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // No if_updated_at and no force — append-only is precondition-exempt.
+    const result = await updateNote.execute({ id: note.id, append: "second line\n" }) as any;
+    expect(result.content).toBe("first line\nsecond line\n");
+
+    const persisted = await store.getNote(note.id);
+    expect(persisted!.content).toBe("first line\nsecond line\n");
+  });
+
+  it("update-note prepend concatenates to start without precondition", async () => {
+    const note = await store.createNote("body", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const result = await updateNote.execute({ id: note.id, prepend: "header\n" }) as any;
+    expect(result.content).toBe("header\nbody");
+  });
+
+  it("update-note append+prepend in one call lands both contributions", async () => {
+    const note = await store.createNote("middle", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const result = await updateNote.execute({
+      id: note.id,
+      prepend: "[start] ",
+      append: " [end]",
+    }) as any;
+    expect(result.content).toBe("[start] middle [end]");
+  });
+
+  it("update-note rejects content + append in same call", async () => {
+    const note = await store.createNote("body", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    let err: any;
+    try {
+      await updateNote.execute({ id: note.id, content: "new", append: "more", force: true });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toMatch(/mutually exclusive/);
+  });
+
+  it("update-note append still requires precondition when combined with other fields", async () => {
+    const note = await store.createNote("body", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // append + metadata is NOT precondition-exempt — metadata mutation
+    // can lose data on a stale read, so the safety gate stays in.
+    let err: any;
+    try {
+      await updateNote.execute({ id: note.id, append: " more", metadata: { x: 1 } });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("PRECONDITION_REQUIRED");
+  });
+
+  it("update-note append is atomic under concurrent calls — both lands", async () => {
+    const note = await store.createNote("seed:", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // Two concurrent appends. SQL-level concat means both contributions
+    // land — neither overwrites the other.
+    const results = await Promise.all([
+      updateNote.execute({ id: note.id, append: " A" }),
+      updateNote.execute({ id: note.id, append: " B" }),
+    ]);
+    expect(results).toHaveLength(2);
+
+    const persisted = await store.getNote(note.id);
+    // Final content is one of "seed: A B" or "seed: B A" — the order
+    // depends on which write got the lock first, but both contributions
+    // are present.
+    expect(persisted!.content === "seed: A B" || persisted!.content === "seed: B A").toBe(true);
+  });
+
+  it("update-note append updates updated_at and respects if_updated_at when supplied", async () => {
+    const note = await store.createNote("seed", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    // With if_updated_at — succeeds because we're using the right token.
+    const ok = await updateNote.execute({ id: note.id, append: " A", if_updated_at: note.updatedAt }) as any;
+    expect(ok.content).toBe("seed A");
+    expect(ok.updatedAt).not.toBe(note.updatedAt);
+
+    // Stale token — conflict.
+    let err: any;
+    try {
+      await updateNote.execute({ id: note.id, append: " B", if_updated_at: note.updatedAt });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("CONFLICT");
+  });
+
+  it("update-note append parses new wikilinks introduced via append", async () => {
+    const target = await store.createNote("Alice's note", { id: "alice", path: "People/Alice" });
+    const source = await store.createNote("intro\n", { id: "src" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    await updateNote.execute({ id: source.id, append: "see [[People/Alice]]" });
+
+    const links = await store.getLinks(source.id, { direction: "outbound" });
+    expect(links.some((l) => l.targetId === target.id && l.relationship === "wikilink")).toBe(true);
+  });
+
   it("query-notes single note by id", async () => {
     const note = await store.createNote("Hello", { path: "test/note" });
     const tools = generateMcpTools(store);

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -363,9 +363,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
       name: "update-note",
       description: `Update one or more notes. Accepts ID or path. Supports content, path, metadata updates plus tag and link mutations.
 
-- Two content-modification modes (mutually exclusive):
+- Three content-modification modes (mutually exclusive):
   - \`content\` — full replace.
   - \`append\` / \`prepend\` — atomic concatenation at the SQL layer. Multiple agents appending to the same note never overwrite each other. No separator is added; include trailing/leading whitespace yourself if needed. May be combined with each other.
+  - \`content_edit: { old_text, new_text }\` — surgical find-and-replace. \`old_text\` must occur exactly once; zero or multiple matches return an error. Add surrounding context to disambiguate.
 - \`tags: { add: ["x"], remove: ["y"] }\` — add/remove tags
 - \`links: { add: [{ target, relationship }], remove: [{ target, relationship }] }\` — add/remove links
 - When removing a wikilink-type link, \`[[brackets]]\` are also removed from content.
@@ -375,9 +376,18 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         type: "object",
         properties: {
           id: { type: "string", description: "Note ID or path" },
-          content: { type: "string", description: "New content (full replace). Mutually exclusive with `append`/`prepend`." },
-          append: { type: "string", description: "Text to append to the end of the note. Atomic at the SQL layer — concurrent appends are safe. Mutually exclusive with `content`. No precondition required." },
-          prepend: { type: "string", description: "Text to prepend to the start of the note. Atomic at the SQL layer. Mutually exclusive with `content`. May combine with `append`. No precondition required." },
+          content: { type: "string", description: "New content (full replace). Mutually exclusive with `append`/`prepend` and `content_edit`." },
+          append: { type: "string", description: "Text to append to the end of the note. Atomic at the SQL layer — concurrent appends are safe. Mutually exclusive with `content` and `content_edit`. No precondition required." },
+          prepend: { type: "string", description: "Text to prepend to the start of the note. Atomic at the SQL layer. Mutually exclusive with `content` and `content_edit`. May combine with `append`. No precondition required." },
+          content_edit: {
+            type: "object",
+            properties: {
+              old_text: { type: "string", description: "Exact text to find. Must match exactly once in the note's current content." },
+              new_text: { type: "string", description: "Replacement text." },
+            },
+            required: ["old_text", "new_text"],
+            description: "Find-and-replace one occurrence. Errors if `old_text` is not found or matches multiple locations. Mutually exclusive with `content` and `append`/`prepend`.",
+          },
           path: { type: "string", description: "New path" },
           metadata: { type: "object", description: "Metadata to merge (keys are merged, not replaced wholesale)" },
           created_at: { type: "string", description: "New created_at timestamp" },
@@ -429,6 +439,14 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
                 content: { type: "string" },
                 append: { type: "string" },
                 prepend: { type: "string" },
+                content_edit: {
+                  type: "object",
+                  properties: {
+                    old_text: { type: "string" },
+                    new_text: { type: "string" },
+                  },
+                  required: ["old_text", "new_text"],
+                },
                 path: { type: "string" },
                 metadata: { type: "object" },
                 created_at: { type: "string" },
@@ -454,9 +472,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           // --- Validate mutual exclusion of content modes ---
           const hasContent = item.content !== undefined;
           const hasAppendPrepend = item.append !== undefined || item.prepend !== undefined;
-          if (hasContent && hasAppendPrepend) {
+          const hasContentEdit = item.content_edit !== undefined;
+          const contentModes = (hasContent ? 1 : 0) + (hasAppendPrepend ? 1 : 0) + (hasContentEdit ? 1 : 0);
+          if (contentModes > 1) {
             throw new Error(
-              `update-note: \`content\` and \`append\`/\`prepend\` are mutually exclusive — pick one mode of content update for note "${note.id}".`,
+              `update-note: \`content\`, \`append\`/\`prepend\`, and \`content_edit\` are mutually exclusive — pick one mode of content update for note "${note.id}".`,
             );
           }
 
@@ -471,6 +491,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           // precondition would be ceremony for no benefit.
           const isAppendOnly = hasAppendPrepend
             && !hasContent
+            && !hasContentEdit
             && item.path === undefined
             && item.metadata === undefined
             && item.created_at === undefined;
@@ -478,11 +499,40 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             throw new PreconditionRequiredError(note.id, note.path ?? null);
           }
 
+          // --- Resolve content_edit into a full content string ---
+          // We do the find-and-replace at the JS level (read note.content,
+          // validate occurrence count, replace). The race window between
+          // this read and the UPDATE is closed by `if_updated_at` for
+          // strict callers; without it, content_edit is fail-closed —
+          // a stale read where someone else removed `old_text` produces
+          // a "not found" error instead of silently overwriting.
+          let contentOverride = item.content as string | undefined;
+          if (hasContentEdit) {
+            const ce = item.content_edit as { old_text: string; new_text: string };
+            if (typeof ce?.old_text !== "string" || typeof ce?.new_text !== "string") {
+              throw new Error(
+                "update-note: `content_edit` requires { old_text: string, new_text: string }.",
+              );
+            }
+            const idx = note.content.indexOf(ce.old_text);
+            if (idx < 0) {
+              throw new Error(
+                `update-note content_edit: \`old_text\` not found in note "${note.id}". The note may have been edited — re-read and retry.`,
+              );
+            }
+            const second = note.content.indexOf(ce.old_text, idx + 1);
+            if (second >= 0) {
+              throw new Error(
+                `update-note content_edit: \`old_text\` matches multiple times in note "${note.id}" — must match exactly once. Add surrounding context to disambiguate.`,
+              );
+            }
+            contentOverride = note.content.slice(0, idx) + ce.new_text + note.content.slice(idx + ce.old_text.length);
+          }
+
           // --- Plan bracket cleanup for wikilink removals (no DB writes yet) ---
           // We compute the cleaned content so we can do the core UPDATE first
           // (with if_updated_at atomically) before any link deletions. If the
           // UPDATE fails on a conflict, nothing has been mutated.
-          let contentOverride = item.content as string | undefined;
           const linksRemove = (item.links as any)?.remove as { target: string; relationship: string }[] | undefined;
           const resolvedLinksToRemove: { targetId: string; relationship: string }[] = [];
           if (linksRemove) {
@@ -492,9 +542,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               resolvedLinksToRemove.push({ targetId: target.id, relationship: link.relationship });
               if (link.relationship === "wikilink" && target.path) {
                 // Wikilink-removal bracket cleanup operates on the prospective
-                // *full* content. For append/prepend callers we pre-materialize
-                // the would-be content (and switch to a `content`-style update
-                // below) so the cleanup doesn't fight the SQL-atomic path.
+                // *full* content. Coexists with content_edit; would fight
+                // append/prepend (which leave existing content untouched at
+                // the JS layer), so we pre-materialize the would-be content
+                // for those callers and switch to a `content`-style update.
                 const currentContent = contentOverride
                   ?? (hasAppendPrepend
                     ? (item.prepend as string ?? "") + note.content + (item.append as string ?? "")
@@ -512,8 +563,8 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           if (contentOverride !== undefined) {
             updates.content = contentOverride;
           } else if (hasAppendPrepend) {
-            // Route append/prepend down to the SQL-atomic path (no wikilink
-            // pre-materialization fired).
+            // No content_edit and no wikilink-removal pre-materialization —
+            // route the append/prepend down to the SQL-atomic path.
             if (item.append !== undefined) updates.append = item.append;
             if (item.prepend !== undefined) updates.prepend = item.prepend;
           }

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -363,20 +363,25 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
       name: "update-note",
       description: `Update one or more notes. Accepts ID or path. Supports content, path, metadata updates plus tag and link mutations.
 
+- Two content-modification modes (mutually exclusive):
+  - \`content\` — full replace.
+  - \`append\` / \`prepend\` — atomic concatenation at the SQL layer. Multiple agents appending to the same note never overwrite each other. No separator is added; include trailing/leading whitespace yourself if needed. May be combined with each other.
 - \`tags: { add: ["x"], remove: ["y"] }\` — add/remove tags
 - \`links: { add: [{ target, relationship }], remove: [{ target, relationship }] }\` — add/remove links
 - When removing a wikilink-type link, \`[[brackets]]\` are also removed from content.
 - For batch: pass a \`notes\` array, each with an \`id\` field.
-- **Optimistic concurrency is required by default.** Pass \`if_updated_at\` with the \`updated_at\` value you last read — the update is rejected with a conflict error if the note has changed since. Re-read, reconcile, and retry. To skip the safety check (e.g. bulk migration), pass \`force: true\` instead; the update then runs unconditionally.`,
+- **Optimistic concurrency is required by default.** Pass \`if_updated_at\` with the \`updated_at\` value you last read — the update is rejected with a conflict error if the note has changed since. Re-read, reconcile, and retry. To skip the safety check (e.g. bulk migration), pass \`force: true\` instead; the update then runs unconditionally. \`append\` / \`prepend\` only updates are exempt from the precondition (no-conflict-by-design).`,
       inputSchema: {
         type: "object",
         properties: {
           id: { type: "string", description: "Note ID or path" },
-          content: { type: "string", description: "New content" },
+          content: { type: "string", description: "New content (full replace). Mutually exclusive with `append`/`prepend`." },
+          append: { type: "string", description: "Text to append to the end of the note. Atomic at the SQL layer — concurrent appends are safe. Mutually exclusive with `content`. No precondition required." },
+          prepend: { type: "string", description: "Text to prepend to the start of the note. Atomic at the SQL layer. Mutually exclusive with `content`. May combine with `append`. No precondition required." },
           path: { type: "string", description: "New path" },
           metadata: { type: "object", description: "Metadata to merge (keys are merged, not replaced wholesale)" },
           created_at: { type: "string", description: "New created_at timestamp" },
-          if_updated_at: { type: "string", description: "Optimistic concurrency check: the updated_at value you last read. Rejects with a conflict error if the note has been modified since. Required unless `force: true` is set." },
+          if_updated_at: { type: "string", description: "Optimistic concurrency check: the updated_at value you last read. Rejects with a conflict error if the note has been modified since. Required unless `force: true` is set or the call is `append`/`prepend`-only." },
           force: { type: "boolean", description: "Override the required `if_updated_at` check and run the update unconditionally. Use only for bulk migrations or scripted writes where concurrency is known-safe." },
           tags: {
             type: "object",
@@ -422,10 +427,12 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               properties: {
                 id: { type: "string" },
                 content: { type: "string" },
+                append: { type: "string" },
+                prepend: { type: "string" },
                 path: { type: "string" },
                 metadata: { type: "object" },
                 created_at: { type: "string" },
-                if_updated_at: { type: "string", description: "Optimistic concurrency check for this item; rejects with a conflict error if the note has been modified since. Required unless `force: true` is set on this item." },
+                if_updated_at: { type: "string", description: "Optimistic concurrency check for this item; rejects with a conflict error if the note has been modified since. Required unless `force: true` is set on this item or the item is `append`/`prepend`-only." },
                 force: { type: "boolean", description: "Override the required `if_updated_at` check for this item." },
                 tags: { type: "object" },
                 links: { type: "object" },
@@ -444,12 +451,30 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         for (const item of items) {
           const note = requireNote(db, item.id as string);
 
+          // --- Validate mutual exclusion of content modes ---
+          const hasContent = item.content !== undefined;
+          const hasAppendPrepend = item.append !== undefined || item.prepend !== undefined;
+          if (hasContent && hasAppendPrepend) {
+            throw new Error(
+              `update-note: \`content\` and \`append\`/\`prepend\` are mutually exclusive — pick one mode of content update for note "${note.id}".`,
+            );
+          }
+
           // --- Safety-by-default: refuse mutations without a precondition ---
           // The caller must either echo the note's last-seen `updated_at`
           // (`if_updated_at`) so the conditional UPDATE can catch lost
           // writes, or explicitly opt out with `force: true`. This runs
           // *before* any DB writes so a rejection leaves the note untouched.
-          if (item.if_updated_at === undefined && item.force !== true) {
+          //
+          // Append/prepend-only updates are exempt: they're SQL-atomic
+          // concatenations that can't lose data on a stale read, so the
+          // precondition would be ceremony for no benefit.
+          const isAppendOnly = hasAppendPrepend
+            && !hasContent
+            && item.path === undefined
+            && item.metadata === undefined
+            && item.created_at === undefined;
+          if (!isAppendOnly && item.if_updated_at === undefined && item.force !== true) {
             throw new PreconditionRequiredError(note.id, note.path ?? null);
           }
 
@@ -466,7 +491,14 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               if (!target) continue;
               resolvedLinksToRemove.push({ targetId: target.id, relationship: link.relationship });
               if (link.relationship === "wikilink" && target.path) {
-                const currentContent = contentOverride ?? note.content;
+                // Wikilink-removal bracket cleanup operates on the prospective
+                // *full* content. For append/prepend callers we pre-materialize
+                // the would-be content (and switch to a `content`-style update
+                // below) so the cleanup doesn't fight the SQL-atomic path.
+                const currentContent = contentOverride
+                  ?? (hasAppendPrepend
+                    ? (item.prepend as string ?? "") + note.content + (item.append as string ?? "")
+                    : note.content);
                 const cleaned = removeWikilinkBrackets(currentContent, target.path);
                 if (cleaned !== currentContent) {
                   contentOverride = cleaned;
@@ -477,7 +509,14 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
 
           // --- Core update (content, path, metadata, created_at + concurrency check) ---
           const updates: any = {};
-          if (contentOverride !== undefined) updates.content = contentOverride;
+          if (contentOverride !== undefined) {
+            updates.content = contentOverride;
+          } else if (hasAppendPrepend) {
+            // Route append/prepend down to the SQL-atomic path (no wikilink
+            // pre-materialization fired).
+            if (item.append !== undefined) updates.append = item.append;
+            if (item.prepend !== undefined) updates.prepend = item.prepend;
+          }
           if (item.path !== undefined) updates.path = item.path;
           if (item.metadata !== undefined) {
             // Merge metadata (don't replace wholesale)

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -152,6 +152,19 @@ export function updateNote(
   id: string,
   updates: {
     content?: string;
+    /**
+     * Atomic content append. Computed via SQL string concatenation
+     * (`content = content || ?`), so two concurrent appends never
+     * overwrite each other — the second simply lands after the first.
+     * Mutually exclusive with `content`.
+     */
+    append?: string;
+    /**
+     * Atomic content prepend. Same SQL-level guarantee as `append`.
+     * Mutually exclusive with `content`. May be combined with `append`
+     * in a single call (both contributions land).
+     */
+    prepend?: string;
     path?: string;
     metadata?: Record<string, unknown>;
     created_at?: string;
@@ -164,6 +177,12 @@ export function updateNote(
     if_updated_at?: string;
   },
 ): Note {
+  if (updates.content !== undefined && (updates.append !== undefined || updates.prepend !== undefined)) {
+    throw new Error(
+      "update-note: `content` is mutually exclusive with `append`/`prepend`. Pick full-replace or additive — not both in the same call.",
+    );
+  }
+
   const sets: string[] = [];
   const values: unknown[] = [];
 
@@ -188,6 +207,15 @@ export function updateNote(
   if (updates.content !== undefined) {
     sets.push("content = ?");
     values.push(updates.content);
+  }
+  if (updates.append !== undefined || updates.prepend !== undefined) {
+    // Atomic concat at the SQL layer. SQLite's `||` operator on the
+    // existing `content` column means a concurrent reader-then-writer
+    // race window is impossible: each `UPDATE` evaluates `content`
+    // under the write lock, so two simultaneous appends both land
+    // (in some order) instead of one clobbering the other.
+    sets.push("content = ? || content || ?");
+    values.push(updates.prepend ?? "", updates.append ?? "");
   }
   if (updates.path !== undefined) {
     sets.push("path = ?");

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -55,6 +55,8 @@ export class BunSqliteStore implements Store {
     id: string,
     updates: {
       content?: string;
+      append?: string;
+      prepend?: string;
       path?: string;
       metadata?: Record<string, unknown>;
       created_at?: string;
@@ -70,8 +72,11 @@ export class BunSqliteStore implements Store {
 
     const note = noteOps.updateNote(this.db, id, updates);
 
-    if (updates.content !== undefined) {
-      syncWikilinks(this.db, id, updates.content);
+    // Wikilink sync runs against the *resulting* content. For append/prepend
+    // we don't have the new value pre-write — read it back off the returned
+    // note so a `[[Foo]]` introduced via append still creates the link.
+    if (updates.content !== undefined || updates.append !== undefined || updates.prepend !== undefined) {
+      syncWikilinks(this.db, id, note.content);
     }
 
     if (updates.path !== undefined && note.path) {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -119,7 +119,7 @@ export interface Store {
   getNote(id: string): Promise<Note | null>;
   getNoteByPath(path: string): Promise<Note | null>;
   getNotes(ids: string[]): Promise<Note[]>;
-  updateNote(id: string, updates: { content?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean; if_updated_at?: string }): Promise<Note>;
+  updateNote(id: string, updates: { content?: string; append?: string; prepend?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean; if_updated_at?: string }): Promise<Note>;
   deleteNote(id: string): Promise<void>;
   queryNotes(opts: QueryOpts): Promise<Note[]>;
   searchNotes(query: string, opts?: { tags?: string[]; limit?: number }): Promise<Note[]>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.9",
+  "version": "0.3.6-rc.10",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -434,11 +434,13 @@ export async function handleNotes(
       // --- Validate mutual exclusion of content modes ---
       const hasContent = body.content !== undefined;
       const hasAppendPrepend = body.append !== undefined || body.prepend !== undefined;
-      if (hasContent && hasAppendPrepend) {
+      const hasContentEdit = body.content_edit !== undefined;
+      const contentModes = (hasContent ? 1 : 0) + (hasAppendPrepend ? 1 : 0) + (hasContentEdit ? 1 : 0);
+      if (contentModes > 1) {
         return json(
           {
             error: "mutually_exclusive",
-            message: "`content` and `append`/`prepend` are mutually exclusive — pick one mode of content update.",
+            message: "`content`, `append`/`prepend`, and `content_edit` are mutually exclusive — pick one mode of content update.",
           },
           400,
         );
@@ -453,6 +455,7 @@ export async function handleNotes(
       // is no-conflict-by-design.
       const isAppendOnly = hasAppendPrepend
         && !hasContent
+        && !hasContentEdit
         && body.path === undefined
         && body.metadata === undefined
         && body.created_at === undefined
@@ -471,10 +474,36 @@ export async function handleNotes(
         );
       }
 
+      // --- Resolve content_edit into a full content string ---
+      let contentOverride = body.content as string | undefined;
+      if (hasContentEdit) {
+        const ce = body.content_edit as { old_text?: unknown; new_text?: unknown };
+        if (typeof ce?.old_text !== "string" || typeof ce?.new_text !== "string") {
+          return json(
+            { error: "bad_request", message: "`content_edit` requires { old_text: string, new_text: string }." },
+            400,
+          );
+        }
+        const idx = note.content.indexOf(ce.old_text);
+        if (idx < 0) {
+          return json(
+            { error: "not_found", message: `content_edit: \`old_text\` not found in note "${note.id}". Re-read and retry.` },
+            404,
+          );
+        }
+        const second = note.content.indexOf(ce.old_text, idx + 1);
+        if (second >= 0) {
+          return json(
+            { error: "ambiguous", message: `content_edit: \`old_text\` matches multiple times in note "${note.id}" — must match exactly once. Add surrounding context.` },
+            409,
+          );
+        }
+        contentOverride = note.content.slice(0, idx) + ce.new_text + note.content.slice(idx + ce.old_text.length);
+      }
+
       // --- Plan bracket cleanup for wikilink removals (no DB writes yet) ---
       // The actual link deletions happen only after the core UPDATE succeeds,
       // so a conflict leaves the note untouched.
-      let contentOverride = body.content as string | undefined;
       const linksRemove = body.links?.remove as { target: string; relationship: string }[] | undefined;
       const resolvedLinksToRemove: { targetId: string; relationship: string }[] = [];
       if (linksRemove) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -431,11 +431,33 @@ export async function handleNotes(
       if (!note) throw new NotFoundError(`Note not found: "${idOrPath}"`);
       const body = await req.json() as any;
 
+      // --- Validate mutual exclusion of content modes ---
+      const hasContent = body.content !== undefined;
+      const hasAppendPrepend = body.append !== undefined || body.prepend !== undefined;
+      if (hasContent && hasAppendPrepend) {
+        return json(
+          {
+            error: "mutually_exclusive",
+            message: "`content` and `append`/`prepend` are mutually exclusive — pick one mode of content update.",
+          },
+          400,
+        );
+      }
+
       // --- Safety-by-default: refuse mutations without a precondition ---
       // Mirror the MCP tool: require `if_updated_at` unless the caller
       // explicitly sets `force: true`. 428 Precondition Required is the
       // RFC 6585 status for exactly this case.
-      if (body.if_updated_at === undefined && body.force !== true) {
+      //
+      // Append/prepend-only updates are exempt — SQL-atomic concatenation
+      // is no-conflict-by-design.
+      const isAppendOnly = hasAppendPrepend
+        && !hasContent
+        && body.path === undefined
+        && body.metadata === undefined
+        && body.created_at === undefined
+        && body.createdAt === undefined;
+      if (!isAppendOnly && body.if_updated_at === undefined && body.force !== true) {
         return json(
           {
             error_type: "precondition_required",
@@ -461,7 +483,12 @@ export async function handleNotes(
           if (!target) continue;
           resolvedLinksToRemove.push({ targetId: target.id, relationship: link.relationship });
           if (link.relationship === "wikilink" && target.path) {
-            const current = contentOverride ?? note.content;
+            // Materialize the prospective content for append/prepend callers
+            // so we don't fight the SQL-atomic path with a JS-level rewrite.
+            const current = contentOverride
+              ?? (hasAppendPrepend
+                ? (body.prepend as string ?? "") + note.content + (body.append as string ?? "")
+                : note.content);
             const cleaned = removeWikilinkBrackets(current, target.path);
             if (cleaned !== current) contentOverride = cleaned;
           }
@@ -470,7 +497,12 @@ export async function handleNotes(
 
       // --- Core update (runs the if_updated_at check atomically) ---
       const updates: any = {};
-      if (contentOverride !== undefined) updates.content = contentOverride;
+      if (contentOverride !== undefined) {
+        updates.content = contentOverride;
+      } else if (hasAppendPrepend) {
+        if (body.append !== undefined) updates.append = body.append;
+        if (body.prepend !== undefined) updates.prepend = body.prepend;
+      }
       if (body.path !== undefined) updates.path = body.path;
       if (body.metadata !== undefined) {
         const existing = (note.metadata as Record<string, unknown>) ?? {};

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1353,8 +1353,9 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect((await store.getNote("x"))!.content).toBe("first");
   });
 
-  test("PATCH append without precondition succeeds (no-conflict-by-design) — #79", async () => {
+  test("PATCH append without precondition succeeds (no-conflict-by-design)", async () => {
     await store.createNote("seed:", { id: "x" });
+
     const res = await handleNotes(
       mkReq("PATCH", "/notes/x", { append: " A" }),
       store,
@@ -1364,8 +1365,54 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect((await store.getNote("x"))!.content).toBe("seed: A");
   });
 
-  test("PATCH rejects content + append combination with 400 — #79", async () => {
+  test("PATCH content_edit replaces a single occurrence", async () => {
+    const note = await store.createNote("hello world", { id: "x" });
+
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", {
+        content_edit: { old_text: "hello", new_text: "hi" },
+        if_updated_at: note.updatedAt,
+      }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(200);
+    expect((await store.getNote("x"))!.content).toBe("hi world");
+  });
+
+  test("PATCH content_edit returns 404 when old_text is not found", async () => {
+    const note = await store.createNote("hello world", { id: "x" });
+
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", {
+        content_edit: { old_text: "missing", new_text: "x" },
+        if_updated_at: note.updatedAt,
+      }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(404);
+    expect((await store.getNote("x"))!.content).toBe("hello world");
+  });
+
+  test("PATCH content_edit returns 409 on multiple matches", async () => {
+    const note = await store.createNote("hi hi", { id: "x" });
+
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", {
+        content_edit: { old_text: "hi", new_text: "hello" },
+        if_updated_at: note.updatedAt,
+      }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(409);
+    expect((await store.getNote("x"))!.content).toBe("hi hi");
+  });
+
+  test("PATCH rejects content + append combination with 400", async () => {
     await store.createNote("seed", { id: "x" });
+
     const res = await handleNotes(
       mkReq("PATCH", "/notes/x", { content: "new", append: "more", force: true }),
       store,

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1353,6 +1353,29 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect((await store.getNote("x"))!.content).toBe("first");
   });
 
+  test("PATCH append without precondition succeeds (no-conflict-by-design) — #79", async () => {
+    await store.createNote("seed:", { id: "x" });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", { append: " A" }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(200);
+    expect((await store.getNote("x"))!.content).toBe("seed: A");
+  });
+
+  test("PATCH rejects content + append combination with 400 — #79", async () => {
+    await store.createNote("seed", { id: "x" });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", { content: "new", append: "more", force: true }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error).toBe("mutually_exclusive");
+  });
+
   test("DELETE resolves note by path", async () => {
     await store.createNote("x", { path: "Temp/note" });
     const res = await handleNotes(


### PR DESCRIPTION
## Summary

Three update-note operations shipped together because they share the conditional-update infrastructure:

- **#79 — `append` / `prepend`**: atomic SQL-level concatenation. Concurrent appends both land. Append/prepend-only updates are exempt from the `if_updated_at` precondition (no-conflict-by-design).
- **#80 — `content_edit: { old_text, new_text }`**: surgical find-and-replace. Fail-closed on zero or multiple matches. Mutually exclusive with `content` and `append`/`prepend`.
- **#81 — `if_updated_at` optimistic concurrency**: already implemented (verified in this branch). Default-required precondition: callers either echo last-seen `updated_at` or pass `force: true`. Append/prepend-only is exempt.

REST mirror at `PATCH /api/notes/:idOrPath` — all three modes available, with HTTP shape:
- `400 mutually_exclusive` for combinations
- `404` when content_edit `old_text` is missing
- `409 ambiguous` when content_edit `old_text` matches multiple times
- `409 stale` for `if_updated_at` mismatch
- `428 precondition_required` for omitted precondition without `force: true`

## Per-issue commits

- `d751cd4` feat(mcp): update-note append + prepend (#79)
- `9e842b2` feat(mcp): update-note content_edit find-and-replace (#80)
- `7f3c3bf` chore(release): 0.3.6-rc.10

## Test plan

- [x] `bun test core/src/` — 311 pass / 0 fail (8 new tests for append/prepend, 4 new tests for content_edit)
- [x] `bun test src/` — 992 pass / 0 fail (PATCH integration tests for all three modes)
- [x] `bunx tsc --noEmit` — 386 errors (baseline; no new errors)
- [ ] Smoke via parachute-vault MCP after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)