### PR TITLE
feat(tokens): REST endpoints for vault token mint/list/revoke (#173)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.12",
+  "version": "0.3.6-rc.13",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -53,6 +53,7 @@ import {
   handleStorage,
   handleViewNote,
 } from "./routes.ts";
+import { handleTokens } from "./tokens-routes.ts";
 import {
   handleProtectedResource,
   handleAuthorizationServer,
@@ -426,6 +427,31 @@ export async function route(
       createdAt: vaultConfig.created_at,
       stats,
     });
+  }
+
+  // /tokens — admin-gated REST surface for minting/listing/revoking pvt_*
+  // tokens. Admin gate applies to every method (POST/GET/DELETE) since both
+  // the plaintext mint and the metadata listing are sensitive — knowing
+  // labels and scopes of issued tokens leaks the deployment's auth shape.
+  // The handler's POST path applies a strict subset check on requested
+  // scopes via `validateMintedScopes` (defense-in-depth: cross-vault and
+  // privilege-escalation rejections survive even if this gate is later
+  // relaxed).
+  const tokensMatch = subpath.match(/^\/tokens(\/.*)?$/);
+  if (tokensMatch) {
+    if (!hasScopeForVault(auth.scopes, vaultName, "admin")) {
+      return Response.json(
+        {
+          error: "Forbidden",
+          error_type: "insufficient_scope",
+          message: `This endpoint requires the '${SCOPE_ADMIN}' scope (or '${SCOPE_ADMIN.replace("vault:", `vault:${vaultName}:`)}').`,
+          required_scope: SCOPE_ADMIN,
+          granted_scopes: auth.scopes,
+        },
+        { status: 403 },
+      );
+    }
+    return handleTokens(req, store.db, vaultName, auth.scopes, tokensMatch[1] ?? "");
   }
 
   const apiMatch = subpath.match(/^\/api(\/.*)?$/);

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -155,6 +155,49 @@ export function verbForMethod(method: string): VaultVerb {
 }
 
 /**
+ * Validate scopes requested for token minting on a specific vault.
+ *
+ * Each requested scope must be (a) a recognized vault scope shape, (b) not
+ * naming a different vault (cross-vault rejected), and (c) within the
+ * caller's verb power on `vaultName`. The third check is defense-in-depth:
+ * the REST endpoint already gates on `vault:admin`, but enforcing subset
+ * here means a future loosening of the gate (or a partially-trusted caller)
+ * still cannot mint a token stronger than what they hold.
+ *
+ * Pass-through on success — we don't rewrite scopes, just decide yes/no.
+ */
+export function validateMintedScopes(
+  requested: string[],
+  vaultName: string,
+  callerScopes: string[],
+): { ok: true } | { ok: false; rejected: { scope: string; reason: string }[] } {
+  const rejected: { scope: string; reason: string }[] = [];
+  for (const s of requested) {
+    const d = decomposeVaultScope(s);
+    if (!d) {
+      rejected.push({ scope: s, reason: "unknown or unsupported scope" });
+      continue;
+    }
+    if (d.vault !== null && d.vault !== vaultName) {
+      rejected.push({
+        scope: s,
+        reason: `cross-vault scope not allowed (this endpoint mints for vault '${vaultName}')`,
+      });
+      continue;
+    }
+    if (!hasScopeForVault(callerScopes, vaultName, d.verb)) {
+      rejected.push({
+        scope: s,
+        reason: `caller lacks '${d.verb}' on vault '${vaultName}' — cannot grant a stronger scope than held`,
+      });
+      continue;
+    }
+  }
+  if (rejected.length > 0) return { ok: false, rejected };
+  return { ok: true };
+}
+
+/**
  * Detect a broad `vault:<verb>` scope in a granted list. Hub-issued JWTs
  * must NOT carry broad vault scopes — the hub mints `vault:<name>:<verb>` so
  * the resource is named on the wire. `authenticateHubJwt` calls this to

--- a/src/tokens-routes.test.ts
+++ b/src/tokens-routes.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Tests for `/vault/<name>/tokens` REST endpoints (issue #173).
+ *
+ * Covers the seven cases the design brief named, plus method-not-allowed
+ * and the hub-JWT auth path. Each test uses its own PARACHUTE_HOME tmp dir,
+ * mirroring `routing.test.ts` and `auth-hub-jwt.test.ts`.
+ *
+ * Key invariants under test:
+ *   - POST returns plaintext exactly once (201 body), but never afterwards
+ *     in GET listings (no plaintext, no token_hash field exposed).
+ *   - Scope subset enforcement: minted scopes must be ≤ caller's vault
+ *     verb power. Cross-vault scopes (`vault:other:*`) rejected.
+ *   - Admin gate: read/write callers cannot reach the endpoint at all.
+ *   - DELETE is intentionally non-leaky — non-existent ids return 200.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { generateKeyPair, exportJWK, SignJWT } from "jose";
+
+const testDir = join(
+  tmpdir(),
+  `vault-tokens-routes-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+);
+process.env.PARACHUTE_HOME = testDir;
+
+const { route } = await import("./routing.ts");
+const { writeGlobalConfig, writeVaultConfig } = await import("./config.ts");
+const { clearVaultStoreCache, getVaultStore } = await import("./vault-store.ts");
+const { generateToken, createToken, resolveToken } = await import("./token-store.ts");
+const { resetJwksCache } = await import("./hub-jwt.ts");
+
+interface Keypair {
+  privateKey: CryptoKey;
+  publicJwk: { kty: string; n: string; e: string; kid: string; alg: string; use: string };
+  kid: string;
+}
+
+async function makeKeypair(kid: string): Promise<Keypair> {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  const jwk = await exportJWK(publicKey);
+  return {
+    privateKey,
+    publicJwk: { kty: "RSA", n: jwk.n!, e: jwk.e!, kid, alg: "RS256", use: "sig" },
+    kid,
+  };
+}
+
+interface JwksFixture {
+  origin: string;
+  stop: () => void;
+}
+
+function startJwksFixture(keys: Keypair[]): JwksFixture {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/.well-known/jwks.json") {
+        return new Response("not found", { status: 404 });
+      }
+      return Response.json({ keys: keys.map((k) => k.publicJwk) });
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    stop: () => server.stop(true),
+  };
+}
+
+async function signHubJwt(
+  kp: Keypair,
+  iss: string,
+  aud: string,
+  scope: string,
+): Promise<string> {
+  const iat = Math.floor(Date.now() / 1000);
+  return await new SignJWT({ scope, client_id: "test-client" })
+    .setProtectedHeader({ alg: "RS256", kid: kp.kid })
+    .setIssuer(iss)
+    .setSubject("user-1")
+    .setAudience(aud)
+    .setIssuedAt(iat)
+    .setExpirationTime(iat + 60)
+    .setJti(`jti-${Math.random().toString(36).slice(2)}`)
+    .sign(kp.privateKey);
+}
+
+function createVault(name: string): void {
+  writeVaultConfig({ name, api_keys: [], created_at: new Date().toISOString() });
+  getVaultStore(name);
+}
+
+function mintAdminToken(vaultName: string): string {
+  const store = getVaultStore(vaultName);
+  const { fullToken } = generateToken();
+  createToken(store.db, fullToken, {
+    label: "test-admin",
+    permission: "full",
+    scopes: ["vault:read", "vault:write", "vault:admin"],
+  });
+  return fullToken;
+}
+
+function mintReadOnlyToken(vaultName: string): string {
+  const store = getVaultStore(vaultName);
+  const { fullToken } = generateToken();
+  createToken(store.db, fullToken, {
+    label: "test-read",
+    permission: "read",
+    scopes: ["vault:read"],
+  });
+  return fullToken;
+}
+
+let fixture: JwksFixture | null = null;
+let kp: Keypair | null = null;
+let prevHubOrigin: string | undefined;
+
+beforeEach(async () => {
+  clearVaultStoreCache();
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(testDir, "vault", "data"), { recursive: true });
+  writeGlobalConfig({ port: 1940 });
+
+  kp = await makeKeypair("k1");
+  fixture = startJwksFixture([kp]);
+  prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+  process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
+  resetJwksCache();
+});
+
+afterEach(() => {
+  if (fixture) fixture.stop();
+  fixture = null;
+  kp = null;
+  if (prevHubOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = prevHubOrigin;
+  clearVaultStoreCache();
+});
+
+function postTokens(
+  vaultName: string,
+  bearer: string | null,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const path = `/vault/${vaultName}/tokens`;
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (bearer) headers.authorization = `Bearer ${bearer}`;
+  return route(
+    new Request(`http://localhost:1940${path}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    }),
+    path,
+  );
+}
+
+function getTokens(vaultName: string, bearer: string | null): Promise<Response> {
+  const path = `/vault/${vaultName}/tokens`;
+  const headers: Record<string, string> = {};
+  if (bearer) headers.authorization = `Bearer ${bearer}`;
+  return route(new Request(`http://localhost:1940${path}`, { headers }), path);
+}
+
+function deleteToken(
+  vaultName: string,
+  id: string,
+  bearer: string | null,
+): Promise<Response> {
+  const path = `/vault/${vaultName}/tokens/${id}`;
+  const headers: Record<string, string> = {};
+  if (bearer) headers.authorization = `Bearer ${bearer}`;
+  return route(
+    new Request(`http://localhost:1940${path}`, { method: "DELETE", headers }),
+    path,
+  );
+}
+
+describe("POST /vault/<name>/tokens — happy path", () => {
+  test("admin pvt_* mints a token with default full scopes; plaintext returned exactly once", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+
+    const res = await postTokens("journal", admin, { label: "agent-x" });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      id: string;
+      token: string;
+      label: string;
+      permission: string;
+      scopes: string[];
+      expires_at: string | null;
+      created_at: string;
+    };
+    expect(body.token).toMatch(/^pvt_/);
+    expect(body.id).toMatch(/^t_/);
+    expect(body.label).toBe("agent-x");
+    expect(body.permission).toBe("full");
+    expect(body.scopes).toEqual(["vault:read", "vault:write", "vault:admin"]);
+    expect(body.expires_at).toBeNull();
+
+    // Minted token actually authenticates against the vault.
+    const store = getVaultStore("journal");
+    const resolved = resolveToken(store.db, body.token);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.permission).toBe("full");
+  });
+
+  test("admin pvt_* mints with explicit narrowed scopes — read-only", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+
+    const res = await postTokens("journal", admin, {
+      label: "reader",
+      scopes: ["vault:read"],
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      permission: string;
+      scopes: string[];
+    };
+    expect(body.permission).toBe("read");
+    expect(body.scopes).toEqual(["vault:read"]);
+  });
+
+  test("admin pvt_* mints with OAuth-style space-separated `scope` string", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+
+    const res = await postTokens("journal", admin, {
+      scope: "vault:read vault:write",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scopes: string[]; permission: string };
+    expect(body.scopes).toEqual(["vault:read", "vault:write"]);
+    expect(body.permission).toBe("full");
+  });
+
+  test("hub JWT with vault:<name>:admin can mint", async () => {
+    createVault("journal");
+    const token = await signHubJwt(
+      kp!,
+      fixture!.origin,
+      "vault.journal",
+      "vault:journal:admin",
+    );
+
+    const res = await postTokens("journal", token, { label: "from-hub" });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { token: string; label: string };
+    expect(body.token).toMatch(/^pvt_/);
+    expect(body.label).toBe("from-hub");
+  });
+
+  test("future expires_at is accepted and round-trips", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+    const exp = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+
+    const res = await postTokens("journal", admin, { expires_at: exp });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { expires_at: string };
+    // The stored value is a re-serialized ISO string — same instant, byte-equal here.
+    expect(body.expires_at).toBe(exp);
+  });
+});
+
+describe("POST /vault/<name>/tokens — scope narrowing", () => {
+  test("hub JWT with write scope can mint a write-or-lower token", async () => {
+    createVault("journal");
+    // Bypass the admin gate by minting with admin first to seed; then test
+    // narrowing by minting via a write-scoped JWT — but the gate blocks
+    // that path. The narrowing rule is most meaningful via subset check
+    // independently of the gate, so we use an admin JWT that requests a
+    // narrower (write-only) token. This is the supported narrowing path.
+    const token = await signHubJwt(
+      kp!,
+      fixture!.origin,
+      "vault.journal",
+      "vault:journal:admin",
+    );
+
+    const res = await postTokens("journal", token, {
+      label: "write-only",
+      scopes: ["vault:write"],
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { permission: string; scopes: string[] };
+    expect(body.scopes).toEqual(["vault:write"]);
+    // Resolved permission derives from the highest scope held — write → full.
+    expect(body.permission).toBe("full");
+  });
+
+  test("cross-vault scope `vault:<other>:read` is rejected with 400", async () => {
+    createVault("journal");
+    createVault("work");
+    const admin = mintAdminToken("journal");
+
+    const res = await postTokens("journal", admin, {
+      label: "cross-vault-attempt",
+      scopes: ["vault:work:read"],
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      message: string;
+      rejected: { scope: string; reason: string }[];
+    };
+    expect(body.message).toBe("scope rejected");
+    expect(body.rejected).toHaveLength(1);
+    expect(body.rejected[0]!.scope).toBe("vault:work:read");
+    expect(body.rejected[0]!.reason).toContain("cross-vault");
+  });
+
+  test("invalid scope name is rejected with 400 (no token created)", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+
+    const res = await postTokens("journal", admin, {
+      scopes: ["vault:read", "not-a-real-scope"],
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      rejected: { scope: string; reason: string }[];
+    };
+    expect(body.rejected.some((r) => r.scope === "not-a-real-scope")).toBe(true);
+
+    // Confirm no token was minted.
+    const list = await getTokens("journal", admin).then((r) => r.json()) as {
+      tokens: { label: string }[];
+    };
+    expect(list.tokens.find((t) => t.label !== "test-admin")).toBeUndefined();
+  });
+
+  test("expires_at in the past is rejected with 400", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+    const past = new Date(Date.now() - 1000).toISOString();
+
+    const res = await postTokens("journal", admin, { expires_at: past });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("future");
+  });
+});
+
+describe("POST /vault/<name>/tokens — auth gates", () => {
+  test("missing auth → 401", async () => {
+    createVault("journal");
+    const res = await postTokens("journal", null, { label: "x" });
+    expect(res.status).toBe(401);
+  });
+
+  test("read-only pvt_* token → 403 insufficient_scope (admin required)", async () => {
+    createVault("journal");
+    const reader = mintReadOnlyToken("journal");
+
+    const res = await postTokens("journal", reader, { label: "x" });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as {
+      error_type: string;
+      required_scope: string;
+    };
+    expect(body.error_type).toBe("insufficient_scope");
+    expect(body.required_scope).toBe("vault:admin");
+  });
+
+  test("hub JWT scoped to a different vault → 401 audience mismatch", async () => {
+    createVault("journal");
+    createVault("work");
+    const wrongAud = await signHubJwt(
+      kp!,
+      fixture!.origin,
+      "vault.work",
+      "vault:work:admin",
+    );
+
+    const res = await postTokens("journal", wrongAud, {});
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /vault/<name>/tokens — list", () => {
+  test("admin can list tokens; response excludes plaintext and hash", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+    // Add a second token via the endpoint so we have multiple rows.
+    await postTokens("journal", admin, { label: "agent-x", scopes: ["vault:read"] });
+
+    const res = await getTokens("journal", admin);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tokens: Array<{
+        id: string;
+        label: string;
+        permission: string;
+        scopes: string[];
+        expires_at: string | null;
+        created_at: string;
+        last_used_at: string | null;
+      }>;
+    };
+    expect(body.tokens.length).toBeGreaterThanOrEqual(2);
+    for (const t of body.tokens) {
+      expect(t.id).toMatch(/^t_/);
+      // Plaintext and hash must never appear, even by accident.
+      expect(JSON.stringify(t)).not.toMatch(/pvt_/);
+      expect(JSON.stringify(t)).not.toMatch(/token_hash/);
+      expect(JSON.stringify(t)).not.toMatch(/sha256:/);
+    }
+    const minted = body.tokens.find((t) => t.label === "agent-x");
+    expect(minted).toBeDefined();
+    expect(minted!.scopes).toEqual(["vault:read"]);
+    expect(minted!.permission).toBe("read");
+  });
+
+  test("read-only token cannot list (admin gate) → 403", async () => {
+    createVault("journal");
+    const reader = mintReadOnlyToken("journal");
+
+    const res = await getTokens("journal", reader);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("DELETE /vault/<name>/tokens/<id> — revoke", () => {
+  test("admin revokes by display id; revoked token no longer resolves", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+
+    const minted = (await (await postTokens("journal", admin, {
+      label: "to-revoke",
+    })).json()) as { id: string; token: string };
+    const store = getVaultStore("journal");
+    expect(resolveToken(store.db, minted.token)).not.toBeNull();
+
+    const res = await deleteToken("journal", minted.id, admin);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { revoked: boolean };
+    expect(body.revoked).toBe(true);
+
+    expect(resolveToken(store.db, minted.token)).toBeNull();
+  });
+
+  test("non-existent id → 200 with revoked:true (no existence leak)", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+
+    const res = await deleteToken("journal", "t_doesnotexist", admin);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { revoked: boolean };
+    expect(body.revoked).toBe(true);
+  });
+
+  test("read-only token cannot revoke → 403", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+    const reader = mintReadOnlyToken("journal");
+
+    const minted = (await (await postTokens("journal", admin, {
+      label: "victim",
+    })).json()) as { id: string };
+
+    const res = await deleteToken("journal", minted.id, reader);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("/vault/<name>/tokens — method handling", () => {
+  test("PUT on collection → 405", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+    const path = "/vault/journal/tokens";
+    const res = await route(
+      new Request(`http://localhost:1940${path}`, {
+        method: "PUT",
+        headers: { authorization: `Bearer ${admin}` },
+      }),
+      path,
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("PATCH on item → 405", async () => {
+    createVault("journal");
+    const admin = mintAdminToken("journal");
+    const path = "/vault/journal/tokens/t_anything";
+    const res = await route(
+      new Request(`http://localhost:1940${path}`, {
+        method: "PATCH",
+        headers: { authorization: `Bearer ${admin}` },
+      }),
+      path,
+    );
+    expect(res.status).toBe(405);
+  });
+});

--- a/src/tokens-routes.ts
+++ b/src/tokens-routes.ts
@@ -1,0 +1,194 @@
+/**
+ * REST handlers for `/vault/<name>/tokens`.
+ *
+ * The endpoint is admin-gated upstream — `route()` checks
+ * `hasScopeForVault(auth.scopes, vaultName, "admin")` before dispatching here,
+ * so any caller reaching this module already holds vault:admin (broad or
+ * narrowed). POST mints a new pvt_* token with caller-narrowed scopes and
+ * returns the plaintext exactly once. GET lists existing tokens (metadata
+ * only — no plaintext, no hash). DELETE revokes by display id (`t_…`); a
+ * non-existent id still returns 200 to avoid leaking which ids exist.
+ *
+ * Scope narrowing is enforced as a strict subset check via
+ * `validateMintedScopes` — defense-in-depth even with the admin gate, so a
+ * future relaxation of the gate cannot accidentally permit privilege
+ * escalation. Cross-vault scopes (`vault:<other>:<verb>`) are rejected with
+ * the same path.
+ */
+
+import type { Database } from "bun:sqlite";
+import {
+  generateToken,
+  createToken,
+  revokeToken,
+  normalizePermission,
+  type TokenPermission,
+} from "./token-store.ts";
+import {
+  validateMintedScopes,
+  parseScopes,
+  hasScope,
+  SCOPE_WRITE,
+  SCOPE_ADMIN,
+} from "./scopes.ts";
+
+interface MintRequestBody {
+  label?: string;
+  /** Either an array (preferred) or a space-separated OAuth-style string. */
+  scopes?: string[];
+  scope?: string;
+  /** ISO-8601 future timestamp, or null/omitted for never-expiring. */
+  expires_at?: string | null;
+}
+
+function badRequest(message: string, extra?: Record<string, unknown>): Response {
+  return Response.json({ error: "Bad Request", message, ...extra }, { status: 400 });
+}
+
+function methodNotAllowed(): Response {
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
+}
+
+function permissionForScopes(scopes: string[]): TokenPermission {
+  return hasScope(scopes, SCOPE_WRITE) || hasScope(scopes, SCOPE_ADMIN) ? "full" : "read";
+}
+
+export async function handleTokens(
+  req: Request,
+  db: Database,
+  vaultName: string,
+  callerScopes: string[],
+  subpath: string,
+): Promise<Response> {
+  if (subpath === "" || subpath === "/") {
+    if (req.method === "GET") return listHandler(db);
+    if (req.method === "POST") return mintHandler(req, db, vaultName, callerScopes);
+    return methodNotAllowed();
+  }
+  const idMatch = subpath.match(/^\/([^/]+)$/);
+  if (idMatch && idMatch[1]) {
+    if (req.method === "DELETE") return revokeHandler(db, idMatch[1]);
+    return methodNotAllowed();
+  }
+  return Response.json({ error: "Not found" }, { status: 404 });
+}
+
+async function mintHandler(
+  req: Request,
+  db: Database,
+  vaultName: string,
+  callerScopes: string[],
+): Promise<Response> {
+  let body: MintRequestBody;
+  try {
+    const raw = await req.text();
+    body = raw.length === 0 ? {} : (JSON.parse(raw) as MintRequestBody);
+  } catch {
+    return badRequest("invalid JSON body");
+  }
+
+  let requested: string[];
+  if (Array.isArray(body.scopes)) {
+    requested = body.scopes.filter((s): s is string => typeof s === "string" && s.length > 0);
+  } else if (typeof body.scope === "string") {
+    requested = parseScopes(body.scope);
+  } else {
+    // Default: full scope set. Admin caller is required to reach this code,
+    // so granting full scope is within their power; explicit narrowing is
+    // available via `scopes` / `scope` for least-privilege deployments.
+    requested = ["vault:read", "vault:write", "vault:admin"];
+  }
+  if (requested.length === 0) {
+    return badRequest("at least one scope required");
+  }
+
+  const validation = validateMintedScopes(requested, vaultName, callerScopes);
+  if (!validation.ok) {
+    return Response.json(
+      { error: "Bad Request", message: "scope rejected", rejected: validation.rejected },
+      { status: 400 },
+    );
+  }
+
+  let expiresAt: string | null = null;
+  if (body.expires_at !== undefined && body.expires_at !== null) {
+    if (typeof body.expires_at !== "string") {
+      return badRequest("expires_at must be an ISO-8601 string or null");
+    }
+    const t = Date.parse(body.expires_at);
+    if (Number.isNaN(t)) {
+      return badRequest("expires_at is not a valid ISO-8601 timestamp");
+    }
+    if (t <= Date.now()) {
+      return badRequest("expires_at must be in the future");
+    }
+    expiresAt = new Date(t).toISOString();
+  }
+
+  const label = typeof body.label === "string" && body.label.length > 0 ? body.label : "API token";
+  const permission = permissionForScopes(requested);
+
+  const { fullToken } = generateToken();
+  const created = createToken(db, fullToken, {
+    label,
+    permission,
+    scopes: requested,
+    expires_at: expiresAt,
+  });
+
+  // Display id mirrors `listTokens`: `t_` + first 12 chars of the SHA-256
+  // hash payload (the part after the `sha256:` prefix). Stable across reads.
+  const id = `t_${created.token_hash.slice(7, 19)}`;
+
+  return Response.json(
+    {
+      id,
+      token: fullToken,
+      label: created.label,
+      permission: created.permission,
+      scopes: requested,
+      expires_at: created.expires_at,
+      created_at: created.created_at,
+    },
+    { status: 201 },
+  );
+}
+
+function listHandler(db: Database): Response {
+  // Direct SELECT (rather than reusing `listTokens`) so we can include the
+  // `scopes` column without changing the existing CLI-facing shape.
+  const rows = db.prepare(`
+    SELECT token_hash, label, permission, scopes, expires_at, created_at, last_used_at
+    FROM tokens ORDER BY created_at DESC
+  `).all() as {
+    token_hash: string;
+    label: string;
+    permission: string;
+    scopes: string | null;
+    expires_at: string | null;
+    created_at: string;
+    last_used_at: string | null;
+  }[];
+
+  return Response.json({
+    tokens: rows.map((r) => ({
+      id: `t_${r.token_hash.slice(7, 19)}`,
+      label: r.label,
+      permission: normalizePermission(r.permission),
+      scopes: parseScopes(r.scopes),
+      expires_at: r.expires_at,
+      created_at: r.created_at,
+      last_used_at: r.last_used_at,
+    })),
+  });
+}
+
+function revokeHandler(db: Database, id: string): Response {
+  // Always 200, never leak whether the id existed. Ambiguous prefix matches
+  // are treated the same (revokeToken returns false; we ignore it). The 12-
+  // char hex prefix collision space is large enough that organic ambiguity
+  // is effectively impossible, and security-significant ambiguity would
+  // require a chosen-prefix attack against SHA-256.
+  revokeToken(db, id);
+  return Response.json({ revoked: true });
+}


### PR DESCRIPTION
Closes #173.

## Summary
- New `POST/GET/DELETE /vault/<name>/tokens` REST surface for hub-JWT-authenticated token management. Reuses the existing pvt_* storage (no schema change).
- Admin-gated (`vault:<name>:admin`); accepts both broad pvt_* tokens and narrowed hub JWTs.
- Scope narrowing enforced via new `validateMintedScopes` helper in `scopes.ts`: each requested scope must be a recognized vault scope, must not name a different vault (cross-vault rejected), and must be ≤ caller's verb power on this vault. Defense-in-depth — admin gate already covers privilege escalation, but the subset check survives any future loosening.
- POST returns plaintext exactly once (201). GET listings expose neither plaintext nor `token_hash`. DELETE always returns 200 to avoid leaking which ids exist.

## API shape

**POST `/vault/<name>/tokens`**
```json
{ "label": "agent-x", "scopes": ["vault:read", "vault:write"], "expires_at": null }
```
→ 201 with `{ id, token, label, permission, scopes, expires_at, created_at }` (token plaintext shown once).

Body also accepts OAuth-style `scope: "vault:read vault:write"` (space-separated) as an alternative to `scopes`. If neither is supplied, defaults to full scope set.

**GET `/vault/<name>/tokens`**
→ 200 with `{ tokens: [{ id, label, permission, scopes, expires_at, created_at, last_used_at }, ...] }`. No plaintext, no hash.

**DELETE `/vault/<name>/tokens/<id>`**
→ 200 with `{ revoked: true }` always (whether the id existed or not).

## Test plan
- [x] POST happy path with admin pvt_* — plaintext returned once, minted token authenticates
- [x] POST with narrowed scopes (read-only) — permission derives correctly
- [x] POST with OAuth-style space-separated scope string
- [x] POST with hub JWT carrying `vault:<name>:admin`
- [x] POST with future `expires_at` round-trips
- [x] POST narrowing — admin can mint a write-only subset
- [x] POST cross-vault scope (`vault:other:read`) rejected with 400 + reason
- [x] POST invalid scope rejected; no token created
- [x] POST past `expires_at` rejected
- [x] POST missing auth → 401
- [x] POST read-only token → 403 `insufficient_scope`
- [x] POST hub JWT scoped to a different vault → 401 audience mismatch
- [x] GET excludes plaintext, hash, sha256 prefix
- [x] GET read-only → 403
- [x] DELETE by id revokes; resolveToken returns null after
- [x] DELETE non-existent id still returns 200 (no leak)
- [x] DELETE read-only → 403
- [x] PUT/PATCH on collection/item → 405

Gates: `bun test src/` 1038 pass / 0 fail; `bun test core/src/` 338 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)