### PR TITLE
chore: cleanup bundle — 9 reviewer nits (#189, #191, #192, #195, #196, #197, #201, #202, #203)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -1341,6 +1341,30 @@ describe("MCP tools", async () => {
     expect(result.content).toBe("header\nbody");
   });
 
+  it("update-note prepend on frontmatter-led content injects after closing --- (#203)", async () => {
+    const original = "---\ntitle: Foo\ntags: [bar]\n---\nbody line 1\n";
+    const note = await store.createNote(original, { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const result = await updateNote.execute({ id: note.id, prepend: "preamble\n" }) as any;
+    // Frontmatter still at byte 0 — parsers expecting `---\n` will find it.
+    expect(result.content.startsWith("---\ntitle: Foo\ntags: [bar]\n---\n")).toBe(true);
+    // Prepend lands immediately after the closing fence, before the body.
+    expect(result.content).toBe(
+      "---\ntitle: Foo\ntags: [bar]\n---\npreamble\nbody line 1\n",
+    );
+  });
+
+  it("update-note prepend on content lacking frontmatter injects at byte 0", async () => {
+    const note = await store.createNote("# Heading\nbody\n", { id: "n1" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const result = await updateNote.execute({ id: note.id, prepend: "preamble\n" }) as any;
+    expect(result.content).toBe("preamble\n# Heading\nbody\n");
+  });
+
   it("update-note append+prepend in one call lands both contributions", async () => {
     const note = await store.createNote("middle", { id: "n1" });
     const tools = generateMcpTools(store);

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -492,13 +492,18 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           //
           // Append/prepend-only updates are exempt: they're SQL-atomic
           // concatenations that can't lose data on a stale read, so the
-          // precondition would be ceremony for no benefit.
+          // precondition would be ceremony for no benefit. Tag and link
+          // mutations are *not* exempt — they're idempotent set-ops at
+          // the SQL layer but still represent a non-content change the
+          // caller should have observed before re-asserting (#201).
           const isAppendOnly = hasAppendPrepend
             && !hasContent
             && !hasContentEdit
             && item.path === undefined
             && item.metadata === undefined
-            && item.created_at === undefined;
+            && item.created_at === undefined
+            && item.tags === undefined
+            && item.links === undefined;
           if (!isAppendOnly && item.if_updated_at === undefined && item.force !== true) {
             throw new PreconditionRequiredError(note.id, note.path ?? null);
           }

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -214,8 +214,27 @@ export function updateNote(
     // race window is impossible: each `UPDATE` evaluates `content`
     // under the write lock, so two simultaneous appends both land
     // (in some order) instead of one clobbering the other.
-    sets.push("content = ? || content || ?");
-    values.push(updates.prepend ?? "", updates.append ?? "");
+    //
+    // Frontmatter-aware prepend (#203): if the note opens with a YAML
+    // frontmatter block (`---\n...\n---\n`), the prepend is injected
+    // *after* the closing `---\n` so parsers that expect frontmatter
+    // at byte 0 still find it. Detection uses `instr(content, '\n---\n')`
+    // — the closing fence is whatever `\n---\n` appears after the
+    // opening one. If no frontmatter is detected, prepend goes at
+    // byte 0 as before. Atomicity is preserved: the entire transform
+    // is one UPDATE expression evaluated under the write lock.
+    sets.push(
+      "content = CASE "
+        + "WHEN substr(content, 1, 4) = '---' || char(10) "
+        + "AND instr(content, char(10) || '---' || char(10)) > 0 "
+        + "THEN substr(content, 1, instr(content, char(10) || '---' || char(10)) + 4) || ? "
+        + "|| substr(content, instr(content, char(10) || '---' || char(10)) + 5) || ? "
+        + "ELSE ? || content || ? "
+        + "END",
+    );
+    const prependVal = updates.prepend ?? "";
+    const appendVal = updates.append ?? "";
+    values.push(prependVal, appendVal, prependVal, appendVal);
   }
   if (updates.path !== undefined) {
     sets.push("path = ?");

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "bin": {
     "parachute-vault": "src/cli.ts"
   },
+  "files": [
+    "src",
+    "core/src",
+    "core/package.json",
+    ".parachute",
+    "tsconfig.json"
+  ],
   "scripts": {
     "start": "bun src/server.ts",
     "cli": "bun src/cli.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.13",
+  "version": "0.3.6-rc.14",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -1993,6 +1993,55 @@ describe("OAuth scope binding (#94, RFC 6749 §3.3 / §6)", () => {
     expect(body.scope).toBe("vault:read");
   });
 
+  test("/token treats whitespace-only scope as absent and falls through to bound scope (#196)", async () => {
+    // Guard at oauth.ts checks `scope !== null && scope.trim().length > 0`.
+    // A client sending `scope=   ` is the same as omitting `scope` — we
+    // must not run subset enforcement against the whitespace string and
+    // reject it as invalid.
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const redirectUri = "https://example.com/callback";
+
+    const authRes = await handleAuthorizePost(
+      makeRequest("https://vault.test/oauth/authorize", {
+        method: "POST",
+        body: new URLSearchParams({
+          action: "authorize",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: "read",
+          owner_token: ownerToken,
+        }),
+      }),
+      db,
+      { vaultName: "default" },
+    );
+    const code = new URL(authRes.headers.get("location")!).searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      makeRequest("https://vault.test/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          scope: "   ", // whitespace only — should fall through to bound
+        }).toString(),
+      }),
+      db,
+      "default",
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as { scope?: string };
+    expect(body.scope).toBe("vault:read");
+  });
+
   test("/token rejects unknown scope strings even when the bound scope is broad", async () => {
     const ownerToken = createOwnerToken();
     const clientId = await registerClient();

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -280,6 +280,28 @@ describe("OAuth authorization", () => {
     expect(location.searchParams.get("state")).toBe("mystate");
   });
 
+  test("POST authorize without scope is rejected (no silent default to 'full', #197)", async () => {
+    const ownerToken = createOwnerToken();
+    const clientId = await registerClient();
+    const { codeChallenge } = generatePkce();
+    const req = makeRequest("https://vault.test/oauth/authorize", {
+      method: "POST",
+      body: new URLSearchParams({
+        action: "authorize",
+        client_id: clientId,
+        redirect_uri: "https://example.com/callback",
+        code_challenge: codeChallenge,
+        code_challenge_method: "S256",
+        // No scope field — pre-#197 this silently consented to "full".
+        owner_token: ownerToken,
+      }),
+    });
+    const res = await handleAuthorizePost(req, db);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("invalid_request");
+  });
+
   test("POST authorize (deny) redirects with error", async () => {
     const clientId = await registerClient();
     const { codeChallenge } = generatePkce();

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -394,13 +394,12 @@ export async function handleAuthorizePost(
   const redirectUri = form.get("redirect_uri") as string;
   const codeChallenge = form.get("code_challenge") as string;
   const codeChallengeMethod = form.get("code_challenge_method") as string || "S256";
-  // Requested scope (from hidden field, carried from GET) and selected scope
-  // (from radio button on the consent page). Default selected to requested.
-  const requestedScope = form.get("scope") as string || "full";
+  // Requested scope is carried from the GET via a hidden field on the consent
+  // page; the user's radio-button choice arrives in `selected_scope`. The
+  // required-ness check runs *after* the deny short-circuit below — a deny
+  // POST doesn't mint anything and shouldn't need scope to refuse.
+  const requestedScopeRaw = form.get("scope");
   const selectedScopeRaw = form.get("selected_scope") as string | null;
-  const selectedScope = selectedScopeRaw === "read" || selectedScopeRaw === "full"
-    ? selectedScopeRaw
-    : (requestedScope === "read" ? "read" : "full");
   const state = form.get("state") as string || "";
 
   if (!clientId || !redirectUri || !codeChallenge) {
@@ -434,6 +433,20 @@ export async function handleAuthorizePost(
     redirect.searchParams.set("error", "access_denied");
     return Response.redirect(redirect.toString(), 302);
   }
+
+  // Past this point we're processing consent — scope must be explicitly
+  // present. Defaulting absent scope to "full" would silently cement a
+  // grant the user never confirmed (#197).
+  if (typeof requestedScopeRaw !== "string" || requestedScopeRaw.length === 0) {
+    return Response.json(
+      { error: "invalid_request", error_description: "scope is required" },
+      { status: 400 },
+    );
+  }
+  const requestedScope = requestedScopeRaw;
+  const selectedScope = selectedScopeRaw === "read" || selectedScopeRaw === "full"
+    ? selectedScopeRaw
+    : (requestedScope === "read" ? "read" : "full");
 
   // Rate-limit the owner-auth step. Applied before any credential check so
   // brute-force attempts are capped regardless of which path (password or

--- a/src/owner-auth.ts
+++ b/src/owner-auth.ts
@@ -184,6 +184,10 @@ export class RateLimiter {
  * through per-vault routing. Fresh callers should prefer
  * `getAuthorizeRateLimiter(vaultName)` so traffic on one vault's consent flow
  * doesn't lock out IPs on another vault's consent flow (#93).
+ *
+ * @deprecated Use `getAuthorizeRateLimiter(vaultName)` instead. The singleton
+ * cross-pollutes per-vault consent traffic — one vault under brute-force can
+ * lock out IPs on every other vault's consent page.
  */
 export const authorizeRateLimit = new RateLimiter();
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -452,14 +452,18 @@ export async function handleNotes(
       // RFC 6585 status for exactly this case.
       //
       // Append/prepend-only updates are exempt — SQL-atomic concatenation
-      // is no-conflict-by-design.
+      // is no-conflict-by-design. Tag/link mutations are *not* exempt
+      // (#201): they're idempotent set-ops, but still represent a
+      // non-content change the caller should observe before re-asserting.
       const isAppendOnly = hasAppendPrepend
         && !hasContent
         && !hasContentEdit
         && body.path === undefined
         && body.metadata === undefined
         && body.created_at === undefined
-        && body.createdAt === undefined;
+        && body.createdAt === undefined
+        && body.tags === undefined
+        && body.links === undefined;
       if (!isAppendOnly && body.if_updated_at === undefined && body.force !== true) {
         return json(
           {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -490,9 +490,13 @@ export async function handleNotes(
         }
         const idx = note.content.indexOf(ce.old_text);
         if (idx < 0) {
+          // 422 Unprocessable Entity, not 404: the note exists, the request is
+          // syntactically valid, but the search string can't be applied to the
+          // current content. Returning 404 implied "note doesn't exist" and
+          // confused operators chasing a missing record (#202).
           return json(
-            { error: "not_found", message: `content_edit: \`old_text\` not found in note "${note.id}". Re-read and retry.` },
-            404,
+            { error: "unprocessable_content", message: `content_edit: \`old_text\` not found in note "${note.id}". Re-read and retry.` },
+            422,
           );
         }
         const second = note.content.indexOf(ce.old_text, idx + 1);

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterAll } from "bun:test";
-import { rmSync, existsSync, mkdirSync } from "fs";
+import { rmSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -42,6 +42,7 @@ const {
 // even when the DB files are already gone.
 const { clearVaultStoreCache, getVaultStore } = await import("./vault-store.ts");
 const { generateToken, createToken } = await import("./token-store.ts");
+const { vaultDbPath } = await import("./config.ts");
 
 function createVault(name: string, description?: string): void {
   writeVaultConfig({
@@ -283,6 +284,24 @@ describe("GET /auth/status (public auth preflight)", () => {
     };
     expect(new Set(body.vaults.map((v) => v.name))).toEqual(new Set(["journal", "work"]));
     expect(body.hasTokens).toBe(true);
+  });
+
+  test("hasTokens degrades to null when one vault has tokens and another DB is unreadable (#192)", async () => {
+    // The probe loop's whole point: a single failed DB read poisons the
+    // overall answer to `null`, even if an earlier vault already proved
+    // tokens exist. Otherwise an operator who locked one DB would see a
+    // misleading `true` and think auth-state is fully observable.
+    createVault("alpha");
+    createAdminToken("alpha");
+    createVault("beta");
+    // Replace beta's DB file with a non-SQLite blob; the readonly Database
+    // open throws at probe time. clearVaultStoreCache so beta's pre-opened
+    // handle (if any) doesn't shadow the on-disk corruption.
+    clearVaultStoreCache();
+    writeFileSync(vaultDbPath("beta"), "not-a-sqlite-file");
+    const res = await route(new Request("http://localhost:1940/auth/status"), "/auth/status");
+    const body = (await res.json()) as { hasTokens: boolean | null };
+    expect(body.hasTokens).toBeNull();
   });
 
   test("owner password / TOTP set in global config surface as true", async () => {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -237,7 +237,14 @@ export async function route(
   // hub's out-of-process filesystem snoop (parachute-hub#86 follow-up).
   // No auth, GET-only, no token counts — `hasTokens` is a yes/no signal
   // only, with `null` for "DB read failed."
+  //
+  // Gated on `discovery: disabled` like /vaults/list — both leak vault
+  // existence (the `vaults` array names them), so an operator who hides
+  // one wants both hidden (#191).
   if (path === "/auth/status" && req.method === "GET") {
+    if (readGlobalConfig().discovery === "disabled") {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
     return Response.json(buildAuthStatus(), {
       headers: { "Access-Control-Allow-Origin": "*" },
     });

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1398,7 +1398,9 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect((await store.getNote("x"))!.content).toBe("hi world");
   });
 
-  test("PATCH content_edit returns 404 when old_text is not found", async () => {
+  test("PATCH content_edit returns 422 when old_text is not found (#202)", async () => {
+    // 404 misleadingly read as "note doesn't exist"; 422 says "request is
+    // valid, but old_text doesn't apply to the current content."
     const note = await store.createNote("hello world", { id: "x" });
 
     const res = await handleNotes(
@@ -1409,7 +1411,9 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
       store,
       "/x",
     );
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(422);
+    const body = await res.json() as any;
+    expect(body.error).toBe("unprocessable_content");
     expect((await store.getNote("x"))!.content).toBe("hello world");
   });
 

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1365,6 +1365,24 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect((await store.getNote("x"))!.content).toBe("seed: A");
   });
 
+  test("PATCH append + tags without precondition is rejected (#201)", async () => {
+    // The append-only exemption is justified by SQL-atomic concat. Tag
+    // mutations don't share that property — they're idempotent, but the
+    // caller should still observe the prior state before re-asserting.
+    await store.createNote("seed:", { id: "x", path: "Inbox/x" });
+
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", { append: " A", tags: { add: ["important"] } }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(428);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("precondition_required");
+    // Unchanged on rejection.
+    expect((await store.getNote("x"))!.content).toBe("seed:");
+  });
+
   test("PATCH content_edit replaces a single occurrence", async () => {
     const note = await store.createNote("hello world", { id: "x" });
 


### PR DESCRIPTION
## Summary

Final cleanup pass bundling 9 filed reviewer NITs from PRs #188, #190, #194, and #200. Each issue is its own commit. After this lands, vault is fully caught up on the launch-critical surface.

## Issues addressed

- **#189** — `package.json` adds explicit `files` allowlist so the published tarball ships only `src`, `core/src`, `core/package.json`, `.parachute`, `tsconfig.json` (was implicitly shipping `deploy/`, scripts, etc.).
- **#191** — `/auth/status` now 404s when global config has `discovery: disabled`, matching the existing gate on `/vaults/list`.
- **#192** — Added a regression test that exercises `readTokenPresence`'s null-degradation path: when one vault has tokens and a later vault DB is unreadable (corrupt file), `hasTokens` resolves to `null` rather than throwing or lying.
- **#195** — `@deprecated` JSDoc tag on the `authorizeRateLimit` singleton, pointing callers at `getAuthorizeRateLimiter(vaultName)`.
- **#196** — Added a `/token` test confirming whitespace-only `scope` (e.g., `\"   \"`) falls through to the bound scope (treated as absent), not interpreted as the literal string.
- **#197** — `/authorize` POST now rejects requests with absent or empty `scope` (400 `invalid_request`) instead of silently defaulting to `full`. The check sits *after* the deny short-circuit so legitimate deny POSTs (which carry no scope) still work.
- **#201** — `update-note` `isAppendOnly` heuristic now also excludes `tags` and `links` mutations. Append+tag-mutation now correctly requires `if_updated_at` precondition (428) instead of taking the SQL-atomic concat path.
- **#202** — `update-note` `content_edit` returns 422 `unprocessable_content` when `old_text` isn't found, instead of 404 (which conflated \"note missing\" with \"text missing in note\"). RFC 9110 §15.5.21 fits: request is well-formed but can't be processed against current content.
- **#203** — `update-note` `prepend` is now frontmatter-aware: when content begins with `---\\n…\\n---\\n`, the prepend lands *after* the closing fence rather than corrupting the YAML block. Implemented as a single SQLite CASE expression over `substr`/`instr`/`char(10)` to preserve the single-statement atomic-concat guarantee.

## Test plan
- [x] 1044/1044 server tests pass (`bun test src/`)
- [x] 220/220 core tests pass (`bun test core/src/` via vitest)
- [x] 0 net TS errors added (519 baseline on main = 519 on branch)
- [x] New tests cover #192, #196, #197, #201, #202 (×1), #203 (×2)
- [x] Bumped `0.3.6-rc.13` → `0.3.6-rc.14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)