### PR TITLE
fix(create): re-register vault in services.json on every create (#208)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.15",
+  "version": "0.3.6-rc.16",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -226,6 +226,27 @@ switch (command) {
 // Command implementations
 // ---------------------------------------------------------------------------
 
+/**
+ * Compute the `paths` array for the parachute-vault entry in services.json.
+ * One entry advertises every vault on this server; `paths[0]` is the
+ * canonical mount the hub stamps into `.well-known/parachute.json`, so the
+ * default vault sorts first when one is set. With no vaults yet, fall back
+ * to "/" so an early-init registration is still well-formed.
+ */
+function buildVaultServicePaths(
+  defaultVault: string | undefined,
+  vaults: string[],
+): string[] {
+  if (vaults.length === 0) return ["/"];
+  if (defaultVault && vaults.includes(defaultVault)) {
+    return [
+      `/vault/${defaultVault}`,
+      ...vaults.filter((v) => v !== defaultVault).map((v) => `/vault/${v}`),
+    ];
+  }
+  return vaults.map((v) => `/vault/${v}`);
+}
+
 async function cmdInit(args: string[] = []) {
   ensureConfigDirSync();
 
@@ -324,18 +345,16 @@ async function cmdInit(args: string[] = []) {
   // init can complete without the manifest, just with a warning.
   //
   // `paths[0]` is the canonical mount point — the hub uses it for the
-  // `.well-known/parachute.json` URL and for `parachute expose`. Advertise
-  // `/vault/<default_vault>` so MCP clients land at the scoped endpoint.
-  // When no default vault exists yet (multi-vault, no fallback), fall back
-  // to "/" — the hub can detect and prompt.
-  const servicePath = globalConfig.default_vault
-    ? `/vault/${globalConfig.default_vault}`
-    : "/";
+  // `.well-known/parachute.json` URL and for `parachute expose`, so the
+  // default vault always sorts first. Remaining vaults follow so the hub
+  // well-known and paraclaw's attach picker see every vault on this server.
+  // Re-running init re-registers the full set; that doubles as the
+  // recovery path for installs whose services.json is stale (#208).
   try {
     upsertService({
       name: "parachute-vault",
       port: globalConfig.port || DEFAULT_PORT,
-      paths: [servicePath],
+      paths: buildVaultServicePaths(globalConfig.default_vault, allVaults),
       health: "/health",
       version: pkg.version,
     });
@@ -800,6 +819,24 @@ function cmdCreate(args: string[]) {
     defaultNote = wasFirst
       ? `Set as default vault (unscoped routes will target "${name}")`
       : `Set as default vault (previous default was missing)`;
+  }
+
+  // Re-register in services.json so the hub well-known and paraclaw's
+  // attach picker see this vault. cmdInit registers on first run; cmdCreate
+  // adds the new path on every subsequent vault. Without this, vaults
+  // created after init were invisible to the hub (#208).
+  // Warnings go to stderr to keep --json stdout clean for the orchestrator.
+  try {
+    upsertService({
+      name: "parachute-vault",
+      port: globalConfig.port || DEFAULT_PORT,
+      paths: buildVaultServicePaths(globalConfig.default_vault, listVaults()),
+      health: "/health",
+      version: pkg.version,
+    });
+  } catch (err) {
+    const msg = err instanceof ServicesManifestError ? err.message : String(err);
+    console.error(`Warning: could not update ~/.parachute/services.json: ${msg}`);
   }
 
   if (jsonMode) {

--- a/src/vault-create.test.ts
+++ b/src/vault-create.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { resolve } from "path";
-import { mkdtempSync, rmSync, existsSync } from "fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -113,6 +113,67 @@ describe("vault create --json", () => {
     expect(exitCode).not.toBe(0);
     expect(stdout).toBe("");
     expect(stderr).toContain("already exists");
+  });
+});
+
+/**
+ * Regression tests for #208: `vault create` was not updating
+ * `~/.parachute/services.json`, so vaults created after init were invisible
+ * to the hub well-known endpoint and to paraclaw's attach picker. cmdCreate
+ * now re-registers the parachute-vault entry with the full vault list every
+ * time. The default vault must sort first because the hub uses `paths[0]`
+ * as the canonical mount for `.well-known/parachute.json`.
+ */
+describe("vault create — services.json registration (#208)", () => {
+  function readServices(): { name: string; paths: string[]; port: number }[] {
+    const raw = readFileSync(join(home, "services.json"), "utf-8");
+    return JSON.parse(raw).services;
+  }
+
+  test("create-first-vault registers parachute-vault entry with /vault/<name>", () => {
+    const { exitCode } = runCli(["create", "first", "--json"], {
+      PARACHUTE_HOME: home,
+    });
+    expect(exitCode).toBe(0);
+
+    const services = readServices();
+    const vault = services.find((s) => s.name === "parachute-vault");
+    expect(vault).toBeDefined();
+    expect(vault!.paths).toEqual(["/vault/first"]);
+  });
+
+  test("create-additional-vault grows the paths array (default stays first)", () => {
+    runCli(["create", "alpha", "--json"], { PARACHUTE_HOME: home });
+    runCli(["create", "beta", "--json"], { PARACHUTE_HOME: home });
+
+    const vault = readServices().find((s) => s.name === "parachute-vault");
+    expect(vault).toBeDefined();
+    // alpha is the default (created first), so it must lead. beta follows.
+    expect(vault!.paths).toEqual(["/vault/alpha", "/vault/beta"]);
+  });
+
+  test("create-multiple preserves default-first ordering across N vaults", () => {
+    runCli(["create", "one", "--json"], { PARACHUTE_HOME: home });
+    runCli(["create", "two", "--json"], { PARACHUTE_HOME: home });
+    runCli(["create", "three", "--json"], { PARACHUTE_HOME: home });
+
+    const vault = readServices().find((s) => s.name === "parachute-vault");
+    expect(vault).toBeDefined();
+    expect(vault!.paths[0]).toBe("/vault/one");
+    expect(vault!.paths.slice(1).sort()).toEqual([
+      "/vault/three",
+      "/vault/two",
+    ]);
+    expect(vault!.paths).toHaveLength(3);
+  });
+
+  test("--json mode keeps stdout parseable even when services.json is updated", () => {
+    // Regression guard: warnings from upsertService must go to stderr, not
+    // stdout — otherwise the hub orchestrator's JSON.parse(stdout) breaks.
+    const { stdout } = runCli(["create", "clean", "--json"], {
+      PARACHUTE_HOME: home,
+    });
+    expect(() => JSON.parse(stdout.trim())).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Closes #208.

## Bug

`parachute-vault create <name>` minted the vault on disk but never updated `~/.parachute/services.json`. Only the vault that `init` had registered showed up — every later create was invisible to the hub's `.well-known/parachute.json` endpoint and to paraclaw's attach picker.

Reproduced today on Aaron's install (the `techne` vault didn't appear), and it's blocking [paraclaw#38](https://github.com/ParachuteComputer/paraclaw/issues/38).

## Fix

`cmdCreate` now calls `upsertService` after writing the per-vault config, publishing the full vault list per the multi-path design from PR #179. A new `buildVaultServicePaths(default_vault, vaults)` helper is shared with `cmdInit` so both code paths produce the same shape: default vault first (so `paths[0]` stays the canonical mount the hub stamps into `.well-known/parachute.json`), other vaults after.

Side benefit: re-running `parachute-vault init` now also writes the full vault list, so it doubles as the recovery path for any install whose services.json is already stale — no new `repair-services-json` command needed.

Warnings from the manifest write go to **stderr** in `cmdCreate` so the `--json` mode the hub orchestrator parses keeps a clean, parseable stdout.

## Tests

Four new tests in `src/vault-create.test.ts`:

- create-first-vault → entry registered, `paths: ['/vault/<name>']`
- create-additional-vault → array grows, default stays first
- create-multiple → default-first ordering preserved across N vaults
- `--json` mode keeps stdout parseable even when services.json updates

## Test plan

- [x] `bun test src/` — 1052 pass, 0 fail
- [x] `bun test core/src/` — 340 pass, 0 fail
- [x] `bunx tsc --noEmit` — no new errors in changed files (pre-existing errors in `vault.test.ts` / `two-factor.test.ts` unchanged)
- [ ] Aaron's recovery: re-run `parachute-vault init` on the install where `techne` is missing, confirm services.json picks it up

## Patterns

Touches **module-protocol** / services.json shape — conforms to the multi-path convention from PR #179. Doesn't establish a new pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)