### PR TITLE
chore: pin init-as-repair test + flip cmdInit warning to stderr (#210)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.16",
+  "version": "0.3.6-rc.17",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -360,7 +360,7 @@ async function cmdInit(args: string[] = []) {
     });
   } catch (err) {
     const msg = err instanceof ServicesManifestError ? err.message : String(err);
-    console.log(`  Warning: could not update ~/.parachute/services.json: ${msg}`);
+    console.error(`  Warning: could not update ~/.parachute/services.json: ${msg}`);
   }
 
   // 2b. Migrate existing legacy keys into per-vault token tables

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
 
@@ -155,6 +155,60 @@ describe("vault init — --no-autostart (#113)", () => {
       expect(second.stdout).toContain("Autostart disabled");
       expect(readFileSync(configPath, "utf-8")).toContain("autostart: false");
       expect(existsSync(join(parachuteHome, "vault", "start.sh"))).toBe(false);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * #210: re-running `parachute-vault init` is the documented recovery path
+ * for installs whose `services.json` is stale (#208 left some vaults out of
+ * the manifest). The recovery is implicit — init re-registers the full
+ * vault list every run via `buildVaultServicePaths` — so this test pins it
+ * down with an explicit fixture: corrupt the manifest to drop one vault,
+ * re-run init, expect the manifest to grow back.
+ */
+describe("vault init — repairs stale services.json (#210)", () => {
+  test("re-running init rewrites services.json to include every vault on disk", () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "vault-init-repair-"));
+    try {
+      const parachuteHome = join(sandbox, ".parachute");
+      const env = { HOME: sandbox, PARACHUTE_HOME: parachuteHome };
+
+      // Use `create` to bootstrap two vaults into a real, healthy state —
+      // this also writes the initial services.json with both vaults so we
+      // have a known-good baseline to corrupt.
+      expect(runCli(["create", "alpha", "--json"], env).exitCode).toBe(0);
+      expect(runCli(["create", "beta", "--json"], env).exitCode).toBe(0);
+
+      const servicesPath = join(parachuteHome, "services.json");
+      const baseline = JSON.parse(readFileSync(servicesPath, "utf-8"));
+      const baselineEntry = baseline.services.find(
+        (s: { name: string }) => s.name === "parachute-vault",
+      );
+      expect(baselineEntry.paths).toEqual(["/vault/alpha", "/vault/beta"]);
+
+      // Corrupt: drop beta from the manifest, mimicking the #208 state where
+      // an older `create` ran without the upsert.
+      baselineEntry.paths = ["/vault/alpha"];
+      writeFileSync(servicesPath, JSON.stringify(baseline, null, 2));
+
+      // Re-run init with no flags that would change vault topology. The
+      // sandbox env keeps launchd / ~/.claude.json side effects out of the
+      // dev environment.
+      const repair = runCli(
+        ["init", "--no-autostart", "--no-mcp", "--no-token"],
+        env,
+      );
+      expect(repair.exitCode).toBe(0);
+
+      const repaired = JSON.parse(readFileSync(servicesPath, "utf-8"));
+      const repairedEntry = repaired.services.find(
+        (s: { name: string }) => s.name === "parachute-vault",
+      );
+      // alpha is still default (created first), so it leads. beta is back.
+      expect(repairedEntry.paths).toEqual(["/vault/alpha", "/vault/beta"]);
     } finally {
       rmSync(sandbox, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #210.

Two small follow-ups from the #208 review:

## 1. `cmdInit`-as-repair test

The "re-run `parachute-vault init` to repair a stale `services.json`" path was implicit — init re-registers the full vault list every run via `buildVaultServicePaths`, so #208's fix gave us recovery for free. This pins it down with an explicit fixture: bootstrap two vaults via `create`, corrupt the manifest to drop one, re-run `init`, assert the manifest grows back with both paths in default-first order.

Sandboxed under `HOME=tmpdir` + `PARACHUTE_HOME=tmpdir/.parachute` with `--no-autostart --no-mcp --no-token` so launchd / `~/.claude.json` / token-store side effects stay out of the dev environment.

## 2. stdout/stderr consistency

`cmdCreate` sends `services.json` warnings to **stderr** so `--json` mode keeps a parseable stdout for the hub orchestrator. `cmdInit` was still using `console.log` for the same warning — asymmetric, and a footgun for any future tooling that pipes init output.

One-line flip: `console.log` → `console.error` at `cli.ts:363`. Init has no `--json` mode today, so this is purely consistency / future-proofing.

## Test plan

- [x] `bun test src/init.test.ts` — 9 pass (was 8)
- [x] `bun test src/` — 1053 pass, 0 fail
- [x] `bun test core/src/` — 340 pass, 0 fail
- [x] `bunx tsc --noEmit` — no new errors in changed files (cli.ts error count unchanged from main; init.test.ts clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)