### PR TITLE
feat(hub-jwt): adopt @openparachute/scope-guard (Step 2 of 4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "parachute-vault",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "@openparachute/scope-guard": "^0.1.0-rc.1",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode-terminal": "^0.12.0",
@@ -24,6 +25,8 @@
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.1.0-rc.1", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-SRRzBmbbf4uWP0nKYLFg6Fasna2zl+BtADedCeQgCoHxmdwE8JaE3y5USZLLNaU5YJ9tzItXhWOsLtTFgJHgtQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.17",
+  "version": "0.3.6-rc.18",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "@openparachute/scope-guard": "^0.1.0-rc.1",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode-terminal": "^0.12.0"

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -2,22 +2,23 @@
  * Hub-issued JWT validation. Vault as resource server: trusts tokens that the
  * hub signs against keys we fetch from the hub's `/.well-known/jwks.json`.
  *
- * Two halves:
- *   - Origin resolution. The hub's URL comes from `PARACHUTE_HUB_ORIGIN` (set
- *     by the hub's `expose` / `start` flow when vault runs behind it). Falls
- *     back to `http://127.0.0.1:1939` for loopback dev. We only resolve once
- *     per process — a server restart picks up an env change.
- *   - JWKS fetch + verify. `jose.createRemoteJWKSet` does the fetching, kid
- *     lookup, and rotation handling. Tokens MUST have `iss = <hub origin>` —
- *     the load-bearing trust check; without it, anyone could forge tokens
- *     against any RSA key. `aud` is strict-checked against
- *     `opts.expectedAudience` when provided (per-vault binding); RFC 7519
- *     `aud` may be a string or string[], and either shape is supported.
+ * The trust kernel — JWKS fetch + verify, issuer pin, audience strict-check,
+ * RFC 7519 string-or-array `aud` handling — lives in the shared
+ * `@openparachute/scope-guard` library so vault, scribe, and paraclaw can't
+ * silently drift on the worst place to drift. This file is the vault-side
+ * adapter: hub-origin resolution (env-var precedence + loopback fallback),
+ * a process-wide guard instance, and re-exports preserving the public
+ * surface every existing call site already imports.
  *
- * Vault#169 / hub-as-issuer Phase B2.
+ * Vault#169 / hub-as-issuer Phase B2; vault#TBD / scope-guard adoption.
  */
-import { type JWTPayload, createRemoteJWKSet, jwtVerify } from "jose";
-import { parseScopes } from "./scopes.ts";
+import {
+  createScopeGuard,
+  HubJwtError,
+  type HubJwtClaims,
+  looksLikeJwt,
+  type ValidateHubJwtOptions,
+} from "@openparachute/scope-guard";
 
 const DEFAULT_HUB_LOOPBACK = "http://127.0.0.1:1939";
 
@@ -36,78 +37,12 @@ export function getHubOrigin(): string {
   return DEFAULT_HUB_LOOPBACK;
 }
 
-/**
- * A presented bearer token is JWT-shaped iff it begins with `eyJ` — the
- * base64url encoding of `{"` from a `{"alg":...}` JSON header. Cheap
- * pre-check so we don't try to verify `pvt_` tokens as JWTs.
- */
-export function looksLikeJwt(token: string): boolean {
-  return token.startsWith("eyJ");
-}
-
-/** Subset of claims we surface to callers. Everything else is dropped. */
-export interface HubJwtClaims {
-  sub: string;
-  /** Parsed `scope` claim (whitespace-separated → array, normalized). */
-  scopes: string[];
-  /** Audience — operator | client_id | module-name. Surfaced for logging. */
-  aud: string | undefined;
-  /** Token id. Surfaced for logging / future revocation lookups. */
-  jti: string | undefined;
-  /** Client id from the `client_id` claim, if present. */
-  clientId: string | undefined;
-}
-
-export class HubJwtError extends Error {
-  override name = "HubJwtError";
-}
-
-// jose's createRemoteJWKSet returns a getter that internally caches keys with
-// a configurable TTL. One getter per origin — recreated only on origin change
-// (rare; survives across requests). Module-scoped so retries / kid lookups
-// reuse the same in-flight fetches.
-type JwksGetter = ReturnType<typeof createRemoteJWKSet>;
-let cachedGetter: JwksGetter | null = null;
-let cachedOrigin: string | null = null;
-
-function getJwksGetter(origin: string): JwksGetter {
-  if (cachedGetter && cachedOrigin === origin) return cachedGetter;
-  cachedGetter = createRemoteJWKSet(new URL(`${origin}/.well-known/jwks.json`), {
-    // 5min cache — keys rarely rotate but DO rotate. Matches hub's signing-key
-    // overlap window expectation.
-    cacheMaxAge: 5 * 60 * 1000,
-    // 30s cooldown between failed fetches. Prevents thundering-herd if the
-    // hub is briefly down: we serve cached keys when possible, and the
-    // cooldown bounds the retry rate.
-    cooldownDuration: 30 * 1000,
-  });
-  cachedOrigin = origin;
-  return cachedGetter;
-}
-
-/**
- * Reset the cached JWKS getter. Tests use this to switch origins between
- * cases; production callers shouldn't need it (origin is process-stable).
- */
-export function resetJwksCache(): void {
-  cachedGetter = null;
-  cachedOrigin = null;
-}
-
-export interface ValidateHubJwtOptions {
-  /**
-   * If set, strict-check the JWT `aud` claim against this exact value. Used
-   * by the per-vault auth path: each request derives the expected audience
-   * from the URL (`vault.<name>`) and rejects tokens stamped for a different
-   * vault. Pass `null` (or omit) to skip — only callers that lack a single
-   * resource binding (e.g. cross-vault routes) should skip.
-   *
-   * The `aud` strict-check is the resource-server backstop. Even if scope
-   * narrowing slips somewhere upstream, `aud=vault.work` cannot reach
-   * `/vault/personal/*` because the audience-mismatch reject fires first.
-   */
-  expectedAudience?: string | null;
-}
+// Process-wide guard. The resolver form lets tests flip
+// `PARACHUTE_HUB_ORIGIN` between cases — the lib re-resolves on every
+// `validateHubJwt` and `resetJwksCache` call so the env-var change picks up
+// without a server restart. JWKS cache (5min/30s defaults) lives inside the
+// guard, shared across requests.
+const guard = createScopeGuard({ hubOrigin: () => getHubOrigin() });
 
 /**
  * Verify a presented JWT against the hub's JWKS. Throws `HubJwtError` on any
@@ -129,58 +64,16 @@ export async function validateHubJwt(
   token: string,
   opts: ValidateHubJwtOptions = {},
 ): Promise<HubJwtClaims> {
-  const origin = getHubOrigin();
-  const getter = getJwksGetter(origin);
-
-  let payload: JWTPayload;
-  try {
-    const verified = await jwtVerify(token, getter, {
-      issuer: origin,
-      // We strict-check audience ourselves below when `expectedAudience` is
-      // provided. Letting jose do it would also work, but keeping the check
-      // local lets us shape a clearer error message and centralize the
-      // "vault.<name>" derivation rule in one place.
-    });
-    payload = verified.payload;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new HubJwtError(`hub JWT verification failed: ${msg}`);
-  }
-
-  if (typeof payload.sub !== "string" || payload.sub.length === 0) {
-    throw new HubJwtError("hub JWT missing required `sub` claim");
-  }
-
-  // RFC 7519 §4.1.3: `aud` may be a string OR an array of strings. We unify
-  // into an array internally and check membership; surfacing back to callers
-  // collapses to a single representative value (the matched one when an
-  // expectation was supplied, else the first array element).
-  const audRaw = payload.aud;
-  const auds: string[] =
-    typeof audRaw === "string"
-      ? [audRaw]
-      : Array.isArray(audRaw)
-        ? audRaw.filter((a): a is string => typeof a === "string")
-        : [];
-
-  if (opts.expectedAudience != null) {
-    if (!auds.includes(opts.expectedAudience)) {
-      const got = auds.length === 0 ? "(missing)" : auds.join(", ");
-      throw new HubJwtError(
-        `hub JWT audience mismatch: expected "${opts.expectedAudience}", got "${got}"`,
-      );
-    }
-  }
-  const aud: string | undefined =
-    opts.expectedAudience != null ? opts.expectedAudience : auds[0];
-
-  const scopeRaw = (payload as { scope?: unknown }).scope;
-  const scopes =
-    typeof scopeRaw === "string" ? parseScopes(scopeRaw) : [];
-
-  const jti = typeof payload.jti === "string" ? payload.jti : undefined;
-  const clientIdRaw = (payload as { client_id?: unknown }).client_id;
-  const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
-
-  return { sub: payload.sub, scopes, aud, jti, clientId };
+  return guard.validateHubJwt(token, opts);
 }
+
+/**
+ * Reset the cached JWKS getter. Tests use this to switch origins between
+ * cases; production callers shouldn't need it (origin is process-stable).
+ */
+export function resetJwksCache(): void {
+  guard.resetJwksCache();
+}
+
+export { HubJwtError, looksLikeJwt };
+export type { HubJwtClaims, ValidateHubJwtOptions };


### PR DESCRIPTION
Step 2 of 4 in the [hub#59 scope-guard migration](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md). Vault is the canonical source — adopting first validates the lib's API against the most-demanding consumer.

## What changed

- **`package.json`**: declares `@openparachute/scope-guard@^0.1.0-rc.1`
- **`src/hub-jwt.ts`**: 171 → 75 lines. The JWKS fetch + `jwtVerify` body, per-process getter cache, audience strict-check, RFC 7519 string-or-array `aud` handling, and error-classifying glue all move into the shared library. What stays: hub-origin resolution (`getHubOrigin` reads `PARACHUTE_HUB_ORIGIN` with a loopback fallback) and a thin adapter around `createScopeGuard({ hubOrigin: () => getHubOrigin() })`.
- **`src/scopes.ts`**: untouched. Vault's resource-narrowed policy (`hasScopeForVault`, `findBroadVaultScopes`, `legacyPermissionToScopes`, `pvt_*` token detection) stays vault-side per the design — the lib is the engine, not the dictionary.

Public surface preserved end-to-end: `getHubOrigin`, `validateHubJwt`, `looksLikeJwt`, `resetJwksCache`, `HubJwtError`, `HubJwtClaims`, `ValidateHubJwtOptions` all continue to export from `src/hub-jwt.ts`. `src/auth.ts` and the test files don't change a single line.

## Critical edge confirmed unchanged

The reviewer of hub#152 flagged this case to validate against vault before landing:

```ts
hasScope(["vault:write"], "vault:work:read") === false
```

- **Lib**: decomposes required as `{resource: vault, name: "work", verb: read}`, narrowed-query branch only matches grants with the same `name`. Granted `vault:write` decomposes to `{name: null}` → skip → returns false.
- **Vault today** (`scopes.ts:96`): `requiredDecomposed.vault !== null` → returns false immediately.

Same answer. No semantics divergence — vault is already strict on this exact edge, no permissive wrapper required.

## External behavior preserved

- Every case in `hub-jwt.test.ts` passes unchanged. Error message wording matches the lib (`hub JWT verification failed:`, `hub JWT audience mismatch:`, `hub JWT missing required \`sub\` claim`) so the regex assertions hold.
- `PARACHUTE_HUB_ORIGIN` precedence preserved via the resolver-function form of `hubOrigin` — the lib re-resolves on every `validateHubJwt` and `resetJwksCache` call so the test pattern that flips env vars between cases keeps working without a server restart.

## Migration sequence

After this lands: scribe (Step 3), paraclaw (Step 4), then the duplicated trust kernel is gone and the pattern doc gets updated to reference the published library.

## Test plan

- [x] `bun test src/hub-jwt.test.ts` — 22 pass, 0 fail
- [x] `bun test src/` — 1053 pass, 0 fail
- [x] `bun test core/src/` — 340 pass, 0 fail
- [x] `bunx tsc --noEmit` — no new errors in changed files (cli.ts pre-existing-error count unchanged from main; hub-jwt.ts clean)

## References

- Design: [parachute-hub/docs/design/2026-04-29-scope-guard-library.md](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md)
- Step 1 lib PR: [parachute-hub#152](https://github.com/ParachuteComputer/parachute-hub/pull/152) (merged)
- Lib on npm: `@openparachute/scope-guard@0.1.0-rc.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)