### PR TITLE
feat(admin): vault management SPA Phase B — tokens (#217)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.19",
+  "version": "0.3.6-rc.20",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -2,7 +2,8 @@
 
 Vite + React + TypeScript SPA mounted at `/admin/` on the running vault
 server. Phase A (vault#216) ships the scaffold + per-vault detail page;
-Phase B (#217) adds tokens; Phase C (#218) adds permissions.
+Phase B (#217) adds tokens (list / mint / revoke + read-only fallback for
+non-admin sessions); Phase C (#218) adds permissions.
 
 ## Mount-aware contract
 
@@ -71,10 +72,13 @@ web/ui/
     ├── styles.css          # brand tokens (kept in sync with hub's)
     ├── lib/
     │   ├── auth.ts         # fragment-token capture, in-memory cache
-    │   └── api.ts          # listVaultNames + getVaultDetail
+    │   ├── scope.ts        # JWT payload decode + hasAdminScope gate
+    │   ├── api.ts          # listVaultNames + getVaultDetail
+    │   └── tokens-api.ts   # listTokens / mintToken / revokeToken
     ├── routes/
     │   ├── VaultsList.tsx  # /
-    │   └── VaultDetail.tsx # /vault/:name
+    │   ├── VaultDetail.tsx # /vault/:name
+    │   └── VaultTokens.tsx # /vault/:name/tokens
     └── test/setup.ts
 ```
 

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { Link, Route, Routes } from "react-router-dom";
 import { VaultDetail } from "./routes/VaultDetail.tsx";
+import { VaultTokens } from "./routes/VaultTokens.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
 export function App() {
@@ -15,6 +16,7 @@ export function App() {
       <Routes>
         <Route path="/" element={<VaultsList />} />
         <Route path="/vault/:name" element={<VaultDetail />} />
+        <Route path="/vault/:name/tokens" element={<VaultTokens />} />
         <Route
           path="*"
           element={

--- a/web/ui/src/lib/scope.test.ts
+++ b/web/ui/src/lib/scope.test.ts
@@ -1,0 +1,90 @@
+/**
+ * JWT scope decoding. Synthetic tokens — we never verify, only inspect, so
+ * any header/signature suffices. The scope shape under test is the one
+ * scope-narrowing-and-audience pins: `vault:<name>:<verb>`. Broad
+ * `vault:admin` should NOT satisfy `hasAdminScope("work")` because the
+ * server's hub-JWT gate rejects broad shapes.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { _setTokenForTest, clearToken } from "./auth.ts";
+import { decodeJwtPayload, hasAdminScope, scopesFromJwt } from "./scope.ts";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+  const body = btoa(JSON.stringify(payload))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+  return `${header}.${body}.signature-stub`;
+}
+
+describe("decodeJwtPayload", () => {
+  it("returns the parsed claims object", () => {
+    const token = makeJwt({ sub: "alice", scope: "vault:work:read" });
+    expect(decodeJwtPayload(token)).toEqual({ sub: "alice", scope: "vault:work:read" });
+  });
+
+  it("returns null for a non-JWT input", () => {
+    expect(decodeJwtPayload("not-a-jwt")).toBeNull();
+    expect(decodeJwtPayload("a.b")).toBeNull();
+  });
+
+  it("returns null when the body isn't valid base64-url JSON", () => {
+    expect(decodeJwtPayload("aaa.@@@.bbb")).toBeNull();
+  });
+});
+
+describe("scopesFromJwt", () => {
+  it("returns [] for null token", () => {
+    expect(scopesFromJwt(null)).toEqual([]);
+  });
+
+  it("splits the OAuth-canonical space-separated `scope` claim", () => {
+    const token = makeJwt({ scope: "vault:work:read vault:work:write" });
+    expect(scopesFromJwt(token)).toEqual(["vault:work:read", "vault:work:write"]);
+  });
+
+  it("falls back to the array-shaped `scopes` claim", () => {
+    const token = makeJwt({ scopes: ["vault:work:admin"] });
+    expect(scopesFromJwt(token)).toEqual(["vault:work:admin"]);
+  });
+
+  it("returns [] when neither claim is present", () => {
+    const token = makeJwt({ sub: "alice" });
+    expect(scopesFromJwt(token)).toEqual([]);
+  });
+});
+
+describe("hasAdminScope", () => {
+  afterEach(() => {
+    clearToken();
+  });
+
+  it("true when narrowed admin scope for the named vault is present", () => {
+    _setTokenForTest(makeJwt({ scope: "vault:work:admin" }));
+    expect(hasAdminScope("work")).toBe(true);
+  });
+
+  it("false when only read/write scopes are present", () => {
+    _setTokenForTest(makeJwt({ scope: "vault:work:read vault:work:write" }));
+    expect(hasAdminScope("work")).toBe(false);
+  });
+
+  it("false when admin is for a different vault", () => {
+    _setTokenForTest(makeJwt({ scope: "vault:other:admin" }));
+    expect(hasAdminScope("work")).toBe(false);
+  });
+
+  it("false when the token carries broad `vault:admin` (server rejects this shape from hub)", () => {
+    _setTokenForTest(makeJwt({ scope: "vault:admin" }));
+    expect(hasAdminScope("work")).toBe(false);
+  });
+
+  it("false when no token is cached", () => {
+    _setTokenForTest(null);
+    expect(hasAdminScope("work")).toBe(false);
+  });
+});

--- a/web/ui/src/lib/scope.ts
+++ b/web/ui/src/lib/scope.ts
@@ -1,0 +1,64 @@
+/**
+ * Client-side JWT scope inspection.
+ *
+ * **Not** a verifier — signature, issuer, audience, and expiry are checked
+ * by the vault server (`src/auth.ts` → `src/hub-jwt.ts` → scope-guard). The
+ * server is the trust boundary; this util only decides whether to *render*
+ * the mutate UI (mint, revoke). A client that lies about its scopes still
+ * has its requests rejected at the API.
+ *
+ * Why this matters: Phase A's only auth state was "have token / don't have
+ * token". Phase B introduces tokens UI with mint + revoke, both of which
+ * require `vault:<name>:admin`. A read-scoped JWT shouldn't see the buttons
+ * — it should see a read-only list with a banner explaining what's needed.
+ *
+ * Inheritance follows the same `admin ⊇ write ⊇ read` rule scope-guard
+ * encodes server-side; for *admin* checks the rule is trivial (only admin
+ * grants admin), but the helper is named generically so a future call site
+ * checking write/read works without a second util.
+ */
+import { getToken } from "./auth.ts";
+
+/** Decode the payload of a JWT without verifying its signature. Returns
+ * `null` on any malformed input. */
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const padded = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padding = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+    const json = atob(padded + padding);
+    const parsed = JSON.parse(json) as unknown;
+    if (parsed === null || typeof parsed !== "object") return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/** Pull the scopes claim off a JWT. Accepts the OAuth-canonical
+ * space-separated `scope` string; falls back to the array-shaped `scopes`
+ * claim some legacy paths emit. Anything else → empty list. */
+export function scopesFromJwt(token: string | null): string[] {
+  if (!token) return [];
+  const claims = decodeJwtPayload(token);
+  if (!claims) return [];
+  const scope = claims["scope"];
+  if (typeof scope === "string" && scope.length > 0) {
+    return scope.split(/\s+/).filter((s) => s.length > 0);
+  }
+  const scopes = claims["scopes"];
+  if (Array.isArray(scopes)) {
+    return scopes.filter((s): s is string => typeof s === "string" && s.length > 0);
+  }
+  return [];
+}
+
+/** True iff the cached token grants admin on the named vault. Hub-issued
+ * tokens use the narrowed `vault:<name>:admin` shape per
+ * scope-narrowing-and-audience. Broad `vault:admin` is rejected by the
+ * server's hub-JWT gate and we mirror that here so the UI gate matches. */
+export function hasAdminScope(vaultName: string): boolean {
+  const scopes = scopesFromJwt(getToken());
+  return scopes.includes(`vault:${vaultName}:admin`);
+}

--- a/web/ui/src/lib/tokens-api.test.ts
+++ b/web/ui/src/lib/tokens-api.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tokens REST client. Tests cover the auth gate (no cached token → 401), the
+ * shape of the GET / POST / DELETE calls (URL, method, headers), and the
+ * server-error surfacing path that matches `getVaultDetail`'s behavior.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { _setTokenForTest, clearToken } from "./auth.ts";
+import { HttpError } from "./api.ts";
+import { listTokens, mintToken, revokeToken } from "./tokens-api.ts";
+
+interface Call {
+  url: string;
+  method: string;
+  auth: string | null;
+  contentType: string | null;
+  body: string | null;
+}
+
+function mockFetch(impl: (call: Call) => Promise<Response>) {
+  const calls: Call[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const headers = new Headers(init?.headers);
+      const call: Call = {
+        url,
+        method: init?.method ?? "GET",
+        auth: headers.get("authorization"),
+        contentType: headers.get("content-type"),
+        body: typeof init?.body === "string" ? init.body : null,
+      };
+      calls.push(call);
+      return impl(call);
+    }),
+  );
+  return calls;
+}
+
+describe("tokens-api auth gate", () => {
+  afterEach(() => {
+    clearToken();
+  });
+
+  it("listTokens throws HttpError(401) when no token is cached", async () => {
+    _setTokenForTest(null);
+    await expect(listTokens("work")).rejects.toMatchObject({
+      name: "HttpError",
+      status: 401,
+    });
+  });
+
+  it("mintToken throws HttpError(401) when no token is cached", async () => {
+    _setTokenForTest(null);
+    await expect(mintToken("work", { label: "test" })).rejects.toBeInstanceOf(HttpError);
+  });
+
+  it("revokeToken throws HttpError(401) when no token is cached", async () => {
+    _setTokenForTest(null);
+    await expect(revokeToken("work", "t_abc")).rejects.toBeInstanceOf(HttpError);
+  });
+});
+
+describe("listTokens", () => {
+  afterEach(() => {
+    clearToken();
+  });
+
+  it("hits the right URL with the cached token and returns body.tokens", async () => {
+    _setTokenForTest("jwt-here");
+    const calls = mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          tokens: [
+            {
+              id: "t_abc123",
+              label: "ci",
+              permission: "full",
+              scopes: ["vault:work:write"],
+              expires_at: null,
+              created_at: "2026-05-01T00:00:00Z",
+              last_used_at: null,
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const tokens = await listTokens("work");
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.label).toBe("ci");
+    expect(calls[0]?.url).toBe("/vault/work/tokens");
+    expect(calls[0]?.method).toBe("GET");
+    expect(calls[0]?.auth).toBe("Bearer jwt-here");
+  });
+});
+
+describe("mintToken", () => {
+  afterEach(() => {
+    clearToken();
+  });
+
+  it("POSTs label + scopes as JSON, returns the plaintext token", async () => {
+    _setTokenForTest("jwt-here");
+    const calls = mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          id: "t_new",
+          token: "pvt_secret_value",
+          label: "ci",
+          permission: "full",
+          scopes: ["vault:work:write"],
+          expires_at: null,
+          created_at: "2026-05-02T00:00:00Z",
+          last_used_at: null,
+        }),
+        { status: 201 },
+      ),
+    );
+
+    const result = await mintToken("work", { label: "ci", scopes: ["vault:work:write"] });
+
+    expect(result.token).toBe("pvt_secret_value");
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.contentType).toBe("application/json");
+    const parsed = calls[0]?.body ? JSON.parse(calls[0].body) : {};
+    expect(parsed).toEqual({ label: "ci", scopes: ["vault:work:write"] });
+  });
+
+  it("omits empty fields from the request body", async () => {
+    _setTokenForTest("jwt-here");
+    const calls = mockFetch(async () =>
+      new Response(JSON.stringify({ id: "t_x", token: "pvt_x", label: "API token", permission: "full", scopes: [], expires_at: null, created_at: "x", last_used_at: null }), { status: 201 }),
+    );
+
+    await mintToken("work", {});
+
+    const parsed = calls[0]?.body ? JSON.parse(calls[0].body) : null;
+    expect(parsed).toEqual({});
+  });
+
+  it("surfaces the server message on a 400 (e.g. scope rejected)", async () => {
+    _setTokenForTest("jwt-here");
+    mockFetch(async () =>
+      new Response(
+        JSON.stringify({ error: "Bad Request", message: "scope rejected", rejected: ["vault:other:write"] }),
+        { status: 400 },
+      ),
+    );
+
+    await expect(mintToken("work", { scopes: ["vault:other:write"] })).rejects.toMatchObject({
+      status: 400,
+      message: "scope rejected",
+    });
+  });
+});
+
+describe("revokeToken", () => {
+  afterEach(() => {
+    clearToken();
+  });
+
+  it("DELETEs the right URL with the cached token", async () => {
+    _setTokenForTest("jwt-here");
+    const calls = mockFetch(async () =>
+      new Response(JSON.stringify({ revoked: true }), { status: 200 }),
+    );
+
+    await revokeToken("work", "t_abc123");
+
+    expect(calls[0]?.url).toBe("/vault/work/tokens/t_abc123");
+    expect(calls[0]?.method).toBe("DELETE");
+    expect(calls[0]?.auth).toBe("Bearer jwt-here");
+  });
+});

--- a/web/ui/src/lib/tokens-api.ts
+++ b/web/ui/src/lib/tokens-api.ts
@@ -1,0 +1,102 @@
+/**
+ * HTTP client for the per-vault tokens REST surface.
+ *
+ * Hits `GET|POST /vault/<name>/tokens` (list + mint) and
+ * `DELETE /vault/<name>/tokens/<id>` (revoke). Backed by `src/tokens-routes.ts`
+ * — the server enforces `vault:<name>:admin` for all three; we send the cached
+ * hub-issued JWT as `Authorization: Bearer <jwt>`.
+ *
+ * Mint returns the plaintext `pvt_*` token exactly once (server can't re-emit
+ * it). The caller is responsible for stashing it and surfacing the one-time
+ * banner; this module just relays the response.
+ */
+import { getToken } from "./auth.ts";
+import { HttpError } from "./api.ts";
+
+export interface TokenSummary {
+  id: string;
+  label: string;
+  permission: "read" | "full";
+  scopes: string[];
+  expires_at: string | null;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+export interface MintTokenResult extends TokenSummary {
+  /** Plaintext `pvt_*` token. Shown once; the server never re-emits. */
+  token: string;
+}
+
+export interface MintTokenInput {
+  label?: string;
+  /** Optional narrowing. Omit to inherit caller's full scope set. */
+  scopes?: string[];
+  expires_at?: string | null;
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getToken();
+  if (!token) {
+    throw new HttpError(401, "no admin token — open this page from the hub directory");
+  }
+  return {
+    accept: "application/json",
+    authorization: `Bearer ${token}`,
+  };
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const text = await res.text();
+    const parsed = JSON.parse(text) as { error?: string; error_description?: string; message?: string };
+    if (parsed.error_description) return parsed.error_description;
+    if (parsed.message) return parsed.message;
+    if (parsed.error) return parsed.error;
+    if (text) return text;
+  } catch {
+    // not JSON
+  }
+  return `${res.status} ${res.statusText}`;
+}
+
+export async function listTokens(vaultName: string): Promise<TokenSummary[]> {
+  const res = await fetch(`/vault/${encodeURIComponent(vaultName)}/tokens`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  const body = (await res.json()) as { tokens?: TokenSummary[] };
+  return body.tokens ?? [];
+}
+
+export async function mintToken(vaultName: string, input: MintTokenInput): Promise<MintTokenResult> {
+  const body: Record<string, unknown> = {};
+  if (input.label && input.label.length > 0) body["label"] = input.label;
+  if (input.scopes && input.scopes.length > 0) body["scopes"] = input.scopes;
+  if (input.expires_at !== undefined) body["expires_at"] = input.expires_at;
+
+  const res = await fetch(`/vault/${encodeURIComponent(vaultName)}/tokens`, {
+    method: "POST",
+    headers: { ...authHeaders(), "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as MintTokenResult;
+}
+
+export async function revokeToken(vaultName: string, tokenId: string): Promise<void> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/tokens/${encodeURIComponent(tokenId)}`,
+    {
+      method: "DELETE",
+      headers: authHeaders(),
+    },
+  );
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+}

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -167,10 +167,17 @@ export function VaultDetail() {
       </div>
 
       <div className="section">
-        <p className="muted">
-          Token mint/revoke (Phase B / vault#217) and permissions editing (Phase C / vault#218) land here. For now,
-          manage tokens directly with <code>parachute-vault tokens</code> on the host.
-        </p>
+        <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>Manage</h3>
+        <ul className="manage-list">
+          <li>
+            <Link to={`/vault/${encodeURIComponent(vault.name)}/tokens`}>Tokens →</Link>
+            <span className="dim"> mint, list, and revoke <code>pvt_*</code> tokens</span>
+          </li>
+          <li className="dim">
+            Permissions editing (Phase C / vault#218) lands here next. For now, mint scope-narrowed
+            tokens above to delegate restricted access.
+          </li>
+        </ul>
       </div>
     </div>
   );

--- a/web/ui/src/routes/VaultTokens.test.tsx
+++ b/web/ui/src/routes/VaultTokens.test.tsx
@@ -93,6 +93,24 @@ describe("VaultTokens — admin scope", () => {
     });
   });
 
+  it("rejects mint when label is empty (no API call, error shown)", async () => {
+    vi.mocked(tokensApi.listTokens).mockResolvedValue([]);
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /mint token/i })).toBeInTheDocument(),
+    );
+    // Submit button is disabled when label is empty — type then clear to
+    // exercise the form-onSubmit guard rather than the disabled state alone.
+    const labelInput = screen.getByLabelText(/label/i);
+    await user.type(labelInput, "x");
+    await user.clear(labelInput);
+    expect(screen.getByRole("button", { name: /mint token/i })).toBeDisabled();
+    expect(tokensApi.mintToken).not.toHaveBeenCalled();
+  });
+
   it("revoke shows a confirm step before deleting", async () => {
     vi.mocked(tokensApi.listTokens).mockResolvedValue([tokenFixture()]);
     vi.mocked(tokensApi.revokeToken).mockResolvedValue();

--- a/web/ui/src/routes/VaultTokens.test.tsx
+++ b/web/ui/src/routes/VaultTokens.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * VaultTokens smoke tests — list render, scope-gated mutate UI, mint banner
+ * single-emit, revoke confirm flow.
+ *
+ * `lib/tokens-api.ts` is mocked so the wire isn't touched; `lib/scope.ts` is
+ * mocked so we control admin-vs-read gating without crafting JWTs in every
+ * test (decode is tested separately in scope.test.ts).
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as scope from "../lib/scope.ts";
+import * as tokensApi from "../lib/tokens-api.ts";
+import { VaultTokens } from "./VaultTokens.tsx";
+
+vi.mock("../lib/tokens-api.ts");
+vi.mock("../lib/scope.ts");
+
+const tokenFixture = (over: Partial<tokensApi.TokenSummary> = {}): tokensApi.TokenSummary => ({
+  id: "t_abc123",
+  label: "ci",
+  permission: "full",
+  scopes: ["vault:work:write"],
+  expires_at: null,
+  created_at: "2026-05-01T00:00:00Z",
+  last_used_at: null,
+  ...over,
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={["/vault/work/tokens"]}>
+      <Routes>
+        <Route path="/vault/:name/tokens" element={<VaultTokens />} />
+        <Route path="/vault/:name" element={<div>detail</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("VaultTokens — admin scope", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(true);
+  });
+
+  it("renders the existing-tokens list", async () => {
+    vi.mocked(tokensApi.listTokens).mockResolvedValue([
+      tokenFixture({ label: "ci" }),
+      tokenFixture({ id: "t_def456", label: "paraclaw" }),
+    ]);
+
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByText("ci")).toBeInTheDocument());
+    expect(screen.getByText("paraclaw")).toBeInTheDocument();
+    expect(screen.getByText("t_abc123")).toBeInTheDocument();
+  });
+
+  it("shows the mint form and minted-token banner on success", async () => {
+    vi.mocked(tokensApi.listTokens).mockResolvedValue([]);
+    vi.mocked(tokensApi.mintToken).mockResolvedValue({
+      ...tokenFixture({ label: "new-token" }),
+      token: "pvt_super_secret",
+    });
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /mint token/i })).toBeInTheDocument(),
+    );
+    await user.type(screen.getByLabelText(/label/i), "new-token");
+    await user.click(screen.getByRole("button", { name: /mint token/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/new token \(shown once\)/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText("pvt_super_secret")).toBeInTheDocument();
+    expect(screen.getByText(/don't dismiss this banner/i)).toBeInTheDocument();
+    expect(tokensApi.mintToken).toHaveBeenCalledWith("work", {
+      label: "new-token",
+      scopes: ["vault:work:admin"],
+    });
+  });
+
+  it("revoke shows a confirm step before deleting", async () => {
+    vi.mocked(tokensApi.listTokens).mockResolvedValue([tokenFixture()]);
+    vi.mocked(tokensApi.revokeToken).mockResolvedValue();
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^revoke$/i })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    // Confirm step replaces the bare Revoke button with Confirm + Cancel.
+    expect(screen.getByRole("button", { name: /confirm revoke/i })).toBeInTheDocument();
+    expect(tokensApi.revokeToken).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /confirm revoke/i }));
+    await waitFor(() =>
+      expect(tokensApi.revokeToken).toHaveBeenCalledWith("work", "t_abc123"),
+    );
+  });
+});
+
+describe("VaultTokens — read scope", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(false);
+  });
+
+  it("hides the mint form and the per-token revoke buttons", async () => {
+    vi.mocked(tokensApi.listTokens).mockResolvedValue([tokenFixture()]);
+
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByText("ci")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /mint token/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^revoke$/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/read-only token/i)).toBeInTheDocument();
+  });
+});

--- a/web/ui/src/routes/VaultTokens.tsx
+++ b/web/ui/src/routes/VaultTokens.tsx
@@ -10,12 +10,11 @@
  *     state and lose it on navigation away. Dismissal clears it explicitly.
  *   - **Revoke**   — confirm modal then DELETE.
  *
- * Mutate UI is gated on `hasAdminScope(name)`. A read-scoped token still
- * sees the list (the server allows `vault:<name>:read` for GET on this
- * surface? — actually no, the server requires `:admin` for all three; the
- * gate is defense-in-depth so a read-only token sees a banner directing
- * them to re-auth instead of a 403 toast). When the gate is closed, the
- * mint form and revoke buttons are hidden and a banner explains.
+ * Mutate UI is gated on `hasAdminScope(name)`. The vault server requires
+ * `vault:<name>:admin` for all three verbs (list, mint, revoke), so the
+ * client-side gate is defense-in-depth: a read-scoped session sees a
+ * banner directing them to re-auth instead of getting a 403 toast on
+ * every interaction.
  */
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
@@ -100,6 +99,14 @@ export function VaultTokens() {
 
       {minted ? <MintBanner result={minted} onDismiss={() => setMinted(null)} /> : null}
 
+      {/*
+       * MintForm is hidden while the just-minted banner is showing. The
+       * banner is the single point at which the operator copies the
+       * plaintext pvt_*; if a second mint happens before the first is
+       * saved, the first is gone forever (the server can't re-emit). The
+       * dismissal-then-mint sequence makes that loss impossible by
+       * construction. Keep the gate; don't "fix" it back to always-on.
+       */}
       {state.kind === "ok" && isAdmin && !minted ? (
         <MintForm
           vaultName={name}
@@ -188,14 +195,20 @@ function MintForm({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const trimmedLabel = label.trim();
+  const labelMissing = trimmedLabel.length === 0;
+
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (labelMissing) {
+      setError("label required — give the token a recognizable name");
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
-      const trimmedLabel = label.trim();
       const result = await mintToken(vaultName, {
-        label: trimmedLabel.length > 0 ? trimmedLabel : undefined,
+        label: trimmedLabel,
         scopes: [`vault:${vaultName}:${verb}`],
       });
       onMinted(result);
@@ -217,7 +230,9 @@ function MintForm({
         </div>
       ) : null}
       <div className="form-row">
-        <label htmlFor="mint-label">Label</label>
+        <label htmlFor="mint-label">
+          Label <span className="dim">(required)</span>
+        </label>
         <input
           id="mint-label"
           type="text"
@@ -225,6 +240,7 @@ function MintForm({
           onChange={(e) => setLabel(e.target.value)}
           placeholder="e.g. ci, paraclaw-prod, my-laptop"
           maxLength={120}
+          required
         />
       </div>
       <div className="form-row">
@@ -243,7 +259,7 @@ function MintForm({
         </p>
       </div>
       <div className="actions">
-        <button type="submit" disabled={submitting}>
+        <button type="submit" disabled={submitting || labelMissing}>
           {submitting ? "Minting…" : "Mint token"}
         </button>
       </div>
@@ -372,8 +388,8 @@ function TokenRow({
 }
 
 function fmtDate(iso: string): string {
-  // ISO timestamps are fine in monospace; humans skim them with locale
-  // formatting but exact wall-clock time is what an operator usually wants
-  // for incident triage. Keep as-is.
+  // v1 shows ISO timestamps verbatim — exact wall-clock UTC is what an
+  // operator wants for incident triage. Phase C may add a relative +
+  // local-time formatting pass once the broader admin UI gets a date util.
   return iso;
 }

--- a/web/ui/src/routes/VaultTokens.tsx
+++ b/web/ui/src/routes/VaultTokens.tsx
@@ -1,0 +1,379 @@
+/**
+ * `/vault/:name/tokens` — token management.
+ *
+ * Phase B (vault#217). Three operations against `/vault/<name>/tokens`:
+ *
+ *   - **List**     — table of label / scopes / created / last-used.
+ *   - **Mint**     — form for label + (optional) scope-narrowing. On 201
+ *     the plaintext `pvt_*` is rendered exactly once in a banner with copy
+ *     + dismissal warning. Server can't re-emit; we hold it in component
+ *     state and lose it on navigation away. Dismissal clears it explicitly.
+ *   - **Revoke**   — confirm modal then DELETE.
+ *
+ * Mutate UI is gated on `hasAdminScope(name)`. A read-scoped token still
+ * sees the list (the server allows `vault:<name>:read` for GET on this
+ * surface? — actually no, the server requires `:admin` for all three; the
+ * gate is defense-in-depth so a read-only token sees a banner directing
+ * them to re-auth instead of a 403 toast). When the gate is closed, the
+ * mint form and revoke buttons are hidden and a banner explains.
+ */
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { HttpError } from "../lib/api.ts";
+import { hasAdminScope } from "../lib/scope.ts";
+import {
+  type MintTokenResult,
+  type TokenSummary,
+  listTokens,
+  mintToken,
+  revokeToken,
+} from "../lib/tokens-api.ts";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ok"; tokens: TokenSummary[] }
+  | { kind: "auth-required" }
+  | { kind: "error"; message: string };
+
+const KNOWN_SCOPE_VERBS = ["read", "write", "admin"] as const;
+
+export function VaultTokens() {
+  const { name } = useParams<{ name: string }>();
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [minted, setMinted] = useState<MintTokenResult | null>(null);
+  const [confirmingRevokeId, setConfirmingRevokeId] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!name) return;
+    setState({ kind: "loading" });
+    listTokens(name)
+      .then((tokens) => {
+        if (cancelled) return;
+        setState({ kind: "ok", tokens });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof HttpError && (err.status === 401 || err.status === 403)) {
+          setState({ kind: "auth-required" });
+          return;
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name, reloadTick]);
+
+  if (!name) {
+    return (
+      <div>
+        <h2>Tokens</h2>
+        <p className="muted">Missing vault name.</p>
+        <Link to="/">← Back to vaults</Link>
+      </div>
+    );
+  }
+
+  const isAdmin = hasAdminScope(name);
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>
+          Tokens for <code>{name}</code>
+        </h2>
+        <Link to={`/vault/${encodeURIComponent(name)}`} className="muted">
+          ← Vault detail
+        </Link>
+      </div>
+
+      {!isAdmin ? (
+        <div className="warn-banner">
+          You're viewing this page with a read-only token. Mint and revoke require{" "}
+          <code>vault:{name}:admin</code>. Re-enter from the hub directory's "Manage" link with an
+          admin-scoped session to manage tokens.
+        </div>
+      ) : null}
+
+      {minted ? <MintBanner result={minted} onDismiss={() => setMinted(null)} /> : null}
+
+      {state.kind === "ok" && isAdmin && !minted ? (
+        <MintForm
+          vaultName={name}
+          onMinted={(result) => {
+            setMinted(result);
+            setReloadTick((n) => n + 1);
+          }}
+        />
+      ) : null}
+
+      <div className="section">
+        <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>Existing tokens</h3>
+        {state.kind === "loading" ? <p className="muted">Loading…</p> : null}
+        {state.kind === "auth-required" ? (
+          <div className="warn-banner">
+            Open this page from the hub's directory — the "Manage" link supplies the admin token.
+          </div>
+        ) : null}
+        {state.kind === "error" ? (
+          <div className="error-banner">
+            <code>{state.message}</code>
+          </div>
+        ) : null}
+        {state.kind === "ok" ? (
+          <TokenList
+            vaultName={name}
+            tokens={state.tokens}
+            allowRevoke={isAdmin}
+            confirmingRevokeId={confirmingRevokeId}
+            onAskConfirm={setConfirmingRevokeId}
+            onRevoked={() => {
+              setConfirmingRevokeId(null);
+              setReloadTick((n) => n + 1);
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MintBanner({ result, onDismiss }: { result: MintTokenResult; onDismiss: () => void }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(result.token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard fails outside secure contexts; the token's still in the box.
+    }
+  };
+  return (
+    <div className="mint-banner">
+      <h3>New token (shown once)</h3>
+      <p className="muted">
+        This is the only time the vault will show this token. Copy it now and store it somewhere
+        safe — a password manager, the operator's notes, paraclaw's secrets store. If you lose it,
+        revoke it and mint a new one.
+      </p>
+      <div className="token-box">
+        <code>{result.token}</code>
+        <button type="button" onClick={onCopy} className="secondary">
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <p className="warn">⚠ Don't dismiss this banner until you've saved the token.</p>
+      <div className="actions">
+        <button type="button" onClick={onDismiss}>
+          Done — I've saved the token
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MintForm({
+  vaultName,
+  onMinted,
+}: {
+  vaultName: string;
+  onMinted: (result: MintTokenResult) => void;
+}) {
+  const [label, setLabel] = useState("");
+  const [verb, setVerb] = useState<(typeof KNOWN_SCOPE_VERBS)[number]>("admin");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const trimmedLabel = label.trim();
+      const result = await mintToken(vaultName, {
+        label: trimmedLabel.length > 0 ? trimmedLabel : undefined,
+        scopes: [`vault:${vaultName}:${verb}`],
+      });
+      onMinted(result);
+      setLabel("");
+      setVerb("admin");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="section">
+      <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>Mint a token</h3>
+      {error ? (
+        <div className="error-banner">
+          <code>{error}</code>
+        </div>
+      ) : null}
+      <div className="form-row">
+        <label htmlFor="mint-label">Label</label>
+        <input
+          id="mint-label"
+          type="text"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="e.g. ci, paraclaw-prod, my-laptop"
+          maxLength={120}
+        />
+      </div>
+      <div className="form-row">
+        <label htmlFor="mint-scope">Scope</label>
+        <select
+          id="mint-scope"
+          value={verb}
+          onChange={(e) => setVerb(e.target.value as typeof verb)}
+        >
+          <option value="read">read — query notes only</option>
+          <option value="write">write — query + create/update notes</option>
+          <option value="admin">admin — full control (incl. token mgmt)</option>
+        </select>
+        <p className="dim" style={{ margin: "0.35rem 0 0" }}>
+          Issued as <code>vault:{vaultName}:{verb}</code>. Lower scopes inherit narrower powers.
+        </p>
+      </div>
+      <div className="actions">
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Minting…" : "Mint token"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function TokenList({
+  vaultName,
+  tokens,
+  allowRevoke,
+  confirmingRevokeId,
+  onAskConfirm,
+  onRevoked,
+}: {
+  vaultName: string;
+  tokens: TokenSummary[];
+  allowRevoke: boolean;
+  confirmingRevokeId: string | null;
+  onAskConfirm: (id: string | null) => void;
+  onRevoked: () => void;
+}) {
+  if (tokens.length === 0) {
+    return <p className="muted">No tokens yet. Mint one above to get started.</p>;
+  }
+  return (
+    <div className="token-list">
+      {tokens.map((tok) => (
+        <TokenRow
+          key={tok.id}
+          vaultName={vaultName}
+          token={tok}
+          allowRevoke={allowRevoke}
+          confirming={confirmingRevokeId === tok.id}
+          onAskConfirm={onAskConfirm}
+          onRevoked={onRevoked}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TokenRow({
+  vaultName,
+  token,
+  allowRevoke,
+  confirming,
+  onAskConfirm,
+  onRevoked,
+}: {
+  vaultName: string;
+  token: TokenSummary;
+  allowRevoke: boolean;
+  confirming: boolean;
+  onAskConfirm: (id: string | null) => void;
+  onRevoked: () => void;
+}) {
+  const [revoking, setRevoking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onConfirm = async () => {
+    setRevoking(true);
+    setError(null);
+    try {
+      await revokeToken(vaultName, token.id);
+      onRevoked();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setRevoking(false);
+    }
+  };
+
+  return (
+    <div className="token-row">
+      <div className="body">
+        <div className="name">
+          <strong>{token.label}</strong>
+          <code className="dim">{token.id}</code>
+        </div>
+        <div className="meta">
+          <span className="dim">scopes:</span>{" "}
+          {token.scopes.length > 0 ? (
+            token.scopes.map((s) => (
+              <code key={s} className="scope-tag">
+                {s}
+              </code>
+            ))
+          ) : (
+            <span className="dim">(legacy — {token.permission})</span>
+          )}
+        </div>
+        <div className="meta dim">
+          created {fmtDate(token.created_at)}
+          {token.last_used_at ? ` · last used ${fmtDate(token.last_used_at)}` : " · never used"}
+          {token.expires_at ? ` · expires ${fmtDate(token.expires_at)}` : ""}
+        </div>
+        {error ? (
+          <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+            <code>{error}</code>
+          </div>
+        ) : null}
+      </div>
+      {allowRevoke ? (
+        confirming ? (
+          <div className="actions">
+            <button type="button" onClick={onConfirm} disabled={revoking}>
+              {revoking ? "Revoking…" : "Confirm revoke"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => onAskConfirm(null)}
+              disabled={revoking}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button type="button" className="secondary" onClick={() => onAskConfirm(token.id)}>
+            Revoke
+          </button>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+function fmtDate(iso: string): string {
+  // ISO timestamps are fine in monospace; humans skim them with locale
+  // formatting but exact wall-clock time is what an operator usually wants
+  // for incident triage. Keep as-is.
+  return iso;
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -220,3 +220,146 @@ h2 {
   font-weight: 500;
   font-family: var(--font-mono);
 }
+
+button {
+  font: inherit;
+  background: var(--accent);
+  color: white;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.55rem 1.1rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+button:hover {
+  background: var(--accent-hover);
+}
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+button.secondary {
+  background: white;
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+button.secondary:hover {
+  background: var(--bg-soft);
+}
+
+input,
+select {
+  font: inherit;
+  background: white;
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.7rem;
+  width: 100%;
+  max-width: 28rem;
+}
+input:focus,
+select:focus {
+  outline: 2px solid var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.form-row {
+  margin-bottom: 1rem;
+}
+.form-row label {
+  display: block;
+  font-size: 0.88rem;
+  color: var(--fg-muted);
+  margin-bottom: 0.3rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.manage-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.95rem;
+}
+.manage-list li {
+  margin-bottom: 0.4rem;
+}
+
+.mint-banner {
+  background: var(--success-soft);
+  border: 1px solid var(--success);
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.mint-banner h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: var(--success);
+}
+.mint-banner .token-box {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.85rem 0 0.5rem;
+}
+.mint-banner code {
+  flex: 1;
+  font-size: 0.9rem;
+  padding: 0.6rem 0.75rem;
+  background: white;
+  border: 1px solid var(--border);
+  word-break: break-all;
+  user-select: all;
+}
+.mint-banner .warn {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: var(--warn);
+}
+.mint-banner .actions {
+  margin-top: 1rem;
+}
+
+.token-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.token-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.token-row .body {
+  flex: 1;
+  min-width: 0;
+}
+.token-row .name {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.3rem;
+}
+.token-row .meta {
+  font-size: 0.85rem;
+  margin-bottom: 0.2rem;
+}
+.token-row .actions {
+  margin-top: 0;
+  flex-shrink: 0;
+}
+.scope-tag {
+  font-size: 0.78rem;
+  padding: 0.1em 0.4em;
+  margin-right: 0.3em;
+}


### PR DESCRIPTION
## Summary

Phase B of the per-vault management SPA, building on the Phase A scaffold (#219). Adds token list / mint / revoke under `/admin/vault/<name>/tokens`.

- **`lib/scope.ts`** — client-side JWT payload decode (no signature verify; the vault server is the trust boundary). `hasAdminScope(name)` checks for the narrowed `vault:<name>:admin` shape so the SPA can hide mutate UI from a read-only token instead of letting the operator click buttons that 403 anyway. Mirrors the server's hub-JWT gate (broad `vault:admin` is rejected, so we don't accept it client-side either).
- **`lib/tokens-api.ts`** — `listTokens` / `mintToken` / `revokeToken` against `/vault/<name>/tokens` (existing REST surface in `src/tokens-routes.ts`). Mint relays the one-time plaintext `pvt_*`; the caller surfaces the banner.
- **`routes/VaultTokens.tsx`** — list table (label / id / scopes / created / last-used / expires), mint form (label + scope verb), one-time `pvt_*` reveal banner mirroring hub's `NewVault.tsx` shape (copy button + dismissal warning + `user-select: all` codebox), per-token revoke with confirm step. Wired from VaultDetail's "Manage" section.
- **Read-only fallback** — when `hasAdminScope` is false, the mint form and per-token revoke buttons are hidden and a banner directs the operator to re-enter via hub with an admin-scoped session. Reviewer-flagged item from #219.

## Auth flow (unchanged from Phase A)

JWT arrives via URL fragment from hub's "Manage" link; SPA captures + strips on bootstrap; module-scoped cache; sent as `Authorization: Bearer` to vault. Reload-without-hub leaves the SPA unauthenticated — the same Phase A trade-off applies.

## Out of scope (deferred)

- Permissions UI → vault#218 (Phase C)
- Vault delete / disable
- Direct redirect from hub to `/admin/vault/<name>` rather than `/admin/` — UX gap reviewer flagged on #219; lands when hub#158 ships and is verified post-merge.

## Reference shape

- Phase A SPA: vault PR #219 (mount, auth, build pipeline)
- Mint-banner pattern: `parachute-hub/web/ui/src/routes/NewVault.tsx` (PR #157)
- Server REST surface: `src/tokens-routes.ts` (existing — no server changes in this PR)
- Mount-path contract: `parachute-patterns/patterns/mount-path-convention.md`

## Test plan

- [x] `bun run typecheck` (web/ui) — clean
- [x] `bun run test` (web/ui vitest) — 34 pass (10 carried from Phase A + 24 new across `lib/scope.test.ts`, `lib/tokens-api.test.ts`, `routes/VaultTokens.test.tsx`)
- [x] `bun run build` + `verify-base.mjs` — `/admin/`-prefixed assets confirmed
- [x] `bun test ./src/` (vault host) — 728 pass
- [x] `bun test ./core/src/` (vault core) — 340 pass
- [ ] Manual: launch vault, hit `http://127.0.0.1:1940/admin/#token=<jwt>`, navigate to a vault, click Manage → Tokens, mint a token, confirm pvt_* reveal + revoke confirm step

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)