### PR TITLE
feat(admin): vault SPA Phase C — permissions link (#218)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.20",
+  "version": "0.3.6-rc.21",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -3,7 +3,10 @@
 Vite + React + TypeScript SPA mounted at `/admin/` on the running vault
 server. Phase A (vault#216) ships the scaffold + per-vault detail page;
 Phase B (#217) adds tokens (list / mint / revoke + read-only fallback for
-non-admin sessions); Phase C (#218) adds permissions.
+non-admin sessions); Phase C (#218) surfaces a forward-pointing link from
+each vault's detail page to hub's permissions UI (hub#162; grants live in
+hub's grants table — modular play is "vault links to hub" rather than
+"vault inlines hub data").
 
 ## Mount-aware contract
 

--- a/web/ui/src/lib/scope.test.ts
+++ b/web/ui/src/lib/scope.test.ts
@@ -7,7 +7,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { _setTokenForTest, clearToken } from "./auth.ts";
-import { decodeJwtPayload, hasAdminScope, scopesFromJwt } from "./scope.ts";
+import { decodeJwtPayload, getIssuerOrigin, hasAdminScope, scopesFromJwt } from "./scope.ts";
 
 function makeJwt(payload: Record<string, unknown>): string {
   const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }))
@@ -86,5 +86,36 @@ describe("hasAdminScope", () => {
   it("false when no token is cached", () => {
     _setTokenForTest(null);
     expect(hasAdminScope("work")).toBe(false);
+  });
+});
+
+describe("getIssuerOrigin", () => {
+  afterEach(() => {
+    clearToken();
+  });
+
+  it("returns the iss claim from the cached token", () => {
+    _setTokenForTest(makeJwt({ iss: "http://127.0.0.1:1939", scope: "vault:work:admin" }));
+    expect(getIssuerOrigin()).toBe("http://127.0.0.1:1939");
+  });
+
+  it("strips a trailing slash so callers don't double up", () => {
+    _setTokenForTest(makeJwt({ iss: "https://hub.example.com/", scope: "vault:work:read" }));
+    expect(getIssuerOrigin()).toBe("https://hub.example.com");
+  });
+
+  it("returns null when no token is cached", () => {
+    _setTokenForTest(null);
+    expect(getIssuerOrigin()).toBeNull();
+  });
+
+  it("returns null when the iss claim is missing", () => {
+    _setTokenForTest(makeJwt({ scope: "vault:work:read" }));
+    expect(getIssuerOrigin()).toBeNull();
+  });
+
+  it("returns null when the iss claim is non-string (defensive)", () => {
+    _setTokenForTest(makeJwt({ iss: 42 as unknown as string }));
+    expect(getIssuerOrigin()).toBeNull();
   });
 });

--- a/web/ui/src/lib/scope.ts
+++ b/web/ui/src/lib/scope.ts
@@ -62,3 +62,27 @@ export function hasAdminScope(vaultName: string): boolean {
   const scopes = scopesFromJwt(getToken());
   return scopes.includes(`vault:${vaultName}:admin`);
 }
+
+/**
+ * Hub origin where the cached JWT was issued. Pulled from the `iss` claim
+ * (RFC 7519 §4.1.1) — the hub sets it via `setIssuer()` during token mint
+ * and pins the value to its own origin (see parachute-hub/src/jwt-sign.ts).
+ *
+ * Used to construct cross-origin links from the vault SPA back to hub
+ * surfaces (e.g. the permissions UI at `/hub/permissions`). Pulling from
+ * the token avoids needing a separate runtime-config endpoint or hub
+ * coordination — the data's already in hand.
+ *
+ * Returns `null` when no token is cached, the token is malformed, or the
+ * `iss` claim isn't a string. Callers fall back to "managed on hub" copy
+ * without a link in that case.
+ */
+export function getIssuerOrigin(): string | null {
+  const token = getToken();
+  if (!token) return null;
+  const claims = decodeJwtPayload(token);
+  if (!claims) return null;
+  const iss = claims["iss"];
+  if (typeof iss !== "string" || iss.length === 0) return null;
+  return iss.replace(/\/$/, "");
+}

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -6,11 +6,15 @@
  * returns all of these in a single round trip. Authenticated — requires a
  * hub-issued JWT carrying `vault:<name>:read` or higher.
  *
- * Phase B (vault#217) adds tokens; Phase C (vault#218) adds permissions.
+ * Phase B (vault#217) added tokens. Phase C (vault#218) surfaces a link to
+ * hub's permissions UI under the "Manage" section — grants live in hub's
+ * grants table (the OAuth issuer is the source of truth), so the modular
+ * play is "vault links to hub" rather than "vault inlines hub data."
  */
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { HttpError, type VaultDetailResult, getVaultDetail } from "../lib/api.ts";
+import { getIssuerOrigin } from "../lib/scope.ts";
 
 type State =
   | { kind: "loading" }
@@ -173,12 +177,48 @@ export function VaultDetail() {
             <Link to={`/vault/${encodeURIComponent(vault.name)}/tokens`}>Tokens →</Link>
             <span className="dim"> mint, list, and revoke <code>pvt_*</code> tokens</span>
           </li>
-          <li className="dim">
-            Permissions editing (Phase C / vault#218) lands here next. For now, mint scope-narrowed
-            tokens above to delegate restricted access.
-          </li>
+          <PermissionsLink vaultName={vault.name} />
         </ul>
       </div>
     </div>
+  );
+}
+
+/**
+ * Forward-pointing link to hub's permissions UI. Hub origin is read from
+ * the JWT's `iss` claim (the OAuth issuer set during token mint), so we
+ * don't need a runtime-config endpoint or hub coordination — the data's
+ * already in hand from the same token that authenticated the page.
+ *
+ * The destination (hub#162 — `GET /hub/permissions?vault=<name>`) doesn't
+ * exist yet; clicks 404 until hub catches up. The copy says so explicitly
+ * so an operator who clicks isn't confused by the empty page.
+ *
+ * Without an `iss` claim (no token, malformed token), we render an
+ * informational line instead of a broken link — same content, no false
+ * affordance.
+ */
+function PermissionsLink({ vaultName }: { vaultName: string }) {
+  const issuer = getIssuerOrigin();
+  const description = (
+    <span className="dim">
+      {" "}grants are managed on hub (the OAuth issuer); link is forward-pointing — hub#162 is the
+      destination.
+    </span>
+  );
+  if (!issuer) {
+    return (
+      <li>
+        <span>Permissions →</span>
+        {description}
+      </li>
+    );
+  }
+  const href = `${issuer}/hub/permissions?vault=${encodeURIComponent(vaultName)}`;
+  return (
+    <li>
+      <a href={href}>Permissions →</a>
+      {description}
+    </li>
   );
 }

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -200,17 +200,14 @@ export function VaultDetail() {
  */
 function PermissionsLink({ vaultName }: { vaultName: string }) {
   const issuer = getIssuerOrigin();
-  const description = (
-    <span className="dim">
-      {" "}grants are managed on hub (the OAuth issuer); link is forward-pointing — hub#162 is the
-      destination.
-    </span>
-  );
   if (!issuer) {
     return (
       <li>
         <span>Permissions →</span>
-        {description}
+        <span className="dim">
+          {" "}grants are managed on hub (the OAuth issuer); link will be live when hub ships its
+          permissions UI.
+        </span>
       </li>
     );
   }
@@ -218,7 +215,10 @@ function PermissionsLink({ vaultName }: { vaultName: string }) {
   return (
     <li>
       <a href={href}>Permissions →</a>
-      {description}
+      <span className="dim">
+        {" "}grants are managed on hub (the OAuth issuer); link will be live when hub ships its
+        permissions UI.
+      </span>
     </li>
   );
 }


### PR DESCRIPTION
## Summary

- **Per-vault detail page now surfaces a forward-pointing "Permissions →" link** to hub's permissions UI (`<hub-origin>/hub/permissions?vault=<name>`). Modular contract: hub owns the OAuth grants table + UI; vault links out rather than inlining hub data.
- **Hub origin discovered from the JWT's `iss` claim** (RFC 7519 §4.1.1) — the hub sets it during token mint, so the SPA reads what's already in hand. No runtime-config endpoint, no hub coordination, no hard-coded loopback.
- **Falls back gracefully** when no token / malformed token / non-string `iss`: renders the "Permissions →" copy without an `<a>` so there's no false affordance.

## Phase context

- Phase A (#219) — scaffold + per-vault detail page
- Phase B (#220) — tokens UI (list / mint / revoke + read-only fallback)
- **Phase C (this PR)** — forward-pointing permissions link
- Hub#162 is the destination; clicks 404 until hub catches up. The link copy says so explicitly so an operator who clicks isn't confused by an empty page.

## Why "doesn't exist yet" isn't a reason to invert the contract

Briefly considered inlining hub-side grants in the vault SPA because hub has no permissions UI today. Rejected — hub is the OAuth issuer and the source of truth for grants. Building the link first ratifies the boundary; building the inline view first ratifies a transient shortcut that we'd then have to unwind.

## Files

- `web/ui/src/lib/scope.ts` — `getIssuerOrigin()` helper (decode token, pull `iss`, strip trailing slash)
- `web/ui/src/lib/scope.test.ts` — +5 specs (happy / trailing-slash / no-token / no-iss / non-string-iss)
- `web/ui/src/routes/VaultDetail.tsx` — `PermissionsLink` component under "Manage"
- `web/ui/CLAUDE.md` — Phase C section + lib/scope.ts entry in layout map
- `package.json` — `0.3.6-rc.20` → `0.3.6-rc.21`

## Test plan

- [x] `bun run typecheck` (web/ui)
- [x] `bun run test` (web/ui — 40/40, +5 from Phase B)
- [x] `bun run build` + `verify-base.mjs`
- [x] `bun test ./src/` (vault host — 728/728)
- [x] `bun test ./core/src/` (vault core — 340/340)

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)