### PR TITLE
fix(query-notes): accept camelCase/singular aliases + route via store

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2283,6 +2283,29 @@ describe("MCP tools", async () => {
     expect(r).toHaveLength(2);
     expect(r.map((n) => n.content).sort()).toEqual(["text memo", "voice memo"]);
   });
+
+  it("query-notes does not mutate caller's params object across repeated calls", async () => {
+    // normalizeTags returns a defensive copy of array inputs so the downstream
+    // store layer can sort/dedupe without touching the caller's reference.
+    // Without the copy, a caller reusing the same params object would see its
+    // exclude_tags array reordered (or worse) on the second call.
+    await store.createNote("a", { tags: ["email"] });
+    await store.createNote("b", { tags: ["email", "urgent"] });
+    await store.createNote("c", { tags: ["email", "spam"] });
+
+    const tools = generateMcpTools(store);
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
+    const params = { tag: "email", exclude_tags: ["urgent", "spam"], include_content: true };
+
+    const r1 = await queryNotes.execute(params) as any[];
+    expect(params.exclude_tags).toEqual(["urgent", "spam"]);
+
+    const r2 = await queryNotes.execute(params) as any[];
+    expect(params.exclude_tags).toEqual(["urgent", "spam"]);
+
+    expect(r1.map((n) => n.content).sort()).toEqual(["a"]);
+    expect(r2.map((n) => n.content).sort()).toEqual(["a"]);
+  });
 });
 
 // ---- query-notes link expansion ----

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2216,6 +2216,73 @@ describe("MCP tools", async () => {
     expect(fresh.metadata.priority).toBe(0);
     expect(fresh.metadata.status).toBe("active");
   });
+
+  // ---- query-notes input-shape tolerance (vault#214) ----
+  //
+  // The MCP framework drops top-level keys not in the inputSchema without
+  // raising — so an LLM caller passing the wrong field name gets a silent
+  // no-op rather than an error. We accept canonical + camelCase + singular
+  // aliases so the most common LLM mistakes still apply the filter, and
+  // we mirror the `tag` param's string-or-array shape so a single excluded
+  // tag doesn't need a wrapping array.
+
+  it("query-notes accepts `excludeTags` (camelCase alias)", async () => {
+    await store.createNote("a", { tags: ["email"] });
+    await store.createNote("b", { tags: ["email", "urgent"] });
+    const tools = generateMcpTools(store);
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
+    const r = await queryNotes.execute({ tag: "email", excludeTags: ["urgent"], include_content: true }) as any[];
+    expect(r).toHaveLength(1);
+    expect(r[0].content).toBe("a");
+  });
+
+  it("query-notes accepts `exclude_tag` (singular alias)", async () => {
+    await store.createNote("a", { tags: ["email"] });
+    await store.createNote("b", { tags: ["email", "urgent"] });
+    const tools = generateMcpTools(store);
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
+    const r = await queryNotes.execute({ tag: "email", exclude_tag: "urgent", include_content: true }) as any[];
+    expect(r).toHaveLength(1);
+    expect(r[0].content).toBe("a");
+  });
+
+  it("query-notes `exclude_tags` accepts a single string (mirrors `tag`)", async () => {
+    await store.createNote("a", { tags: ["email"] });
+    await store.createNote("b", { tags: ["email", "urgent"] });
+    const tools = generateMcpTools(store);
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
+    const r = await queryNotes.execute({ tag: "email", exclude_tags: "urgent", include_content: true }) as any[];
+    expect(r).toHaveLength(1);
+    expect(r[0].content).toBe("a");
+  });
+
+  it("query-notes canonical `exclude_tags: [...]` still works (regression)", async () => {
+    await store.createNote("a", { tags: ["email"] });
+    await store.createNote("b", { tags: ["email", "urgent"] });
+    const tools = generateMcpTools(store);
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
+    const r = await queryNotes.execute({ tag: "email", exclude_tags: ["urgent"], include_content: true }) as any[];
+    expect(r).toHaveLength(1);
+    expect(r[0].content).toBe("a");
+  });
+
+  it("query-notes routes through store.queryNotes so tag-hierarchy expansion fires", async () => {
+    // `_tags/voice` and `_tags/text` declare "manual" as their parent. A
+    // query for `tag: "manual"` should match notes tagged with either child
+    // — that expansion only happens when the call goes through
+    // `store.queryNotes`, not `noteOps.queryNotes` directly.
+    await store.createNote("", { path: "_tags/voice", metadata: { parents: ["manual"] } });
+    await store.createNote("", { path: "_tags/text", metadata: { parents: ["manual"] } });
+    await store.createNote("voice memo", { tags: ["voice"] });
+    await store.createNote("text memo", { tags: ["text"] });
+    await store.createNote("unrelated", { tags: ["other"] });
+
+    const tools = generateMcpTools(store);
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
+    const r = await queryNotes.execute({ tag: "manual", include_content: true }) as any[];
+    expect(r).toHaveLength(2);
+    expect(r.map((n) => n.content).sort()).toEqual(["text memo", "voice memo"]);
+  });
 });
 
 // ---- query-notes link expansion ----

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -107,7 +107,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               { type: "string" },
               { type: "array", items: { type: "string" } },
             ],
-            description: "Exclude notes with these tag(s). Accepts a single tag or an array. Aliases `excludeTags` and `exclude_tag` are also accepted.",
+            description: "Exclude notes with these tag(s). Accepts a single tag or an array. Aliases `excludeTags` and `exclude_tag` are also accepted. If multiple alias forms are provided, `exclude_tags` takes precedence (then `excludeTags`, then `exclude_tag`).",
           },
           // The runtime alias-fallback chain accepts these too. Declared
           // here so schema-introspecting clients (Claude, MCP clients

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -109,6 +109,24 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             ],
             description: "Exclude notes with these tag(s). Accepts a single tag or an array. Aliases `excludeTags` and `exclude_tag` are also accepted.",
           },
+          // The runtime alias-fallback chain accepts these too. Declared
+          // here so schema-introspecting clients (Claude, MCP clients
+          // that surface tool schemas) see them as valid inputs rather
+          // than thinking the canonical is the only option.
+          excludeTags: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+            description: "Alias for `exclude_tags` (camelCase). Same shape and semantics — pick whichever is more natural for your client.",
+          },
+          exclude_tag: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+            description: "Alias for `exclude_tags` (singular). Same shape and semantics — accepts a single tag or an array.",
+          },
           has_tags: { type: "boolean", description: "Presence filter: true = only notes with at least one tag; false = only untagged notes. Ignored when `tag` is set." },
           has_links: { type: "boolean", description: "Presence filter: true = only notes with at least one inbound or outbound link; false = only orphaned notes (no links in either direction)." },
           path: { type: "string", description: "Exact path match (case-insensitive)" },
@@ -1203,7 +1221,10 @@ function attachValidationStatus(store: Store, _db: Database, note: Note): Note {
 
 function normalizeTags(tag: unknown): string[] | undefined {
   if (!tag) return undefined;
-  if (Array.isArray(tag)) return tag;
+  // Defensive copy: callers downstream sometimes mutate the array (sort,
+  // splice, push for hierarchy expansion). Returning a fresh array keeps
+  // the original `params` object untouched.
+  if (Array.isArray(tag)) return [...tag];
   return [tag as string];
 }
 

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -102,7 +102,13 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             description: "Filter by tag(s)",
           },
           tag_match: { type: "string", enum: ["any", "all"], description: "How to match multiple tags: 'any' (OR, default) or 'all' (AND)" },
-          exclude_tags: { type: "array", items: { type: "string" }, description: "Exclude notes with these tags" },
+          exclude_tags: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+            description: "Exclude notes with these tag(s). Accepts a single tag or an array. Aliases `excludeTags` and `exclude_tag` are also accepted.",
+          },
           has_tags: { type: "boolean", description: "Presence filter: true = only notes with at least one tag; false = only untagged notes. Ignored when `tag` is set." },
           has_links: { type: "boolean", description: "Presence filter: true = only notes with at least one inbound or outbound link; false = only orphaned notes (no links in either direction)." },
           path: { type: "string", description: "Exact path match (case-insensitive)" },
@@ -205,10 +211,21 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         } else {
           // --- Structured query ---
           const tags = normalizeTags(params.tag);
-          results = noteOps.queryNotes(db, {
+          // Accept canonical `exclude_tags` plus camelCase / singular aliases.
+          // LLM callers frequently pick the wrong name (training-data drift
+          // toward camelCase across MCP tools) and the JSON-RPC layer drops
+          // unknown keys silently; aliasing here closes the silent-no-op gap.
+          const excludeTagsRaw = params.exclude_tags ?? params.excludeTags ?? params.exclude_tag;
+          const excludeTags = normalizeTags(excludeTagsRaw);
+          // Route through `store.queryNotes` (not `noteOps.queryNotes`) so
+          // tag-hierarchy expansion fires for MCP callers the same as for
+          // HTTP REST callers — `tag: "manual"` matches descendants declared
+          // via `_tags/*` config notes. The previous direct-noteOps call
+          // bypassed the wrapper and silently dropped hierarchy expansion.
+          results = await store.queryNotes({
             tags,
             tagMatch: (params.tag_match as "all" | "any") ?? (tags && tags.length > 1 ? "any" : undefined),
-            excludeTags: params.exclude_tags as string[] | undefined,
+            excludeTags,
             hasTags: params.has_tags as boolean | undefined,
             hasLinks: params.has_links as boolean | undefined,
             path: params.path as string | undefined,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.23",
+  "version": "0.3.6-rc.24",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Closes #214.

Empirical diagnosis: `exclude_tags: ["urgent"]` on the canonical shape already works. The silent-no-op surface only fires when callers pick a near-miss field name — JSON-RPC drops unknown keys with no inputSchema enforcement, so `excludeTags` / `exclude_tag` / a bare string vanish without a trace.

Two changes:

1. **Defensive aliases.** `query-notes` execute body normalizes `params.exclude_tags ?? params.excludeTags ?? params.exclude_tag` through `normalizeTags`, accepting string-or-array. The inputSchema advertises the canonical name + `oneOf` string-or-array; the description names the aliases so a caller reading the schema knows what's accepted.

2. **Store-bypass fix.** Same path now routes through `store.queryNotes(...)` instead of `noteOps.queryNotes(db, ...)`. The store wrapper applies tag-hierarchy expansion (`_tags/<name>` config notes) — the direct noteOps call bypassed it, so `tag: "manual"` did not match descendants the way it does for HTTP REST callers.

## Test plan

- [x] 5 regression tests added in `core/src/core.test.ts` covering each variant:
  - `excludeTags` (camelCase alias)
  - `exclude_tag` (singular alias)
  - `exclude_tags` accepts single string
  - canonical `exclude_tags` array (regression)
  - tag-hierarchy expansion via store routing
- [x] `bun test ./core/src/` — 345/345 pass (was 340 before, +5 new)
- [x] `bun test ./src/` — 728/728 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)