### PR TITLE
fix(web/ui): beforeunload warning while pvt_* banner is showing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.21",
+  "version": "0.3.6-rc.23",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/web/ui/src/routes/VaultTokens.test.tsx
+++ b/web/ui/src/routes/VaultTokens.test.tsx
@@ -93,6 +93,52 @@ describe("VaultTokens — admin scope", () => {
     });
   });
 
+  it("attaches a beforeunload guard while the pvt_* banner is showing and detaches on dismiss", async () => {
+    vi.mocked(tokensApi.listTokens).mockResolvedValue([]);
+    vi.mocked(tokensApi.mintToken).mockResolvedValue({
+      ...tokenFixture({ label: "ci" }),
+      token: "pvt_super_secret",
+    });
+
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /mint token/i })).toBeInTheDocument(),
+    );
+    expect(addSpy.mock.calls.some(([type]) => type === "beforeunload")).toBe(false);
+
+    await user.type(screen.getByLabelText(/label/i), "ci");
+    await user.click(screen.getByRole("button", { name: /mint token/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/new token \(shown once\)/i)).toBeInTheDocument(),
+    );
+    const beforeunloadCall = addSpy.mock.calls.find(([type]) => type === "beforeunload");
+    expect(beforeunloadCall).toBeDefined();
+    const handler = beforeunloadCall![1] as (e: BeforeUnloadEvent) => void;
+
+    // The handler must call preventDefault + set returnValue so Chrome /
+    // Firefox actually fire the "leave site?" confirm. Browsers gate the
+    // prompt on both signals; missing either makes the guard a no-op.
+    const fakeEvent = {
+      preventDefault: vi.fn(),
+      returnValue: undefined as unknown as string,
+    } as unknown as BeforeUnloadEvent;
+    handler(fakeEvent);
+    expect(fakeEvent.preventDefault).toHaveBeenCalled();
+    expect(fakeEvent.returnValue).toBe("");
+
+    await user.click(screen.getByRole("button", { name: /done — i've saved the token/i }));
+
+    await waitFor(() =>
+      expect(removeSpy.mock.calls.some(([type, fn]) => type === "beforeunload" && fn === handler)).toBe(true),
+    );
+  });
+
   it("rejects mint when label is empty (no API call, error shown)", async () => {
     vi.mocked(tokensApi.listTokens).mockResolvedValue([]);
 

--- a/web/ui/src/routes/VaultTokens.tsx
+++ b/web/ui/src/routes/VaultTokens.tsx
@@ -66,6 +66,21 @@ export function VaultTokens() {
     };
   }, [name, reloadTick]);
 
+  // Belt-and-suspenders for the single-emit contract: while the plaintext
+  // pvt_* is on screen, prompt the browser's "leave site?" confirm on tab
+  // close / refresh / back. Dismissing the banner (the explicit "I've
+  // saved it" path) detaches the listener. Doesn't cover in-SPA navigation
+  // — react-router blocking is a separate, larger surface.
+  useEffect(() => {
+    if (!minted) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [minted]);
+
   if (!name) {
     return (
       <div>


### PR DESCRIPTION
## Summary

Closes #221.

After mint, the SPA renders the plaintext `pvt_*` exactly once in a banner — the server can't re-emit. An accidental tab close / refresh / back before the operator copies loses the token (forces revoke + re-mint).

While `minted !== null`, attach a `beforeunload` listener that triggers the browser's "leave site?" confirm. Both `preventDefault()` and `event.returnValue = \"\"` are required — Chrome and Firefox each gate the prompt on a different signal, missing either makes the guard a no-op. Detach when the operator dismisses via the explicit "I've saved it" button.

Belt-and-suspenders for the existing single-emit contract; doesn't cover in-SPA navigation (react-router blocking is a separate, larger surface).

## Test plan

- [x] New regression test in `VaultTokens.test.tsx` — spies on `window.add/removeEventListener`, asserts:
  - listener is **not** attached on initial render
  - listener **is** attached after mint completes
  - handler calls `preventDefault()` and sets `event.returnValue = \"\"`
  - listener is detached when banner is dismissed
- [x] `bun run test` (web/ui vitest) — 41/41 pass (was 40)
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean (verify-base passes)

## Notes

- Bumps to `0.3.6-rc.23` (rc.22 is held by #224)
- Independent of #224 (different file, different surface) — safe to merge in either order

🤖 Generated with [Claude Code](https://claude.com/claude-code)