### PR TITLE
feat(query-notes): generalized date_filter on indexed metadata fields

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -585,6 +585,95 @@ describe("queryNotes", async () => {
     expect(results.length).toBeGreaterThan(0);
   });
 
+  // ---- Generalized date_filter (vault#215) ----
+  //
+  // The legacy `dateFrom` / `dateTo` always filter on `n.created_at` (vault
+  // ingestion time). The new `dateFilter: { field, from, to }` shape lets a
+  // caller filter on any *content* date — an email's received date, a
+  // meeting's scheduled date — by pointing `field` at an indexed metadata
+  // field. `field` defaults to `created_at`, in which case the SQL is
+  // identical to the legacy path.
+  describe("dateFilter (generalized)", () => {
+    async function declareEmailDate() {
+      const { declareField } = await import("./indexed-fields.js");
+      declareField(db, "email_date", "TEXT", "email");
+    }
+
+    it("dateFilter with no field defaults to created_at (matches the legacy shorthand)", async () => {
+      await store.createNote("A", { created_at: "2026-01-15T00:00:00.000Z" });
+      await store.createNote("B", { created_at: "2026-02-15T00:00:00.000Z" });
+      await store.createNote("C", { created_at: "2026-03-15T00:00:00.000Z" });
+
+      const results = await store.queryNotes({
+        dateFilter: { from: "2026-02-01", to: "2026-03-01" },
+      });
+      expect(results.map((n) => n.content)).toEqual(["B"]);
+    });
+
+    it("dateFilter on an indexed metadata field filters on content date, not ingestion date", async () => {
+      await declareEmailDate();
+      // Ingestion order doesn't match email_date order — that's the whole
+      // point: the bug was that `dateFrom` returned rows by ingestion time.
+      await store.createNote("recently-synced old email", {
+        metadata: { email_date: "2025-12-01T00:00:00.000Z" },
+      });
+      await store.createNote("recently-synced new email", {
+        metadata: { email_date: "2026-04-25T00:00:00.000Z" },
+      });
+      await store.createNote("recently-synced ancient", {
+        metadata: { email_date: "2024-08-15T00:00:00.000Z" },
+      });
+
+      const results = await store.queryNotes({
+        dateFilter: { field: "email_date", from: "2026-04-01", to: "2026-05-01" },
+      });
+      expect(results.map((n) => n.content)).toEqual(["recently-synced new email"]);
+    });
+
+    it("dateFilter on a non-indexed field rejects with FIELD_NOT_INDEXED", async () => {
+      await store.createNote("X", { metadata: { meeting_date: "2026-04-25T00:00:00.000Z" } });
+      // Note: not declared via declareField, so the field has no generated
+      // column. The error mirrors the metadata-operator + order_by gate.
+      try {
+        await store.queryNotes({
+          dateFilter: { field: "meeting_date", from: "2026-04-01" },
+        });
+        throw new Error("expected QueryError");
+      } catch (err: any) {
+        expect(err.name).toBe("QueryError");
+        expect(err.code).toBe("FIELD_NOT_INDEXED");
+        expect(err.message).toContain("meeting_date");
+      }
+    });
+
+    it("dateFilter combined with top-level dateFrom rejects with INVALID_QUERY", async () => {
+      await declareEmailDate();
+      try {
+        await store.queryNotes({
+          dateFrom: "2026-01-01",
+          dateFilter: { field: "email_date", from: "2026-04-01" },
+        });
+        throw new Error("expected QueryError");
+      } catch (err: any) {
+        expect(err.name).toBe("QueryError");
+        expect(err.code).toBe("INVALID_QUERY");
+        expect(err.message).toMatch(/cannot combine/i);
+      }
+    });
+
+    it("dateFilter with only `from` is open-ended on the upper bound", async () => {
+      await declareEmailDate();
+      await store.createNote("old", { metadata: { email_date: "2025-01-01T00:00:00.000Z" } });
+      await store.createNote("middle", { metadata: { email_date: "2026-04-15T00:00:00.000Z" } });
+      await store.createNote("new", { metadata: { email_date: "2026-05-01T00:00:00.000Z" } });
+
+      const results = await store.queryNotes({
+        dateFilter: { field: "email_date", from: "2026-04-01" },
+      });
+      expect(results.map((n) => n.content).sort()).toEqual(["middle", "new"]);
+    });
+  });
+
   it("sorts ascending and descending", async () => {
     await store.createNote("First", { id: "first" });
     await store.createNote("Second", { id: "second" });
@@ -1757,6 +1846,26 @@ describe("MCP tools", async () => {
       offset: 1,
     }) as any[];
     expect(page).toHaveLength(2);
+  });
+
+  it("query-notes accepts date_filter on an indexed metadata field (vault#215)", async () => {
+    const { declareField } = await import("./indexed-fields.js");
+    declareField(db, "email_date", "TEXT", "email");
+
+    await store.createNote("old email", {
+      metadata: { email_date: "2025-12-01T00:00:00.000Z" },
+    });
+    await store.createNote("recent email", {
+      metadata: { email_date: "2026-04-25T00:00:00.000Z" },
+    });
+
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const results = await query.execute({
+      date_filter: { field: "email_date", from: "2026-04-01", to: "2026-05-01" },
+      include_content: true,
+    }) as any[];
+    expect(results.map((n) => n.content)).toEqual(["recent email"]);
   });
 
   it("query-notes full-text search works", async () => {

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -672,6 +672,37 @@ describe("queryNotes", async () => {
       });
       expect(results.map((n) => n.content).sort()).toEqual(["middle", "new"]);
     });
+
+    it("dateFilter with explicit field='created_at' routes to the legacy SQL path", async () => {
+      // The implicit-default case is covered above; this asserts the explicit
+      // form behaves identically — no indexed-field gate, same n.created_at SQL.
+      await store.createNote("A", { created_at: "2026-01-15T00:00:00.000Z" });
+      await store.createNote("B", { created_at: "2026-02-15T00:00:00.000Z" });
+      await store.createNote("C", { created_at: "2026-03-15T00:00:00.000Z" });
+
+      const results = await store.queryNotes({
+        dateFilter: { field: "created_at", from: "2026-02-01", to: "2026-03-01" },
+      });
+      expect(results.map((n) => n.content)).toEqual(["B"]);
+    });
+
+    it("query-notes accepts date_filter on an indexed metadata field (vault#215)", async () => {
+      await declareEmailDate();
+      await store.createNote("old email", {
+        metadata: { email_date: "2025-12-01T00:00:00.000Z" },
+      });
+      await store.createNote("recent email", {
+        metadata: { email_date: "2026-04-25T00:00:00.000Z" },
+      });
+
+      const tools = generateMcpTools(store);
+      const query = tools.find((t) => t.name === "query-notes")!;
+      const results = await query.execute({
+        date_filter: { field: "email_date", from: "2026-04-01", to: "2026-05-01" },
+        include_content: true,
+      }) as any[];
+      expect(results.map((n) => n.content)).toEqual(["recent email"]);
+    });
   });
 
   it("sorts ascending and descending", async () => {
@@ -1846,26 +1877,6 @@ describe("MCP tools", async () => {
       offset: 1,
     }) as any[];
     expect(page).toHaveLength(2);
-  });
-
-  it("query-notes accepts date_filter on an indexed metadata field (vault#215)", async () => {
-    const { declareField } = await import("./indexed-fields.js");
-    declareField(db, "email_date", "TEXT", "email");
-
-    await store.createNote("old email", {
-      metadata: { email_date: "2025-12-01T00:00:00.000Z" },
-    });
-    await store.createNote("recent email", {
-      metadata: { email_date: "2026-04-25T00:00:00.000Z" },
-    });
-
-    const tools = generateMcpTools(store);
-    const query = tools.find((t) => t.name === "query-notes")!;
-    const results = await query.execute({
-      date_filter: { field: "email_date", from: "2026-04-01", to: "2026-05-01" },
-      include_content: true,
-    }) as any[];
-    expect(results.map((n) => n.content)).toEqual(["recent email"]);
   });
 
   it("query-notes full-text search works", async () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -137,8 +137,17 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             description: "Filter by metadata values. Each value is either a primitive (exact match, scans JSON) or an operator object: `{eq|ne|gt|gte|lt|lte|in|not_in|exists: value}`. Operator objects require the field to be declared `indexed: true` in a tag schema — they route through the backing B-tree index. Multiple operators on one field AND together (e.g. `{gt: 5, lt: 10}`). `in`/`not_in` take arrays; `exists` takes a boolean.",
           },
           order_by: { type: "string", description: "Sort by an indexed metadata field instead of `created_at`. Field must be declared `indexed: true`; errors otherwise. Direction is taken from `sort` (default 'asc'); `created_at` is appended as a stable tiebreaker." },
-          date_from: { type: "string", description: "Start date (ISO, inclusive)" },
-          date_to: { type: "string", description: "End date (ISO, exclusive)" },
+          date_from: { type: "string", description: "Start date (ISO, inclusive). Filters on `created_at` (vault ingestion time). Shorthand for `date_filter: { field: 'created_at', from }`." },
+          date_to: { type: "string", description: "End date (ISO, exclusive). Filters on `created_at` (vault ingestion time). Shorthand for `date_filter: { field: 'created_at', to }`." },
+          date_filter: {
+            type: "object",
+            properties: {
+              field: { type: "string", description: "Field to filter on. Defaults to `created_at` (vault ingestion time). Any other field must be declared `indexed: true` in a tag schema — same contract as metadata operator queries and `order_by`." },
+              from: { type: "string", description: "Inclusive lower bound (ISO date)." },
+              to: { type: "string", description: "Exclusive upper bound (ISO date)." },
+            },
+            description: "Generalized date-range filter. Use this when the date that matters is the *content* date (e.g. an email's received date, a meeting's scheduled date), not the vault ingestion time — set `field` to the indexed metadata field that holds it. Mutually exclusive with the top-level `date_from` / `date_to` shorthand.",
+          },
           near: {
             type: "object",
             properties: {
@@ -257,6 +266,9 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             metadata: params.metadata as Record<string, unknown> | undefined,
             dateFrom: params.date_from as string | undefined,
             dateTo: params.date_to as string | undefined,
+            dateFilter: params.date_filter as
+              | { field?: string; from?: string; to?: string }
+              | undefined,
             sort: params.sort as "asc" | "desc" | undefined,
             orderBy: params.order_by as string | undefined,
             limit: (params.limit as number) ?? 50,

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -4,6 +4,7 @@ import { normalizePath } from "./paths.js";
 import {
   buildOperatorClause,
   isOperatorObject,
+  QueryError,
   requireIndexedField,
 } from "./query-operators.js";
 
@@ -416,14 +417,51 @@ export function queryNotes(db: Database, opts: QueryOpts): Note[] {
     }
   }
 
-  // Date range
-  if (opts.dateFrom) {
-    conditions.push("n.created_at >= ?");
-    params.push(opts.dateFrom);
+  // Date range. Two accepted shapes:
+  //   - Legacy `dateFrom` / `dateTo` — always filters on `n.created_at`
+  //     (vault ingestion time).
+  //   - Generalized `dateFilter: { field, from, to }` — filters on the
+  //     named field. `created_at` (default) maps to `n.created_at`; any
+  //     other field must be declared `indexed: true` so the SQL targets
+  //     a real B-tree index. The two shapes are mutually exclusive — the
+  //     combination would silently AND, which would be surprising.
+  const hasLegacyDate = opts.dateFrom !== undefined || opts.dateTo !== undefined;
+  const hasDateFilter = opts.dateFilter !== undefined;
+  if (hasLegacyDate && hasDateFilter) {
+    throw new QueryError(
+      `cannot combine top-level date_from/date_to with date_filter — pass one or the other`,
+      "INVALID_QUERY",
+    );
   }
-  if (opts.dateTo) {
-    conditions.push("n.created_at < ?");
-    params.push(opts.dateTo);
+  if (hasDateFilter) {
+    const filter = opts.dateFilter!;
+    const field = filter.field ?? "created_at";
+    let column: string;
+    if (field === "created_at") {
+      column = "n.created_at";
+    } else {
+      // Re-uses the same indexed-field gate as `metadata` operator queries
+      // and `orderBy` so the error message and contract are consistent.
+      requireIndexedField(db, field);
+      column = `"meta_${field}"`;
+    }
+    if (filter.from !== undefined) {
+      conditions.push(`${column} >= ?`);
+      params.push(filter.from);
+    }
+    if (filter.to !== undefined) {
+      conditions.push(`${column} < ?`);
+      params.push(filter.to);
+    }
+  } else if (hasLegacyDate) {
+    if (opts.dateFrom) {
+      conditions.push("n.created_at >= ?");
+      params.push(opts.dateFrom);
+    }
+    if (opts.dateTo) {
+      conditions.push("n.created_at < ?");
+      params.push(opts.dateTo);
+    }
   }
 
   const direction = opts.sort === "desc" ? "DESC" : "ASC";

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -68,8 +68,22 @@ export interface QueryOpts {
   // for the field. Operator queries require the field to be declared
   // `indexed: true` in a tag schema; undeclared fields error loudly.
   metadata?: Record<string, unknown>;
+  // Legacy shorthand: filters on `n.created_at` (vault ingestion time).
+  // Equivalent to `dateFilter: { field: "created_at", from, to }`. Kept
+  // as the common path; specifying both this and `dateFilter` rejects.
   dateFrom?: string;    // ISO date
   dateTo?: string;      // ISO date
+  // Generalized date range. `field` defaults to `created_at`; any other
+  // field must be declared `indexed: true` in a tag schema (so the SQL
+  // hits a real B-tree index, same contract as `metadata` operator
+  // queries and `orderBy`). Use this to filter on a *content* date — an
+  // email's received date, a meeting's scheduled date — rather than the
+  // ingestion timestamp.
+  dateFilter?: {
+    field?: string;
+    from?: string;
+    to?: string;
+  };
   sort?: "asc" | "desc";
   // Sort by an indexed metadata field instead of `created_at`. Must be
   // declared `indexed: true`; errors loudly otherwise. Direction is taken

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.24",
+  "version": "0.3.6-rc.25",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -202,8 +202,22 @@ export async function handleNotes(
           path: parseQuery(url, "path") ?? undefined,
           pathPrefix: parseQuery(url, "path_prefix") ?? undefined,
           metadata: undefined, // metadata filter not practical in query params
-          dateFrom: parseQuery(url, "date_from") ?? undefined,
-          dateTo: parseQuery(url, "date_to") ?? undefined,
+          // `date_field=<name>&date_from=...&date_to=...` activates the
+          // generalized filter (filters on the named indexed field). Without
+          // `date_field`, `date_from`/`date_to` keep their legacy meaning of
+          // filtering on `created_at` (vault ingestion time).
+          ...(parseQuery(url, "date_field")
+            ? {
+                dateFilter: {
+                  field: parseQuery(url, "date_field")!,
+                  from: parseQuery(url, "date_from") ?? undefined,
+                  to: parseQuery(url, "date_to") ?? undefined,
+                },
+              }
+            : {
+                dateFrom: parseQuery(url, "date_from") ?? undefined,
+                dateTo: parseQuery(url, "date_to") ?? undefined,
+              }),
           sort: (parseQuery(url, "sort") as "asc" | "desc") ?? undefined,
           orderBy: parseQuery(url, "order_by") ?? undefined,
           limit: parseInt10(parseQuery(url, "limit")) ?? 50,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -190,6 +190,13 @@ export async function handleNotes(
       }
 
       // Structured query
+      //
+      // Surface asymmetry: REST uses three flat query params
+      // (`date_field`, `date_from`, `date_to`) while MCP takes a nested
+      // `date_filter: { field, from, to }` object. Both lower to the same
+      // store-level `dateFilter` shape — the difference is just that query
+      // strings are flat by nature. This mirrors the broader REST/MCP
+      // pattern across the API and is intentional, not a fix-it-up TODO.
       const tags = parseQueryList(url, "tag");
       let results: Note[];
       try {


### PR DESCRIPTION
## Summary

Closes #215. Re-opens #226 (auto-closed when its base `fix/query-notes-aliases` was deleted on #224 merge).

The legacy `date_from` / `date_to` always filter on `n.created_at` (vault ingestion time). When Prism syncs an old email today, the email's note has `created_at = now`, so a "last 7 days" query returns the old email — and excludes a recent email that was synced last week. The semantic date — when the email was *received* — lives in `metadata.email_date`, which the legacy filter has no way to reach.

This adds a generalized shape that composes with the existing indexed-fields machinery:

```jsonc
{
  "date_filter": { "field": "email_date", "from": "2026-04-25", "to": "2026-05-02" }
}
```

`field` defaults to `created_at`, in which case the SQL is identical to the legacy path. Any other field must be declared `indexed: true` in a tag schema — same gate as `metadata` operator queries and `order_by`. Unknown field rejects with `FIELD_NOT_INDEXED`. Combining `date_filter` with the legacy `date_from`/`date_to` rejects with `INVALID_QUERY` (silent AND would surprise the caller).

**Backwards-compatible**: nothing about the legacy shorthand changes; existing callers keep working unmodified.

## Surfaces

- `core/src/types.ts` — new `dateFilter` field on `QueryOpts`
- `core/src/notes.ts` — SQL builder switches column based on `dateFilter.field`; uses `requireIndexedField` for non-`created_at` targets
- `core/src/mcp.ts` — `date_filter` exposed in inputSchema + execute body
- `src/routes.ts` — HTTP query string `date_field=<name>` activates the generalized path; without it, `date_from`/`date_to` retain legacy meaning. Comment block on the structured-query branch documents the REST/MCP surface asymmetry.

## Test plan

Seven regression tests in `core/src/core.test.ts`, all under `describe("dateFilter (generalized)")`:

- [x] legacy `date_from`/`date_to` still works (existing test, unchanged)
- [x] `date_filter` with no field defaults to `created_at` (matches legacy shorthand)
- [x] `date_filter` on indexed field filters on **content** date, not ingestion date — *the bug*
- [x] `date_filter` on non-indexed field rejects with `FIELD_NOT_INDEXED`
- [x] `date_filter` + `date_from` rejects with `INVALID_QUERY`
- [x] `date_filter` with only `from` is open-ended on the upper bound
- [x] explicit `field: "created_at"` routes to the legacy SQL path (added per reviewer)
- [x] MCP `query-notes` execute accepts the wire shape end-to-end

**Gates on rebased head:**
- core: 353/353 (was 346 on main; +7 new)
- host: 728/728

Bumps to `0.3.6-rc.25` (rc.24 was taken by #224 when it merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)