### PR TITLE
fix(query-notes): route FTS path through store.searchNotes (closes #227)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2404,6 +2404,25 @@ describe("MCP tools", async () => {
     expect(r.map((n) => n.content).sort()).toEqual(["text memo", "voice memo"]);
   });
 
+  it("query-notes FTS path routes through store.searchNotes so tag-hierarchy expansion fires (vault#227)", async () => {
+    // Same fixture shape as the structured-query hierarchy test above, but
+    // exercising the search branch. Pre-fix the FTS path called
+    // `noteOps.searchNotes` directly and silently dropped descendant matches —
+    // `tag: "manual"` would only return notes literally tagged #manual, not
+    // notes tagged with the declared children #voice / #text.
+    await store.createNote("", { path: "_tags/voice", metadata: { parents: ["manual"] } });
+    await store.createNote("", { path: "_tags/text", metadata: { parents: ["manual"] } });
+    await store.createNote("voice handoff notes", { tags: ["voice"] });
+    await store.createNote("text handoff notes", { tags: ["text"] });
+    await store.createNote("unrelated handoff", { tags: ["other"] });
+
+    const tools = generateMcpTools(store);
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
+    const r = await queryNotes.execute({ search: "handoff", tag: "manual", include_content: true }) as any[];
+    expect(r).toHaveLength(2);
+    expect(r.map((n) => n.content).sort()).toEqual(["text handoff notes", "voice handoff notes"]);
+  });
+
   it("query-notes does not mutate caller's params object across repeated calls", async () => {
     // normalizeTags returns a defensive copy of array inputs so the downstream
     // store layer can sort/dedupe without touching the caller's reference.

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2421,6 +2421,7 @@ describe("MCP tools", async () => {
     const r = await queryNotes.execute({ search: "handoff", tag: "manual", include_content: true }) as any[];
     expect(r).toHaveLength(2);
     expect(r.map((n) => n.content).sort()).toEqual(["text handoff notes", "voice handoff notes"]);
+    expect(r.map((n) => n.content)).not.toContain("unrelated handoff");
   });
 
   it("query-notes does not mutate caller's params object across repeated calls", async () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -231,7 +231,12 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         if (params.search) {
           // Normalize tag param
           const tags = normalizeTags(params.tag);
-          results = noteOps.searchNotes(db, params.search as string, {
+          // Route through `store.searchNotes` (not `noteOps.searchNotes`) so
+          // tag-hierarchy expansion fires for MCP callers the same as for
+          // HTTP REST callers — `tag: "manual"` matches descendants declared
+          // via `_tags/*` config notes. Mirrors the structured-query fix
+          // from #214; same class of bypass bug (tracked as #227).
+          results = await store.searchNotes(params.search as string, {
             tags,
             limit: (params.limit as number) ?? 50,
           });

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1006,6 +1006,10 @@ This is the graph-aware sibling of \`query-notes\`. Where \`query-notes\` return
         if (queryParam) {
           // Cap the FTS pull at 2× limit so the post-scope filter still leaves
           // enough headroom to fill the result set with real hits.
+          // Direct noteOps.searchNotes (no tag-hierarchy expansion) is intentional
+          // here — synthesize-notes uses the FTS result only as a candidate seed,
+          // and scope filtering happens post-hydration. Don't route through the
+          // store.searchNotes wrapper for this specific tool.
           const searchHits = noteOps.searchNotes(db, queryParam, { limit: Math.min(limit * 2, 100) });
           searchHits.forEach((n, idx) => upsert(n.id, { source: "search", ftsRank: idx }));
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.25",
+  "version": "0.3.6-rc.26",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Closes #227. Same class of bug as #214 (closed by #224) — different surface.

The full-text search branch of `query-notes` (MCP) called `noteOps.searchNotes(db, ...)` directly, bypassing the store wrapper. `store.searchNotes` does tag-hierarchy expansion via `_tags/<name>` config notes' `metadata.parents` — a query for `tag: "<parent>"` should match notes tagged with declared descendants. Without the wrapper, `query-notes({ search, tag: "manual" })` only matched literal `#manual` notes, silently dropping `#voice` / `#text` matches.

HTTP REST callers were already correct (`src/routes.ts` always uses `store.searchNotes`); this brings the MCP path in line.

## Surface

- `core/src/mcp.ts` — single-line route swap in the `query-notes` `if (params.search)` branch, with a `// Route through store.searchNotes ...` comment that mirrors the one added in #224 for the structured-query path.

## Test plan

One regression test in `core/src/core.test.ts`, mirroring the #224 hierarchy-expansion test (same fixture shape, same describe block):

- [x] `_tags/voice` and `_tags/text` declare `manual` as their parent
- [x] notes tagged `#voice` and `#text` exist with `"handoff"` in their content
- [x] `query-notes({ search: "handoff", tag: "manual" })` returns both descendant-tagged notes
- [x] unrelated `#other`-tagged note with `"handoff"` is excluded

**Gates:**
- core: 354/354 (was 353; +1 new test)
- host: 728/728

Bumps to `0.3.6-rc.26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)