### PR TITLE
fix(auth): readGlobalConfig parses scope field (priv-esc fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.26",
+  "version": "0.3.6-rc.27",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -286,3 +286,56 @@ describe("OAuth-minted tokens — per-vault coherence", () => {
     expect("error" in crossCheck).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Legacy YAML global keys — scope must round-trip through the parser
+// ---------------------------------------------------------------------------
+
+describe("auth — legacy global YAML keys honor declared scope", () => {
+  test("scope: read on a global config.yaml key resolves to read permission, not full", async () => {
+    // Regression: the global parser used to drop the `scope` field, leaving
+    // `globalKey.scope` undefined. The auth check `=== "read"` then resolved
+    // any undefined value to "full", silently escalating read-only keys.
+    const { fullKey, keyId } = generateApiKey();
+    writeGlobalConfig({
+      port: 1940,
+      api_keys: [
+        {
+          id: keyId,
+          label: "reader",
+          scope: "read",
+          key_hash: hashKey(fullKey),
+          created_at: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = await authenticateGlobalRequest(bearer(fullKey));
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("read");
+    }
+  });
+
+  test("scope: write on a global config.yaml key resolves to full permission", async () => {
+    const { fullKey, keyId } = generateApiKey();
+    writeGlobalConfig({
+      port: 1940,
+      api_keys: [
+        {
+          id: keyId,
+          label: "writer",
+          scope: "write",
+          key_hash: hashKey(fullKey),
+          created_at: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = await authenticateGlobalRequest(bearer(fullKey));
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("full");
+    }
+  });
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -181,6 +181,35 @@ describe("config", () => {
     expect(readGlobalConfig().discovery).toBe("disabled");
   });
 
+  test("global api_keys round-trip scope: read|write and default missing scope to write", () => {
+    // Regression for the silent privilege-escalation bug: the global YAML
+    // parser used to drop the `scope` field, leaving `globalKey.scope`
+    // undefined. Auth then resolved any non-"read" value to "full", so a
+    // user-authored `scope: read` global key would silently get full access.
+    writeGlobalConfig({
+      port: 1940,
+      api_keys: [
+        { id: "k_r", label: "reader", scope: "read", key_hash: "sha256:r", created_at: "2026-01-01T00:00:00.000Z" },
+        { id: "k_w", label: "writer", scope: "write", key_hash: "sha256:w", created_at: "2026-01-01T00:00:00.000Z" },
+      ],
+    });
+    const loaded = readGlobalConfig();
+    expect(loaded.api_keys?.find((k) => k.id === "k_r")?.scope).toBe("read");
+    expect(loaded.api_keys?.find((k) => k.id === "k_w")?.scope).toBe("write");
+
+    // Missing-scope branch: a hand-edited config.yaml entry without a
+    // `scope:` line must default to "write" (matches vault-level parser
+    // and the historical behavior the writer round-trips).
+    const fs = require("fs");
+    const path = `${process.env.PARACHUTE_HOME}/vault/config.yaml`;
+    fs.writeFileSync(
+      path,
+      `port: 1940\napi_keys:\n  - id: k_legacy\n    label: legacy\n    key_hash: sha256:legacy\n    created_at: "2026-01-01T00:00:00.000Z"\n`,
+    );
+    const reloaded = readGlobalConfig();
+    expect(reloaded.api_keys?.find((k) => k.id === "k_legacy")?.scope).toBe("write");
+  });
+
   test("round-trips autostart: true|false (#113)", () => {
     // Default: absent means autostart-on (init registers the daemon).
     writeGlobalConfig({ port: 1940 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1162,6 +1162,7 @@ export function readGlobalConfig(): GlobalConfig {
         for (const block of keyBlocks) {
           const idMatch = block.match(/^(\S+)/);
           const labelMatch = block.match(/label:\s*(.+)/);
+          const scopeMatch = block.match(/scope:\s*(\S+)/);
           const hashMatch = block.match(/key_hash:\s*(\S+)/);
           const createdAtMatch = block.match(/created_at:\s*"?([^"\n]+)"?/);
           const lastUsedMatch = block.match(/last_used_at:\s*"?([^"\n]+)"?/);
@@ -1169,6 +1170,7 @@ export function readGlobalConfig(): GlobalConfig {
             config.api_keys.push({
               id: idMatch[1],
               label: (labelMatch?.[1] ?? "default").trim(),
+              scope: (scopeMatch?.[1] as KeyScope) ?? "write",
               key_hash: hashMatch[1],
               created_at: createdAtMatch?.[1] ?? new Date().toISOString(),
               last_used_at: lastUsedMatch?.[1],
@@ -1213,6 +1215,7 @@ export function writeGlobalConfig(config: GlobalConfig): void {
     for (const key of config.api_keys) {
       lines.push(`  - id: ${key.id}`);
       lines.push(`    label: ${key.label}`);
+      lines.push(`    scope: ${key.scope ?? "write"}`);
       lines.push(`    key_hash: ${key.key_hash}`);
       lines.push(`    created_at: "${key.created_at}"`);
       if (key.last_used_at) {


### PR DESCRIPTION
## Summary

The legacy global `config.yaml` `api_keys` parser dropped the `scope` field, so `globalKey.scope` was always `undefined`. The auth check at `src/auth.ts:196` (`globalKey.scope === "read" ? "read" : "full"`) then silently resolved every global YAML key — including ones the user wrote with `scope: read` — to `permission: "full"`.

Two-line fix mirroring the vault-level parser at `src/config.ts:465`:
- Parser: read `scope` with `block.match(/scope:\s*(\S+)/)`, default to `"write"` when absent.
- Writer: serialize `scope` on rewrite so values round-trip (without this, the parser fix would lose user-set scope on the next config-rewrite cycle — `auth.ts` calls `writeGlobalConfig` after every legacy match).

## Behavior change

**No behavior change for existing users without an explicit `scope:` field.** Both `undefined` (pre-fix) and `"write"` (post-fix default) resolve to `"full"` via the auth ternary `=== "read" ? "read" : "full"`, so users with no explicit scope continue to get `"full"` access.

**Only `scope: read` keys see a change** — they were previously silently elevated to `"full"` and are now correctly downgraded to `"read"`. Write attempts with such keys that used to succeed will now return `forbidden`.

**Impact scan** of local `~/.parachute/vault*/` configs: zero `scope: read` global keys found (`grep -r "scope: read" --include='*.yaml' --include='*.yml' /Users/parachute/.parachute/vault*/` exit 1). No known users affected — flagging anyway for the broader RC audience.

## Tests

- `src/config.test.ts` — round-trips `scope: read | write | missing` through `writeGlobalConfig` + `readGlobalConfig`.
- `src/auth.test.ts` — end-to-end: `scope: read` global key → `authenticateGlobalRequest` → `permission: "read"` (not `"full"`); `scope: write` global key → `permission: "full"`.
- `bun test ./src/` — 731 / 731 pass.

## Follow-up

Reviewer flagged that the `scope` regex (and its siblings) is unanchored — `block.match(/scope:\s*(\S+)/)` will match commented `# scope: read` lines and trailing-space malformed entries. Same parity gap exists in the vault-level parser at line 456 (this PR mirrors that pattern intentionally). Filed as #234 for a symmetric follow-up; risk is negligible since the writer never emits these patterns.

## Test plan

- [x] `bun test ./src/config.test.ts` (25 pass)
- [x] `bun test ./src/auth.test.ts` (10 pass)
- [x] `bun test ./src/` (731 pass)
- [x] `bun test ./src/backup.test.ts` (30 pass — answer to reviewer query about backup-test failures elsewhere)
- [x] Impact scan against local config

## Context

Caught in #232 review — that PR's typecheck cleanup hardcoded `scope: "write"` to silence `noUncheckedIndexedAccess`, which would have preserved the bug under a more visible name. Splitting the real fix to its own RC so the typecheck PR stays narrowly-scoped to surface-level cleanup. After this lands, #232 rebases onto new main and bumps to rc.28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)