### PR TITLE
fix(notes): reject content+path-empty creates and updates + 500-cap batches (closes #213)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2521,14 +2521,15 @@ describe("MCP tools", async () => {
     expect(err?.code).toBe("EMPTY_NOTE");
   });
 
-  it("create-note batch rejects when any entry is empty content + no path", async () => {
+  it("create-note batch rejects when any entry is empty content + no path (atomic)", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
+    const beforeCount = (await store.queryNotes({ search: "atomic-marker" })).length;
     let err: any;
     try {
       await createNote.execute({
         notes: [
-          { content: "ok" },
+          { content: "atomic-marker first" },
           { content: "" },
         ],
       });
@@ -2536,6 +2537,11 @@ describe("MCP tools", async () => {
       err = e;
     }
     expect(err?.code).toBe("EMPTY_NOTE");
+    // The first item must NOT have been created — pre-validation rolls
+    // the whole batch back atomically. Partial-create would leak prefixes
+    // on every runaway-client burst (#213).
+    const afterCount = (await store.queryNotes({ search: "atomic-marker" })).length;
+    expect(afterCount).toBe(beforeCount);
   });
 
   it("create-note batch over MAX_BATCH_SIZE rejects with BATCH_TOO_LARGE", async () => {

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -187,6 +187,66 @@ describe("notes", async () => {
     expect(updated.content).toBe("edited");
     expect(updated.path).toBe("a");
   });
+
+  // -------------------------------------------------------------------------
+  // Empty-note invariant at the Store boundary (#213)
+  // -------------------------------------------------------------------------
+
+  it("createNote rejects content+path both absent → EmptyNoteError", async () => {
+    await expect(store.createNote("")).rejects.toMatchObject({ code: "EMPTY_NOTE" });
+    await expect(store.createNote("   ")).rejects.toMatchObject({ code: "EMPTY_NOTE" });
+    await expect(store.createNote("", { metadata: { x: 1 } })).rejects.toMatchObject({
+      code: "EMPTY_NOTE",
+    });
+  });
+
+  it("createNote accepts content-only (un-pathed jot)", async () => {
+    const n = await store.createNote("just a jot");
+    expect(n.content).toBe("just a jot");
+    expect(n.path).toBeUndefined();
+  });
+
+  it("createNote accepts path-only (wikilink placeholder / _schemas/* shape)", async () => {
+    const n = await store.createNote("", { path: "wiki/placeholder" });
+    expect(n.content).toBe("");
+    expect(n.path).toBe("wiki/placeholder");
+  });
+
+  it("updateNote rejects clearing both content and path → EmptyNoteError", async () => {
+    const n = await store.createNote("body", { path: "p" });
+    await expect(
+      store.updateNote(n.id, { content: "", path: "", if_updated_at: n.createdAt }),
+    ).rejects.toMatchObject({ code: "EMPTY_NOTE", note_id: n.id });
+  });
+
+  it("updateNote rejects clearing content when path is already null", async () => {
+    const n = await store.createNote("body");
+    await expect(
+      store.updateNote(n.id, { content: "", if_updated_at: n.createdAt }),
+    ).rejects.toMatchObject({ code: "EMPTY_NOTE" });
+  });
+
+  it("updateNote allows clearing content when path is set (or being set)", async () => {
+    const n = await store.createNote("body", { path: "p" });
+    const updated = await store.updateNote(n.id, { content: "", if_updated_at: n.createdAt });
+    expect(updated.content).toBe("");
+    expect(updated.path).toBe("p");
+  });
+
+  it("updateNote with metadata-only update against a (legacy) empty row passes", async () => {
+    // Tag/metadata-only updates don't touch content or path, so they don't
+    // trigger the new guard — important so any pre-existing empty rows
+    // (from before #213) can still be cleaned up via metadata operations.
+    const n = await store.createNote("seed", { path: "x" });
+    // Simulate a legacy row by directly clearing content via SQL (bypasses
+    // the guard); this mirrors what an old data row could look like.
+    db.prepare("UPDATE notes SET content = '', path = NULL WHERE id = ?").run(n.id);
+    const updated = await store.updateNote(n.id, {
+      metadata: { tag: "cleanup" },
+      if_updated_at: n.createdAt,
+    });
+    expect(updated.metadata).toMatchObject({ tag: "cleanup" });
+  });
 });
 
 // ---- Backfill migration: legacy rows with NULL updated_at ----
@@ -2445,6 +2505,71 @@ describe("MCP tools", async () => {
 
     expect(r1.map((n) => n.content).sort()).toEqual(["a"]);
     expect(r2.map((n) => n.content).sort()).toEqual(["a"]);
+  });
+
+  // ---- empty-note + batch-cap MCP regressions (#213) ----
+
+  it("create-note rejects bare empty content with no path (EMPTY_NOTE)", async () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    let err: any;
+    try {
+      await createNote.execute({ content: "" });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("EMPTY_NOTE");
+  });
+
+  it("create-note batch rejects when any entry is empty content + no path", async () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    let err: any;
+    try {
+      await createNote.execute({
+        notes: [
+          { content: "ok" },
+          { content: "" },
+        ],
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("EMPTY_NOTE");
+  });
+
+  it("create-note batch over MAX_BATCH_SIZE rejects with BATCH_TOO_LARGE", async () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    const notes = Array.from({ length: 501 }, (_, i) => ({ content: `n${i}` }));
+    let err: any;
+    try {
+      await createNote.execute({ notes });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("BATCH_TOO_LARGE");
+    expect(err.limit).toBe(500);
+    expect(err.got).toBe(501);
+  });
+
+  it("update-note batch over MAX_BATCH_SIZE rejects with BATCH_TOO_LARGE", async () => {
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const notes = Array.from({ length: 501 }, (_, i) => ({
+      id: `id${i}`,
+      content: "x",
+      force: true,
+    }));
+    let err: any;
+    try {
+      await updateNote.execute({ notes });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("BATCH_TOO_LARGE");
+    expect(err.limit).toBe(500);
+    expect(err.got).toBe(501);
   });
 });
 

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2521,7 +2521,7 @@ describe("MCP tools", async () => {
     expect(err?.code).toBe("EMPTY_NOTE");
   });
 
-  it("create-note batch rejects when any entry is empty content + no path (atomic)", async () => {
+  it("create-note batch rejects when any entry is empty content + no path (atomic, with item_index)", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;
     const beforeCount = (await store.queryNotes({ search: "atomic-marker" })).length;
@@ -2542,6 +2542,23 @@ describe("MCP tools", async () => {
     // on every runaway-client burst (#213).
     const afterCount = (await store.queryNotes({ search: "atomic-marker" })).length;
     expect(afterCount).toBe(beforeCount);
+    // Parity with HTTP route: MCP callers with multi-item batches need to
+    // know which entry triggered the rejection. The bad entry is at index 1.
+    expect(err.item_index).toBe(1);
+  });
+
+  it("create-note single empty has null item_index (not a batch position)", async () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    let err: any;
+    try {
+      await createNote.execute({ content: "" });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("EMPTY_NOTE");
+    // Single-call (no `notes` array) — there's no batch position to report.
+    expect(err.item_index).toBeNull();
   });
 
   it("create-note batch over MAX_BATCH_SIZE rejects with BATCH_TOO_LARGE", async () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -375,6 +375,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         const batch = params.notes as any[] | undefined;
         const items = batch ?? [params];
 
+        if (items.length > MAX_BATCH_SIZE) {
+          throw new BatchTooLargeError(items.length);
+        }
+
         const created: Note[] = [];
         for (const item of items) {
           const note = await store.createNote(item.content as string ?? "", {
@@ -520,6 +524,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
       execute: async (params) => {
         const batch = params.notes as any[] | undefined;
         const items = batch ?? [params];
+
+        if (items.length > MAX_BATCH_SIZE) {
+          throw new BatchTooLargeError(items.length);
+        }
 
         const updated: Note[] = [];
         for (const item of items) {
@@ -1272,6 +1280,28 @@ export class PreconditionRequiredError extends Error {
     this.name = "PreconditionRequiredError";
     this.note_id = noteId;
     this.note_path = notePath;
+  }
+}
+
+/** Per-call item cap on `create-note` and `update-note` batches (#213). */
+export const MAX_BATCH_SIZE = 500;
+
+/**
+ * Thrown by `create-note` / `update-note` when a batch exceeds
+ * `MAX_BATCH_SIZE`. The cap exists to bound the blast radius of a runaway
+ * client — see #213, where one MCP burst created 7,453 empty notes in
+ * minutes. Surfaces as 413 at the HTTP layer.
+ */
+export class BatchTooLargeError extends Error {
+  code = "BATCH_TOO_LARGE" as const;
+  limit: number;
+  got: number;
+
+  constructor(got: number) {
+    super(`batch_too_large: max ${MAX_BATCH_SIZE} notes per call, got ${got}`);
+    this.name = "BatchTooLargeError";
+    this.limit = MAX_BATCH_SIZE;
+    this.got = got;
   }
 }
 

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -383,7 +383,12 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         // the empty-note case. The Store will throw EmptyNoteError on the
         // empty entry, but in a sequential batch loop the prefix would have
         // already committed before we hit it. Pre-walk so the whole call
-        // either creates everything or nothing.
+        // either creates everything or nothing. The error carries
+        // `item_index` so MCP callers with multi-item batches can pinpoint
+        // the bad entry — parity with the HTTP route's response shape.
+        // TODO: tighten batch input type — `items[i] as any` mirrors the
+        // top-of-call cast at `params.notes as any[]`. A typed McpCreateNoteInput
+        // would let us drop both casts.
         for (let i = 0; i < items.length; i++) {
           const item = items[i] as any;
           const content = ((item?.content as string | undefined) ?? "").toString();
@@ -391,7 +396,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           const pathEmpty = rawPath === undefined || rawPath === null
             || (typeof rawPath === "string" && rawPath.trim() === "");
           if (!content.trim() && pathEmpty) {
-            throw new noteOps.EmptyNoteError();
+            throw new noteOps.EmptyNoteError(null, batch ? i : null);
           }
         }
 

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import type { Store, Note } from "./types.js";
 import * as noteOps from "./notes.js";
-import { filterMetadata } from "./notes.js";
+import { filterMetadata, MAX_BATCH_SIZE } from "./notes.js";
 import * as linkOps from "./links.js";
 import * as tagSchemaOps from "./tag-schemas.js";
 import type { TagFieldSchema } from "./tag-schemas.js";
@@ -1275,7 +1275,7 @@ function normalizeTags(tag: unknown): string[] | undefined {
 
 // Re-exported for backward compat; defined in notes.ts alongside the
 // conditional-UPDATE implementation that raises it.
-export { ConflictError, PathConflictError, EmptyNoteError } from "./notes.js";
+export { ConflictError, PathConflictError, EmptyNoteError, MAX_BATCH_SIZE } from "./notes.js";
 
 /**
  * Thrown by the `update-note` MCP tool (and the REST PATCH handler) when a
@@ -1299,14 +1299,12 @@ export class PreconditionRequiredError extends Error {
   }
 }
 
-/** Per-call item cap on `create-note` and `update-note` batches (#213). */
-export const MAX_BATCH_SIZE = 500;
-
 /**
  * Thrown by `create-note` / `update-note` when a batch exceeds
- * `MAX_BATCH_SIZE`. The cap exists to bound the blast radius of a runaway
- * client — see #213, where one MCP burst created 7,453 empty notes in
- * minutes. Surfaces as 413 at the HTTP layer.
+ * `MAX_BATCH_SIZE` (re-exported from `./notes.js` — single source of truth).
+ * Bounds the blast radius of a runaway client — see #213, where one MCP
+ * burst created 7,453 empty notes in minutes. Surfaces as 413 at the HTTP
+ * layer.
  */
 export class BatchTooLargeError extends Error {
   code = "BATCH_TOO_LARGE" as const;

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -379,6 +379,22 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           throw new BatchTooLargeError(items.length);
         }
 
+        // Empty-note pre-validation (#213): make mixed batches atomic for
+        // the empty-note case. The Store will throw EmptyNoteError on the
+        // empty entry, but in a sequential batch loop the prefix would have
+        // already committed before we hit it. Pre-walk so the whole call
+        // either creates everything or nothing.
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i] as any;
+          const content = ((item?.content as string | undefined) ?? "").toString();
+          const rawPath = item?.path;
+          const pathEmpty = rawPath === undefined || rawPath === null
+            || (typeof rawPath === "string" && rawPath.trim() === "");
+          if (!content.trim() && pathEmpty) {
+            throw new noteOps.EmptyNoteError();
+          }
+        }
+
         const created: Note[] = [];
         for (const item of items) {
           const note = await store.createNote(item.content as string ?? "", {
@@ -1259,7 +1275,7 @@ function normalizeTags(tag: unknown): string[] | undefined {
 
 // Re-exported for backward compat; defined in notes.ts alongside the
 // conditional-UPDATE implementation that raises it.
-export { ConflictError, PathConflictError } from "./notes.js";
+export { ConflictError, PathConflictError, EmptyNoteError } from "./notes.js";
 
 /**
  * Thrown by the `update-note` MCP tool (and the REST PATCH handler) when a

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -167,15 +167,25 @@ export const MAX_BATCH_SIZE = 500;
 export class EmptyNoteError extends Error {
   code = "EMPTY_NOTE" as const;
   note_id: string | null;
+  /**
+   * Zero-based position in a batch call when the empty entry is rejected via
+   * the transport-layer pre-validation pass (HTTP `POST /api/notes` or MCP
+   * `create-note` with `notes: [...]`). `null` for single-update rejections
+   * and for Store-level throws that don't know their batch context.
+   */
+  item_index: number | null;
 
-  constructor(noteId: string | null = null) {
+  constructor(noteId: string | null = null, itemIndex: number | null = null) {
     super(
       noteId
         ? `empty_note: update would leave note "${noteId}" with neither content nor path`
-        : `empty_note: a note must have either content or a path`,
+        : itemIndex !== null
+          ? `empty_note: a note must have either content or a path (item index ${itemIndex})`
+          : `empty_note: a note must have either content or a path`,
     );
     this.name = "EmptyNoteError";
     this.note_id = noteId;
+    this.item_index = itemIndex;
   }
 }
 

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -36,6 +36,16 @@ export function createNote(
   const metadata = opts?.metadata ? JSON.stringify(opts.metadata) : "{}";
   const path = normalizePath(opts?.path);
 
+  // Empty-note invariant (#213): reject `content+path both absent`. Three
+  // legit shapes — content-only, path-only, both — only the empty+empty
+  // combo is the runaway-client signature that flooded a deployment with
+  // 7,453 pathless empty notes in one MCP burst. `content` only is a
+  // legitimate un-pathed jot; `path` only is a wikilink placeholder or
+  // `_schemas/*` config note.
+  if (!content.trim() && path === null) {
+    throw new EmptyNoteError();
+  }
+
   // `updated_at` is set to `created_at` on insert so a client whose optimistic
   // concurrency check falls back to `createdAt` on a never-updated note
   // (the common shape: `note.updatedAt ?? note.createdAt`) matches the stored
@@ -138,6 +148,29 @@ export class PathConflictError extends Error {
 }
 
 /**
+ * Thrown by `createNote` / `updateNote` when the proposed note state has
+ * neither content nor path. The vault accepts un-pathed jots (content only)
+ * and path-only placeholders (wikilink stubs, `_schemas/*`), but a note
+ * with neither is the runaway-client signature flagged in #213 — one MCP
+ * burst flooded a deployment with 7,453 empty pathless rows. Surfaces as
+ * 400 at the HTTP layer.
+ */
+export class EmptyNoteError extends Error {
+  code = "EMPTY_NOTE" as const;
+  note_id: string | null;
+
+  constructor(noteId: string | null = null) {
+    super(
+      noteId
+        ? `empty_note: update would leave note "${noteId}" with neither content nor path`
+        : `empty_note: a note must have either content or a path`,
+    );
+    this.name = "EmptyNoteError";
+    this.note_id = noteId;
+  }
+}
+
+/**
  * Match bun:sqlite's UNIQUE-constraint error on the notes.path index. The
  * error class is `SQLiteError` but matching on the message is sufficient
  * here — the index name and column are stable parts of the schema, and
@@ -182,6 +215,37 @@ export function updateNote(
     throw new Error(
       "update-note: `content` is mutually exclusive with `append`/`prepend`. Pick full-replace or additive — not both in the same call.",
     );
+  }
+
+  // Empty-note invariant (#213): when this update touches content or path,
+  // reject if the post-state would be empty content + null path. We only
+  // enforce on transitions that actually touch the relevant fields, so
+  // metadata-only or tag-only updates against legacy empty rows still pass.
+  // Hook-style writes (skipUpdatedAt) are exempted — they're machine-level
+  // marker writes that legitimately may run against any shape of row.
+  const touchesContent = updates.content !== undefined
+    || updates.append !== undefined
+    || updates.prepend !== undefined;
+  const touchesPath = updates.path !== undefined;
+  if ((touchesContent || touchesPath) && !updates.skipUpdatedAt) {
+    const current = getNote(db, id);
+    if (current) {
+      let finalContent: string;
+      if (updates.content !== undefined) {
+        finalContent = updates.content;
+      } else if (touchesContent) {
+        finalContent = (updates.prepend ?? "") + current.content + (updates.append ?? "");
+      } else {
+        finalContent = current.content;
+      }
+      const finalPath = touchesPath ? normalizePath(updates.path) : (current.path ?? null);
+      if (!finalContent.trim() && !finalPath) {
+        throw new EmptyNoteError(id);
+      }
+    }
+    // If `current` is null we fall through — existing code paths handle the
+    // missing-row case downstream (the conditional UPDATE returns 0 rows;
+    // OC throws ConflictError; non-OC returns silently).
   }
 
   const sets: string[] = [];

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -148,6 +148,15 @@ export class PathConflictError extends Error {
 }
 
 /**
+ * Per-call item cap on `createNote`/`updateNote` batch entry points
+ * (MCP `create-note` / `update-note` and HTTP `POST /api/notes`).
+ * Single source of truth — both transports import from here so the cap
+ * can never silently drift between them. See #213 for the runaway-client
+ * incident that motivated the cap (7,453 empty notes in one MCP burst).
+ */
+export const MAX_BATCH_SIZE = 500;
+
+/**
  * Thrown by `createNote` / `updateNote` when the proposed note state has
  * neither content nor path. The vault accepts un-pathed jots (content only)
  * and path-only placeholders (wikilink stubs, `_schemas/*`), but a note

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.28",
+  "version": "0.3.6-rc.29",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -377,7 +377,12 @@ export async function handleNotes(
         }
         if (e && e.code === "EMPTY_NOTE") {
           return json(
-            { error_type: "empty_note", error: "EmptyNoteError", message: e.message },
+            {
+              error_type: "empty_note",
+              error: "EmptyNoteError",
+              message: e.message,
+              item_index: e.item_index ?? null,
+            },
             400,
           );
         }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -325,6 +325,30 @@ export async function handleNotes(
         );
       }
 
+      // Empty-note pre-validation (#213): walk the batch first and reject the
+      // whole request if any item would be content+path empty. This makes
+      // mixed batches atomic for the empty-note case — no caller gets a
+      // half-applied batch where the prefix landed and the empty entry
+      // surfaced the 400. Mirrors the Store-level invariant exactly.
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        const content = (item?.content ?? "").toString();
+        const rawPath = item?.path;
+        const pathEmpty = rawPath === undefined || rawPath === null
+          || (typeof rawPath === "string" && rawPath.trim() === "");
+        if (!content.trim() && pathEmpty) {
+          return json(
+            {
+              error_type: "empty_note",
+              error: "EmptyNoteError",
+              message: `empty_note: a note must have either content or a path (item index ${i})`,
+              item_index: i,
+            },
+            400,
+          );
+        }
+      }
+
       const created: Note[] = [];
       try {
         for (const item of items) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,7 +14,7 @@
 
 import type { Store, Note } from "../core/src/types.ts";
 import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
-import { toNoteIndex, filterMetadata } from "../core/src/notes.ts";
+import { toNoteIndex, filterMetadata, MAX_BATCH_SIZE } from "../core/src/notes.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
 import {
@@ -123,9 +123,6 @@ class NotFoundError extends Error {
     this.name = "NotFoundError";
   }
 }
-
-/** Per-request item cap on POST /notes batches (#213). */
-const MAX_BATCH_SIZE = 500;
 
 // ---------------------------------------------------------------------------
 // Notes — GET/POST/PATCH/DELETE /api/notes[/:idOrPath]

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -124,6 +124,9 @@ class NotFoundError extends Error {
   }
 }
 
+/** Per-request item cap on POST /notes batches (#213). */
+const MAX_BATCH_SIZE = 500;
+
 // ---------------------------------------------------------------------------
 // Notes — GET/POST/PATCH/DELETE /api/notes[/:idOrPath]
 // ---------------------------------------------------------------------------
@@ -307,6 +310,21 @@ export async function handleNotes(
       const body = await req.json() as any;
       const items: any[] = body.notes ?? [body];
 
+      // Batch cap (#213): refuse oversized batches before doing any work. 500
+      // is the cap (Benjamin's number) — tighter blast radius than 1000 for
+      // the runaway-client case that flooded a deployment with 7,453 notes.
+      if (items.length > MAX_BATCH_SIZE) {
+        return json(
+          {
+            error_type: "batch_too_large",
+            error: "BatchTooLarge",
+            message: `max ${MAX_BATCH_SIZE} notes per request, got ${items.length}`,
+            limit: MAX_BATCH_SIZE,
+          },
+          413,
+        );
+      }
+
       const created: Note[] = [];
       try {
         for (const item of items) {
@@ -334,6 +352,12 @@ export async function handleNotes(
           return json(
             { error_type: "path_conflict", error: "path_conflict", path: e.path, message: e.message },
             409,
+          );
+        }
+        if (e && e.code === "EMPTY_NOTE") {
+          return json(
+            { error_type: "empty_note", error: "EmptyNoteError", message: e.message },
+            400,
           );
         }
         throw e;
@@ -628,6 +652,20 @@ export async function handleNotes(
         return json(
           { error_type: "path_conflict", error: "path_conflict", path: e.path, message: e.message },
           409,
+        );
+      }
+      // Empty-note guard from the Store boundary (#213) — the proposed update
+      // would clear both content AND path. Surface as 400 so callers can fix
+      // the request without retrying.
+      if (e && e.code === "EMPTY_NOTE") {
+        return json(
+          {
+            error_type: "empty_note",
+            error: "EmptyNoteError",
+            message: e.message,
+            note_id: e.note_id ?? null,
+          },
+          400,
         );
       }
       throw e;

--- a/src/transcription-worker.test.ts
+++ b/src/transcription-worker.test.ts
@@ -126,8 +126,13 @@ describe("transcription worker", () => {
   });
 
   test("no placeholder: replaces full body when stub is set", async () => {
+    // Voice memos have a path in production, so the empty-content path is
+    // legitimate (paired with the stub marker, the worker fills the body
+    // when the transcript lands). The Store's empty-note invariant (#213)
+    // requires content OR path; this is the path-only case.
     await store.createNote("", {
       id: "n3",
+      path: "memos/n3",
       metadata: { transcribe_stub: true },
     });
     seedAudio("memos/c.webm");

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1146,6 +1146,114 @@ describe("HTTP /notes", async () => {
       expect(res.status).toBe(405);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Empty-note guard + batch cap (#213) — runaway-client protection
+  // -------------------------------------------------------------------------
+
+  describe("empty-note guard (#213)", async () => {
+    test("POST bare {} body → 400 EmptyNoteError", async () => {
+      const res = await handleNotes(mkReq("POST", "/notes", {}), store, "");
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.error_type).toBe("empty_note");
+      expect(body.error).toBe("EmptyNoteError");
+    });
+
+    test("POST batch with one empty entry → 400 EmptyNoteError (atomic reject)", async () => {
+      const res = await handleNotes(
+        mkReq("POST", "/notes", { notes: [{ path: "ok-1" }, {}] }),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.error_type).toBe("empty_note");
+      // The first item may have been created before the loop hit the empty
+      // entry — that's acceptable, the cap is defense-in-depth and the
+      // 400 surfaces the bug to the caller.
+    });
+
+    test("POST single content-only (path absent) → 201", async () => {
+      const res = await handleNotes(
+        mkReq("POST", "/notes", { content: "un-pathed jot" }),
+        store,
+        "",
+      );
+      expect(res.status).toBe(201);
+    });
+
+    test("POST single path-only (content absent) → 201, no warning log", async () => {
+      // Path-only is a wikilink placeholder / `_schemas/*` shape — must
+      // remain accepted (per #223 design Q3).
+      const res = await handleNotes(
+        mkReq("POST", "/notes", { path: "wiki/placeholder" }),
+        store,
+        "",
+      );
+      expect(res.status).toBe(201);
+    });
+
+    test("PATCH that would clear both content and path → 400 EmptyNoteError", async () => {
+      const note = await store.createNote("starts with content", { id: "ep1" });
+      const updated = await store.getNote("ep1");
+      const res = await handleNotes(
+        mkReq("PATCH", "/notes/ep1", {
+          content: "",
+          path: "",
+          if_updated_at: updated!.updatedAt,
+        }),
+        store,
+        "/ep1",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.error_type).toBe("empty_note");
+      expect(body.note_id).toBe("ep1");
+    });
+
+    test("PATCH that clears content but preserves path → 200", async () => {
+      const note = await store.createNote("body", { id: "ep2", path: "p2" });
+      const updated = await store.getNote("ep2");
+      const res = await handleNotes(
+        mkReq("PATCH", "/notes/ep2", {
+          content: "",
+          if_updated_at: updated!.updatedAt,
+        }),
+        store,
+        "/ep2",
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("batch cap (#213)", async () => {
+    test("POST with 501-item batch → 413 BatchTooLarge", async () => {
+      const oversized = Array.from({ length: 501 }, (_, i) => ({ content: `n${i}` }));
+      const res = await handleNotes(
+        mkReq("POST", "/notes", { notes: oversized }),
+        store,
+        "",
+      );
+      expect(res.status).toBe(413);
+      const body = await res.json() as any;
+      expect(body.error_type).toBe("batch_too_large");
+      expect(body.error).toBe("BatchTooLarge");
+      expect(body.limit).toBe(500);
+    });
+
+    test("POST with exactly 500-item batch → 201 (boundary)", async () => {
+      const exactly500 = Array.from({ length: 500 }, (_, i) => ({ content: `n${i}` }));
+      const res = await handleNotes(
+        mkReq("POST", "/notes", { notes: exactly500 }),
+        store,
+        "",
+      );
+      expect(res.status).toBe(201);
+      const body = await res.json() as any[];
+      expect(body).toHaveLength(500);
+    });
+  });
 });
 
 describe("HTTP GET /notes?format=graph", async () => {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1160,7 +1160,12 @@ describe("HTTP /notes", async () => {
       expect(body.error).toBe("EmptyNoteError");
     });
 
-    test("POST batch with one empty entry → 400 EmptyNoteError (atomic reject)", async () => {
+    test("POST batch with one empty entry → 400 EmptyNoteError, NOTHING created (atomic)", async () => {
+      // Pre-validate the batch before any DB writes so a mixed batch with one
+      // bad entry rolls back the whole call. The runaway-client signature
+      // (#213) is "thousands of empties" — partial-create semantics would
+      // still leak the prefix on every burst. Atomic is the only safe shape.
+      const beforeCount = (await store.queryNotes({ path: "ok-1" })).length;
       const res = await handleNotes(
         mkReq("POST", "/notes", { notes: [{ path: "ok-1" }, {}] }),
         store,
@@ -1169,9 +1174,10 @@ describe("HTTP /notes", async () => {
       expect(res.status).toBe(400);
       const body = await res.json() as any;
       expect(body.error_type).toBe("empty_note");
-      // The first item may have been created before the loop hit the empty
-      // entry — that's acceptable, the cap is defense-in-depth and the
-      // 400 surfaces the bug to the caller.
+      expect(body.item_index).toBe(1);
+      // ok-1 must NOT have been created — atomic rollback.
+      const afterCount = (await store.queryNotes({ path: "ok-1" })).length;
+      expect(afterCount).toBe(beforeCount);
     });
 
     test("POST single content-only (path absent) → 201", async () => {


### PR DESCRIPTION
## Summary

Closes #213. The vault flooded with 7,453 empty pathless notes when a misbehaving MCP client batched empty-body create calls. This adds the durable server-side guard.

- **Empty-note invariant** enforced at the **Store boundary** (`core/src/notes.ts`) — a `EmptyNoteError` throws when `createNote`/`updateNote` would produce a row with both empty content AND null path. Closes both HTTP + MCP transports atomically.
- **Three legit shapes accepted**: content-only (un-pathed jot), path-only (wikilink stub / `_schemas/*` config note), or both. Only the empty+empty combo is rejected.
- **Update-path symmetry**: `updateNote` validates the post-state when content or path is touched. Tag/metadata-only updates against legacy empty rows still pass; `skipUpdatedAt` hook-style writes are exempt.
- **500-item batch cap** on POST `/api/notes` → 413 `BatchTooLarge`. Same cap on MCP `create-note`/`update-note` → `BatchTooLargeError`. The constant `MAX_BATCH_SIZE` lives in `core/src/notes.ts` and is imported by both transports — single source of truth.
- **Atomic empty-note batch rejection**: HTTP `POST /api/notes` and MCP `create-note` pre-validate the batch synchronously before any DB writes. A mixed batch like `{notes: [{path: "x"}, {}]}` rejects the whole call with 400 / `EMPTY_NOTE` and `item_index` of the bad entry — no prefix is committed.

Bumped to `0.3.6-rc.29`.

## Atomicity scope (call out for reviewers)

The atomicity guarantees in this PR cover the runaway-client signature only:

- ✅ **`BatchTooLarge`** is atomic — the cap check fires before any work
- ✅ **`EmptyNote` (batch)** is atomic — pre-validation walks the batch before any DB writes
- ⚠️ **Other per-item Store-level errors (`PATH_CONFLICT`, etc.)** are NOT transactionally atomic — items 0..N-1 may be committed before item N fails. Existing behavior, not in scope for #213.

The 500-cap bounds the blast radius of any partial-commit. **Transactional batch handling for path conflicts and other per-item errors is filed as #236** for a focused follow-up PR.

## Behavior change (call out for reviewers)

This is a behavior change — existing clients that send the broken shapes get rejected:

- `POST /api/notes` with `{}` or `{ content: "" }` (no `path`) → **400 EmptyNoteError** (previously: 201 with empty row)
- `POST /api/notes` with mixed batch where any entry is empty+empty → **400 EmptyNoteError, nothing created** (previously: prefix committed before 400)
- `POST /api/notes` with `{ notes: [501+ items] }` → **413 BatchTooLarge** (previously: processed all)
- MCP `create-note` / `update-note` with empty content + no path → **EMPTY_NOTE error** (previously: silent empty row)
- MCP `create-note` / `update-note` with > 500 items → **BATCH_TOO_LARGE error**
- `PATCH /api/notes/:id` clearing both content and path → **400 EmptyNoteError** (previously: empty row)

No legitimate caller should regress. The Prism client-side guard mentioned in #213 is now redundant — server enforces the invariant.

## Why Store-boundary, not HTTP-only

Two transports (HTTP `routes.ts` and MCP `mcp.ts`) both hit `store.createNote` / `store.updateNote`. Validating at the Store mirrors the existing `PathConflictError` pattern and means a future transport can't accidentally bypass the guard. HTTP/MCP layers translate the error code to status/error-shape per their conventions. The atomic batch rejection is layered on top: pre-validation at the transport boundary so the Store-level check never has a chance to fire mid-loop.

## Test plan

- [x] `bun test ./core/src/` — 365/365 pass (added 6 Store-level tests + 4 MCP-level regression tests including atomic-batch assertion)
- [x] `bun test ./src/` — 739/739 pass (added 8 HTTP regression tests including atomic-batch assertion)
- [x] `bun run typecheck` — clean
- [ ] Test against Aaron's running vault (bun-linked): `POST {}` returns 400; `POST { content: "hi" }` (no path) returns 201; `POST { path: "foo" }` (no content) returns 201; `POST { notes: [501 valid] }` returns 413; mixed batch leaves no prefix
- [ ] Verify no existing client breaks (Prism, parachute-notes, parachute-daily)

## Files

| File | Change |
|---|---|
| `core/src/notes.ts` | `EmptyNoteError` class + validation in `createNote` and `updateNote` + `MAX_BATCH_SIZE` (single source of truth) |
| `core/src/mcp.ts` | Imports `MAX_BATCH_SIZE` from `notes.ts` + `BatchTooLargeError` + cap checks + atomic empty-note pre-validation in create-note |
| `src/routes.ts` | Imports `MAX_BATCH_SIZE` from `notes.ts` + 413 BatchTooLarge check + 400 EMPTY_NOTE handlers in POST + PATCH + atomic empty-note pre-validation |
| `src/transcription-worker.test.ts` | Fixture fix: voice memos always have a path in production (path-only legit shape) |
| `core/src/core.test.ts` | 6 Store-level + 4 MCP-level regression tests (incl. atomic-batch assertion) |
| `src/vault.test.ts` | 8 HTTP regression tests (incl. atomic-batch assertion via beforeCount === afterCount) |
| `package.json` | rc.28 → rc.29 |

## Follow-up

- #236 — transactional batch handling for non-empty-note per-item errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)