### PR TITLE
fix(schemas): wrap migrateToV14 in BEGIN IMMEDIATE / COMMIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.3.6-rc.34] — 2026-05-04
+
+vault#248 — wrap the v13 → v14 migration in an explicit `BEGIN IMMEDIATE / COMMIT` transaction so a crash mid-migration leaves the DB in either pre-v14 or post-v14 state, never half-migrated. Surfaced during review of vault#245: every step in `migrateToV14` is individually idempotent (ALTER TABLE adds are guarded by `hasColumn`, data copies are upsert-and-update, the final `DROP TABLE tag_schemas` is guarded by `hasTable`), but the failure mode wasn't specified — a future reader could remove the guards thinking "we have transactions now." Wrapping the body makes the guarantee explicit; the idempotent guards become belt-and-suspenders.
+
+### Fixed
+
+- **`migrateToV14` body wrapped in `BEGIN IMMEDIATE / COMMIT` with try/catch ROLLBACK.** Mirrors the v15 transaction wrap that landed in rc.32. The early-return guard (`if (!hasTable(db, "tags")) return`) stays outside the envelope — if there's no `tags` table at all, there's nothing to roll back. Inside: ALTERs, two data copies (`tag_schemas` → `tags`; `_tags/<name>` notes → `tags.parent_names`), the timestamp backfill, and the final `DROP TABLE tag_schemas` all live inside one envelope; a thrown exception in any step rolls back the whole migration. Modern SQLite (3.6+ via bun:sqlite) supports DDL inside transactions, so ALTER and DROP both honor the rollback. New regression test (`crash mid-migration rolls back to pre-migration state, then retry succeeds`) injects a throw on `DROP TABLE tag_schemas`, asserts the DB returns to pre-v13 shape (tag_schemas table present with rows intact, tags has `(name)` only, `_tags/voice` note untouched), then drops the injection and re-runs `initSchema` — convergence to the same final post-v14 state as a clean run.
+
 ## [0.3.6-rc.33] — 2026-05-03
 
 vault#249 reviewer-fold pass: tighten the auth boundary on the new `/api/note-schemas` (+ matching MCP tools) so tag-scoped tokens can't enumerate or write `tag`-kind `schema_mappings` outside their allowlist, fix the `migrateToV15` short-circuit to use `||` instead of `&&` (a vault with schemas but zero mappings is a valid state — the buggy condition re-scanned `_schema_defaults` on every boot), and refresh the `resolveApplicableSchemas` JSDoc to point at `note_schemas` instead of the retired `_schemas/<name>` convention. No data shape or version-bump trigger; rc.33 carries the reviewer feedback only.

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -3691,6 +3691,94 @@ describe("schema migration v13 → v14", async () => {
     expect(tableExists).toBeNull();
     db.close();
   });
+
+  // vault#248 — the migration body is wrapped in BEGIN IMMEDIATE / COMMIT
+  // with a try/catch ROLLBACK. A crash mid-migration must leave the DB in
+  // its pre-migration state (NOT half-migrated), and a retry must converge
+  // to the same final state as a clean run. The transaction wrap is what
+  // makes that guarantee — the `hasColumn` / `hasTable` idempotency guards
+  // are belt-and-suspenders, not load-bearing.
+  it("crash mid-migration rolls back to pre-migration state, then retry succeeds", async () => {
+    const { Database } = await import("bun:sqlite");
+    const { initSchema } = await import("./schema.ts");
+
+    const db = new Database(":memory:");
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec(`CREATE TABLE notes (
+      id TEXT PRIMARY KEY, content TEXT DEFAULT '', path TEXT,
+      metadata TEXT DEFAULT '{}', created_at TEXT NOT NULL, updated_at TEXT
+    )`);
+    db.exec(`CREATE TABLE tags (name TEXT PRIMARY KEY)`);
+    db.exec(`CREATE TABLE tag_schemas (
+      tag_name TEXT PRIMARY KEY REFERENCES tags(name) ON DELETE CASCADE,
+      description TEXT, fields TEXT
+    )`);
+
+    db.prepare("INSERT INTO tags (name) VALUES (?)").run("voice");
+    db.prepare("INSERT INTO tag_schemas (tag_name, description, fields) VALUES (?, ?, ?)")
+      .run("voice", "voice notes", '{"recorded_at":{"type":"string"}}');
+    db.prepare(`INSERT INTO notes (id, path, metadata, created_at) VALUES (?, ?, ?, ?)`)
+      .run("n1", "_tags/voice", JSON.stringify({ parents: ["manual"] }), new Date().toISOString());
+
+    // Patch db.exec to simulate a crash on the final DROP TABLE step. That's
+    // the right injection point: every ALTER + data copy has already landed
+    // inside the transaction, so a successful rollback proves the wrap
+    // covers the full migration body — not just the tail.
+    const origExec = db.exec.bind(db);
+    let crashOnDrop: boolean = true;
+    (db as any).exec = function (sql: string) {
+      if (crashOnDrop && sql.includes("DROP TABLE tag_schemas")) {
+        throw new Error("simulated crash mid-migration");
+      }
+      return origExec(sql);
+    };
+
+    expect(() => initSchema(db)).toThrow("simulated crash mid-migration");
+
+    // Pre-migration shape: tag_schemas table still exists with its row,
+    // tags table back to (name) only — none of the v14 columns landed,
+    // `_tags/voice` note untouched, schema_version row not yet written.
+    const tagSchemasStill = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='tag_schemas'",
+    ).get();
+    expect(tagSchemasStill).toBeTruthy();
+    const schemaRow = db.prepare(
+      "SELECT description, fields FROM tag_schemas WHERE tag_name = 'voice'",
+    ).get() as any;
+    expect(schemaRow.description).toBe("voice notes");
+
+    const tagsCols = db.prepare("PRAGMA table_info(tags)").all() as { name: string }[];
+    const colNames = tagsCols.map((c) => c.name).sort();
+    expect(colNames).toEqual(["name"]);
+
+    const note = db.prepare("SELECT path, metadata FROM notes WHERE id = 'n1'").get() as any;
+    expect(note.path).toBe("_tags/voice");
+    expect(JSON.parse(note.metadata).parents).toEqual(["manual"]);
+
+    // No lingering open transaction — a SELECT after rollback succeeds, and
+    // a fresh BEGIN IMMEDIATE doesn't fail with "cannot start a transaction
+    // within a transaction".
+    db.exec("BEGIN IMMEDIATE");
+    db.exec("ROLLBACK");
+
+    // Retry: drop the crash injection, run initSchema again. It must
+    // converge to the same final post-v14 state as a clean run.
+    crashOnDrop = false;
+    initSchema(db);
+
+    const tableGone = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='tag_schemas'",
+    ).get();
+    expect(tableGone).toBeNull();
+    const post = db.prepare(
+      "SELECT description, fields, parent_names FROM tags WHERE name = 'voice'",
+    ).get() as any;
+    expect(post.description).toBe("voice notes");
+    expect(JSON.parse(post.fields).recorded_at.type).toBe("string");
+    expect(JSON.parse(post.parent_names)).toEqual(["manual"]);
+
+    db.close();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -434,97 +434,108 @@ function migrateToV13(db: Database): void {
  * are LEFT IN PLACE — they're harmless historical record and a user might
  * have other content there. Future writes go to the tags row directly.
  *
- * Idempotent: ALTER TABLE adds are guarded by hasColumn; the data copy
- * only runs when tag_schemas / `_tags/*` notes still exist; running the
- * migration twice on the same DB is a no-op the second time.
+ * Wrapped in BEGIN IMMEDIATE / COMMIT (with a try/catch ROLLBACK) so a
+ * crash mid-migration leaves the DB in either pre-v14 or post-v14 state,
+ * never half-migrated. Each step remains individually idempotent — the
+ * transaction wrap is belt-and-suspenders, not load-bearing — so a future
+ * reader who removes the `hasColumn` / `hasTable` guards still gets correct
+ * behavior on retry.
  */
 function migrateToV14(db: Database): void {
   if (!hasTable(db, "tags")) return;
 
-  // 1. ALTER TABLE — additive, idempotent.
-  const cols: [string, string][] = [
-    ["description", "TEXT"],
-    ["fields", "TEXT"],
-    ["relationships", "TEXT"],
-    ["parent_names", "TEXT"],
-    ["created_at", "TEXT"],
-    ["updated_at", "TEXT"],
-  ];
-  for (const [col, type] of cols) {
-    if (!hasColumn(db, "tags", col)) {
-      db.exec(`ALTER TABLE tags ADD COLUMN ${col} ${type}`);
-    }
-  }
-
-  const now = new Date().toISOString();
-  let copiedSchemas = 0;
-  let copiedHierarchy = 0;
-
-  // 2. Copy tag_schemas → tags.{description,fields}.
-  if (hasTable(db, "tag_schemas")) {
-    const rows = db.prepare(
-      "SELECT tag_name, description, fields FROM tag_schemas",
-    ).all() as { tag_name: string; description: string | null; fields: string | null }[];
-    const upsert = db.prepare(
-      "INSERT OR IGNORE INTO tags (name, created_at, updated_at) VALUES (?, ?, ?)",
-    );
-    const update = db.prepare(
-      "UPDATE tags SET description = ?, fields = ?, updated_at = ? WHERE name = ?",
-    );
-    for (const row of rows) {
-      upsert.run(row.tag_name, now, now);
-      update.run(row.description, row.fields, now, row.tag_name);
-      copiedSchemas++;
-    }
-  }
-
-  // 3. Copy `_tags/<name>` notes' metadata.parents → tags.parent_names.
-  // Only runs if the notes table exists (it always does post-SCHEMA_SQL,
-  // but stay defensive — initSchema runs SCHEMA_SQL first so this is true).
-  if (hasTable(db, "notes")) {
-    const tagNotes = db.prepare(
-      "SELECT path, metadata FROM notes WHERE path GLOB '_tags/*'",
-    ).all() as { path: string; metadata: string | null }[];
-    const upsert = db.prepare(
-      "INSERT OR IGNORE INTO tags (name, created_at, updated_at) VALUES (?, ?, ?)",
-    );
-    const update = db.prepare(
-      "UPDATE tags SET parent_names = ?, updated_at = ? WHERE name = ?",
-    );
-    for (const note of tagNotes) {
-      const tagName = note.path.slice("_tags/".length);
-      if (!tagName) continue;
-      let parents: string[] | null = null;
-      try {
-        const meta = note.metadata ? JSON.parse(note.metadata) : {};
-        const raw = meta?.parents;
-        if (Array.isArray(raw) && raw.length > 0) {
-          const cleaned = raw.filter((p: unknown): p is string => typeof p === "string" && p.length > 0);
-          if (cleaned.length > 0) parents = cleaned;
-        }
-      } catch {
-        // Malformed metadata — skip; the note is left untouched.
-        continue;
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    // 1. ALTER TABLE — additive, idempotent.
+    const cols: [string, string][] = [
+      ["description", "TEXT"],
+      ["fields", "TEXT"],
+      ["relationships", "TEXT"],
+      ["parent_names", "TEXT"],
+      ["created_at", "TEXT"],
+      ["updated_at", "TEXT"],
+    ];
+    for (const [col, type] of cols) {
+      if (!hasColumn(db, "tags", col)) {
+        db.exec(`ALTER TABLE tags ADD COLUMN ${col} ${type}`);
       }
-      if (!parents) continue;
-      upsert.run(tagName, now, now);
-      update.run(JSON.stringify(parents), now, tagName);
-      copiedHierarchy++;
     }
-  }
 
-  // 4. Backfill timestamps for rows the copies didn't touch.
-  db.exec(`UPDATE tags SET created_at = '${now}' WHERE created_at IS NULL`);
+    const now = new Date().toISOString();
+    let copiedSchemas = 0;
+    let copiedHierarchy = 0;
 
-  // 5. Drop the sidecar after the copy is complete.
-  if (hasTable(db, "tag_schemas")) {
-    db.exec("DROP TABLE tag_schemas");
-  }
+    // 2. Copy tag_schemas → tags.{description,fields}.
+    if (hasTable(db, "tag_schemas")) {
+      const rows = db.prepare(
+        "SELECT tag_name, description, fields FROM tag_schemas",
+      ).all() as { tag_name: string; description: string | null; fields: string | null }[];
+      const upsert = db.prepare(
+        "INSERT OR IGNORE INTO tags (name, created_at, updated_at) VALUES (?, ?, ?)",
+      );
+      const update = db.prepare(
+        "UPDATE tags SET description = ?, fields = ?, updated_at = ? WHERE name = ?",
+      );
+      for (const row of rows) {
+        upsert.run(row.tag_name, now, now);
+        update.run(row.description, row.fields, now, row.tag_name);
+        copiedSchemas++;
+      }
+    }
 
-  if (copiedSchemas > 0 || copiedHierarchy > 0) {
-    console.log(
-      `[vault] migrated to schema v14: copied ${copiedSchemas} tag_schemas + ${copiedHierarchy} _tags/* hierarchies onto tags rows`,
-    );
+    // 3. Copy `_tags/<name>` notes' metadata.parents → tags.parent_names.
+    // Only runs if the notes table exists (it always does post-SCHEMA_SQL,
+    // but stay defensive — initSchema runs SCHEMA_SQL first so this is true).
+    if (hasTable(db, "notes")) {
+      const tagNotes = db.prepare(
+        "SELECT path, metadata FROM notes WHERE path GLOB '_tags/*'",
+      ).all() as { path: string; metadata: string | null }[];
+      const upsert = db.prepare(
+        "INSERT OR IGNORE INTO tags (name, created_at, updated_at) VALUES (?, ?, ?)",
+      );
+      const update = db.prepare(
+        "UPDATE tags SET parent_names = ?, updated_at = ? WHERE name = ?",
+      );
+      for (const note of tagNotes) {
+        const tagName = note.path.slice("_tags/".length);
+        if (!tagName) continue;
+        let parents: string[] | null = null;
+        try {
+          const meta = note.metadata ? JSON.parse(note.metadata) : {};
+          const raw = meta?.parents;
+          if (Array.isArray(raw) && raw.length > 0) {
+            const cleaned = raw.filter((p: unknown): p is string => typeof p === "string" && p.length > 0);
+            if (cleaned.length > 0) parents = cleaned;
+          }
+        } catch {
+          // Malformed metadata — skip; the note is left untouched.
+          continue;
+        }
+        if (!parents) continue;
+        upsert.run(tagName, now, now);
+        update.run(JSON.stringify(parents), now, tagName);
+        copiedHierarchy++;
+      }
+    }
+
+    // 4. Backfill timestamps for rows the copies didn't touch.
+    db.exec(`UPDATE tags SET created_at = '${now}' WHERE created_at IS NULL`);
+
+    // 5. Drop the sidecar after the copy is complete.
+    if (hasTable(db, "tag_schemas")) {
+      db.exec("DROP TABLE tag_schemas");
+    }
+
+    db.exec("COMMIT");
+
+    if (copiedSchemas > 0 || copiedHierarchy > 0) {
+      console.log(
+        `[vault] migrated to schema v14: copied ${copiedSchemas} tag_schemas + ${copiedHierarchy} _tags/* hierarchies onto tags rows`,
+      );
+    }
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.33",
+  "version": "0.3.6-rc.34",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Closes #248.

## Summary

- Wraps `migrateToV14` body in `BEGIN IMMEDIATE` / `COMMIT` with a `try/catch ROLLBACK` on the catch path. Mirrors the v15 wrap that landed in rc.32.
- A crash in any step (ALTER, two data copies, timestamp backfill, final `DROP TABLE tag_schemas`) now rolls back the whole migration. Idempotent guards (`hasColumn` / `hasTable`) become belt-and-suspenders rather than load-bearing — a future reader who removes them still gets correct retry behavior.
- Modern SQLite (3.6+ via bun:sqlite) supports DDL inside transactions, so both ALTER and DROP honor the rollback.

## Test plan

- [x] New regression test: `crash mid-migration rolls back to pre-migration state, then retry succeeds`. Injects a throw on `DROP TABLE tag_schemas`, asserts pre-v13 shape is restored (tag_schemas table + rows intact, `tags` has `(name)` only, `_tags/voice` note untouched), then drops the injection and re-runs `initSchema` — converges to the same post-v14 state as a clean run.
- [x] Existing v13 → v14 migration tests still pass (no behavioral change for the success path).
- [x] `bun test ./core/src/` — 404/0 (was 403; +1 crash-rollback test).
- [x] `bun test ./src/` — 795/0.
- [x] `bun --bun tsc --noEmit` — clean.
- [x] Real-DB harness skipped per team-lead's brief — this is a transaction wrap, not a logic change.

## Versioning

Bumps `0.3.6-rc.33` → `0.3.6-rc.34`. CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)