### PR TITLE
fix(admin-spa): per-vault mount at /vault/<name>/admin/* (closes #252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ vault#252 — remount the admin SPA from origin-rooted `/admin/*` to per-vault `
 - **`web/ui/scripts/verify-base.mjs` asserts `./assets/` (was `/admin/assets/`).** Same drift check, adapted to the new relative-base contract; the override skip-condition now matches `VITE_BASE_PATH=./`.
 - **`web/ui/CLAUDE.md` mount-aware contract section + lib/auth.ts JSDoc** updated to document the per-vault mount, runtime basename detection, and the new "Manage" link shape (`<hub-origin>/vault/<name>/admin#token=…`).
 
+### Fixed
+
+- **`serveAdminSpa` redirects bare `/vault/<name>/admin` → `/vault/<name>/admin/` (301).** Browsers resolve relative URLs against the **directory** of the current document, not the document URL itself — so Vite's `./assets/index-abc.js` resolves correctly only when the SPA is loaded with a trailing slash. Hub's `resolveManagementUrl` (`web/ui/src/lib/api.ts`) generates the bare form (strip trailing slash, append `/admin`), which means without this canonicalization the SPA bundle's asset URLs would resolve to `/vault/<name>/assets/...` and 404 against the per-vault auth wall — the SPA would never boot. Same shape the notes-server uses for its `--mount` canonicalization. Reviewer-caught blocker on the initial #252 push; the redirect ships in the same PR. New regression test in `admin-spa.test.ts` pins the 301 + Location header so future refactors can't silently regress the asset-resolution contract.
+
 ### Tests
 
 - `src/admin-spa.test.ts` — 8 new cases for the per-vault regex (matches `/vault/<name>/admin[/...]`, rejects `/vault/<name>/admin-foo`, `/vault/<name>`, origin-rooted `/admin/*`, percent-encoded vault names strip cleanly).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.3.6-rc.35] — 2026-05-03
+
+vault#252 — remount the admin SPA from origin-rooted `/admin/*` to per-vault `/vault/<name>/admin/*` so it's reachable through hub's `/vault/<name>/*` proxy. The hub doesn't proxy origin-rooted paths, which left an operator clicking "Manage Vault" on the hub directory landing on a 401-walled vault metadata endpoint instead of the SPA. Three layers move in lockstep — the server's static-file dispatch, the React Router runtime basename, and Vite's asset-base — so the same compiled bundle works at any per-vault mount without a rebuild.
+
+### Changed
+
+- **`src/admin-spa.ts:isAdminSpaPath` regex + `serveAdminSpa` strip.** New mount regex `/^\/vault\/([^/]+)\/admin(?=\/|$)/` matches `/vault/<name>/admin` and any subpath under it (assets, client-routed paths). The strip-prefix collapses to `pathname.replace(MOUNT_RE, "")` so `/vault/foo/admin/assets/x.js` maps to `/assets/x.js` against the same `dist/` directory. Bare `/vault/<name>/admin-foo` and `/vault/<name>` (the metadata endpoint) explicitly do not trigger the SPA — only the mount root and its true subpaths. Routing test `/vault/<name>/api/notes` still reaches the per-vault API (regression pin).
+- **`src/routing.ts` admin-spa dispatch must fire BEFORE per-vault dispatch.** Already the case, but the comment block now spells out why — the per-vault auth wall would otherwise short-circuit static-asset responses with a 401 JSON body. The legacy origin-rooted `/admin/*` no longer matches anything; falls through to the catch-all 404. Hub's directory page links to `/vault/<name>/admin#token=…` post-hub#162-realignment.
+- **`web/ui/src/lib/mount.ts` (new): runtime basename detection.** `getMountedVaultName()` extracts `<name>` from `window.location.pathname`; `getBasename()` returns the matching React Router basename (`/vault/<name>/admin`, with percent-encoding preserved so it matches the URL byte-for-byte). Legacy fallback to `/admin` for dev served at the old mount; empty string for stand-alone root. Mirrors hub#173's dual-mount basename detection on the hub side.
+- **`web/ui/src/main.tsx` BrowserRouter basename pulled from `getBasename()`.** No longer reads `import.meta.env.BASE_URL` since the build base is now relative — and the runtime mount is per-vault anyway, which can't be baked at build time.
+- **`web/ui/src/App.tsx` redirects `/` to `/vault/<name>` when mounted under a specific vault.** The generic vault picker (`VaultsList`) calls `/vaults/list`, which hub doesn't proxy — so when reached via the hub proxy the picker would show an empty/erroring list. Per-vault mount jumps straight to the detail page using `<Navigate to="/vault/<name>" replace />`. Nav-bar label switches to the vault name (`<code>boulder</code>`) under per-vault mount instead of the generic "Vaults" link. Legacy `/admin/*` and stand-alone root mounts still get the picker.
+- **`web/ui/vite.config.ts` `base: "./"` (was `/admin/`).** Asset URLs resolve relative to wherever `index.html` was served, so the same bundle works at any `/vault/<name>/admin/` mount without a rebuild. `VITE_BASE_PATH` override still works for stand-alone dev (`VITE_BASE_PATH=/`).
+- **`web/ui/scripts/verify-base.mjs` asserts `./assets/` (was `/admin/assets/`).** Same drift check, adapted to the new relative-base contract; the override skip-condition now matches `VITE_BASE_PATH=./`.
+- **`web/ui/CLAUDE.md` mount-aware contract section + lib/auth.ts JSDoc** updated to document the per-vault mount, runtime basename detection, and the new "Manage" link shape (`<hub-origin>/vault/<name>/admin#token=…`).
+
+### Tests
+
+- `src/admin-spa.test.ts` — 8 new cases for the per-vault regex (matches `/vault/<name>/admin[/...]`, rejects `/vault/<name>/admin-foo`, `/vault/<name>`, origin-rooted `/admin/*`, percent-encoded vault names strip cleanly).
+- `src/routing.test.ts` — 7 new cases for the dispatch (per-vault SPA mount fires before per-vault dispatch, even when the vault doesn't exist — the SPA shell is static; POST 405; `/vault/<name>/admin-foo` falls through to per-vault auth wall; legacy `/admin/*` returns 404; `/vault/<name>/api/notes` regression pin).
+- `web/ui/src/lib/mount.test.ts` — 11 new cases covering vault-name extraction (per-vault mount, deep client-routed paths, percent-decoded names), null cases (legacy `/admin/`, stand-alone root, per-vault metadata path, `/vault/<name>/admin-foo`), and basename construction (preserves percent-encoding for byte-for-byte React Router matching).
+
 ## [0.3.6-rc.34] — 2026-05-04
 
 vault#248 — wrap the v13 → v14 migration in an explicit `BEGIN IMMEDIATE / COMMIT` transaction so a crash mid-migration leaves the DB in either pre-v14 or post-v14 state, never half-migrated. Surfaced during review of vault#245: every step in `migrateToV14` is individually idempotent (ALTER TABLE adds are guarded by `hasColumn`, data copies are upsert-and-update, the final `DROP TABLE tag_schemas` is guarded by `hasTable`), but the failure mode wasn't specified — a future reader could remove the guards thinking "we have transactions now." Wrapping the body makes the guarantee explicit; the idempotent guards become belt-and-suspenders.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.34",
+  "version": "0.3.6-rc.35",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/admin-spa.test.ts
+++ b/src/admin-spa.test.ts
@@ -70,17 +70,22 @@ describe("serveAdminSpa", () => {
     expect(body).toContain("bun run build");
   });
 
-  test("/vault/<name>/admin returns the SPA index", async () => {
+  test("bare /vault/<name>/admin redirects to trailing-slash form (301)", async () => {
+    // Vite's relative asset URLs (./assets/...) resolve against the
+    // *directory* of the current document — without a trailing slash,
+    // /vault/foo/admin's directory is /vault/foo/ and assets 404 against
+    // the per-vault auth wall. Hub's resolveManagementUrl generates the
+    // bare form, so this redirect is the load-bearing canonicalization.
     const res = await serveAdminSpa(fixtureDir, "/vault/work/admin");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toContain("text/html");
-    expect(await res.text()).toContain("shell");
+    expect(res.status).toBe(301);
+    expect(res.headers.get("Location")).toBe("/vault/work/admin/");
   });
 
   test("/vault/<name>/admin/ returns the SPA index", async () => {
     const res = await serveAdminSpa(fixtureDir, "/vault/work/admin/");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("shell");
   });
 
   test("client-routed path (no extension) falls through to index.html", async () => {

--- a/src/admin-spa.test.ts
+++ b/src/admin-spa.test.ts
@@ -12,7 +12,7 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { isAdminSpaPath, serveAdminSpa, ADMIN_SPA_MOUNT } from "./admin-spa.ts";
+import { isAdminSpaPath, serveAdminSpa } from "./admin-spa.ts";
 
 const fixtureDir = join(tmpdir(), `vault-admin-spa-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 
@@ -28,72 +28,87 @@ afterAll(() => {
 });
 
 describe("isAdminSpaPath", () => {
-  test("matches /admin and /admin/...", () => {
-    expect(isAdminSpaPath("/admin")).toBe(true);
-    expect(isAdminSpaPath("/admin/")).toBe(true);
-    expect(isAdminSpaPath("/admin/vault/foo")).toBe(true);
-    expect(isAdminSpaPath("/admin/assets/index.js")).toBe(true);
+  test("matches /vault/<name>/admin and /vault/<name>/admin/...", () => {
+    expect(isAdminSpaPath("/vault/work/admin")).toBe(true);
+    expect(isAdminSpaPath("/vault/work/admin/")).toBe(true);
+    expect(isAdminSpaPath("/vault/work/admin/tokens")).toBe(true);
+    expect(isAdminSpaPath("/vault/boulder/admin/assets/index.js")).toBe(true);
+    // Vault names with URL-safe punctuation should still match — the regex
+    // captures up to the next "/" so dashes / dots / digits all pass.
+    expect(isAdminSpaPath("/vault/my-vault.2/admin")).toBe(true);
   });
 
-  test("does not match /administrative or /admin-foo", () => {
-    expect(isAdminSpaPath("/administrative")).toBe(false);
-    expect(isAdminSpaPath("/admin-foo")).toBe(false);
-    expect(isAdminSpaPath("/adminx")).toBe(false);
+  test("does not match adjacent paths under the same vault", () => {
+    expect(isAdminSpaPath("/vault/work")).toBe(false);
+    expect(isAdminSpaPath("/vault/work/")).toBe(false);
+    expect(isAdminSpaPath("/vault/work/api/notes")).toBe(false);
+    expect(isAdminSpaPath("/vault/work/tokens")).toBe(false);
+    // Bare `admin-foo` suffix must not trigger — only the SPA mount itself.
+    expect(isAdminSpaPath("/vault/work/admin-foo")).toBe(false);
+    expect(isAdminSpaPath("/vault/work/administrative")).toBe(false);
+  });
+
+  test("does not match origin-rooted /admin (legacy mount retired)", () => {
+    expect(isAdminSpaPath("/admin")).toBe(false);
+    expect(isAdminSpaPath("/admin/")).toBe(false);
+    expect(isAdminSpaPath("/admin/tokens")).toBe(false);
   });
 
   test("does not match unrelated paths", () => {
     expect(isAdminSpaPath("/")).toBe(false);
-    expect(isAdminSpaPath("/vault/work")).toBe(false);
     expect(isAdminSpaPath("/vaults")).toBe(false);
-  });
-
-  test("export of mount constant is /admin", () => {
-    expect(ADMIN_SPA_MOUNT).toBe("/admin");
+    expect(isAdminSpaPath("/auth/status")).toBe(false);
   });
 });
 
 describe("serveAdminSpa", () => {
   test("503 when the dist dir is absent (unbuilt)", async () => {
-    const res = await serveAdminSpa("/nonexistent/dist/dir", "/admin/");
+    const res = await serveAdminSpa("/nonexistent/dist/dir", "/vault/work/admin/");
     expect(res.status).toBe(503);
     const body = await res.text();
     expect(body).toContain("not found");
     expect(body).toContain("bun run build");
   });
 
-  test("/admin returns the SPA index", async () => {
-    const res = await serveAdminSpa(fixtureDir, "/admin");
+  test("/vault/<name>/admin returns the SPA index", async () => {
+    const res = await serveAdminSpa(fixtureDir, "/vault/work/admin");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
     expect(await res.text()).toContain("shell");
   });
 
-  test("/admin/ returns the SPA index", async () => {
-    const res = await serveAdminSpa(fixtureDir, "/admin/");
+  test("/vault/<name>/admin/ returns the SPA index", async () => {
+    const res = await serveAdminSpa(fixtureDir, "/vault/work/admin/");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
   });
 
   test("client-routed path (no extension) falls through to index.html", async () => {
-    const res = await serveAdminSpa(fixtureDir, "/admin/vault/work");
+    const res = await serveAdminSpa(fixtureDir, "/vault/work/admin/tokens");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
     expect(await res.text()).toContain("shell");
   });
 
   test("real asset path returns the asset with the right content-type", async () => {
-    const jsRes = await serveAdminSpa(fixtureDir, "/admin/assets/index-abc.js");
+    const jsRes = await serveAdminSpa(fixtureDir, "/vault/work/admin/assets/index-abc.js");
     expect(jsRes.status).toBe(200);
     expect(jsRes.headers.get("content-type")).toContain("application/javascript");
     expect(await jsRes.text()).toContain("console.log");
 
-    const cssRes = await serveAdminSpa(fixtureDir, "/admin/assets/index-abc.css");
+    const cssRes = await serveAdminSpa(fixtureDir, "/vault/work/admin/assets/index-abc.css");
     expect(cssRes.status).toBe(200);
     expect(cssRes.headers.get("content-type")).toContain("text/css");
   });
 
+  test("vault names with URL-safe punctuation strip cleanly", async () => {
+    const res = await serveAdminSpa(fixtureDir, "/vault/my-vault.2/admin/assets/index-abc.js");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/javascript");
+  });
+
   test("typo'd asset path falls through to index.html (not a 404)", async () => {
-    const res = await serveAdminSpa(fixtureDir, "/admin/assets/missing-xyz.js");
+    const res = await serveAdminSpa(fixtureDir, "/vault/work/admin/assets/missing-xyz.js");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
   });
@@ -101,7 +116,7 @@ describe("serveAdminSpa", () => {
   test("path traversal (..) cannot escape dist dir", async () => {
     // Triggers the asset-shape filter (.. is rejected) so this falls through
     // to the SPA shell rather than reading something outside dist/.
-    const res = await serveAdminSpa(fixtureDir, "/admin/../../etc/passwd");
+    const res = await serveAdminSpa(fixtureDir, "/vault/work/admin/../../etc/passwd");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
     const body = await res.text();

--- a/src/admin-spa.ts
+++ b/src/admin-spa.ts
@@ -1,10 +1,17 @@
 /**
- * Admin SPA mount. Serves `web/ui/dist/` under `/admin/*`.
+ * Admin SPA mount. Serves `web/ui/dist/` under `/vault/<name>/admin/*`.
  *
  * The vault HTTP server hosts an admin SPA (vault#216) co-located in the
  * source tree at `web/ui/`. Vite produces the bundle in `web/ui/dist/`
  * (gitignored — built locally before publish, or by a release pipeline).
  * This module turns the bundle into a static-file response.
+ *
+ * Per-vault mount (vault#252): the SPA lives under `/vault/<name>/admin/*`
+ * rather than the origin-rooted `/admin/*` it shipped with. The hub only
+ * proxies `/vault/<name>/*` paths (per parachute-patterns/module-protocol),
+ * so an origin-rooted SPA is unreachable through the hub. Asset URLs are
+ * relative (Vite `base: "./"`), so the same bundle works at any mount
+ * point — no rebuild per vault.
  *
  * Mirrors `parachute-hub/src/hub-server.ts:serveSpa` — the conventions
  * (strip mount, asset-shape filter, `.html` fallthrough for client routes)
@@ -14,7 +21,12 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const ADMIN_SPA_MOUNT = "/admin";
+/**
+ * Regex anchoring the per-vault SPA mount. Matches `/vault/<name>/admin`
+ * exactly and any subpath under it. The `<name>` capture is reused by the
+ * prefix-strip below — keep the two in sync if this regex moves.
+ */
+const ADMIN_SPA_MOUNT_RE = /^\/vault\/([^/]+)\/admin(?=\/|$)/;
 
 /**
  * Resolve the default SPA bundle dir. Anchored to this file's location so
@@ -87,8 +99,11 @@ export async function serveAdminSpa(spaDistDir: string, pathname: string): Promi
       { status: 503, headers: { "content-type": "text/plain; charset=utf-8" } },
     );
   }
-  // Strip the mount prefix; "/admin" → "", "/admin/" → "/", "/admin/x" → "/x".
-  const sub = pathname === ADMIN_SPA_MOUNT ? "" : pathname.slice(ADMIN_SPA_MOUNT.length);
+  // Strip the mount prefix:
+  //   /vault/foo/admin       → ""
+  //   /vault/foo/admin/      → "/"
+  //   /vault/foo/admin/x.js  → "/x.js"
+  const sub = pathname.replace(ADMIN_SPA_MOUNT_RE, "");
   const indexPath = join(spaDistDir, "index.html");
 
   // Empty / mount-root / any non-asset request → SPA shell. The router
@@ -122,9 +137,10 @@ export async function serveAdminSpa(spaDistDir: string, pathname: string): Promi
 }
 
 /**
- * Match `/admin` or `/admin/...`. Bare `/administrative-thing` must not
- * trigger this — only the mount root and its true subpaths.
+ * Match `/vault/<name>/admin` or `/vault/<name>/admin/...`. Bare
+ * `/vault/<name>/admin-foo` and `/vault/<name>` (the metadata endpoint)
+ * must NOT trigger this — only the SPA mount root and its true subpaths.
  */
 export function isAdminSpaPath(pathname: string): boolean {
-  return pathname === ADMIN_SPA_MOUNT || pathname.startsWith(`${ADMIN_SPA_MOUNT}/`);
+  return ADMIN_SPA_MOUNT_RE.test(pathname);
 }

--- a/src/admin-spa.ts
+++ b/src/admin-spa.ts
@@ -104,6 +104,21 @@ export async function serveAdminSpa(spaDistDir: string, pathname: string): Promi
   //   /vault/foo/admin/      → "/"
   //   /vault/foo/admin/x.js  → "/x.js"
   const sub = pathname.replace(ADMIN_SPA_MOUNT_RE, "");
+
+  // Canonicalize the bare mount → trailing-slash form. Vite emits
+  // *relative* asset URLs (`./assets/index-abc.js`) since `<name>` isn't
+  // known at build time, and browsers resolve relative URLs against the
+  // **directory** of the current document — not the document itself. So:
+  //   /vault/foo/admin/  → asset resolves to /vault/foo/admin/assets/...  ✓
+  //   /vault/foo/admin   → asset resolves to /vault/foo/assets/...        ✗
+  // Without this redirect, the bare-form URL hub#162 generates (per
+  // `resolveManagementUrl` — strip trailing slash, append `/admin`)
+  // would 404 every asset against the per-vault auth wall, and the SPA
+  // would never boot. Same canonicalization the notes-server `--mount`
+  // path does for the same reason.
+  if (sub === "") {
+    return Response.redirect(`${pathname}/`, 301);
+  }
   const indexPath = join(spaDistDir, "index.html");
 
   // Empty / mount-root / any non-asset request → SPA shell. The router

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -218,40 +218,79 @@ describe("GET /vaults/list (public discovery)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// /admin/* — admin SPA static-file mount. Detailed tests live in
-// admin-spa.test.ts (with a tmp dist dir); these only pin the dispatch
-// — i.e. /admin paths reach the SPA layer rather than falling through to
-// the per-vault dispatcher's "Not found".
+// /vault/<name>/admin/* — admin SPA static-file mount. Detailed tests live
+// in admin-spa.test.ts (with a tmp dist dir); these pin the dispatch — i.e.
+// the SPA layer fires *before* the per-vault dispatcher swallows the path.
+// Per-vault mount (vault#252): the SPA used to live at /admin/* but is now
+// scoped under each vault so it's reachable through hub's /vault/<name>/*
+// proxy.
 // ---------------------------------------------------------------------------
 
-describe("/admin/* SPA mount", () => {
-  test("/admin/ never returns the per-vault dispatcher's 404 JSON", async () => {
+describe("/vault/<name>/admin/* SPA mount", () => {
+  test("/vault/<name>/admin/ never returns the per-vault dispatcher's 404 JSON", async () => {
     // dist may or may not be built in CI; the dispatch check just asserts
     // that we don't fall through to the catch-all. Both 200 (dist present)
     // and 503 (dist absent) are valid SPA-layer responses.
-    const req = new Request("http://localhost:1940/admin/");
-    const res = await route(req, "/admin/");
+    createVault("work");
+    const req = new Request("http://localhost:1940/vault/work/admin/");
+    const res = await route(req, "/vault/work/admin/");
     expect(res.status === 200 || res.status === 503).toBe(true);
     expect(res.headers.get("content-type") ?? "").not.toContain("application/json");
   });
 
-  test("/admin/vault/work (client-routed path) reaches the SPA layer", async () => {
-    const req = new Request("http://localhost:1940/admin/vault/work");
-    const res = await route(req, "/admin/vault/work");
+  test("/vault/<name>/admin/tokens (client-routed path) reaches the SPA layer", async () => {
+    createVault("work");
+    const req = new Request("http://localhost:1940/vault/work/admin/tokens");
+    const res = await route(req, "/vault/work/admin/tokens");
     expect(res.status === 200 || res.status === 503).toBe(true);
     expect(res.headers.get("content-type") ?? "").not.toContain("application/json");
   });
 
-  test("POST /admin/ returns 405 (no admin SPA writes today)", async () => {
-    const req = new Request("http://localhost:1940/admin/", { method: "POST" });
-    const res = await route(req, "/admin/");
+  test("/vault/<name>/admin fires the SPA layer even when the vault doesn't exist", async () => {
+    // Admin-spa dispatch sits *before* the per-vault config check — the SPA
+    // shell is static and surfaces its own auth-required state, so 404'ing
+    // here would just hide the operator's typo behind the SPA layer's own
+    // empty-state. Belt-and-braces: the SPA layer never reads vault config.
+    const req = new Request("http://localhost:1940/vault/ghost/admin/");
+    const res = await route(req, "/vault/ghost/admin/");
+    expect(res.status === 200 || res.status === 503).toBe(true);
+    expect(res.headers.get("content-type") ?? "").not.toContain("application/json");
+  });
+
+  test("POST /vault/<name>/admin/ returns 405 (no admin SPA writes today)", async () => {
+    createVault("work");
+    const req = new Request("http://localhost:1940/vault/work/admin/", { method: "POST" });
+    const res = await route(req, "/vault/work/admin/");
     expect(res.status).toBe(405);
   });
 
-  test("/administrative does NOT match the admin mount (falls through to 404)", async () => {
-    const req = new Request("http://localhost:1940/administrative");
-    const res = await route(req, "/administrative");
+  test("/vault/<name>/admin-foo does NOT match the admin mount", async () => {
+    // Falls through to the per-vault dispatcher; the auth wall there 401s
+    // before any route lookup runs, which is exactly the signal that the
+    // SPA layer didn't swallow this path. (Same shape as /api/notes below.)
+    createVault("work");
+    const req = new Request("http://localhost:1940/vault/work/admin-foo");
+    const res = await route(req, "/vault/work/admin-foo");
+    expect(res.status).toBe(401);
+  });
+
+  test("origin-rooted /admin (legacy mount retired) returns 404", async () => {
+    // Pre-vault#252 the SPA was at /admin/*. Routing now lets that fall
+    // through to the catch-all — hub's directory page should link to
+    // /vault/<name>/admin instead.
+    const req = new Request("http://localhost:1940/admin/");
+    const res = await route(req, "/admin/");
     expect(res.status).toBe(404);
+  });
+
+  test("/vault/<name>/api/notes still reaches the per-vault API (not the SPA)", async () => {
+    // Regression: the SPA mount must not shadow the existing API surface.
+    // No auth here — the per-vault dispatcher 401s, which is exactly the
+    // signal that the request reached the API layer rather than the SPA.
+    createVault("work");
+    const req = new Request("http://localhost:1940/vault/work/api/notes");
+    const res = await route(req, "/vault/work/api/notes");
+    expect(res.status).toBe(401);
   });
 });
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -254,12 +254,14 @@ export async function route(
     });
   }
 
-  // Admin SPA — origin-rooted at `/admin/*`. Static-file serving only
-  // (index.html + Vite asset bundle); no auth at this seam since the bundle
-  // reveals nothing privileged. The SPA's data fetches land on existing
-  // per-vault routes that enforce `vault:<name>:read` / `:admin`. GET-only —
-  // POSTs to `/admin/*` aren't a thing the SPA bundle exposes; rejecting
-  // them here keeps surprises out.
+  // Admin SPA — per-vault at `/vault/<name>/admin/*` (vault#252). Static-
+  // file serving only (index.html + Vite asset bundle); no auth at this
+  // seam since the bundle reveals nothing privileged. The SPA's data
+  // fetches land on existing per-vault routes that enforce
+  // `vault:<name>:read` / `:admin`. GET-only — POSTs to `.../admin/*` aren't
+  // a thing the SPA bundle exposes; rejecting them here keeps surprises
+  // out. Must fire BEFORE the per-vault dispatch below or the auth wall
+  // there would short-circuit the static-asset response.
   if (isAdminSpaPath(path)) {
     if (req.method !== "GET") {
       return Response.json({ error: "Method not allowed" }, { status: 405 });

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -1,14 +1,15 @@
 # Vault admin web UI
 
 Vite + React + TypeScript SPA mounted per-vault at `/vault/<name>/admin/`
-on the running vault server. Phase A (vault#216) ships the scaffold +
-per-vault detail page; Phase B (#217) adds tokens (list / mint / revoke
-+ read-only fallback for non-admin sessions); Phase C (#218) surfaces a
-forward-pointing link from each vault's detail page to hub's permissions
-UI (hub#162; grants live in hub's grants table — modular play is "vault
-links to hub" rather than "vault inlines hub data"). Vault#252 moved the
-mount from origin-rooted `/admin/*` to `/vault/<name>/admin/*` so the
-SPA is reachable through hub's `/vault/<name>/*` proxy.
+on the running vault server. Phase A (vault#219, closes #216) ships the
+scaffold + per-vault detail page; Phase B (vault#220, closes #217) adds
+tokens (list / mint / revoke + read-only fallback for non-admin sessions);
+Phase C (vault#222, closes #218) surfaces a forward-pointing link from
+each vault's detail page to hub's permissions UI (hub#162; grants live in
+hub's grants table — modular play is "vault links to hub" rather than
+"vault inlines hub data"). Vault#252 moved the mount from origin-rooted
+`/admin/*` to `/vault/<name>/admin/*` so the SPA is reachable through
+hub's `/vault/<name>/*` proxy.
 
 ## Mount-aware contract
 
@@ -48,10 +49,14 @@ consumes a hub-issued JWT that carries a `vault:<name>:admin` scope —
 the canonical token shape per scope-narrowing-and-audience.
 
 The token reaches the SPA via URL fragment (`#token=…`), which the hub
-appends when its directory page renders the "Manage" link to vault's
-`managementUrl: "/admin"` (relative to `/vault/<name>` per the module
-protocol — so the full URL is `/vault/<name>/admin#token=…`). On
-bootstrap (`main.tsx`) the SPA calls
+appends when its directory page renders the "Manage" link. Vault's
+module info declares `managementUrl: "/admin"`; per the module protocol
+that string is interpreted **relative to** the module URL `/vault/<name>`
+— hub's `resolveManagementUrl` joins them — so the resulting click
+target is `/vault/<name>/admin#token=…`. (Vault doesn't expose an
+origin-rooted `/admin` route post-vault#252; the literal `/admin` only
+lives in the module-info string and gets resolved against the per-vault
+module URL.) On bootstrap (`main.tsx`) the SPA calls
 `lib/auth.ts:captureTokenFromFragment()`:
 
 1. Read `window.location.hash`, parse `token`.

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -1,35 +1,45 @@
 # Vault admin web UI
 
-Vite + React + TypeScript SPA mounted at `/admin/` on the running vault
-server. Phase A (vault#216) ships the scaffold + per-vault detail page;
-Phase B (#217) adds tokens (list / mint / revoke + read-only fallback for
-non-admin sessions); Phase C (#218) surfaces a forward-pointing link from
-each vault's detail page to hub's permissions UI (hub#162; grants live in
-hub's grants table — modular play is "vault links to hub" rather than
-"vault inlines hub data").
+Vite + React + TypeScript SPA mounted per-vault at `/vault/<name>/admin/`
+on the running vault server. Phase A (vault#216) ships the scaffold +
+per-vault detail page; Phase B (#217) adds tokens (list / mint / revoke
++ read-only fallback for non-admin sessions); Phase C (#218) surfaces a
+forward-pointing link from each vault's detail page to hub's permissions
+UI (hub#162; grants live in hub's grants table — modular play is "vault
+links to hub" rather than "vault inlines hub data"). Vault#252 moved the
+mount from origin-rooted `/admin/*` to `/vault/<name>/admin/*` so the
+SPA is reachable through hub's `/vault/<name>/*` proxy.
 
 ## Mount-aware contract
 
-The same bundle has to work two places:
+The same bundle has to work at any per-vault mount — the vault name
+isn't known at build time, so it gets discovered at runtime:
 
-- **Production** — served by `src/admin-spa.ts` at `/admin/*` on the vault
-  HTTP server. Vite's `base` defaults to `/admin/` (`vite.config.ts`), so
-  asset URLs come out as `/admin/assets/...` and react-router's `basename`
-  resolves to `/admin`.
+- **Production** — served by `src/admin-spa.ts` at `/vault/<name>/admin/*`
+  on the vault HTTP server. Vite's `base` is RELATIVE (`./`) so asset
+  URLs come out as `./assets/...` and resolve under whichever path
+  served `index.html`. React Router's `basename` is computed at runtime
+  by `lib/mount.ts:getBasename()` from `window.location.pathname` —
+  hub#173 uses the same shape on the hub side for its dual /hub /vault
+  mount.
 - **Dev** (`bun run dev`) — Vite serves at `http://127.0.0.1:5175/admin/`
   with a proxy that forwards `/vault` and `/vaults` to `VAULT_ORIGIN`
-  (default `http://127.0.0.1:1940`). Override the base with
-  `VITE_BASE_PATH=/` if you need to dev against the origin root.
+  (default `http://127.0.0.1:1940`). The runtime basename detector
+  treats `/admin/*` as a legacy fallback so dev still works without
+  spinning up a real vault. Override the base with `VITE_BASE_PATH=/`
+  if you need to dev against the origin root.
 
 `scripts/verify-base.mjs` runs after every build and aborts if
-`dist/index.html` doesn't carry the `/admin/`-prefixed asset URLs — the
-same drift hub#157 / paraclaw#25 codified.
+`dist/index.html` doesn't carry relative `./assets/` URLs — the same
+drift hub#157 / paraclaw#25 codified, adapted for the per-vault mount.
 
 **Lesson: never hardcode a leading-slash URL** in `Link to=`, `fetch`,
-or `<a href>`. `Link` resolves against `BASE_URL` automatically; `fetch`
-calls hit the origin root regardless of mount, which is what we want for
-`/vaults/list` and `/vault/<name>/...`. If you need the mounted prefix,
-use `import.meta.env.BASE_URL`.
+or `<a href>`. `Link` resolves against the runtime basename
+automatically; `fetch` calls to `/vault/<name>/...` hit the origin root
+regardless of mount and route through to the per-vault API surface
+either directly or via hub's proxy. `import.meta.env.BASE_URL` is no
+longer the source of truth — read `lib/mount.ts:getBasename()` instead
+since it knows about the runtime per-vault prefix.
 
 ## Auth
 
@@ -38,9 +48,11 @@ consumes a hub-issued JWT that carries a `vault:<name>:admin` scope —
 the canonical token shape per scope-narrowing-and-audience.
 
 The token reaches the SPA via URL fragment (`#token=…`), which the hub
-will append when its directory page renders the "Manage" link to
-vault's `managementUrl: "/admin"`. On bootstrap (`main.tsx`) the SPA
-calls `lib/auth.ts:captureTokenFromFragment()`:
+appends when its directory page renders the "Manage" link to vault's
+`managementUrl: "/admin"` (relative to `/vault/<name>` per the module
+protocol — so the full URL is `/vault/<name>/admin#token=…`). On
+bootstrap (`main.tsx`) the SPA calls
+`lib/auth.ts:captureTokenFromFragment()`:
 
 1. Read `window.location.hash`, parse `token`.
 2. Stash in a module-scoped variable. **Never** localStorage —
@@ -70,16 +82,18 @@ web/ui/
 ├── tsconfig.json
 ├── scripts/verify-base.mjs # post-build regression check
 └── src/
-    ├── main.tsx            # BrowserRouter w/ mount-aware basename
-    ├── App.tsx             # nav + Routes
+    ├── main.tsx            # BrowserRouter w/ runtime-detected basename
+    ├── App.tsx             # nav + Routes (redirects / to /vault/<name>
+    │                       #               when mounted under a vault)
     ├── styles.css          # brand tokens (kept in sync with hub's)
     ├── lib/
     │   ├── auth.ts         # fragment-token capture, in-memory cache
+    │   ├── mount.ts        # runtime basename + vault-name detection
     │   ├── scope.ts        # JWT payload decode + hasAdminScope gate
     │   ├── api.ts          # listVaultNames + getVaultDetail
     │   └── tokens-api.ts   # listTokens / mintToken / revokeToken
     ├── routes/
-    │   ├── VaultsList.tsx  # /
+    │   ├── VaultsList.tsx  # /  (legacy / dev mount only)
     │   ├── VaultDetail.tsx # /vault/:name
     │   └── VaultTokens.tsx # /vault/:name/tokens
     └── test/setup.ts

--- a/web/ui/scripts/verify-base.mjs
+++ b/web/ui/scripts/verify-base.mjs
@@ -1,8 +1,9 @@
-// Regression check mirroring hub/paraclaw's verify-base: the canonical-mount
-// default build must produce asset URLs prefixed with `/admin/`. If
-// `vite.config.ts`'s `base` ever drifts back to `/`, the bundle HTML loses
-// the prefix and 404s under the vault admin mount — the same silent failure
-// paraclaw#25 codified in mount-path-convention.md.
+// Regression check: the per-vault SPA mount (vault#252) needs asset URLs to
+// resolve under `/vault/<name>/admin/` — and `<name>` isn't known at build
+// time, so the only shape that works is *relative* (`./assets/...`). If
+// `vite.config.ts`'s `base` ever drifts to an absolute prefix like `/admin/`,
+// the bundle HTML loses portability and 404s under any non-`/admin/` mount —
+// the same silent failure paraclaw#25 codified in mount-path-convention.md.
 //
 // Skipped when VITE_BASE_PATH is set explicitly (legitimate override).
 
@@ -10,21 +11,23 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const override = process.env.VITE_BASE_PATH;
-if (override && override !== "/admin/") {
+if (override && override !== "./") {
   console.log(`verify-base: VITE_BASE_PATH=${override} (override) — skipping default-mount check.`);
   process.exit(0);
 }
 
 const html = readFileSync(resolve("dist/index.html"), "utf8");
-const wantPrefix = "/admin/assets/";
-const hasMounted = html.includes(`src="${wantPrefix}`) || html.includes(`href="${wantPrefix}`);
-if (!hasMounted) {
+const wantPrefix = "./assets/";
+const hasRelative = html.includes(`src="${wantPrefix}`) || html.includes(`href="${wantPrefix}`);
+if (!hasRelative) {
   console.error(
-    "✖ verify-base: dist/index.html is missing /admin/-prefixed asset URLs.\n" +
-      "  This means vite's `base` resolved to something other than `/admin/`.\n" +
-      "  Check web/ui/vite.config.ts (default should be `/admin/`) and any\n" +
-      "  VITE_BASE_PATH env var leaking into the build environment.",
+    "✖ verify-base: dist/index.html is missing relative (./assets/...) asset URLs.\n" +
+      "  This means vite's `base` resolved to something other than `./`.\n" +
+      "  Check web/ui/vite.config.ts (default should be `./`) and any\n" +
+      "  VITE_BASE_PATH env var leaking into the build environment.\n" +
+      "  Per-vault mount (/vault/<name>/admin/) requires relative asset URLs\n" +
+      "  since <name> isn't known at build time.",
   );
   process.exit(1);
 }
-console.log("verify-base: ✓ dist/index.html references /admin/-prefixed assets.");
+console.log("verify-base: ✓ dist/index.html references relative ./assets/ paths.");

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,27 +1,46 @@
-import { Link, Route, Routes } from "react-router-dom";
+import { Link, Navigate, Route, Routes } from "react-router-dom";
+import { getMountedVaultName } from "./lib/mount.ts";
 import { VaultDetail } from "./routes/VaultDetail.tsx";
 import { VaultTokens } from "./routes/VaultTokens.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
 export function App() {
+  // When the SPA is mounted under a specific vault (`/vault/<name>/admin/*`
+  // post-vault#252), the `/` landing page should jump straight to that
+  // vault's detail page — `/vaults/list` isn't proxied by hub, so the
+  // generic picker would render an empty/erroring list. The legacy origin-
+  // rooted `/admin/*` and stand-alone `/` mounts still get the picker.
+  const mountedVault = getMountedVaultName();
+  const homeElement = mountedVault ? (
+    <Navigate to={`/vault/${encodeURIComponent(mountedVault)}`} replace />
+  ) : (
+    <VaultsList />
+  );
+
   return (
     <div className="page">
       <nav className="nav">
         <Link to="/" className="brand">
           Parachute Vault <span className="sub">admin</span>
         </Link>
-        <Link to="/">Vaults</Link>
+        {mountedVault ? (
+          <Link to={`/vault/${encodeURIComponent(mountedVault)}`}>
+            <code>{mountedVault}</code>
+          </Link>
+        ) : (
+          <Link to="/">Vaults</Link>
+        )}
       </nav>
 
       <Routes>
-        <Route path="/" element={<VaultsList />} />
+        <Route path="/" element={homeElement} />
         <Route path="/vault/:name" element={<VaultDetail />} />
         <Route path="/vault/:name/tokens" element={<VaultTokens />} />
         <Route
           path="*"
           element={
             <div className="empty">
-              404 — back to <Link to="/">vaults</Link>.
+              404 — back to <Link to="/">vault</Link>.
             </div>
           }
         />

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -8,7 +8,10 @@
  * directory page renders the "Manage" link to vault's managementUrl.
  *
  * Flow:
- *   1. Hub renders "Manage" → navigates to `<vault-origin>/admin/#token=<jwt>`.
+ *   1. Hub renders "Manage" → navigates to
+ *      `<hub-origin>/vault/<name>/admin/#token=<jwt>` (vault#252 per-vault
+ *      mount; the bundle is reachable through hub's `/vault/<name>/*`
+ *      proxy).
  *   2. SPA bootstrap calls `captureTokenFromFragment()`, which reads the
  *      fragment, stashes the token in module-scoped state, and rewrites the
  *      URL with `history.replaceState` so a refresh / copy-paste / screenshot

--- a/web/ui/src/lib/mount.test.ts
+++ b/web/ui/src/lib/mount.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Mount detection round-trips. The runtime basename is what makes the same
+ * compiled SPA bundle work at any `/vault/<name>/admin/` mount post-vault#252
+ * — a regression here means React Router can't strip the basename and the
+ * SPA renders a blank 404 shell.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBasename, getMountedVaultName } from "./mount.ts";
+
+describe("mount detection", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  describe("getMountedVaultName", () => {
+    it("extracts the vault name from a per-vault mount", () => {
+      window.history.replaceState(null, "", "/vault/boulder/admin/");
+      expect(getMountedVaultName()).toBe("boulder");
+    });
+
+    it("extracts the vault name from a deep client-routed path", () => {
+      window.history.replaceState(null, "", "/vault/boulder/admin/vault/boulder/tokens");
+      expect(getMountedVaultName()).toBe("boulder");
+    });
+
+    it("decodes percent-encoded vault names", () => {
+      window.history.replaceState(null, "", "/vault/my%20vault/admin/");
+      expect(getMountedVaultName()).toBe("my vault");
+    });
+
+    it("returns null on origin-rooted /admin (legacy / dev)", () => {
+      window.history.replaceState(null, "", "/admin/");
+      expect(getMountedVaultName()).toBeNull();
+    });
+
+    it("returns null on stand-alone root", () => {
+      window.history.replaceState(null, "", "/");
+      expect(getMountedVaultName()).toBeNull();
+    });
+
+    it("returns null on the per-vault metadata path (no admin segment)", () => {
+      // The plain per-vault mount serves JSON metadata, not the SPA — only
+      // /admin under it should activate the runtime mount.
+      window.history.replaceState(null, "", "/vault/boulder/");
+      expect(getMountedVaultName()).toBeNull();
+    });
+
+    it("does not match adjacent paths under the vault", () => {
+      window.history.replaceState(null, "", "/vault/boulder/api/notes");
+      expect(getMountedVaultName()).toBeNull();
+      window.history.replaceState(null, "", "/vault/boulder/admin-foo");
+      expect(getMountedVaultName()).toBeNull();
+    });
+  });
+
+  describe("getBasename", () => {
+    it("returns /vault/<name>/admin under a per-vault mount", () => {
+      window.history.replaceState(null, "", "/vault/boulder/admin/");
+      expect(getBasename()).toBe("/vault/boulder/admin");
+    });
+
+    it("preserves percent-encoding in the vault name", () => {
+      // Decoding the name would break basename matching against
+      // window.location.pathname (which is encoded).
+      window.history.replaceState(null, "", "/vault/my%20vault/admin/");
+      expect(getBasename()).toBe("/vault/my%20vault/admin");
+    });
+
+    it("falls back to /admin for the legacy origin-rooted mount", () => {
+      window.history.replaceState(null, "", "/admin/tokens");
+      expect(getBasename()).toBe("/admin");
+    });
+
+    it("returns empty string at the stand-alone root", () => {
+      window.history.replaceState(null, "", "/");
+      expect(getBasename()).toBe("");
+    });
+  });
+});

--- a/web/ui/src/lib/mount.ts
+++ b/web/ui/src/lib/mount.ts
@@ -1,0 +1,60 @@
+/**
+ * Mount detection for the vault admin SPA.
+ *
+ * Vault#252 moved the SPA from origin-rooted `/admin/*` to per-vault
+ * `/vault/<name>/admin/*` so the bundle is reachable through hub's
+ * `/vault/<name>/*` proxy. The same compiled bundle has to work at any
+ * mount — Vite's `base` is relative (`./`) so asset URLs resolve under
+ * whichever path served `index.html`, and the React Router basename has
+ * to be discovered at runtime since the vault name isn't known at build
+ * time.
+ *
+ * Two callers today:
+ *   - `main.tsx` reads `getBasename()` once at bootstrap to feed
+ *     `<BrowserRouter basename={...}>`.
+ *   - `App.tsx` reads `getMountedVaultName()` to redirect the `/` route
+ *     to the vault's detail page when the SPA is mounted under a
+ *     specific vault (no `/vaults/list` round-trip needed — and that
+ *     endpoint isn't reachable through the hub proxy anyway).
+ */
+
+const MOUNT_RE = /^\/vault\/([^/]+)\/admin(?=\/|$)/;
+
+/**
+ * Extract `<name>` from a `/vault/<name>/admin/...` mount, decoded.
+ * Returns `null` when the SPA is loaded outside a per-vault mount —
+ * i.e. dev served at `/admin/*` or a stand-alone `/`-rooted bundle.
+ */
+export function getMountedVaultName(): string | null {
+  if (typeof window === "undefined") return null;
+  const m = window.location.pathname.match(MOUNT_RE);
+  if (!m) return null;
+  try {
+    return decodeURIComponent(m[1]!);
+  } catch {
+    // Malformed percent-encoding — treat as no mount rather than crashing
+    // the entire SPA bootstrap.
+    return null;
+  }
+}
+
+/**
+ * Compute the React Router basename matching the current mount.
+ *
+ *   /vault/boulder/admin/...  → "/vault/boulder/admin"
+ *   /admin/...                → "/admin"          (legacy / dev fallback)
+ *   anything else             → ""                (stand-alone root)
+ *
+ * The returned value preserves the URL's percent-encoding so React Router
+ * matches it byte-for-byte against `window.location.pathname` — decoding
+ * would break basename stripping for vault names with URL-reserved
+ * characters.
+ */
+export function getBasename(): string {
+  if (typeof window === "undefined") return "";
+  const path = window.location.pathname;
+  const m = path.match(MOUNT_RE);
+  if (m) return `/vault/${m[1]}/admin`;
+  if (path === "/admin" || path.startsWith("/admin/")) return "/admin";
+  return "";
+}

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App.tsx";
 import { captureTokenFromFragment } from "./lib/auth.ts";
+import { getBasename } from "./lib/mount.ts";
 import "./styles.css";
 
 // Capture a hub-issued JWT from the URL fragment if present (e.g. when the
@@ -13,13 +14,15 @@ captureTokenFromFragment();
 const root = document.getElementById("root");
 if (!root) throw new Error("#root not found");
 
-// `basename` is mount-aware: production builds use `/admin/`, dev uses `/`.
-// Stripping the trailing slash matches react-router's expectation. Without
-// this the SPA's <Link to="/vault/..."> would resolve at the origin root,
-// blowing past vault's /admin/* mount and 404ing.
+// `basename` is detected at runtime, not baked from `import.meta.env.BASE_URL`:
+// vault#252 mounts this SPA per-vault at `/vault/<name>/admin/*`, and `<name>`
+// isn't known at build time. Build sets a relative `base` (`./`) so asset URLs
+// resolve under whichever path served `index.html`; React Router needs the
+// matching runtime mount so `<Link to="/vault/foo/tokens">` resolves under
+// `/vault/<name>/admin/...` rather than at the origin root.
 createRoot(root).render(
   <StrictMode>
-    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "")}>
+    <BrowserRouter basename={getBasename()}>
       <App />
     </BrowserRouter>
   </StrictMode>,

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -77,7 +77,7 @@ export function VaultDetail() {
         </h2>
         <div className="warn-banner">
           Open this page from the hub's directory — the "Manage" link supplies the admin token. Direct loads of{" "}
-          <code>/admin/vault/{name}</code> can't see protected vault data.
+          <code>/vault/{name}/admin</code> can't see protected vault data.
         </div>
         <Link to="/">← Back to vaults</Link>
       </div>

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -1,18 +1,19 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-// Vault mounts this SPA at `/admin/` (see src/admin-spa.ts dispatch). Build
-// default IS the canonical mount so asset URLs resolve under the admin path
-// when the bundle is served by the vault server — same drift paraclaw#25
-// codified in mount-path-convention.md. Override with `VITE_BASE_PATH=/` for
-// stand-alone dev served at the origin root.
-const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/admin/");
-
-function normalizeBase(input: string): string {
-  let b = input.startsWith("/") ? input : `/${input}`;
-  if (!b.endsWith("/")) b += "/";
-  return b;
-}
+// Vault#252 moves the SPA from origin-rooted `/admin/*` to per-vault
+// `/vault/<name>/admin/*`. The vault name isn't known at build time, so we
+// can't bake an absolute base path into asset URLs the way hub does. The
+// build default is RELATIVE (`./`): asset references in `dist/index.html`
+// look like `./assets/index-abc.js` and resolve correctly under whichever
+// `/vault/<name>/admin/` mount served the HTML.
+//
+// Dev (`bun run dev`) still serves under `/admin/` to mirror the legacy
+// origin-rooted mount — the proxy below forwards `/vault/*` and `/vaults/*`
+// to the running vault server so SPA fetches land on real per-vault APIs.
+// Override with `VITE_BASE_PATH=/` for stand-alone dev served at the
+// origin root.
+const basePath = process.env.VITE_BASE_PATH ?? "./";
 
 export default defineConfig({
   base: basePath,
@@ -20,8 +21,8 @@ export default defineConfig({
   server: {
     port: 5175,
     proxy: {
-      // Dev server runs under /admin/ to mirror production. Vault's own
-      // surfaces — per-vault metadata, public discovery — live under
+      // Dev server runs under /admin/ to mirror the legacy mount. Vault's
+      // own surfaces — per-vault metadata, public discovery — live under
       // /vault/* and /vaults/* on the origin; proxy those so SPA fetches
       // hit the running vault server (default http://127.0.0.1:1940).
       "/vault": {


### PR DESCRIPTION
## Summary

Move the admin SPA from origin-rooted `/admin/*` to per-vault `/vault/<name>/admin/*` so the bundle is reachable through hub's `/vault/<name>/*` proxy. Pre-#252, an operator clicking "Manage Vault" in the hub directory landed on a 401-walled vault metadata endpoint — the SPA was unreachable through the proxy because hub doesn't forward origin-rooted paths.

Three layers move in lockstep so the same compiled bundle works at any per-vault mount without a rebuild:

- **Server static-file dispatch** (`src/admin-spa.ts` + `src/routing.ts`) — `isAdminSpaPath` regex now matches `/vault/<name>/admin[/...]`; `serveAdminSpa` strip-prefix collapses to `pathname.replace(MOUNT_RE, "")`. Bare `/vault/<name>/admin-foo` and `/vault/<name>` (the metadata endpoint) explicitly do not trigger the SPA. Admin-spa dispatch fires before per-vault dispatch — comment now spells out why (the auth wall there would otherwise swallow static-asset responses with a 401).
- **SPA runtime basename** (`web/ui/src/lib/mount.ts` new + `main.tsx` + `App.tsx`) — `<name>` isn't known at build time, so `getBasename()` reads `window.location.pathname` at bootstrap. `/` redirects to `/vault/<name>` via `<Navigate replace>` when mounted under a specific vault — the `VaultsList` picker calls `/vaults/list` which hub doesn't proxy, so the picker can't render through the hub anyway. Legacy `/admin/*` and stand-alone root mounts still get the picker for dev. Mirrors hub#173's dual-mount basename pattern.
- **Vite asset-base** (`web/ui/vite.config.ts` + `verify-base.mjs`) — `base: "./"` (was `/admin/`) so asset URLs in `dist/index.html` resolve relative to wherever `index.html` was served. `verify-base.mjs` regression check adapted to assert relative URLs.

CHANGELOG entry, RC bump (rc.34 → rc.35), `web/ui/CLAUDE.md` mount-aware contract section rewritten.

## Smoke

Verified locally on an isolated server (`PORT=51941 PARACHUTE_HOME=/tmp/...`):

- `GET /vault/default/admin/` → 200 HTML with `./assets/...` references ✓
- `GET /vault/default/admin/tokens` → 200 HTML (client-routed) ✓
- `GET /vault/default/admin/assets/index-*.js` → 200 application/javascript ✓
- `GET /admin/` (legacy retired) → 404 ✓
- `GET /vault/default/admin-foo` → 401 (per-vault dispatch, not SPA) ✓
- `GET /vault/default/api/notes` → 401 (per-vault API still works) ✓

## Test plan

- [x] `bun test ./src/` — 799 pass / 0 fail
- [x] `bun test ./core/src/` — 404 pass / 0 fail
- [x] `web/ui` `bun run typecheck && bun run test` — 52 pass / 0 fail (11 new mount.test.ts cases)
- [x] `web/ui` `bun run build` — `verify-base.mjs ✓ dist/index.html references relative ./assets/ paths.`
- [x] Server smoke against an isolated `PARACHUTE_HOME` confirms each dispatch path
- [ ] Aaron clicks "Manage Vault" in hub directory and lands on the SPA with a working token (needs hub#162-realignment to update the directory link from `/admin` to `/vault/<name>/admin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)