### PR TITLE
fix(web/ui): per-vault mount uses dedicated routes (no redirect doubling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.3.6-rc.36] — 2026-05-04
+
+vault#252 follow-up — fix URL doubling under per-vault mount. The rc.35 SPA used `<Navigate to="/vault/<name>" replace />` from the `/` route to jump operators landing at `/vault/<name>/admin/` straight to the vault detail page. Under React Router v6 with `<BrowserRouter basename="/vault/<name>/admin">`, paths in `<Navigate to>` and `<Link to>` are basename-relative absolute paths — so the redirect resolved to `/vault/<name>/admin/vault/<name>` (basename + path), and the operator landed on a doubled URL with no matching route, falling through to the auth-required shell. The redirect was the wrong shape: the SPA needs different routes per mount mode, not a clever redirect.
+
+### Fixed
+
+- **`web/ui/src/App.tsx` switches the route table on mount mode instead of redirecting.** When `getMountedVaultName()` returns a name (per-vault mount), the route table is `{ "/" → VaultDetail, "/tokens" → VaultTokens }` with the mounted vault name passed as a prop. When it returns null (legacy `/admin/*` or stand-alone), the table is the original picker tree (`{ "/" → VaultsList, "/vault/:name" → VaultDetail, "/vault/:name/tokens" → VaultTokens }`). No `<Navigate>` anywhere — the route table answers the URL directly. Nav-bar's vault-name link points at `/` under per-vault mount (was `/vault/<name>` — the same doubling).
+- **`VaultDetail` and `VaultTokens` accept an optional `vaultName` prop, fall back to `useParams()`.** Per-vault mount passes the prop straight through (no `:name` segment exists under `basename="/vault/<name>/admin"`); stand-alone reads it from the URL params. The presence of the prop also picks the inner-Link shape — `/tokens` vs `/vault/<name>/tokens` from VaultDetail's Manage section, `/` vs `/vault/<name>` for VaultTokens's "← Vault detail" back-link. Picking the wrong shape re-introduces the doubled-URL bug, so the choice is local to where the link is emitted.
+- **Back-to-vaults links suppressed under per-vault mount.** The hub doesn't proxy `/vaults/list`, so a "← Back to vaults" link under per-vault mount would land on a broken picker. The auth-required banner already directs the operator back to the hub directory; that's the actual remediation path.
+
+### Tests
+
+- `web/ui/src/App.test.tsx` (new) — 8 cases pinning the mount-mode split: per-vault mount renders `VaultDetail` directly at `/` (no redirect, no doubled URL), emits the Tokens link as `/tokens` (NOT `/vault/<name>/tokens`), and renders `VaultTokens` at `/tokens`; stand-alone mount keeps the picker-then-detail tree with the full `/vault/<name>` shape. The Tokens-link href assertion is the explicit regression pin — under `<BrowserRouter basename="/vault/<name>/admin">` the wrong shape would re-introduce the bug.
+
 ## [0.3.6-rc.35] — 2026-05-03
 
 vault#252 — remount the admin SPA from origin-rooted `/admin/*` to per-vault `/vault/<name>/admin/*` so it's reachable through hub's `/vault/<name>/*` proxy. The hub doesn't proxy origin-rooted paths, which left an operator clicking "Manage Vault" on the hub directory landing on a 401-walled vault metadata endpoint instead of the SPA. Three layers move in lockstep — the server's static-file dispatch, the React Router runtime basename, and Vite's asset-base — so the same compiled bundle works at any per-vault mount without a rebuild.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.35",
+  "version": "0.3.6-rc.36",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Per-vault mount pins the route-doubling fix.
+ *
+ * The bug: under `<BrowserRouter basename="/vault/<name>/admin">`, a
+ * `<Navigate to="/vault/<name>">` from a `/` route resolved to
+ * `/vault/<name>/admin/vault/<name>` (basename + path). The fix splits
+ * App into two route tables based on mount mode — these tests assert
+ * that:
+ *   - per-vault mount renders VaultDetail directly at `/` (no redirect)
+ *     and emits sub-route Links without the `/vault/<name>` prefix
+ *     (so a click can't re-double the URL);
+ *   - stand-alone mount keeps the picker-then-detail tree.
+ *
+ * `lib/mount.ts:getMountedVaultName()` is mocked so we can flip mount
+ * mode without manipulating window.location across tests.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "./lib/api.ts";
+import * as mount from "./lib/mount.ts";
+import * as scope from "./lib/scope.ts";
+import { App } from "./App.tsx";
+
+vi.mock("./lib/api.ts");
+vi.mock("./lib/mount.ts");
+vi.mock("./lib/scope.ts");
+
+const detailFixture = (over: Partial<api.VaultDetailResult> = {}): api.VaultDetailResult => ({
+  name: "boulder",
+  description: "ops vault",
+  createdAt: "2026-05-01T00:00:00Z",
+  stats: { notes: 0, tags: 0, attachments: 0, links: 0 },
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(scope.getIssuerOrigin).mockReturnValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("App — per-vault mount", () => {
+  beforeEach(() => {
+    vi.mocked(mount.getMountedVaultName).mockReturnValue("boulder");
+    vi.mocked(api.getVaultDetail).mockResolvedValue(detailFixture());
+  });
+
+  it("renders VaultDetail at `/` (no redirect, no doubled URL)", async () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    // The detail component fetches by the vault name passed as a prop —
+    // if App had used <Navigate to="/vault/boulder"> instead, the route
+    // table wouldn't have a matching entry under per-vault mount and we'd
+    // see the 404 shell or a redirect loop instead.
+    await waitFor(() => {
+      expect(api.getVaultDetail).toHaveBeenCalledWith("boulder");
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Vault\s+boulder/i })).toBeInTheDocument();
+    });
+  });
+
+  it("emits sub-route Tokens link as `/tokens`, not `/vault/<name>/tokens`", async () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    const link = await screen.findByRole("link", { name: /Tokens/ });
+    // Under `basename="/vault/boulder/admin"` in production, this href is
+    // joined to the basename → final URL `/vault/boulder/admin/tokens`.
+    // If we emitted `/vault/boulder/tokens` here we'd get the doubled
+    // `/vault/boulder/admin/vault/boulder/tokens` — exactly the bug this
+    // PR fixes. Pin the shape to prevent regression.
+    expect(link).toHaveAttribute("href", "/tokens");
+  });
+
+  it("renders VaultTokens at `/tokens`", async () => {
+    vi.mocked(api.HttpError).mockImplementation((status, message) => {
+      const err = new Error(message);
+      Object.assign(err, { status });
+      return err as never;
+    });
+    render(
+      <MemoryRouter initialEntries={["/tokens"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole("heading", { name: /Tokens for/ })).toBeInTheDocument();
+  });
+
+  it("nav-bar shows the mounted vault name as a link to `/`", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    const navLink = screen.getAllByRole("link").find((l) => l.textContent?.trim() === "boulder");
+    expect(navLink).toBeDefined();
+    expect(navLink).toHaveAttribute("href", "/");
+  });
+});
+
+describe("App — stand-alone mount", () => {
+  beforeEach(() => {
+    vi.mocked(mount.getMountedVaultName).mockReturnValue(null);
+    vi.mocked(api.listVaultNames).mockResolvedValue(["boulder", "work"]);
+    vi.mocked(api.getVaultDetail).mockResolvedValue(detailFixture());
+  });
+
+  it("renders the picker (VaultsList) at `/`", async () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(api.listVaultNames).toHaveBeenCalled();
+    });
+    expect(await screen.findByRole("link", { name: /boulder/ })).toBeInTheDocument();
+  });
+
+  it("renders VaultDetail at `/vault/:name`", async () => {
+    render(
+      <MemoryRouter initialEntries={["/vault/boulder"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(api.getVaultDetail).toHaveBeenCalledWith("boulder");
+    });
+  });
+
+  it("VaultDetail emits the Tokens link with the full `/vault/<name>/tokens` shape", async () => {
+    render(
+      <MemoryRouter initialEntries={["/vault/boulder"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    const link = await screen.findByRole("link", { name: /Tokens/ });
+    expect(link).toHaveAttribute("href", "/vault/boulder/tokens");
+  });
+
+  it("nav-bar shows the generic Vaults link", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("link", { name: "Vaults" })).toBeInTheDocument();
+  });
+});

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,22 +1,30 @@
-import { Link, Navigate, Route, Routes } from "react-router-dom";
+import { Link, Route, Routes } from "react-router-dom";
 import { getMountedVaultName } from "./lib/mount.ts";
 import { VaultDetail } from "./routes/VaultDetail.tsx";
 import { VaultTokens } from "./routes/VaultTokens.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
+/**
+ * The SPA carries two route shapes that don't share a tree.
+ *
+ * Under a per-vault mount (`/vault/<name>/admin/*` post-vault#252),
+ * `<BrowserRouter basename="/vault/<name>/admin">` strips the basename
+ * before matching — so `<Link to="/">` lives at the vault detail page,
+ * `<Link to="/tokens">` lives at the vault's tokens page, and there is
+ * no path that addresses any *other* vault. A route table that names
+ * `/vault/:name` would only match `/vault/<basename>/admin/vault/:name`
+ * after basename-stripping — i.e. an absurd doubled URL no link in this
+ * SPA produces. So under per-vault mount we render a tiny route table
+ * that's already vault-scoped and pass the mounted vault name down to
+ * the route components as a prop.
+ *
+ * Under stand-alone mount (legacy origin-rooted `/admin/*` or unmounted
+ * dev), the basename is `/admin` (or empty) and the route table looks
+ * like the original picker-then-detail tree. The detail components fall
+ * back to `useParams()` for `:name` in this branch.
+ */
 export function App() {
-  // When the SPA is mounted under a specific vault (`/vault/<name>/admin/*`
-  // post-vault#252), the `/` landing page should jump straight to that
-  // vault's detail page — `/vaults/list` isn't proxied by hub, so the
-  // generic picker would render an empty/erroring list. The legacy origin-
-  // rooted `/admin/*` and stand-alone `/` mounts still get the picker.
   const mountedVault = getMountedVaultName();
-  const homeElement = mountedVault ? (
-    <Navigate to={`/vault/${encodeURIComponent(mountedVault)}`} replace />
-  ) : (
-    <VaultsList />
-  );
-
   return (
     <div className="page">
       <nav className="nav">
@@ -24,7 +32,7 @@ export function App() {
           Parachute Vault <span className="sub">admin</span>
         </Link>
         {mountedVault ? (
-          <Link to={`/vault/${encodeURIComponent(mountedVault)}`}>
+          <Link to="/">
             <code>{mountedVault}</code>
           </Link>
         ) : (
@@ -32,19 +40,28 @@ export function App() {
         )}
       </nav>
 
-      <Routes>
-        <Route path="/" element={homeElement} />
-        <Route path="/vault/:name" element={<VaultDetail />} />
-        <Route path="/vault/:name/tokens" element={<VaultTokens />} />
-        <Route
-          path="*"
-          element={
-            <div className="empty">
-              404 — back to <Link to="/">vault</Link>.
-            </div>
-          }
-        />
-      </Routes>
+      {mountedVault ? (
+        <Routes>
+          <Route path="/" element={<VaultDetail vaultName={mountedVault} />} />
+          <Route path="/tokens" element={<VaultTokens vaultName={mountedVault} />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      ) : (
+        <Routes>
+          <Route path="/" element={<VaultsList />} />
+          <Route path="/vault/:name" element={<VaultDetail />} />
+          <Route path="/vault/:name/tokens" element={<VaultTokens />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      )}
+    </div>
+  );
+}
+
+function NotFound() {
+  return (
+    <div className="empty">
+      404 — back to <Link to="/">vault</Link>.
     </div>
   );
 }

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -23,8 +23,18 @@ type State =
   | { kind: "missing" }
   | { kind: "error"; message: string };
 
-export function VaultDetail() {
-  const { name } = useParams<{ name: string }>();
+export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
+  // Two callers: the per-vault mount passes `vaultName` straight through
+  // (no `:name` segment exists under `basename="/vault/<name>/admin"`);
+  // the stand-alone `/vault/:name` route reads it from useParams. The
+  // presence of the prop also tells us which Link shape to emit — under
+  // per-vault mount the tokens sub-route is `/tokens`; under stand-alone
+  // it's `/vault/<name>/tokens`. Picking the wrong one re-introduces the
+  // doubled-URL bug that motivated this refactor.
+  const params = useParams<{ name: string }>();
+  const name = vaultName ?? params.name;
+  const isPerVaultMount = vaultName !== undefined;
+  const tokensHref = isPerVaultMount ? "/tokens" : `/vault/${encodeURIComponent(name ?? "")}/tokens`;
   const [state, setState] = useState<State>({ kind: "loading" });
 
   useEffect(() => {
@@ -79,7 +89,7 @@ export function VaultDetail() {
           Open this page from the hub's directory — the "Manage" link supplies the admin token. Direct loads of{" "}
           <code>/vault/{name}/admin</code> can't see protected vault data.
         </div>
-        <Link to="/">← Back to vaults</Link>
+        {isPerVaultMount ? null : <Link to="/">← Back to vaults</Link>}
       </div>
     );
   }
@@ -91,7 +101,7 @@ export function VaultDetail() {
         <p className="muted">
           No vault named <code>{name}</code> is registered on this server.
         </p>
-        <Link to="/">← Back to vaults</Link>
+        {isPerVaultMount ? null : <Link to="/">← Back to vaults</Link>}
       </div>
     );
   }
@@ -105,7 +115,7 @@ export function VaultDetail() {
         <div className="error-banner">
           <code>{state.message}</code>
         </div>
-        <Link to="/">← Back to vaults</Link>
+        {isPerVaultMount ? null : <Link to="/">← Back to vaults</Link>}
       </div>
     );
   }
@@ -118,9 +128,11 @@ export function VaultDetail() {
         <h2>
           Vault <code>{vault.name}</code>
         </h2>
-        <Link to="/" className="muted">
-          ← All vaults
-        </Link>
+        {isPerVaultMount ? null : (
+          <Link to="/" className="muted">
+            ← All vaults
+          </Link>
+        )}
       </div>
 
       <div className="kv section">
@@ -174,7 +186,7 @@ export function VaultDetail() {
         <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>Manage</h3>
         <ul className="manage-list">
           <li>
-            <Link to={`/vault/${encodeURIComponent(vault.name)}/tokens`}>Tokens →</Link>
+            <Link to={tokensHref}>Tokens →</Link>
             <span className="dim"> mint, list, and revoke <code>pvt_*</code> tokens</span>
           </li>
           <PermissionsLink vaultName={vault.name} />

--- a/web/ui/src/routes/VaultTokens.tsx
+++ b/web/ui/src/routes/VaultTokens.tsx
@@ -37,8 +37,15 @@ type LoadState =
 
 const KNOWN_SCOPE_VERBS = ["read", "write", "admin"] as const;
 
-export function VaultTokens() {
-  const { name } = useParams<{ name: string }>();
+export function VaultTokens({ vaultName }: { vaultName?: string } = {}) {
+  // Per-vault mount passes `vaultName` directly (no `:name` segment under
+  // `basename="/vault/<name>/admin"`); stand-alone `/vault/:name/tokens`
+  // reads it from useParams. The presence of the prop also picks the
+  // detail-link shape — `/` under per-vault, `/vault/<name>` stand-alone.
+  const params = useParams<{ name: string }>();
+  const name = vaultName ?? params.name;
+  const isPerVaultMount = vaultName !== undefined;
+  const detailHref = isPerVaultMount ? "/" : `/vault/${encodeURIComponent(name ?? "")}`;
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [minted, setMinted] = useState<MintTokenResult | null>(null);
   const [confirmingRevokeId, setConfirmingRevokeId] = useState<string | null>(null);
@@ -87,7 +94,7 @@ export function VaultTokens() {
       <div>
         <h2>Tokens</h2>
         <p className="muted">Missing vault name.</p>
-        <Link to="/">← Back to vaults</Link>
+        {isPerVaultMount ? null : <Link to="/">← Back to vaults</Link>}
       </div>
     );
   }
@@ -100,7 +107,7 @@ export function VaultTokens() {
         <h2>
           Tokens for <code>{name}</code>
         </h2>
-        <Link to={`/vault/${encodeURIComponent(name)}`} className="muted">
+        <Link to={detailHref} className="muted">
           ← Vault detail
         </Link>
       </div>


### PR DESCRIPTION
## Summary

vault#252 follow-up. The rc.35 SPA used `<Navigate to=\"/vault/<name>\" replace />` from the `/` route to jump operators landing at `/vault/<name>/admin/` straight to the detail page. Under React Router v6 with `<BrowserRouter basename=\"/vault/<name>/admin\">`, paths in `<Navigate to>` and `<Link to>` are basename-relative absolute paths — so the redirect resolved to `/vault/<name>/admin/vault/<name>` (basename + path), landing the operator on a doubled URL with no matching route and falling through to the auth-required shell.

The redirect was the wrong shape: the SPA needs different routes per mount mode, not a clever redirect.

## Fix

- `App.tsx` switches the route table on `getMountedVaultName()`:
  - per-vault mount → `{ \"/\" → VaultDetail, \"/tokens\" → VaultTokens }` with the mounted vault name passed as a prop
  - stand-alone → original picker tree (`{ \"/\" → VaultsList, \"/vault/:name\" → VaultDetail, \"/vault/:name/tokens\" → VaultTokens }`)
  - no `<Navigate>` anywhere — the route table answers the URL directly
- `VaultDetail` and `VaultTokens` accept optional `vaultName` prop, fall back to `useParams()`. The presence of the prop also picks the inner-Link shape (`/tokens` vs `/vault/<name>/tokens`) locally where the link is emitted, so a sub-route click can't re-introduce the doubling.
- Back-to-vaults links suppressed under per-vault mount (hub doesn't proxy `/vaults/list`).
- Bumps `0.3.6-rc.35` → `0.3.6-rc.36`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 60 pass (was 52; +8 in new `App.test.tsx`)
- [x] `bun run build` + `verify-base` — `dist/index.html` references relative `./assets/`
- [x] Server-side regression: `bun test ./src/admin-spa.test.ts ./src/routing.test.ts` — 104 pass
- [ ] **Manual smoke (Aaron)**: hub directory \"Manage\" link → `/vault/<name>/admin/` should render the detail page directly with NO doubled URL

## Regression pin

`App.test.tsx` asserts the Tokens-link href is `/tokens` under per-vault mount and `/vault/<name>/tokens` stand-alone — picking the wrong shape would re-introduce the bug under `<BrowserRouter basename>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)