### PR TITLE
fix(module): trailing slash on managementUrl avoids fragment-losing 301

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -7,7 +7,7 @@
   "port": 1940,
   "paths": ["/vault/default"],
   "health": "/vault/default/health",
-  "managementUrl": "/admin",
+  "managementUrl": "/admin/",
   "startCmd": ["parachute-vault", "serve"],
   "scopes": {
     "defines": ["vault:read", "vault:write", "vault:admin"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.3.6-rc.37] — 2026-05-04
+
+vault#252 second follow-up — fix the actual root cause of Aaron's no-token error after rc.36 closed the URL-doubling bug. Browsers drop URL fragments when following a 301 redirect (RFC 7231 says SHOULD preserve, but Chrome/Firefox/Safari behavior is inconsistent in practice — WebKit historically drops, Chrome sometimes preserves). The hub-issued JWT travels in `#token=…`, so the redirect rc.35 added (`/vault/<name>/admin` → `/vault/<name>/admin/`) was dropping the token before the SPA could capture it. The SPA then booted unauthenticated and rendered the no-token error — even though the operator clicked through hub correctly.
+
+### Fixed
+
+- **`.parachute/module.json` `managementUrl: "/admin"` → `"/admin/"`.** Hub's `resolveManagementUrl` (parachute-hub `web/ui/src/lib/api.ts`) joins the per-vault module URL with this string verbatim. With the trailing slash the canonical click target is `/vault/<name>/admin/` directly — no redirect, no fragment loss, browser preserves `#token=…` end-to-end. The server-side 301 from rc.35 stays as defense-in-depth (covers manual URL typing and old bookmarks), but it's no longer load-bearing for the hub flow. Establishes the contract: SPA-style `managementUrl`s should end with `/` so the URL the operator's browser sees is the same URL the server serves.
+
+### Tests
+
+- `src/admin-spa.test.ts` (2 new) — pin the hub↔vault `managementUrl` contract: (a) `module.json`'s `managementUrl` ends with `/`, (b) the canonical hub-emitted URL (per-vault module URL joined with `managementUrl` à la `resolveManagementUrl`) serves the SPA shell with status 200 and no `Location` header. The "no Location header" assertion is the explicit regression pin — if a future change re-introduces a 301 on the canonical form, fragments would silently drop again.
+
 ## [0.3.6-rc.36] — 2026-05-04
 
 vault#252 follow-up — fix URL doubling under per-vault mount. The rc.35 SPA used `<Navigate to="/vault/<name>" replace />` from the `/` route to jump operators landing at `/vault/<name>/admin/` straight to the vault detail page. Under React Router v6 with `<BrowserRouter basename="/vault/<name>/admin">`, paths in `<Navigate to>` and `<Link to>` are basename-relative absolute paths — so the redirect resolved to `/vault/<name>/admin/vault/<name>` (basename + path), and the operator landed on a doubled URL with no matching route, falling through to the auth-required shell. The redirect was the wrong shape: the SPA needs different routes per mount mode, not a clever redirect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.36",
+  "version": "0.3.6-rc.37",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/admin-spa.test.ts
+++ b/src/admin-spa.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { isAdminSpaPath, serveAdminSpa } from "./admin-spa.ts";
@@ -127,5 +127,35 @@ describe("serveAdminSpa", () => {
     const body = await res.text();
     expect(body).toContain("shell");
     expect(body).not.toContain("root:");
+  });
+});
+
+describe("hub <-> vault managementUrl contract", () => {
+  // Browsers drop the URL fragment when following a 301 (RFC 7231 SHOULD
+  // preserve, but Chrome/Firefox/Safari are inconsistent in practice). The
+  // hub-issued JWT travels in `#token=...`, so a redirected click loses the
+  // token and the SPA boots unauthenticated. Hub's resolveManagementUrl joins
+  // the per-vault module URL with module.json's `managementUrl` verbatim — if
+  // it ends with "/" the canonical click target is `/vault/<name>/admin/`
+  // (no redirect, fragment preserved). Without the trailing slash hub emits
+  // `/vault/<name>/admin`, the server 301s, and the fragment is gone.
+  test("module.json managementUrl ends with '/' so hub emits the no-redirect form", () => {
+    const moduleJson = JSON.parse(
+      readFileSync(join(import.meta.dir, "..", ".parachute", "module.json"), "utf8"),
+    );
+    expect(moduleJson.managementUrl).toMatch(/\/$/);
+  });
+
+  test("the canonical hub-emitted URL serves the SPA shell directly (no 301)", async () => {
+    // Mirror hub's resolveManagementUrl shape: per-vault module URL +
+    // managementUrl. With managementUrl="/admin/" the result is
+    // /vault/<name>/admin/ — which serveAdminSpa returns as 200, not 301.
+    const moduleJson = JSON.parse(
+      readFileSync(join(import.meta.dir, "..", ".parachute", "module.json"), "utf8"),
+    );
+    const canonical = `/vault/work${moduleJson.managementUrl}`;
+    const res = await serveAdminSpa(fixtureDir, canonical);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Location")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

vault#252 second follow-up — fix the actual root cause of Aaron's no-token error after rc.36 closed the URL-doubling bug. The fix is one character; the trace is what matters.

## The trace

1. Hub renders \"Manage\" → navigates to `https://...ts.net/vault/boulder/admin#token=eyJ...`
2. Browser sends `GET /vault/boulder/admin` (fragment is client-only, never on the wire)
3. Vault server (rc.35) sees `sub === \"\"` → `Response.redirect(\"/vault/boulder/admin/\", 301)`
4. **Browser follows redirect — and drops the fragment.** RFC 7231 says SHOULD preserve, but in practice Chrome/Firefox/Safari are inconsistent; WebKit historically drops, Chrome sometimes preserves.
5. Browser loads `/vault/boulder/admin/` with NO fragment.
6. SPA bootstraps, `captureTokenFromFragment()` runs, finds empty hash, no token cached.
7. VaultDetail renders, sees `getToken() === null`, shows the no-token error.

The error message is technically correct (\"Direct loads of `/vault/<name>/admin` can't see protected vault data\") but misleading — Aaron didn't direct-load, the click flow lost the fragment in the redirect.

## Fix

One character in `.parachute/module.json`:

```diff
-  \"managementUrl\": \"/admin\",
+  \"managementUrl\": \"/admin/\",
```

Hub's `resolveManagementUrl` (parachute-hub `web/ui/src/lib/api.ts`) joins the per-vault module URL with managementUrl verbatim — with the trailing slash the canonical click target is `/vault/<name>/admin/` directly. No redirect, no fragment loss, browser preserves `#token=…` end-to-end.

The server-side 301 from rc.35 (`serveAdminSpa` redirects bare → trailing-slash) stays as **defense-in-depth** for manual URL typing and old bookmarks, but is no longer load-bearing for the hub flow. Specifically: `pathname.replace(MOUNT_RE, \"\")` on `/vault/<name>/admin/` produces `\"/\"` (not `\"\"`), so `sub === \"\"` is false → no redirect → falls through to SPA shell. Verified.

## Contract this establishes

SPA-style `managementUrl` values should end with `/` so the URL the browser sees is the URL the server serves. Worth adding to `parachute-patterns/patterns/module-json-extensibility.md` — filing as a follow-up if not folded.

## Bumps `0.3.6-rc.36` → `0.3.6-rc.37`.

## Test plan

- [x] `bun test ./src/admin-spa.test.ts` — 14 pass (12 prior + 2 new contract tests)
  - module.json's `managementUrl` ends with `/`
  - canonical hub-emitted URL serves SPA shell with status 200 and **no Location header** (the regression pin — re-introducing the 301 on the canonical form would silently drop fragments again)
- [x] `bun test ./src/` — 801/801 pass (full server suite)
- [x] `web/ui` typecheck + tests + build still green from rc.36
- [x] Existing `auth.test.ts` already pins `captureTokenFromFragment()` round-trip (token captured from hash, hash stripped, no leak)
- [ ] **Manual smoke (Aaron)**: hub directory \"Manage\" link → SPA boots authenticated, fetches data, displays UI. No 301 in network tab on the canonical click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)