### PR TITLE
fix(admin-spa): vault detail stats render with actual counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.3.6-rc.38] — 2026-05-04
+
+vault#252 third follow-up — fix the empty-stats render Aaron caught after rc.37 unblocked the auth flow. The Stats section on the per-vault detail page rendered all four labels (Notes / Tags / Attachments / Links) but the values next to them were blank. Two contributing bugs: the SPA's `VaultStats` interface used short names (`notes`, `tags`, `attachments`, `links`) that don't exist in the wire payload, and the server-side `VaultStats` had no attachment count at all. Every read coerced `undefined` → `""` and rendered blank.
+
+### Changed
+
+- **`core/src/types.ts:VaultStats` adds `attachmentCount: number`.** Single `SELECT COUNT(*) FROM attachments` in `core/src/notes.ts:getVaultStats`. Cheap query against a small table — same shape as the existing `tagCount` / `linkCount` adjacent counters. Non-breaking addition: `vault-info` MCP tool, `/api/vault?include_stats=true`, and the bare `/vault/<name>/` detail endpoint all surface the new field automatically. Fills the gap between the documented four-stat UI and the previously-three-stat server payload.
+- **`web/ui/src/lib/api.ts:VaultStats` field names align with the server.** `notes` → `totalNotes`, `tags` → `tagCount`, `attachments` → `attachmentCount`, `links` → `linkCount`. The wire payload's keys are the canonical source — the SPA used to shadow them with shorter names, which silently failed. New JSDoc documents the contract: SPA's interface mirrors `core/src/types.ts:VaultStats` byte-for-byte for the fields it reads.
+- **`web/ui/src/routes/VaultDetail.tsx` reads the wire-shape field names directly.** No transform layer — the server returns what the SPA renders, so a future field rename trips the typechecker, not the user.
+
+### Tests
+
+- `core/src/core.test.ts` — new `getVaultStats counts attachments` case (creates two notes, attaches three files across them, asserts `attachmentCount === 3`); existing `getVaultStats returns correct stats` case extended to assert `attachmentCount === 0` for the no-attachments baseline.
+- `web/ui/src/App.test.tsx` — new `renders the actual stat counts from the wire payload` case under per-vault mount: mocks `getVaultDetail` with `{totalNotes: 12, tagCount: 3, attachmentCount: 1, linkCount: 4}` and asserts every value renders. Explicit regression pin against the field-name drift that motivated this fix; future rename on either side trips this test.
+- `web/ui/src/lib/api.test.ts` — fixture migrated to wire-shape names (was the source of the silent drift — the test passed even when the SPA was reading nonexistent keys, because the test fixture matched the SPA's reads, not the server's writes).
+
 ## [0.3.6-rc.37] — 2026-05-04
 
 vault#252 second follow-up — fix the actual root cause of Aaron's no-token error after rc.36 closed the URL-doubling bug. Browsers drop URL fragments when following a 301 redirect (RFC 7231 says SHOULD preserve, but Chrome/Firefox/Safari behavior is inconsistent in practice — WebKit historically drops, Chrome sometimes preserves). The hub-issued JWT travels in `#token=…`, so the redirect rc.35 added (`/vault/<name>/admin` → `/vault/<name>/admin/`) was dropping the token before the SPA could capture it. The SPA then booted unauthenticated and rendered the no-token error — even though the operator clicked through hub correctly.

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -587,11 +587,23 @@ describe("vault stats", async () => {
     const result = await store.getVaultStats();
     expect(result.totalNotes).toBe(2);
     expect(result.tagCount).toBe(2);
+    expect(result.attachmentCount).toBe(0);
     expect(result.topTags[0].tag).toBe("x");
     expect(result.topTags[0].count).toBe(2);
     expect(result.notesByMonth).toHaveLength(2);
     expect(result.earliestNote!.createdAt).toBe("2025-05-01T00:00:00.000Z");
     expect(result.latestNote!.createdAt).toBe("2025-06-01T00:00:00.000Z");
+  });
+
+  it("getVaultStats counts attachments", async () => {
+    const n1 = await store.createNote("one");
+    const n2 = await store.createNote("two");
+    await store.addAttachment(n1.id, "/tmp/a1.mp3", "audio/mp3");
+    await store.addAttachment(n1.id, "/tmp/i1.png", "image/png");
+    await store.addAttachment(n2.id, "/tmp/a2.mp3", "audio/mp3");
+
+    const result = await store.getVaultStats();
+    expect(result.attachmentCount).toBe(3);
   });
 });
 

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -879,6 +879,9 @@ export function getVaultStats(
   const tagCountRow = db.prepare("SELECT COUNT(DISTINCT tag_name) as c FROM note_tags").get() as { c: number };
   const tagCount = tagCountRow.c;
 
+  const attachmentCountRow = db.prepare("SELECT COUNT(*) as c FROM attachments").get() as { c: number };
+  const attachmentCount = attachmentCountRow.c;
+
   const linkCountRow = db.prepare("SELECT COUNT(*) as c FROM links").get() as { c: number };
   const linkCount = linkCountRow.c;
 
@@ -893,6 +896,7 @@ export function getVaultStats(
     notesByMonth: monthRows,
     topTags: topTagRows,
     tagCount,
+    attachmentCount,
     linkCount,
   };
 }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -62,6 +62,7 @@ export interface VaultStats {
   notesByMonth: { month: string; count: number }[];
   topTags: { tag: string; count: number }[];
   tagCount: number;
+  attachmentCount: number;
   linkCount: number;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.37",
+  "version": "0.3.6-rc.38",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -31,7 +31,7 @@ const detailFixture = (over: Partial<api.VaultDetailResult> = {}): api.VaultDeta
   name: "boulder",
   description: "ops vault",
   createdAt: "2026-05-01T00:00:00Z",
-  stats: { notes: 0, tags: 0, attachments: 0, links: 0 },
+  stats: { totalNotes: 0, tagCount: 0, attachmentCount: 0, linkCount: 0 },
   ...over,
 });
 
@@ -48,6 +48,31 @@ describe("App — per-vault mount", () => {
   beforeEach(() => {
     vi.mocked(mount.getMountedVaultName).mockReturnValue("boulder");
     vi.mocked(api.getVaultDetail).mockResolvedValue(detailFixture());
+  });
+
+  it("renders the actual stat counts from the wire payload (regression: empty values)", async () => {
+    // Aaron caught this in the rc.37 ship: labels rendered (Notes / Tags /
+    // Attachments / Links) but the values were empty because the SPA's old
+    // VaultStats interface used short names (`notes`, `tags`, `attachments`,
+    // `links`) that don't exist on the wire — the server returns
+    // `totalNotes`, `tagCount`, `attachmentCount`, `linkCount` per
+    // `core/src/types.ts:VaultStats`. Every read coerced undefined → "" and
+    // rendered blank. Pin the four values explicitly so a future drift on
+    // either side trips this test.
+    vi.mocked(api.getVaultDetail).mockResolvedValue(
+      detailFixture({
+        stats: { totalNotes: 12, tagCount: 3, attachmentCount: 1, linkCount: 4 },
+      }),
+    );
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("12")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
   });
 
   it("renders VaultDetail at `/` (no redirect, no doubled URL)", async () => {

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -69,7 +69,7 @@ describe("getVaultDetail", () => {
           name: "work",
           description: null,
           createdAt: "2026-04-01T00:00:00Z",
-          stats: { notes: 12, tags: 3, attachments: 1, links: 4 },
+          stats: { totalNotes: 12, tagCount: 3, attachmentCount: 1, linkCount: 4 },
         }),
         { status: 200 },
       );
@@ -78,7 +78,7 @@ describe("getVaultDetail", () => {
     const detail = await getVaultDetail("work");
 
     expect(detail.name).toBe("work");
-    expect(detail.stats.notes).toBe(12);
+    expect(detail.stats.totalNotes).toBe(12);
     expect(calls[0]?.url).toBe("/vault/work/");
     expect(calls[0]?.auth).toBe("Bearer jwt-here");
   });

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -14,11 +14,22 @@
  */
 import { getToken } from "./auth.ts";
 
+/**
+ * Counts surface in `VaultDetail.tsx`'s Stats section. Field names mirror
+ * the server's `core/src/types.ts:VaultStats` shape so the JSON parses
+ * straight in — historically the SPA shadowed the server with shorter
+ * names (`notes`, `tags`, `attachments`, `links`) which silently rendered
+ * as empty strings since none of those keys actually exist on the wire.
+ *
+ * The wire payload carries more fields than this (timeline, top tags,
+ * earliest/latest note); we only declare the ones the SPA reads, since
+ * adding the rest just buys drift surface.
+ */
 export interface VaultStats {
-  notes: number;
-  tags: number;
-  attachments: number;
-  links: number;
+  totalNotes: number;
+  tagCount: number;
+  attachmentCount: number;
+  linkCount: number;
 }
 
 export interface VaultDetailResult {

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -165,19 +165,19 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
         <div className="stats">
           <div className="stat">
             <div className="label">Notes</div>
-            <div className="value">{vault.stats.notes}</div>
+            <div className="value">{vault.stats.totalNotes}</div>
           </div>
           <div className="stat">
             <div className="label">Tags</div>
-            <div className="value">{vault.stats.tags}</div>
+            <div className="value">{vault.stats.tagCount}</div>
           </div>
           <div className="stat">
             <div className="label">Attachments</div>
-            <div className="value">{vault.stats.attachments}</div>
+            <div className="value">{vault.stats.attachmentCount}</div>
           </div>
           <div className="stat">
             <div className="label">Links</div>
-            <div className="value">{vault.stats.links}</div>
+            <div className="value">{vault.stats.linkCount}</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

vault#252 third follow-up. After rc.37 unblocked the auth flow, Aaron loaded the per-vault detail page and saw the four stat labels (Notes / Tags / Attachments / Links) but blank values next to them.

## Root cause

Two contributing bugs in the same render:

1. **SPA field-name drift.** `web/ui/src/lib/api.ts:VaultStats` declared `{notes, tags, attachments, links}` — none of those keys exist on the wire. The server returns `core/src/types.ts:VaultStats` shape: `{totalNotes, tagCount, linkCount, ...}`. Every read coerced `undefined` → `\"\"` and rendered blank.
2. **Server-side gap.** No `attachmentCount` in `VaultStats` at all — even after fixing the SPA's reads, the Attachments stat would still render empty.

The `api.test.ts` fixture is the meta-bug: it matched the SPA's reads instead of the server's writes, so the test passed while the actual integration silently failed.

## Fix

- **Align SPA's interface with the server's wire shape.** `web/ui/src/lib/api.ts:VaultStats` now mirrors `core/src/types.ts:VaultStats` byte-for-byte for the fields the SPA reads (`totalNotes`, `tagCount`, `attachmentCount`, `linkCount`). No transform layer — the server returns what the SPA renders, so a future field rename trips the typechecker.
- **Add `attachmentCount` to server-side `VaultStats`.** Single `SELECT COUNT(*) FROM attachments` in `core/src/notes.ts:getVaultStats`. Cheap query against a small table — same shape as the existing `tagCount` / `linkCount` adjacent counters. Non-breaking addition: the bare `/vault/<name>/` detail endpoint, `/api/vault?include_stats=true`, and the `vault-info` MCP tool all surface the new field automatically.
- Bumps `0.3.6-rc.37` → `0.3.6-rc.38`.

## Test plan

- [x] `bun test ./core/src/` — 405 pass (existing case extended with `attachmentCount === 0` baseline; new `getVaultStats counts attachments` case creates 3 attachments across 2 notes)
- [x] `bun test ./src/` — 801 pass (server-side regression check)
- [x] `cd web/ui && bun run typecheck && bun run test && bun run build` — typecheck clean, 61 pass (new App.test.tsx case asserts every value renders against the actual wire shape), build green
- [ ] **Manual smoke (Aaron)**: hub directory \"Manage\" → vault detail page → Stats section shows actual numbers (not blanks)

## Regression pin

`web/ui/src/App.test.tsx` mocks `getVaultDetail` with `{totalNotes: 12, tagCount: 3, attachmentCount: 1, linkCount: 4}` and asserts every value appears in the DOM. The fixture in `api.test.ts` was migrated to wire-shape names — both sides now use the same vocabulary, so a future drift on either trips the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)