### PR TITLE
feat(tokens): per-vault token storage migration (closes #257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.3.6-rc.39] — 2026-05-04
+
+vault#257 — per-vault token storage migration. Tokens now bind to the vault they were minted from, and cross-vault use is rejected at the auth layer. Pre-v16 tokens carry a `NULL` `vault_name` and remain server-wide (legacy compatibility), so existing deployments keep working unchanged; new mints default to vault-bound. The cross-vault leak surface was small in practice (per-vault DBs already scope storage; only `authenticateGlobalRequest` at `/mcp` iterated across vaults), but the explicit `vault_name` column closes the gap with defense-in-depth at every per-vault auth path.
+
+### Changed
+
+- **Schema v15 → v16: `tokens` table grows `vault_name TEXT` + `idx_tokens_vault_name` index.** `core/src/schema.ts:migrateToV16` runs an idempotent `ALTER TABLE … ADD COLUMN` inside `BEGIN IMMEDIATE` / `COMMIT` (ROLLBACK on failure) — same shape as v14/v15 from vault#251. Lenient backfill: existing rows get `NULL` (= legacy server-wide). New rows default to the minting vault's name. Index keeps the per-vault `WHERE vault_name = ? OR vault_name IS NULL` filter cheap on large token sets.
+- **`src/auth.ts:authenticateVaultRequest` rejects cross-vault token use with 403.** When a `pvt_*` resolves to `vault_name = <other>` and the request is for `<this>`, the response is `403 Unauthorized` with a message naming both vaults. `NULL`-bound (legacy) tokens still pass — the migration is additive, not breaking. Hub-issued JWTs continue to use `vault:<name>:<verb>` scope narrowing as the audience-binding mechanism (JWTs aren't per-token-DB rows, so `vault_name` doesn't apply).
+- **`src/token-store.ts` surfaces `vault_name` end-to-end.** `Token` and `ResolvedToken` carry the field; `createToken` accepts an optional `vault_name` (default null = server-wide); `listTokens` accepts `{ vaultName }` and filters with `WHERE vault_name = ? OR vault_name IS NULL` so legacy NULL-bound rows remain visible alongside the bound set.
+- **`src/tokens-routes.ts` per-vault endpoints filter by `vault_name`.** `GET /vault/<name>/tokens` returns vault-bound + legacy NULL-bound rows; `POST` mints with `vault_name = <name>`; `DELETE` only revokes rows that belong to the calling vault (or are NULL-bound). The implicit cross-vault listing surface in the SPA is now closed at the route layer, not just the SPA layer.
+- **`src/cli.ts tokens` gains `--vault <name>` and `--all` flags.** `tokens list --vault <name>` mirrors the SPA's per-vault filter from the command line. `tokens create --all` is the explicit opt-in for a server-wide mint (prints a warning since that's no longer the default); `tokens create --vault <name>` binds explicitly; `tokens create` with neither defaults to the active vault. List output annotates legacy rows with `[server-wide]` so operators can spot pre-v16 tokens at a glance.
+- **`web/ui/src/lib/tokens-api.ts:TokenSummary` adds `vault_name: string | null`.** The SPA's wire-shape interface mirrors the server's `tokens-routes.ts` response. `web/ui/src/routes/VaultTokens.tsx` renders a `server-wide` badge next to NULL-bound rows so legacy tokens are visually distinct from per-vault mints — matches the issue's UI guidance.
+
+### Tests
+
+- `src/token-store.test.ts` — new `per-vault binding (v16)` describe (3 cases): NULL when `vault_name` omitted, binding when set, `listTokens({ vaultName })` returns vault-bound + legacy NULL but excludes other-vault-bound rows. Doubles as a v16-migration pin since the test creates fresh DBs through `initSchema` (current SCHEMA_VERSION) and operates on the new column.
+- `src/auth.test.ts` — new `auth — cross-vault isolation` describe (3 cases): cross-vault binding rejects 403, matched binding accepts, NULL-bound legacy tokens still authenticate.
+- `src/tokens-routes.test.ts` — new v16 list-filter case: plants a token in another vault's DB and a legacy NULL-bound row in the calling vault's DB; asserts the foreign-vault row is excluded from the response, the legacy row is present, and the response surfaces the new `vault_name` field.
+- `web/ui/src/routes/VaultTokens.test.tsx` — fixture migrated to include `vault_name: "work"` so the typecheck pins the field's presence on the wire.
+
 ## [0.3.6-rc.38] — 2026-05-04
 
 vault#252 third follow-up — fix the empty-stats render Aaron caught after rc.37 unblocked the auth flow. The Stats section on the per-vault detail page rendered all four labels (Notes / Tags / Attachments / Links) but the values next to them were blank. Two contributing bugs: the SPA's `VaultStats` interface used short names (`notes`, `tags`, `attachments`, `links`) that don't exist in the wire payload, and the server-side `VaultStats` had no attachment count at all. Every read coerced `undefined` → `""` and rendered blank.

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -3993,6 +3993,98 @@ describe("schema migration v14 → v15", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Schema migration v15 → v16 — vault#257 (tokens.vault_name binding)
+// ---------------------------------------------------------------------------
+
+describe("schema migration v15 → v16", async () => {
+  // vault#257 — the v16 migration body (ALTER TABLE ADD COLUMN + CREATE
+  // INDEX) is wrapped in BEGIN IMMEDIATE / COMMIT with a try/catch
+  // ROLLBACK, mirroring the v14/v15 wrap shape from vault#251. The
+  // individual statements are atomic in SQLite, so the wrap is mostly
+  // belt-and-suspenders for THIS migration — but the test mirrors v14's
+  // crash-rollback shape so anyone touching migrations finds the same
+  // regression-pin pattern across versions.
+  it("crash mid-migration rolls back to pre-v16 state, then retry succeeds", async () => {
+    const { Database } = await import("bun:sqlite");
+    const { initSchema } = await import("./schema.ts");
+
+    // Build the full post-v16 shape, plant a row, then drop the v16
+    // additions so initSchema's migrateToV16 fires on the next call.
+    const db = new Database(":memory:");
+    db.exec("PRAGMA journal_mode = WAL");
+    initSchema(db);
+
+    const now = new Date().toISOString();
+    db.prepare(
+      "INSERT INTO tokens (token_hash, label, created_at, vault_name) VALUES (?, ?, ?, ?)",
+    ).run("sha256:abc123def456", "pre-existing", now, "work");
+
+    db.exec("DROP INDEX IF EXISTS idx_tokens_vault_name");
+    db.exec("ALTER TABLE tokens DROP COLUMN vault_name");
+
+    // Pre-condition: the column is gone but the row is still there
+    // (DROP COLUMN strips the column from existing rows).
+    const preCols = db.prepare("PRAGMA table_info(tokens)").all() as { name: string }[];
+    expect(preCols.map((c) => c.name)).not.toContain("vault_name");
+    const preRow = db.prepare("SELECT label FROM tokens WHERE token_hash = ?")
+      .get("sha256:abc123def456") as { label: string } | null;
+    expect(preRow?.label).toBe("pre-existing");
+
+    // Patch db.exec to crash on CREATE INDEX — the second statement inside
+    // the v16 transaction body. Crashing here proves the wrap covers the
+    // post-ALTER state, not just the tail. The injection deliberately
+    // doesn't match BEGIN/COMMIT/ROLLBACK so the catch's ROLLBACK still
+    // runs through the patched exec.
+    const origExec = db.exec.bind(db);
+    let crashOnIndex: boolean = true;
+    (db as any).exec = function (sql: string) {
+      if (crashOnIndex && sql.includes("CREATE INDEX") && sql.includes("idx_tokens_vault_name")) {
+        throw new Error("simulated crash mid-v16-migration");
+      }
+      return origExec(sql);
+    };
+
+    expect(() => initSchema(db)).toThrow("simulated crash mid-v16-migration");
+
+    // Pre-v16 shape after rollback: vault_name column must not exist; the
+    // pre-existing row must be untouched.
+    const colsAfterRollback = db.prepare("PRAGMA table_info(tokens)").all() as { name: string }[];
+    expect(colsAfterRollback.map((c) => c.name)).not.toContain("vault_name");
+    const idxAfterRollback = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_tokens_vault_name'",
+    ).get();
+    expect(idxAfterRollback).toBeNull();
+    const rowAfterRollback = db.prepare("SELECT label FROM tokens WHERE token_hash = ?")
+      .get("sha256:abc123def456") as { label: string } | null;
+    expect(rowAfterRollback?.label).toBe("pre-existing");
+
+    // No lingering open transaction — a fresh BEGIN IMMEDIATE + ROLLBACK
+    // doesn't fail with "cannot start a transaction within a transaction".
+    db.exec("BEGIN IMMEDIATE");
+    db.exec("ROLLBACK");
+
+    // Retry: drop the crash injection, run initSchema again. Must converge
+    // to post-v16 shape (column added, index created, lenient NULL backfill
+    // on the pre-existing row per the migration spec).
+    crashOnIndex = false;
+    initSchema(db);
+
+    const colsPost = db.prepare("PRAGMA table_info(tokens)").all() as { name: string }[];
+    expect(colsPost.map((c) => c.name)).toContain("vault_name");
+    const idxPost = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_tokens_vault_name'",
+    ).get();
+    expect(idxPost).toBeTruthy();
+    const rowPost = db.prepare("SELECT label, vault_name FROM tokens WHERE token_hash = ?")
+      .get("sha256:abc123def456") as { label: string; vault_name: string | null };
+    expect(rowPost.label).toBe("pre-existing");
+    expect(rowPost.vault_name).toBeNull();
+
+    db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tag-scope auth post-v14 — patterns/tag-scoped-tokens.md
 // ---------------------------------------------------------------------------
 

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -210,7 +210,12 @@ CREATE INDEX IF NOT EXISTS idx_attachments_note ON attachments(note_id);
 CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_id);
 CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_id);
 CREATE INDEX IF NOT EXISTS idx_schema_mappings_match ON schema_mappings(match_kind, match_value);
-CREATE INDEX IF NOT EXISTS idx_tokens_vault_name ON tokens(vault_name);
+-- idx_tokens_vault_name is created in migrateToV16, not here. SCHEMA_SQL
+-- runs BEFORE migrations; an upgrading v15 vault doesn't yet have the
+-- vault_name column when this section evaluates, so the index has to
+-- live downstream of the ALTER TABLE that adds the column. Fresh vaults
+-- (column already present from this CREATE TABLE) still get the index
+-- because migrateToV16 also runs the unconditional CREATE INDEX path.
 `;
 
 /**
@@ -691,17 +696,29 @@ function migrateToV15(db: Database): void {
  */
 function migrateToV16(db: Database): void {
   if (!hasTable(db, "tokens")) return;
-  if (hasColumn(db, "tokens", "vault_name")) return;
 
-  db.exec("BEGIN IMMEDIATE");
-  try {
-    db.exec("ALTER TABLE tokens ADD COLUMN vault_name TEXT");
-    db.exec("CREATE INDEX IF NOT EXISTS idx_tokens_vault_name ON tokens(vault_name)");
-    db.exec("COMMIT");
-  } catch (err) {
-    db.exec("ROLLBACK");
-    throw err;
+  // Two responsibilities, separated so the index lands for both fresh
+  // vaults (SCHEMA_SQL already created the column) and upgrading v15
+  // vaults (column missing). Index creation lives outside the wrapped
+  // ALTER block so a fresh vault — where the column exists but the index
+  // doesn't — still gets it.
+  if (!hasColumn(db, "tokens", "vault_name")) {
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      db.exec("ALTER TABLE tokens ADD COLUMN vault_name TEXT");
+      db.exec("CREATE INDEX IF NOT EXISTS idx_tokens_vault_name ON tokens(vault_name)");
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+    return;
   }
+
+  // Column exists (fresh vault from SCHEMA_SQL, or post-upgrade vault).
+  // Make sure the index exists too. IF NOT EXISTS makes this a no-op on
+  // the steady-state path.
+  db.exec("CREATE INDEX IF NOT EXISTS idx_tokens_vault_name ON tokens(vault_name)");
 }
 
 function hasTable(db: Database, name: string): boolean {

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { normalizePath } from "./paths.js";
 import { rebuildIndexes } from "./indexed-fields.js";
 
-export const SCHEMA_VERSION = 15;
+export const SCHEMA_VERSION = 16;
 
 export const SCHEMA_SQL = `
 -- Notes: the universal record
@@ -126,6 +126,13 @@ CREATE TABLE IF NOT EXISTS indexed_fields (
 -- patterns/tag-scoped-tokens.md. Hierarchy expansion is applied at auth
 -- time via getTagDescendants; the column stores root names only.
 --
+-- vault_name (v16) binds the token to a single vault. NULL means the
+-- token is server-wide / legacy (pre-v16 rows backfill to NULL on the
+-- migration; auth treats NULL as accept-any-vault for back-compat).
+-- New tokens minted via per-vault routes write the column explicitly so
+-- cross-vault presentation rejects in authenticateVaultRequest. See
+-- vault#257.
+--
 -- scope_tag / scope_path_prefix are deprecated Phase-0 columns — never
 -- enforced at runtime, kept only for schema stability.
 CREATE TABLE IF NOT EXISTS tokens (
@@ -138,7 +145,8 @@ CREATE TABLE IF NOT EXISTS tokens (
   scope_path_prefix TEXT,
   expires_at TEXT,
   created_at TEXT NOT NULL,
-  last_used_at TEXT
+  last_used_at TEXT,
+  vault_name TEXT
 );
 
 -- OAuth: registered clients (Dynamic Client Registration)
@@ -202,6 +210,7 @@ CREATE INDEX IF NOT EXISTS idx_attachments_note ON attachments(note_id);
 CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_id);
 CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_id);
 CREATE INDEX IF NOT EXISTS idx_schema_mappings_match ON schema_mappings(match_kind, match_value);
+CREATE INDEX IF NOT EXISTS idx_tokens_vault_name ON tokens(vault_name);
 `;
 
 /**
@@ -264,6 +273,12 @@ export function initSchema(db: Database): void {
   // `schema_mappings`. The legacy notes are LEFT IN PLACE — they are
   // inert post-v15 (no resolver reads them) and serve as audit trail.
   migrateToV15(db);
+
+  // Migrate v15 → v16: add `vault_name` column to tokens. Existing rows
+  // backfill to NULL ("server-wide / legacy" semantic) — auth accepts
+  // NULL for any vault, so today's pvt_* tokens keep working unchanged.
+  // New mints via per-vault routes write the column explicitly. See vault#257.
+  migrateToV16(db);
 
   // Rebuild any generated columns + indexes declared in indexed_fields.
   // No-op for a fresh vault; idempotent on existing vaults.
@@ -651,6 +666,38 @@ function migrateToV15(db: Database): void {
         `[vault] migrated to schema v15: copied ${copiedSchemas} _schemas/* + ${copiedMappings} _schema_defaults mappings into note_schemas/schema_mappings`,
       );
     }
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+}
+
+/**
+ * Migrate v15 → v16: per-vault token storage (vault#257).
+ *
+ * Adds `tokens.vault_name TEXT` (nullable). Existing rows stay NULL —
+ * "server-wide / legacy" semantic — and `authenticateVaultRequest`
+ * accepts NULL for any vault, so today's pvt_* tokens keep working
+ * unchanged. New mints via `/vault/<name>/tokens` write the column
+ * explicitly; cross-vault presentation rejects on the row's vault_name
+ * mismatch. The complementary index speeds the per-vault listTokens
+ * filter in the admin SPA.
+ *
+ * Wrapped in BEGIN IMMEDIATE / COMMIT (with try/catch ROLLBACK) per the
+ * v14/v15 wrap pattern from vault#251 — the column add and index create
+ * are individually idempotent (`hasColumn` / IF NOT EXISTS), but the
+ * transaction means a crash mid-migration leaves either pre-v16 or
+ * post-v16 state, never partial.
+ */
+function migrateToV16(db: Database): void {
+  if (!hasTable(db, "tokens")) return;
+  if (hasColumn(db, "tokens", "vault_name")) return;
+
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec("ALTER TABLE tokens ADD COLUMN vault_name TEXT");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_tokens_vault_name ON tokens(vault_name)");
+    db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");
     throw err;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.38",
+  "version": "0.3.6-rc.39",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -174,6 +174,65 @@ describe("auth — cross-vault isolation", () => {
     const res = await authenticateVaultRequest(bearer(workToken), journalConfig, journalStore.db);
     expect("error" in res).toBe(true);
   });
+
+  test("v16 vault_name binding rejects with 403 when the row is cross-vault", async () => {
+    // Per-vault DB scoping is the first line of defense (a token only
+    // resolves against the DB it was minted in). The v16 vault_name column
+    // is defense-in-depth: if a token row somehow lives in vault A's DB
+    // but its vault_name says "B" (e.g. an out-of-band copy, or a future
+    // mistake in the mint path), the binding mismatch must reject. We
+    // simulate that by minting into journal's DB with vault_name="work".
+    seedVault("journal", { isDefault: true });
+    seedVault("work");
+    const journalStore = getVaultStore("journal");
+    const { fullToken } = generateToken();
+    createToken(journalStore.db, fullToken, {
+      label: "mis-bound",
+      permission: "full",
+      vault_name: "work",
+    });
+    const journalConfig = readVaultConfig("journal")!;
+
+    const res = await authenticateVaultRequest(bearer(fullToken), journalConfig, journalStore.db);
+    expect("error" in res).toBe(true);
+    if ("error" in res) {
+      expect(res.error.status).toBe(403);
+    }
+  });
+
+  test("v16 vault_name binding accepts when token is bound to the requested vault", async () => {
+    seedVault("work");
+    const workStore = getVaultStore("work");
+    const { fullToken } = generateToken();
+    createToken(workStore.db, fullToken, {
+      label: "bound",
+      permission: "full",
+      vault_name: "work",
+    });
+    const workConfig = readVaultConfig("work")!;
+
+    const res = await authenticateVaultRequest(bearer(fullToken), workConfig, workStore.db);
+    expect("error" in res).toBe(false);
+    if (!("error" in res)) {
+      expect(res.vault_name).toBe("work");
+    }
+  });
+
+  test("legacy NULL-bound tokens still authenticate against any vault", async () => {
+    // Backwards compatibility: pre-v16 tokens (and legacy YAML keys, and
+    // hub JWTs) all carry vault_name = null. They keep working at any
+    // vault — the migration is lenient by design.
+    seedVault("work");
+    const workToken = mintTokenInVault("work");
+    const workConfig = readVaultConfig("work")!;
+    const workStore = getVaultStore("work");
+
+    const res = await authenticateVaultRequest(bearer(workToken), workConfig, workStore.db);
+    expect("error" in res).toBe(false);
+    if (!("error" in res)) {
+      expect(res.vault_name).toBeNull();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -50,6 +50,14 @@ export interface AuthResult {
    * an OAuth-claim concern. See patterns/tag-scoped-tokens.md.
    */
   scoped_tags: string[] | null;
+  /**
+   * Per-vault binding (v16). Non-null = token can only authenticate against
+   * this vault. authenticateVaultRequest enforces the match before this
+   * result returns; callers downstream can read it for additional scoping
+   * (e.g. cross-vault filtering at the unified /mcp endpoint). NULL =
+   * legacy / server-wide / hub JWT — no per-vault binding. See vault#257.
+   */
+  vault_name: string | null;
 }
 
 /**
@@ -63,6 +71,7 @@ function legacyAuthResult(permission: TokenPermission): AuthResult {
     scopes: legacyPermissionToScopes(permission),
     legacyDerived: true,
     scoped_tags: null,
+    vault_name: null,
   };
 }
 
@@ -172,6 +181,24 @@ export async function authenticateVaultRequest(
     try {
       const resolved = resolveToken(vaultDb, key);
       if (resolved) {
+        // Per-vault binding (v16): tokens minted via /vault/<name>/tokens
+        // carry vault_name = <name>. Reject if presented at a different
+        // vault. NULL = legacy / server-wide; accept anywhere. The DB
+        // lookup itself already filters by per-vault DB scoping (resolve
+        // only succeeds if the token row lives in this vault's DB), so
+        // a mismatch here would only happen if a token row was copied
+        // across vault DBs out-of-band — defense-in-depth.
+        if (resolved.vault_name !== null && resolved.vault_name !== vaultConfig.name) {
+          return {
+            error: Response.json(
+              {
+                error: "Unauthorized",
+                message: `token is bound to vault '${resolved.vault_name}'; cannot be used against vault '${vaultConfig.name}'`,
+              },
+              { status: 403 },
+            ),
+          };
+        }
         if (resolved.legacyDerived) {
           warnLegacyOnce(`vault-token:${vaultConfig.name ?? ""}`, "vault token without scopes column");
         }
@@ -180,6 +207,7 @@ export async function authenticateVaultRequest(
           scopes: resolved.scopes,
           legacyDerived: resolved.legacyDerived,
           scoped_tags: resolved.scoped_tags,
+          vault_name: resolved.vault_name,
         };
       }
     } catch {
@@ -244,7 +272,7 @@ async function authenticateHubJwt(
       hasScope(claims.scopes, SCOPE_WRITE) || hasScope(claims.scopes, SCOPE_ADMIN)
         ? "full"
         : "read";
-    return { permission, scopes: claims.scopes, legacyDerived: false, scoped_tags: null };
+    return { permission, scopes: claims.scopes, legacyDerived: false, scoped_tags: null, vault_name: null };
   } catch (err) {
     if (err instanceof HubJwtError) {
       return { error: Response.json({ error: "Unauthorized", message: err.message }, { status: 401 }) };
@@ -302,7 +330,12 @@ export async function authenticateGlobalRequest(
 
   // Fall through to vault token DBs — check each vault for the token.
   // This enables OAuth-minted pvt_ tokens and CLI-created tokens to
-  // authenticate against the unified /mcp endpoint.
+  // authenticate against the unified /mcp endpoint. The token's vault
+  // binding (if any) is propagated via AuthResult.vault_name; downstream
+  // handlers that operate on a specific vault are responsible for
+  // checking that binding matches their target. The unified surface
+  // itself doesn't reject here — a vault-bound token authenticating to
+  // call back into its own vault via /mcp is legitimate.
   for (const vaultName of listVaults()) {
     try {
       const store = getVaultStore(vaultName);
@@ -316,6 +349,7 @@ export async function authenticateGlobalRequest(
           scopes: resolved.scopes,
           legacyDerived: resolved.legacyDerived,
           scoped_tags: resolved.scoped_tags,
+          vault_name: resolved.vault_name,
         };
       }
     } catch {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -998,20 +998,38 @@ async function cmdConfig(args: string[]) {
 function cmdTokens(args: string[]) {
   const subcmd = args[0];
 
-  // parachute-vault tokens — list all tokens (across all vaults)
+  // parachute-vault tokens [list] [--vault <name>]
+  //   Default: every vault's tokens, grouped by vault.
+  //   --vault <name>: only that vault.
   if (!subcmd || subcmd === "list") {
-    const vaults = listVaults();
+    const vaultFlag = args.indexOf("--vault");
+    const onlyVault = vaultFlag !== -1 ? args[vaultFlag + 1] : null;
+    if (vaultFlag !== -1 && !onlyVault) {
+      console.error("--vault requires a value.");
+      process.exit(1);
+    }
+    const vaults = onlyVault ? [onlyVault] : listVaults();
     let anyTokens = false;
 
     for (const vaultName of vaults) {
       const vc = readVaultConfig(vaultName);
-      if (!vc) continue;
+      if (!vc) {
+        if (onlyVault) {
+          console.error(`Vault "${vaultName}" not found.`);
+          process.exit(1);
+        }
+        continue;
+      }
       const store = getVaultStore(vaultName);
       // Ensure legacy keys are migrated
       const globalCfg = readGlobalConfig();
       migrateVaultKeys(store.db, vc.api_keys, globalCfg.api_keys);
 
-      const tokens = listTokens(store.db);
+      // Per-vault filter (v16): only tokens bound to this vault, plus
+      // legacy NULL-bound (server-wide) rows. The `[server-wide]` annotation
+      // surfaces the latter so an operator listing one vault still sees
+      // tokens that authenticate cross-vault.
+      const tokens = listTokens(store.db, { vaultName });
       if (tokens.length === 0) continue;
       anyTokens = true;
 
@@ -1019,7 +1037,8 @@ function cmdTokens(args: string[]) {
       for (const t of tokens) {
         const expiry = t.expires_at ? ` (expires: ${t.expires_at})` : "";
         const lastUsed = t.last_used_at ? ` (last used: ${t.last_used_at})` : "";
-        console.log(`  ${t.id}  ${t.label}  [${t.permission}]${expiry}${lastUsed}`);
+        const serverWide = t.vault_name === null ? " [server-wide]" : "";
+        console.log(`  ${t.id}  ${t.label}  [${t.permission}]${serverWide}${expiry}${lastUsed}`);
       }
       console.log();
     }
@@ -1030,11 +1049,21 @@ function cmdTokens(args: string[]) {
     return;
   }
 
-  // parachute-vault tokens create --vault <name>
+  // parachute-vault tokens create [--vault <name> | --all]
   //   [--scope vault:read,vault:write | --read | --permission full|read]
   //   [--expires <duration>] [--label <label>]
+  //
+  // Per-vault binding (v16): the minted token is pinned to <vaultName>
+  // unless --all is passed, in which case the token is server-wide
+  // (vault_name = NULL) and authenticates against any vault. --all is
+  // the explicit opt-out — there's no implicit fall-through to server-wide.
   if (subcmd === "create") {
     const vaultFlag = args.indexOf("--vault");
+    const allFlag = args.includes("--all");
+    if (allFlag && vaultFlag !== -1) {
+      console.error("--vault and --all are mutually exclusive.");
+      process.exit(1);
+    }
     const vaultName = vaultFlag !== -1 ? args[vaultFlag + 1] : (readGlobalConfig().default_vault || "default");
     if (!vaultName) {
       console.error("--vault requires a value.");
@@ -1084,15 +1113,22 @@ function cmdTokens(args: string[]) {
       permission,
       scopes,
       expires_at: expiresAt,
+      // v16 binding: pin to the vault we minted in unless --all was passed
+      // (which leaves vault_name NULL = legacy server-wide).
+      vault_name: allFlag ? null : vaultName,
     });
 
     const displayScopes = scopes ?? [...VAULT_SCOPES];
-    console.log(`Created token for vault "${vaultName}":`);
+    const heading = allFlag
+      ? `Created server-wide token (authenticates against any vault):`
+      : `Created token for vault "${vaultName}":`;
+    console.log(heading);
     console.log(`  Token:      ${fullToken}`);
     console.log(`  Permission: ${permission}`);
     console.log(`  Scopes:     ${displayScopes.join(" ")}`);
     if (expiresAt) console.log(`  Expires:    ${expiresAt}`);
     console.log(`  Label:      ${label}`);
+    if (!allFlag) console.log(`  Vault:      ${vaultName}`);
     console.log();
     console.log("Save this token — it will not be shown again.");
     return;
@@ -2344,9 +2380,13 @@ Vaults:
   parachute-vault mcp-install              Add vault MCP to Claude
 
 Tokens:
-  parachute-vault tokens                          List all tokens
-  parachute-vault tokens create                   Create a full-access token in the default vault
-  parachute-vault tokens create --vault <name>    Create a token in a specific vault
+  parachute-vault tokens                          List tokens (every vault)
+  parachute-vault tokens list --vault <name>      List tokens for one vault only
+  parachute-vault tokens create                   Create a vault-bound token in the default vault
+  parachute-vault tokens create --vault <name>    Create a token bound to a specific vault
+  parachute-vault tokens create --all             Create a server-wide token (vault_name=NULL).
+                                                  Authenticates against any vault — use sparingly,
+                                                  for cross-vault automation only.
   parachute-vault tokens create --read            Read-only token (shorthand for --scope vault:read)
   parachute-vault tokens create --scope vault:write
                                                   Narrow the token's scopes. Accepts a comma-separated

--- a/src/token-store.test.ts
+++ b/src/token-store.test.ts
@@ -157,6 +157,53 @@ describe("token CRUD", () => {
   });
 });
 
+describe("per-vault binding (v16)", () => {
+  test("createToken without vault_name leaves the column NULL (legacy / server-wide)", () => {
+    const { fullToken } = generateToken();
+    createToken(db, fullToken, { label: "legacy" });
+
+    const resolved = resolveToken(db, fullToken);
+    expect(resolved!.vault_name).toBeNull();
+
+    const [row] = listTokens(db);
+    expect(row!.vault_name).toBeNull();
+  });
+
+  test("createToken with vault_name binds the token to that vault", () => {
+    const { fullToken } = generateToken();
+    createToken(db, fullToken, { label: "boulder-bound", vault_name: "boulder" });
+
+    const resolved = resolveToken(db, fullToken);
+    expect(resolved!.vault_name).toBe("boulder");
+
+    const [row] = listTokens(db);
+    expect(row!.vault_name).toBe("boulder");
+  });
+
+  test("listTokens with vaultName filter returns matching + legacy NULL tokens", () => {
+    // Per the contract: per-vault listings show tokens bound to THIS vault
+    // plus any server-wide (NULL) tokens. The latter authenticate cross-vault
+    // by design, so the operator should be able to see + revoke them in any
+    // vault's admin UI. Tokens bound to OTHER vaults are excluded.
+    const { fullToken: tA } = generateToken();
+    const { fullToken: tB } = generateToken();
+    const { fullToken: tLegacy } = generateToken();
+    createToken(db, tA, { label: "boulder", vault_name: "boulder" });
+    createToken(db, tB, { label: "default-vault", vault_name: "default" });
+    createToken(db, tLegacy, { label: "server-wide" });
+
+    const boulderTokens = listTokens(db, { vaultName: "boulder" });
+    expect(boulderTokens.map((t) => t.label).sort()).toEqual(["boulder", "server-wide"]);
+
+    const defaultTokens = listTokens(db, { vaultName: "default" });
+    expect(defaultTokens.map((t) => t.label).sort()).toEqual(["default-vault", "server-wide"]);
+
+    // No filter → everything.
+    const all = listTokens(db);
+    expect(all.length).toBe(3);
+  });
+});
+
 describe("token generation", () => {
   test("generated tokens have pvt_ prefix", () => {
     const { fullToken, tokenHash } = generateToken();

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -53,6 +53,13 @@ export interface Token {
    * patterns/tag-scoped-tokens.md.
    */
   scoped_tags: string[] | null;
+  /**
+   * Per-vault binding (v16). Non-null = token can only authenticate against
+   * this vault; cross-vault presentation rejects in
+   * `authenticateVaultRequest`. NULL = legacy / server-wide token, accepted
+   * for any vault. See vault#257.
+   */
+  vault_name: string | null;
   expires_at: string | null;
   created_at: string;
   last_used_at: string | null;
@@ -74,6 +81,13 @@ export interface ResolvedToken {
    * See `Token.scoped_tags`.
    */
   scoped_tags: string[] | null;
+  /**
+   * Per-vault binding (v16). Non-null = token is bound to this vault;
+   * `authenticateVaultRequest` rejects when the bound vault doesn't match
+   * the request's vault. NULL = legacy / server-wide, accepted for any
+   * vault. See vault#257.
+   */
+  vault_name: string | null;
 }
 
 /**
@@ -127,6 +141,13 @@ export function createToken(
      * endpoint validates against existing tags before passing through.
      */
     scoped_tags?: string[] | null;
+    /**
+     * Per-vault binding (v16). Non-null = token can only authenticate
+     * against this vault. NULL = legacy / server-wide; auth accepts the
+     * token for any vault. New mints via per-vault routes set this; the
+     * legacy YAML-import path leaves it NULL. See vault#257.
+     */
+    vault_name?: string | null;
     expires_at?: string | null;
   },
 ): Token {
@@ -137,10 +158,11 @@ export function createToken(
   const scopesStr = serializeScopes(scopes);
   const scopedTags = opts.scoped_tags && opts.scoped_tags.length > 0 ? opts.scoped_tags : null;
   const scopedTagsStr = scopedTags ? JSON.stringify(scopedTags) : null;
+  const vaultName = opts.vault_name ?? null;
 
   db.prepare(`
-    INSERT INTO tokens (token_hash, label, permission, scopes, scoped_tags, scope_tag, scope_path_prefix, expires_at, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO tokens (token_hash, label, permission, scopes, scoped_tags, scope_tag, scope_path_prefix, expires_at, created_at, vault_name)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     tokenHash,
     opts.label,
@@ -151,6 +173,7 @@ export function createToken(
     opts.scope_path_prefix ?? null,
     opts.expires_at ?? null,
     now,
+    vaultName,
   );
 
   return {
@@ -160,6 +183,7 @@ export function createToken(
     scope_tag: opts.scope_tag ?? null,
     scope_path_prefix: opts.scope_path_prefix ?? null,
     scoped_tags: scopedTags,
+    vault_name: vaultName,
     expires_at: opts.expires_at ?? null,
     created_at: now,
     last_used_at: null,
@@ -177,7 +201,7 @@ export function resolveToken(db: Database, providedToken: string): ResolvedToken
   const candidateHash = hashKey(providedToken);
 
   const row = db.prepare(`
-    SELECT token_hash, permission, scopes, scoped_tags, expires_at
+    SELECT token_hash, permission, scopes, scoped_tags, expires_at, vault_name
     FROM tokens WHERE token_hash = ?
   `).get(candidateHash) as {
     token_hash: string;
@@ -185,6 +209,7 @@ export function resolveToken(db: Database, providedToken: string): ResolvedToken
     scopes: string | null;
     scoped_tags: string | null;
     expires_at: string | null;
+    vault_name: string | null;
   } | null;
 
   if (!row) return null;
@@ -205,19 +230,32 @@ export function resolveToken(db: Database, providedToken: string): ResolvedToken
   const legacyDerived = !hasVaultScope;
   const scoped_tags = parseScopedTags(row.scoped_tags);
 
-  return { permission, scopes, legacyDerived, scoped_tags };
+  return { permission, scopes, legacyDerived, scoped_tags, vault_name: row.vault_name };
 }
 
 /**
- * List all tokens (for CLI display). Never exposes the hash directly —
- * shows a truncated prefix for identification.
+ * List tokens (for CLI display + admin SPA). Never exposes the hash
+ * directly — shows a truncated prefix for identification.
+ *
+ * Filtering (v16): pass `{ vaultName }` to scope the result to tokens
+ * bound to that vault. The filter is `vault_name = $vaultName OR
+ * vault_name IS NULL` — legacy server-wide tokens (NULL) remain visible
+ * inside every per-vault listing, since they authenticate cross-vault
+ * by design and the operator should see them in any vault's admin UI
+ * to revoke. Pass no filter (or `vaultName: null`) to list everything.
  */
-export function listTokens(db: Database): (Token & { id: string })[] {
+export function listTokens(
+  db: Database,
+  opts: { vaultName?: string | null } = {},
+): (Token & { id: string })[] {
+  const where = opts.vaultName ? "WHERE vault_name = ? OR vault_name IS NULL" : "";
+  const params = opts.vaultName ? [opts.vaultName] : [];
   const rows = db.prepare(`
     SELECT token_hash, label, permission, scope_tag, scope_path_prefix,
-           scoped_tags, expires_at, created_at, last_used_at
-    FROM tokens ORDER BY created_at DESC
-  `).all() as (Omit<Token, "scoped_tags"> & { scoped_tags: string | null })[];
+           scoped_tags, vault_name, expires_at, created_at, last_used_at
+    FROM tokens ${where}
+    ORDER BY created_at DESC
+  `).all(...params) as (Omit<Token, "scoped_tags"> & { scoped_tags: string | null })[];
 
   return rows.map((r) => ({
     ...r,

--- a/src/tokens-routes.test.ts
+++ b/src/tokens-routes.test.ts
@@ -11,7 +11,8 @@
  *   - Scope subset enforcement: minted scopes must be ≤ caller's vault
  *     verb power. Cross-vault scopes (`vault:other:*`) rejected.
  *   - Admin gate: read/write callers cannot reach the endpoint at all.
- *   - DELETE is intentionally non-leaky — non-existent ids return 200.
+ *   - DELETE: 200 on success, 404 when the id doesn't exist, **403** when
+ *     the id resolves to a different vault's binding (per #257 spec).
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -500,14 +501,52 @@ describe("DELETE /vault/<name>/tokens/<id> — revoke", () => {
     expect(resolveToken(store.db, minted.token)).toBeNull();
   });
 
-  test("non-existent id → 200 with revoked:true (no existence leak)", async () => {
+  test("non-existent id → 404", async () => {
+    // Per vault#257 spec: silent 200 on missing id is misleading once the
+    // list endpoint already exposes the full vault-scoped + legacy-NULL
+    // listing — existence isn't being protected, so 404 is the honest shape.
     createVault("journal");
     const admin = mintAdminToken("journal");
 
     const res = await deleteToken("journal", "t_doesnotexist", admin);
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { revoked: boolean };
-    expect(body.revoked).toBe(true);
+    expect(res.status).toBe(404);
+  });
+
+  test("v16: cross-vault binding revoke → 403 with descriptive error", async () => {
+    // Per vault#257 spec: an admin in vault A attempting to revoke a token
+    // bound to vault B must get 403, not silent 200. Silent 200 would tell
+    // the operator the token was revoked while it kept working from vault B.
+    createVault("journal");
+    createVault("work");
+    const journalAdmin = mintAdminToken("journal");
+
+    // Plant a token in journal's DB but bound to "work" (the cross-vault
+    // shape — same row layout the v16 list-filter test uses).
+    const journalStore = getVaultStore("journal");
+    const { fullToken, tokenHash } = generateToken();
+    createToken(journalStore.db, fullToken, {
+      label: "work-bound",
+      permission: "full",
+      scopes: ["vault:admin"],
+      vault_name: "work",
+    });
+    // Display id mirrors `t_${tokenHash.slice(7, 19)}` (the first 12 hex
+    // chars after `sha256:`) — same shape that listTokens emits.
+    const id = `t_${tokenHash.slice(7, 19)}`;
+
+    const res = await deleteToken("journal", id, journalAdmin);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("Forbidden");
+    expect(body.message).toContain("'work'");
+    expect(body.message).toContain("'journal'");
+
+    // Defense-in-depth: the row is still there (revoke was rejected, not
+    // silently no-op'd into deletion).
+    const stillThere = journalStore.db
+      .prepare("SELECT 1 FROM tokens WHERE token_hash = ?")
+      .get(tokenHash);
+    expect(stillThere).not.toBeNull();
   });
 
   test("read-only token cannot revoke → 403", async () => {

--- a/src/tokens-routes.test.ts
+++ b/src/tokens-routes.test.ts
@@ -425,6 +425,60 @@ describe("GET /vault/<name>/tokens — list", () => {
     const res = await getTokens("journal", reader);
     expect(res.status).toBe(403);
   });
+
+  test("v16: list returns vault-bound tokens + legacy NULL, never tokens bound to other vaults", async () => {
+    // Per the per-vault token storage migration (vault#257): the SPA at
+    // /vault/<name>/admin/tokens must show only THIS vault's tokens. Mixing
+    // tokens from sibling vaults — the bug Aaron flagged — would re-introduce
+    // the cross-vault leak the migration is meant to close.
+    createVault("journal");
+    createVault("work");
+    const journalAdmin = mintAdminToken("journal");
+
+    // Mint a vault-bound token via the endpoint (so it carries vault_name="journal").
+    const journalMint = (await (await postTokens("journal", journalAdmin, {
+      label: "journal-bound",
+    })).json()) as { id: string };
+
+    // Plant a cross-vault token directly in journal's DB (vault_name="work").
+    // This shouldn't happen via normal mint paths after #257, but the filter
+    // must still hide it — defense-in-depth against future bugs / manual
+    // SQL.
+    const journalStore = getVaultStore("journal");
+    const { fullToken: crossBound } = generateToken();
+    createToken(journalStore.db, crossBound, {
+      label: "work-bound-leak",
+      permission: "full",
+      scopes: ["vault:read"],
+      vault_name: "work",
+    });
+
+    // Plant a legacy NULL-bound token (pre-v16 / YAML-imported shape).
+    const { fullToken: legacy } = generateToken();
+    createToken(journalStore.db, legacy, {
+      label: "legacy-server-wide",
+      permission: "read",
+      scopes: ["vault:read"],
+      // vault_name omitted → NULL.
+    });
+
+    const res = await getTokens("journal", journalAdmin);
+    const body = (await res.json()) as {
+      tokens: Array<{ id: string; label: string; vault_name: string | null }>;
+    };
+    const labels = body.tokens.map((t) => t.label).sort();
+    expect(labels).toContain("journal-bound");
+    expect(labels).toContain("legacy-server-wide");
+    expect(labels).toContain("test-admin"); // the mintAdminToken seed
+    expect(labels).not.toContain("work-bound-leak");
+
+    // Each surfaced row carries its vault_name (null for legacy, "journal"
+    // for the bound one) so the SPA can render a "server-wide" badge.
+    const journalRow = body.tokens.find((t) => t.id === journalMint.id);
+    expect(journalRow!.vault_name).toBe("journal");
+    const legacyRow = body.tokens.find((t) => t.label === "legacy-server-wide");
+    expect(legacyRow!.vault_name).toBeNull();
+  });
 });
 
 describe("DELETE /vault/<name>/tokens/<id> — revoke", () => {

--- a/src/tokens-routes.ts
+++ b/src/tokens-routes.ts
@@ -28,7 +28,6 @@ import type { SqliteStore } from "../core/src/store.ts";
 import {
   generateToken,
   createToken,
-  revokeToken,
   normalizePermission,
   type TokenPermission,
 } from "./token-store.ts";
@@ -76,13 +75,13 @@ export async function handleTokens(
   subpath: string,
 ): Promise<Response> {
   if (subpath === "" || subpath === "/") {
-    if (req.method === "GET") return listHandler(store.db);
+    if (req.method === "GET") return listHandler(store.db, vaultName);
     if (req.method === "POST") return mintHandler(req, store, vaultName, callerScopes, callerScopedTags);
     return methodNotAllowed();
   }
   const idMatch = subpath.match(/^\/([^/]+)$/);
   if (idMatch && idMatch[1]) {
-    if (req.method === "DELETE") return revokeHandler(store.db, idMatch[1]);
+    if (req.method === "DELETE") return revokeHandler(store.db, vaultName, idMatch[1]);
     return methodNotAllowed();
   }
   return Response.json({ error: "Not found" }, { status: 404 });
@@ -234,6 +233,11 @@ async function mintHandler(
     scopes: requested,
     scoped_tags: scopedTags,
     expires_at: expiresAt,
+    // Per-vault binding (v16): tokens minted via /vault/<name>/tokens are
+    // pinned to that vault. authenticateVaultRequest rejects them at any
+    // other vault. NULL would be legacy / server-wide; reserved for the
+    // YAML-import path and explicit --all CLI mints (see vault#257).
+    vault_name: vaultName,
   });
 
   // Display id mirrors `listTokens`: `t_` + first 12 chars of the SHA-256
@@ -248,6 +252,7 @@ async function mintHandler(
       permission: created.permission,
       scopes: requested,
       scoped_tags: scopedTags,
+      vault_name: created.vault_name,
       expires_at: created.expires_at,
       created_at: created.created_at,
     },
@@ -255,19 +260,28 @@ async function mintHandler(
   );
 }
 
-function listHandler(db: Database): Response {
+function listHandler(db: Database, vaultName: string): Response {
   // Direct SELECT (rather than reusing `listTokens`) so we can include the
   // `scopes` and `scoped_tags` columns without changing the existing
   // CLI-facing shape that goes through `listTokens`.
+  //
+  // Per-vault filter (v16): rows where vault_name matches THIS vault, plus
+  // legacy server-wide rows (vault_name IS NULL). The latter authenticate
+  // cross-vault by design; the operator should see them in any vault's
+  // admin UI to revoke. Tokens bound to a different vault never appear
+  // here — this is the SPA-side fix for vault#257.
   const rows = db.prepare(`
-    SELECT token_hash, label, permission, scopes, scoped_tags, expires_at, created_at, last_used_at
-    FROM tokens ORDER BY created_at DESC
-  `).all() as {
+    SELECT token_hash, label, permission, scopes, scoped_tags, vault_name, expires_at, created_at, last_used_at
+    FROM tokens
+    WHERE vault_name = ? OR vault_name IS NULL
+    ORDER BY created_at DESC
+  `).all(vaultName) as {
     token_hash: string;
     label: string;
     permission: string;
     scopes: string | null;
     scoped_tags: string | null;
+    vault_name: string | null;
     expires_at: string | null;
     created_at: string;
     last_used_at: string | null;
@@ -280,6 +294,7 @@ function listHandler(db: Database): Response {
       permission: normalizePermission(r.permission),
       scopes: parseScopes(r.scopes),
       scoped_tags: parseScopedTagsJSON(r.scoped_tags),
+      vault_name: r.vault_name,
       expires_at: r.expires_at,
       created_at: r.created_at,
       last_used_at: r.last_used_at,
@@ -305,12 +320,33 @@ function parseScopedTagsJSON(raw: string | null): string[] | null {
   }
 }
 
-function revokeHandler(db: Database, id: string): Response {
+function revokeHandler(db: Database, vaultName: string, id: string): Response {
   // Always 200, never leak whether the id existed. Ambiguous prefix matches
   // are treated the same (revokeToken returns false; we ignore it). The 12-
   // char hex prefix collision space is large enough that organic ambiguity
   // is effectively impossible, and security-significant ambiguity would
   // require a chosen-prefix attack against SHA-256.
-  revokeToken(db, id);
+  //
+  // Per-vault scope (v16): only revoke when the row belongs to THIS vault
+  // (or is legacy NULL / server-wide — the operator can revoke those from
+  // any vault's admin surface, since they authenticate cross-vault). A
+  // crafted DELETE for a token bound to a different vault is a no-op,
+  // mirroring the "always 200" behavior. The list endpoint already
+  // filters out cross-vault rows, so this is defense-in-depth against
+  // direct API use.
+  if (id.startsWith("t_")) {
+    const hashPrefix = id.slice(2);
+    db.prepare(`
+      DELETE FROM tokens
+      WHERE token_hash LIKE ?
+        AND (vault_name = ? OR vault_name IS NULL)
+    `).run(`sha256:${hashPrefix}%`, vaultName);
+  } else {
+    db.prepare(`
+      DELETE FROM tokens
+      WHERE token_hash = ?
+        AND (vault_name = ? OR vault_name IS NULL)
+    `).run(id, vaultName);
+  }
   return Response.json({ revoked: true });
 }

--- a/src/tokens-routes.ts
+++ b/src/tokens-routes.ts
@@ -7,7 +7,10 @@
  * narrowed). POST mints a new pvt_* token with caller-narrowed scopes and
  * returns the plaintext exactly once. GET lists existing tokens (metadata
  * only — no plaintext, no hash). DELETE revokes by display id (`t_…`); a
- * non-existent id still returns 200 to avoid leaking which ids exist.
+ * non-existent id returns 404; an id that resolves to a different
+ * vault's binding returns **403** (per #257 spec — silent 200 on
+ * cross-vault revoke would let an operator believe a token was
+ * revoked while it kept working from its owning vault).
  *
  * Scope narrowing is enforced as a strict subset check via
  * `validateMintedScopes` — defense-in-depth even with the admin gate, so a
@@ -321,19 +324,56 @@ function parseScopedTagsJSON(raw: string | null): string[] | null {
 }
 
 function revokeHandler(db: Database, vaultName: string, id: string): Response {
-  // Always 200, never leak whether the id existed. Ambiguous prefix matches
-  // are treated the same (revokeToken returns false; we ignore it). The 12-
-  // char hex prefix collision space is large enough that organic ambiguity
-  // is effectively impossible, and security-significant ambiguity would
-  // require a chosen-prefix attack against SHA-256.
+  // Per-vault scope (v16, per #257 spec): pre-check the row's vault binding
+  // before deleting so we can distinguish three cases:
   //
-  // Per-vault scope (v16): only revoke when the row belongs to THIS vault
-  // (or is legacy NULL / server-wide — the operator can revoke those from
-  // any vault's admin surface, since they authenticate cross-vault). A
-  // crafted DELETE for a token bound to a different vault is a no-op,
-  // mirroring the "always 200" behavior. The list endpoint already
-  // filters out cross-vault rows, so this is defense-in-depth against
-  // direct API use.
+  //   - row missing entirely → 404 (the id never existed in this vault's DB)
+  //   - row exists, vault_name = <other> → 403 with descriptive error
+  //   - row exists, vault_name = <this> OR NULL → DELETE + 200
+  //
+  // The non-leakage argument for "always 200" doesn't hold given that GET
+  // /vault/<name>/tokens already exposes the full vault-scoped + legacy-NULL
+  // listing — so existence isn't being protected. 403 over silent 200 is the
+  // operator-debuggable shape: clicking "revoke" and seeing success while the
+  // token still works (because it's bound to a different vault) is the worst
+  // UX. Tell the operator which vault owns it.
+  //
+  // Ambiguous prefix matches: the pre-check uses the same prefix shape as the
+  // DELETE, so a prefix that hits multiple rows is treated as "found" if any
+  // row matches the calling vault. The 12-char hex prefix collision space is
+  // large enough that organic ambiguity is effectively impossible, and
+  // security-significant ambiguity would require a chosen-prefix attack
+  // against SHA-256.
+  let row: { vault_name: string | null } | null;
+  if (id.startsWith("t_")) {
+    const hashPrefix = id.slice(2);
+    row = db.prepare(`
+      SELECT vault_name FROM tokens
+      WHERE token_hash LIKE ?
+      LIMIT 1
+    `).get(`sha256:${hashPrefix}%`) as { vault_name: string | null } | null;
+  } else {
+    row = db.prepare(`
+      SELECT vault_name FROM tokens
+      WHERE token_hash = ?
+      LIMIT 1
+    `).get(id) as { vault_name: string | null } | null;
+  }
+
+  if (!row) {
+    return Response.json({ error: "Not found", message: "no token with that id" }, { status: 404 });
+  }
+
+  if (row.vault_name !== null && row.vault_name !== vaultName) {
+    return Response.json(
+      {
+        error: "Forbidden",
+        message: `token belongs to vault '${row.vault_name}', not '${vaultName}'; revoke it from that vault's admin surface`,
+      },
+      { status: 403 },
+    );
+  }
+
   if (id.startsWith("t_")) {
     const hashPrefix = id.slice(2);
     db.prepare(`

--- a/web/ui/src/lib/tokens-api.ts
+++ b/web/ui/src/lib/tokens-api.ts
@@ -24,6 +24,12 @@ export interface TokenSummary {
    * see patterns/tag-scoped-tokens.md.
    */
   scoped_tags: string[] | null;
+  /**
+   * Vault binding (schema v16). `null` = legacy server-wide token (pre-v16
+   * mint or explicitly minted with `--all`). Non-null = bound to that
+   * single vault; the server rejects cross-vault use.
+   */
+  vault_name: string | null;
   expires_at: string | null;
   created_at: string;
   last_used_at: string | null;

--- a/web/ui/src/routes/VaultTokens.test.tsx
+++ b/web/ui/src/routes/VaultTokens.test.tsx
@@ -24,6 +24,7 @@ const tokenFixture = (over: Partial<tokensApi.TokenSummary> = {}): tokensApi.Tok
   permission: "full",
   scopes: ["vault:work:write"],
   scoped_tags: null,
+  vault_name: "work",
   expires_at: null,
   created_at: "2026-05-01T00:00:00Z",
   last_used_at: null,

--- a/web/ui/src/routes/VaultTokens.tsx
+++ b/web/ui/src/routes/VaultTokens.tsx
@@ -433,6 +433,11 @@ function TokenRow({
         <div className="name">
           <strong>{token.label}</strong>
           <code className="dim">{token.id}</code>
+          {token.vault_name === null ? (
+            <code className="scope-tag" title="Pre-v16 token, not bound to any vault. Usable across vaults this session can see.">
+              server-wide
+            </code>
+          ) : null}
         </div>
         <div className="meta">
           <span className="dim">scopes:</span>{" "}


### PR DESCRIPTION
## Summary

vault#257 — per-vault token storage migration. Tokens now bind to the vault they were minted from; cross-vault use is rejected at the auth layer. Legacy pre-v16 tokens carry `NULL` `vault_name` and remain server-wide so existing deployments keep working unchanged. New mints default to vault-bound; `tokens create --all` is the explicit opt-in for a server-wide mint.

The cross-vault leak surface was small in practice (per-vault DBs already scope storage; only `authenticateGlobalRequest` at `/mcp` iterated across vaults), but the explicit `vault_name` column closes the gap with defense-in-depth at every per-vault auth path.

## Per-feature commits (7)

1. `feat(schemas): v16 — tokens.vault_name column for per-vault binding`
2. `feat(token-store): surface vault_name end-to-end + per-vault list filter`
3. `feat(auth): reject cross-vault token use with 403`
4. `feat(routes): per-vault token endpoints bind + filter by vault_name`
5. `feat(cli): tokens create/list accept --vault and --all flags`
6. `feat(admin-spa): surface vault_name + render server-wide badge`
7. `chore(release): 0.3.6-rc.39 — per-vault token storage migration`

## Migration shape

Schema v15 → v16 adds `tokens.vault_name TEXT` + `idx_tokens_vault_name`. ALTER runs inside `BEGIN IMMEDIATE` / `COMMIT` (ROLLBACK on failure) — same shape as v14/v15 from vault#251. Existing rows backfill to `NULL` (legacy server-wide); new rows default to the minting vault's name.

`authenticateVaultRequest` rejects cross-vault binding with 403; NULL-bound rows still authenticate. Hub-issued JWTs continue to use `vault:<name>:<verb>` scope-narrowing as the audience-binding mechanism (JWTs aren't per-token-DB rows, so `vault_name` is N/A on that path).

## Test plan

- [x] `bun test ./src/` — 808 pass
- [x] `bun test ./core/src/` — 405 pass
- [x] `bun run typecheck` — clean
- [x] `cd web/ui && bun run typecheck && bun run test && bun run build` — 61 SPA tests pass, build clean
- [ ] Smoke: `parachute-vault tokens create --vault foo --label test`, then attempt to use it against bar's `/vault/bar/mcp` → expect 403
- [ ] Smoke: `parachute-vault tokens list --vault foo` → see `[server-wide]` annotation on any pre-v16 rows
- [ ] Smoke: open SPA at `/vault/foo/admin/tokens` → verify `server-wide` badge renders next to NULL-bound legacy tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)