### PR TITLE
fix(core): batch atomicity + cleanup (release-prep for 0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.0-rc.1] — 2026-05-04
+
+Release-prep cut for the `0.4.0` `@latest` publish. The minor bump signals
+the meaningful surface change accumulated across 39 RCs on `0.3.6`: admin
+SPA mounted per-vault, per-vault token storage with cross-vault binding,
+schema migrations through v16, and the auth-boundary rewrite. This RC
+itself folds one correctness fix — vault#236 — and clears housekeeping.
+
+### Fixed
+
+- **vault#236 — batch operations are now transactionally atomic.** Wrap
+  multi-item batch loops in `BEGIN` / `COMMIT` / `ROLLBACK` at the three
+  public batch entry points (`src/routes.ts` `POST /api/notes`,
+  `core/src/mcp.ts` `create-note`, `core/src/mcp.ts` `update-note`). Mirrors
+  the existing `core/src/notes.ts:createNotes` pattern. Without this, a
+  mid-batch failure (path conflict, conditional-update conflict) left the
+  prefix items already written. Single-item calls skip the wrap so
+  concurrent callers don't collide on the shared bun:sqlite connection —
+  single-note paths are already atomic at the store layer.
+
+### Tests
+
+- `src/vault.test.ts` — HTTP `POST /notes` batch where mid-item triggers
+  `PATH_CONFLICT`: assert nothing from the prefix lands.
+- `core/src/core.test.ts` — MCP `create-note` batch + `update-note` batch
+  with mid-batch `PATH_CONFLICT`: assert prefix items rolled back.
+
+### Closed without code change
+
+- vault#102 (publish `@openparachute/core` to npm) — mooted; `core/` is
+  bundled into the vault tarball via `package.json` `files`. No external
+  consumer needs the standalone publish today; revisit if that changes.
+
 ## [0.3.6-rc.39] — 2026-05-04
 
 vault#257 — per-vault token storage migration. Tokens now bind to the vault they were minted from, and cross-vault use is rejected at the auth layer. Pre-v16 tokens carry a `NULL` `vault_name` and remain server-wide (legacy compatibility), so existing deployments keep working unchanged; new mints default to vault-bound. The cross-vault leak surface was small in practice (per-vault DBs already scope storage; only `authenticateGlobalRequest` at `/mcp` iterated across vaults), but the explicit `vault_name` column closes the gap with defense-in-depth at every per-vault auth path.

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2613,6 +2613,68 @@ describe("MCP tools", async () => {
     expect(err.limit).toBe(500);
     expect(err.got).toBe(501);
   });
+
+  it("create-note batch where mid-item triggers PATH_CONFLICT rolls back prefix items (#236)", async () => {
+    // The empty-note pre-walk (#213) catches `{}` before any DB write; a
+    // path-conflict can only surface on the actual INSERT, mid-loop. Without
+    // the BEGIN/COMMIT wrap the prefix items would have already landed.
+    await store.createNote("seed", { path: "taken-236" });
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    const beforeIds = (await store.queryNotes({})).map((n) => n.id).sort();
+
+    let err: any;
+    try {
+      await createNote.execute({
+        notes: [
+          { content: "ok-1", path: "fresh-236-1" },
+          { content: "ok-2", path: "fresh-236-2" },
+          { content: "boom", path: "taken-236" },
+        ],
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+
+    // The two prefix items must NOT have been created — atomic rollback.
+    const afterIds = (await store.queryNotes({})).map((n) => n.id).sort();
+    expect(afterIds).toEqual(beforeIds);
+    expect(await store.queryNotes({ path: "fresh-236-1" })).toHaveLength(0);
+    expect(await store.queryNotes({ path: "fresh-236-2" })).toHaveLength(0);
+  });
+
+  it("update-note batch rolls back prefix tag mutation when a later item path-conflicts (#236)", async () => {
+    await store.createNote("A", { id: "a236" });
+    await store.createNote("B", { id: "b236" });
+    await store.createNote("C", { id: "c236", path: "occupied-236" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const aBefore = await store.getNote("a236");
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        notes: [
+          // Item 0 mutates a236's content + adds a tag. force=true skips
+          // the if_updated_at precondition.
+          { id: "a236", content: "A mutated", force: true, tags: { add: ["should-rollback"] } },
+          // Item 1 tries to take a path already owned by c236 — PATH_CONFLICT.
+          { id: "b236", path: "occupied-236", force: true },
+        ],
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("PATH_CONFLICT");
+
+    // Item 0's tag-add + content change must be rolled back — the batch
+    // transaction reverted them when item 1 path-conflicted (#236).
+    const aAfter = await store.getNote("a236");
+    expect(aAfter!.content).toBe(aBefore!.content);
+    expect(aAfter!.tags ?? []).not.toContain("should-rollback");
+  });
 });
 
 // ---- query-notes link expansion ----

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -402,25 +402,39 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         }
 
         const created: Note[] = [];
-        for (const item of items) {
-          const note = await store.createNote(item.content as string ?? "", {
-            path: item.path as string | undefined,
-            tags: item.tags as string[] | undefined,
-            metadata: item.metadata as Record<string, unknown> | undefined,
-            created_at: item.created_at as string | undefined,
-          });
+        // Wrap multi-item batches in a SQLite transaction so a mid-batch
+        // failure rolls back every prior insert — see #236. The pre-walk
+        // above catches empty-note cases; this guards anything thrown from
+        // store.createNote / createLink (path conflict, etc.). Single-item
+        // calls skip the wrap to avoid colliding with concurrent callers
+        // on the shared bun:sqlite connection.
+        const batched = items.length > 1;
+        if (batched) db.exec("BEGIN");
+        try {
+          for (const item of items) {
+            const note = await store.createNote(item.content as string ?? "", {
+              path: item.path as string | undefined,
+              tags: item.tags as string[] | undefined,
+              metadata: item.metadata as Record<string, unknown> | undefined,
+              created_at: item.created_at as string | undefined,
+            });
 
-          // Create explicit links (not wikilinks — those are automatic)
-          if (item.links) {
-            for (const link of item.links as { target: string; relationship: string }[]) {
-              const target = resolveNote(db, link.target);
-              if (target) {
-                await store.createLink(note.id, target.id, link.relationship);
+            // Create explicit links (not wikilinks — those are automatic)
+            if (item.links) {
+              for (const link of item.links as { target: string; relationship: string }[]) {
+                const target = resolveNote(db, link.target);
+                if (target) {
+                  await store.createLink(note.id, target.id, link.relationship);
+                }
               }
             }
-          }
 
-          created.push(noteOps.getNote(db, note.id) ?? note);
+            created.push(noteOps.getNote(db, note.id) ?? note);
+          }
+          if (batched) db.exec("COMMIT");
+        } catch (e) {
+          if (batched) db.exec("ROLLBACK");
+          throw e;
         }
 
         // Apply tag schema effects
@@ -552,6 +566,14 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         }
 
         const updated: Note[] = [];
+        // Wrap multi-item batches in a SQLite transaction so any mid-batch
+        // failure (precondition error, content_edit miss, ConflictError, …)
+        // rolls back every prior mutation in the batch — see #236.
+        // Single-item calls skip the wrap so concurrent callers don't
+        // collide on the shared bun:sqlite connection.
+        const batched = items.length > 1;
+        if (batched) db.exec("BEGIN");
+        try {
         for (const item of items) {
           const note = requireNote(db, item.id as string);
 
@@ -707,6 +729,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
 
           // Re-read for final state
           updated.push(noteOps.getNote(db, note.id) ?? result);
+        }
+          if (batched) db.exec("COMMIT");
+        } catch (e) {
+          if (batched) db.exec("ROLLBACK");
+          throw e;
         }
 
         const final = updated.map((n) => attachValidationStatus(store, db, n));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.3.6-rc.39",
+  "version": "0.4.0-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -400,6 +400,15 @@ export async function handleNotes(
       }
 
       const created: Note[] = [];
+      // Wrap multi-item batches in a SQLite transaction so a mid-batch
+      // failure (path conflict, etc.) rolls back every prior insert. Without
+      // this, callers got half-applied batches where the prefix landed and
+      // the offending entry surfaced the 409 — see #236. Single-item posts
+      // are already atomic at the store layer and skip the wrap so they
+      // don't collide with concurrent single-item callers on the shared
+      // bun:sqlite connection.
+      const batched = items.length > 1;
+      if (batched) db.exec("BEGIN");
       try {
         for (const item of items) {
           const note = await store.createNote(item.content ?? "", {
@@ -420,7 +429,9 @@ export async function handleNotes(
 
           created.push((await store.getNote(note.id)) ?? note);
         }
+        if (batched) db.exec("COMMIT");
       } catch (e: any) {
+        if (batched) db.exec("ROLLBACK");
         // Duck-type for module-boundary robustness (matches the PATCH branch).
         if (e && e.code === "PATH_CONFLICT") {
           return json(

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1508,6 +1508,38 @@ describe("HTTP /notes", async () => {
     });
   });
 
+  describe("batch atomicity (#236)", async () => {
+    test("POST batch where mid-item triggers PATH_CONFLICT → 409, NOTHING created", async () => {
+      // The empty-note pre-walk catches `{}` before any DB write (#213); a
+      // path-conflict only surfaces on the actual INSERT, mid-loop. Without
+      // the BEGIN/COMMIT wrap the prefix would have already landed by then.
+      await store.createNote("existing", { path: "taken" });
+      const beforeIds = (await store.queryNotes({})).map((n) => n.id).sort();
+
+      const res = await handleNotes(
+        mkReq("POST", "/notes", {
+          notes: [
+            { content: "ok-1", path: "fresh-1" },
+            { content: "ok-2", path: "fresh-2" },
+            { content: "boom", path: "taken" },
+            { content: "ok-3", path: "fresh-3" },
+          ],
+        }),
+        store,
+        "",
+      );
+      expect(res.status).toBe(409);
+      const body = await res.json() as any;
+      expect(body.error_type).toBe("path_conflict");
+
+      // The two prefix items must NOT have been created — atomic rollback.
+      const afterIds = (await store.queryNotes({})).map((n) => n.id).sort();
+      expect(afterIds).toEqual(beforeIds);
+      expect(await store.queryNotes({ path: "fresh-1" })).toHaveLength(0);
+      expect(await store.queryNotes({ path: "fresh-2" })).toHaveLength(0);
+    });
+  });
+
   describe("batch cap (#213)", async () => {
     test("POST with 501-item batch → 413 BatchTooLarge", async () => {
       const oversized = Array.from({ length: 501 }, (_, i) => ({ content: `n${i}` }));


### PR DESCRIPTION
## Summary

Single PR off `main` with per-feature commits, prepping for the 0.4.0 `@latest` publish.

- **vault#236 — batch operations are now transactionally atomic.** Wrap the three public batch entry points (`POST /api/notes`, MCP `create-note`, MCP `update-note`) in `BEGIN`/`COMMIT`/`ROLLBACK` so a mid-batch failure rolls back every prior write. Mirrors the existing `core/src/notes.ts:createNotes` pattern. Single-item calls skip the wrap so concurrent callers don't collide on the shared bun:sqlite connection.
- **Tests** — HTTP `POST /notes` batch + MCP `create-note` batch + MCP `update-note` batch each get a regression test asserting prefix items roll back when a later item triggers `PATH_CONFLICT`.
- **Release** — bump `0.3.6-rc.39` → `0.4.0-rc.1`. The minor bump signals the meaningful surface change accumulated across 39 RCs on `0.3.6`: admin SPA mounted per-vault, per-vault token storage with cross-vault binding, schema migrations through v16, auth-boundary rewrite. Aaron is targeting `@latest` for tomorrow afternoon (2026-05-05).
- **Closed without code change** — vault#102 (publish `@openparachute/core` to npm). Mooted: `core/` is bundled into the vault tarball via `package.json` `files`. No external consumer needs the standalone publish today; revisit if that changes.

## Test plan

- [x] `bun --bun tsc --noEmit` — clean
- [x] `bun test ./core/src/` — 408 pass / 0 fail
- [x] `bun test ./src/` — 810 pass / 0 fail
- [x] `cd web/ui && bun run build` — clean (verify-base passes)
- [x] `cd web/ui && bun run test` — 61 pass / 0 fail

## Follow-up filed

- vault#261 — bun:sqlite `Statement.run().changes` can be stale inside a transaction with intervening writes. Production paths affected: `core/src/notes.ts:370` (`if_updated_at` conditional UPDATE), `:346` (probe), `:727` (renameTag). Audit and fix outside this PR (separate arc).

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
