### PR TITLE
fix(core): migrate .changes-based conflict detection to UPDATE...RETURNING (closes #261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.0-rc.2] — 2026-05-04
+
+A correctness fix on top of rc.1. The atomicity wrap landed in rc.1 made a
+latent bun:sqlite quirk reachable through `if_updated_at`-based optimistic
+concurrency; this RC migrates conflict / existence detection off
+`Statement.run().changes` to `UPDATE...RETURNING` / `DELETE...RETURNING`
+across every site that reads it.
+
+### Fixed
+
+- **vault#261 — `.changes`-based conflict detection migrated to
+  `RETURNING`.** Inside a multi-statement transaction with intervening
+  writes, `Statement.run().changes` could carry stale values, silently
+  skipping the `if_updated_at` precondition check in `noteOps.updateNote`.
+  Six sites migrated to detect row presence via SQLite's `RETURNING` clause
+  instead of row-count: `core/src/notes.ts` (main + sets-empty conditional
+  UPDATE, `renameTag` count), `core/src/note-schemas.ts` (`deleteNoteSchema`,
+  `deleteSchemaMapping`), `src/token-store.ts` (`revokeToken`).
+
+### Tests
+
+- `core/src/core.test.ts` — MCP `update-note` batch where item 1's stale
+  `if_updated_at` triggers a `ConflictError`: assert item 0's prefix
+  mutation rolled back. Pre-fix this test silently passes (the bug class);
+  post-fix it asserts the conflict surfaces and the batch unwinds.
+
 ## [0.4.0-rc.1] — 2026-05-04
 
 Release-prep cut for the `0.4.0` `@latest` publish. The minor bump signals

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2675,6 +2675,54 @@ describe("MCP tools", async () => {
     expect(aAfter!.content).toBe(aBefore!.content);
     expect(aAfter!.tags ?? []).not.toContain("should-rollback");
   });
+
+  it("update-note batch rolls back prefix mutation when a later item if_updated_at-conflicts (#261)", async () => {
+    // The companion to the PATH_CONFLICT test above. Item 1's stale
+    // `if_updated_at` must surface as a ConflictError so the batch's
+    // BEGIN/COMMIT wrap can roll back item 0's mutation.
+    //
+    // Pre-fix (vault#261): `noteOps.updateNote` checked `res.changes === 0`
+    // to detect the precondition miss. Inside this multi-statement batch
+    // transaction, `.changes` reported a stale non-zero value from prior
+    // writes, so the conflict was silently missed and item 0's mutation
+    // committed with item 1 ignored.
+    //
+    // Post-fix: the conditional UPDATE uses `RETURNING id` and detects the
+    // miss directly from row presence. ConflictError fires; batch rolls back.
+    //
+    // Standalone bun:sqlite repro is pending — six attempted reductions
+    // (basic txn, async/microtask, prepared-statement reuse, mcp-loop
+    // mirror, hook-dispatch mirror, syncWikilinks-style writes) failed to
+    // hit the .changes-stale path outside the full BunStore plumbing. The
+    // bug surfaces only through `BunStore.updateNote` → hook dispatch.
+    // See vault#261 for the audit trail.
+    await store.createNote("A", { id: "a261" });
+    await store.createNote("B", { id: "b261" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+
+    const aBefore = await store.getNote("a261");
+
+    let err: any;
+    try {
+      await updateNote.execute({
+        notes: [
+          // Item 0 mutates a261's content + adds a tag (force, no precondition).
+          { id: "a261", content: "A mutated", force: true, tags: { add: ["should-rollback"] } },
+          // Item 1 has a stale if_updated_at on b261 — should ConflictError.
+          { id: "b261", content: "B should-not-land", if_updated_at: "2020-01-01T00:00:00.000Z" },
+        ],
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("CONFLICT");
+
+    // Item 0's tag-add + content change must be rolled back.
+    const aAfter = await store.getNote("a261");
+    expect(aAfter!.content).toBe(aBefore!.content);
+    expect(aAfter!.tags ?? []).not.toContain("should-rollback");
+  });
 });
 
 // ---- query-notes link expansion ----

--- a/core/src/note-schemas.ts
+++ b/core/src/note-schemas.ts
@@ -164,8 +164,10 @@ export function upsertNoteSchema(
  * Returns true if the row existed.
  */
 export function deleteNoteSchema(db: Database, name: string): boolean {
-  const result = db.prepare("DELETE FROM note_schemas WHERE name = ?").run(name);
-  return result.changes > 0;
+  const deleted = db.prepare(
+    "DELETE FROM note_schemas WHERE name = ? RETURNING name",
+  ).get(name) as { name: string } | null;
+  return deleted !== null;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,8 +225,8 @@ export function deleteSchemaMapping(
   match_kind: SchemaMappingKind,
   match_value: string,
 ): boolean {
-  const result = db.prepare(
-    "DELETE FROM schema_mappings WHERE schema_name = ? AND match_kind = ? AND match_value = ?",
-  ).run(schema_name, match_kind, match_value);
-  return result.changes > 0;
+  const deleted = db.prepare(
+    "DELETE FROM schema_mappings WHERE schema_name = ? AND match_kind = ? AND match_value = ? RETURNING schema_name",
+  ).get(schema_name, match_kind, match_value) as { schema_name: string } | null;
+  return deleted !== null;
 }

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -337,13 +337,15 @@ export function updateNote(
   // need to validate the precondition; a conditional UPDATE that sets
   // updated_at to itself does exactly that atomically — even a no-net-
   // change UPDATE takes the write lock in WAL mode, so it still serializes
-  // with other writers and `.changes` reflects whether the WHERE matched.
+  // with other writers. `RETURNING id` reports the row only when WHERE
+  // matched — `.changes` is unreliable inside multi-statement transactions
+  // (vault#261).
   if (sets.length === 0) {
     if (updates.if_updated_at !== undefined) {
       const probe = db.prepare(
-        "UPDATE notes SET updated_at = updated_at WHERE id = ? AND updated_at IS ?",
-      ).run(id, updates.if_updated_at);
-      if (probe.changes === 0) {
+        "UPDATE notes SET updated_at = updated_at WHERE id = ? AND updated_at IS ? RETURNING id",
+      ).get(id, updates.if_updated_at) as { id: string } | null;
+      if (probe === null) {
         throwConflictOrMissing(db, id, updates.if_updated_at);
       }
     }
@@ -357,9 +359,15 @@ export function updateNote(
     values.push(updates.if_updated_at);
   }
 
-  let res;
+  let matched: { id: string } | null = null;
   try {
-    res = db.prepare(sql).run(...values);
+    if (updates.if_updated_at !== undefined) {
+      matched = db.prepare(`${sql} RETURNING id`).get(...values) as
+        | { id: string }
+        | null;
+    } else {
+      db.prepare(sql).run(...values);
+    }
   } catch (err) {
     if (updates.path !== undefined && isPathUniqueError(err)) {
       throw new PathConflictError(normalizePath(updates.path) ?? updates.path);
@@ -367,7 +375,7 @@ export function updateNote(
     throw err;
   }
 
-  if (updates.if_updated_at !== undefined && res.changes === 0) {
+  if (updates.if_updated_at !== undefined && matched === null) {
     throwConflictOrMissing(db, id, updates.if_updated_at);
   }
 
@@ -721,10 +729,12 @@ export function renameTag(db: Database, oldName: string, newName: string): Renam
       old?.created_at ?? now,
       now,
     );
-    const updated = db.prepare("UPDATE note_tags SET tag_name = ? WHERE tag_name = ?").run(newName, oldName);
+    const renamed = db.prepare(
+      "UPDATE note_tags SET tag_name = ? WHERE tag_name = ? RETURNING note_id",
+    ).all(newName, oldName) as { note_id: string }[];
     db.prepare("DELETE FROM tags WHERE name = ?").run(oldName);
     db.exec("COMMIT");
-    return { renamed: Number(updated.changes) };
+    return { renamed: renamed.length };
   } catch (err) {
     db.exec("ROLLBACK");
     throw err;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -319,8 +319,10 @@ export function revokeToken(db: Database, idOrHash: string): boolean {
   }
 
   // Try matching by full hash
-  const result = db.prepare("DELETE FROM tokens WHERE token_hash = ?").run(idOrHash);
-  return result.changes > 0;
+  const deleted = db.prepare(
+    "DELETE FROM tokens WHERE token_hash = ? RETURNING token_hash",
+  ).get(idOrHash) as { token_hash: string } | null;
+  return deleted !== null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Migrate every `Statement.run().changes`-based conflict / existence check off `.changes` and onto SQLite's `RETURNING` clause. The vault#236 batch atomicity wrap (#260) made a latent bun:sqlite quirk reachable through `if_updated_at`-based optimistic concurrency: inside a multi-statement transaction with intervening writes, `.changes` carried stale values from prior writes, silently bypassing the precondition check.

This is the bug class we don't ship at `@latest`. Closes #261.

## Why `RETURNING`

`UPDATE ... RETURNING id` returns one row per row written; `.get()` returns the row when WHERE matched, `null` when it didn't. Row presence is the signal — no row-counter quirk. SQLite 3.35+ supports it; bun:sqlite ships 3.46+.

## What changed

Six call sites migrated:

| Site | Before | After |
|---|---|---|
| `core/src/notes.ts:370` | `if (res.changes === 0) throw ConflictError` | `UPDATE ... RETURNING id` + `.get()`, throw on `null` |
| `core/src/notes.ts:346` | `if (probe.changes === 0) throw ConflictError` (sets-empty branch) | same `RETURNING id` shape |
| `core/src/notes.ts:727` | `Number(updated.changes)` (read after subsequent DELETE) | `UPDATE ... RETURNING note_id` + `.all().length` |
| `core/src/note-schemas.ts:166` | `result.changes > 0` (`deleteNoteSchema`) | `DELETE ... RETURNING name` |
| `core/src/note-schemas.ts:226` | `result.changes > 0` (`deleteSchemaMapping`) | `DELETE ... RETURNING schema_name` |
| `src/token-store.ts:322` | `result.changes > 0` (`revokeToken`) | `DELETE ... RETURNING token_hash` |

The first three (in `core/src/notes.ts`) are the load-bearing fix — the conditional UPDATE on `if_updated_at` is the optimistic-concurrency mechanism for collaborative editing, and silent conflict-miss is what we're closing. The other three are standalone DELETEs today, migrated for consistency so no future caller can wrap them in a transaction and inherit the bug class.

Note: `bun:sqlite`'s `Statement.get()` returns `null` (not `undefined`) when the RETURNING clause matches no rows — sentinel checks use `!== null` to keep boolean semantics intact.

## Regression test

`core/src/core.test.ts` — companion to the PATH_CONFLICT test added in #260, but using a stale `if_updated_at` on a batch item to surface the actual bug class:

- Pre-fix: silently passes (no error thrown — the bug).
- Post-fix: `ConflictError` fires; batch BEGIN/COMMIT wrap rolls back item 0's mutation.

I confirmed pre-fix failure by reverting `core/src/notes.ts` and running just this test — it failed with `err.code === undefined` (no error thrown).

The PATH_CONFLICT test from #260 is **kept**: still useful for transport-level path-collision coverage, and a clean signal for "atomicity wrap works" independent of the `.changes` quirk.

## Standalone bun:sqlite repro — pending

Six attempted reductions (basic txn, async/microtask, prepared-statement reuse, mcp-loop mirror, hook-dispatch mirror, syncWikilinks-style writes) failed to hit the `.changes`-stale path outside the full `BunStore` plumbing. The bug surfaces only through `BunStore.updateNote` → hook dispatch. Documented in the test file comment + #261 audit trail. Worth a follow-up reduction attempt before filing upstream against `oven-sh/bun`.

## Test plan

- [x] `bun test ./src/ ./core/src/` — 1219 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] Pre-fix verification — confirmed regression test fails when `core/src/notes.ts` is reverted
- [ ] Reviewer pass

## Refs

- vault#261 — audit trail + call-site inventory
- vault#236 / PR #260 — batch atomicity wrap that made this reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)