### PR TITLE
chore: bump scope-guard dep to 0.1.0 stable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "parachute-vault",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@openparachute/scope-guard": "^0.1.0-rc.1",
+        "@openparachute/scope-guard": "^0.1.0",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode-terminal": "^0.12.0",
@@ -26,7 +26,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
-    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.1.0-rc.1", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-SRRzBmbbf4uWP0nKYLFg6Fasna2zl+BtADedCeQgCoHxmdwE8JaE3y5USZLLNaU5YJ9tzItXhWOsLtTFgJHgtQ=="],
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.1.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-zPusPTeNUVzRQebjed8+vuhbdBaIQ6wpmJIwiXu31ybf8xP4+GrUrlFVkz4IhLJq00+TDFKvqVOKSFtx9s64MQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@openparachute/scope-guard": "^0.1.0-rc.1",
+    "@openparachute/scope-guard": "^0.1.0",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode-terminal": "^0.12.0"


### PR DESCRIPTION
## Summary

Aaron's coordinated cut: scope-guard ships at `0.1.0` stable from the hub workspace; all consumers point at the stable tag rather than the rc line.

`package.json` `dependencies["@openparachute/scope-guard"]`: `^0.1.0-rc.1` → `^0.1.0`. One-line change. No version bump on vault — pin update takes effect on the next publish of vault@0.4.0.

## Gates

- [x] `bun --bun tsc --noEmit` — clean
- [x] `bun test ./core/src/` — 409 pass / 0 fail
- [x] `bun test ./src/` — 810 pass / 0 fail
- [x] `cd web/ui && bun run build` — built in 1.44s; verify-base check passed
- [x] `cd web/ui && bun run test` — 61 pass / 0 fail (7 files)

## Publish order

1. scope-guard@0.1.0 (hub workspace)
2. vault@0.4.0 (this PR's pin in effect)
3. Hub + scribe follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)