### PR TITLE
feat(schemas): tag schema inheritance + _default universal parent (closes #270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,45 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
   ancestors disagree on a field's spec, the loser surfaces as a
   `schema_conflict` advisory warning on `validation_status` — no write
   blocking, consistent with the rest of the schema-validation model.
+  Each `schema_conflict` warning carries `schema` (winner) and
+  `loser_schema` (overridden) as structured fields so agents can resolve
+  the disagreement without parsing `message`.
 
   Cache hygiene: the schema-config cache invalidates on `parent_names`
   changes (in addition to the existing `fields` mutations) since
   inheritance now walks parent chains.
+
+### Notes
+
+- **`schema_conflict` is a new `ValidationWarning.reason` value.** Existing
+  reasons (`type_mismatch`, `enum_mismatch`) are unchanged. Downstream
+  clients with strict-enum deserialization compiled against pre-`0.4.1-rc.2`
+  `@openparachute/vault` types may see an unrecognized value if they hit
+  vault rows where multiple ancestors declare the same field with diverging
+  specs. The warning is advisory — clients can safely ignore unknown
+  `reason` values.
+- **`_default`-scoped auth tokens grant full-vault access.** Tag-scoped
+  tokens (see `patterns/tag-scoped-tokens.md`) compute their effective tag
+  set by expanding each input tag through `getTagDescendants`. Because
+  `_default` is the universal parent of every tag, expanding it returns
+  the full tag list — so a token scoped to `_default` is functionally
+  equivalent to an unscoped token. **Do not mint `_default`-scoped tokens
+  thinking they restrict to a "default-only" tag.** The semantic is
+  intended (it's symmetric with the schema-inheritance model), but the
+  wide blast radius is worth flagging explicitly.
+
+### Fixed (folded from PR #272 review)
+
+- **`tagMatch: "any"` + `_default` now drops the tag filter entirely.**
+  Pre-fold, an `any`-match query like `tag: ["_default", "task"]` would
+  strip `_default` and narrow to `task`-tagged notes only — wrong, since
+  the OR-semantics with `_default` (which matches everything) should
+  collapse to "every note." The `all`-match behavior (drop `_default`
+  from the AND-set, keep the rest) was already correct and is unchanged.
+- **`searchNotes` honors `_default` filter-strip.** The FTS-backed search
+  path now short-circuits the tag filter when `_default` is requested,
+  matching `queryNotes` semantics so untagged notes are reachable from
+  search.
 
 ## [0.4.1-rc.1] — 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.1-rc.2] — 2026-05-09
+
+### Added
+
+- **Tag schema inheritance via `parent_names` + `_default` universal parent
+  (closes #270).** A tag's `parent_names` column already drove query
+  expansion (a query for `#manual` matched any descendant). It now also
+  drives **schema inheritance**: a child tag's effective `fields` map = its
+  own ∪ all ancestors' (recursive walk, cycle-safe). Multi-inheritance is
+  supported — list multiple parents in `parent_names`.
+
+  A tag named `_default` is treated as the implicit universal parent of
+  every note, tagged or not. Its `fields` declarations apply everywhere.
+  Modeling: magic at resolve time only — `tags.parent_names` is never
+  auto-mutated. Removable by deleting the `_default` tag row. The
+  symmetric query expansion: `query-notes { tag: "_default" }` returns
+  every note in the vault (including untagged).
+
+  Conflict resolution for multi-inheritance is **first-in-walk wins**:
+  the child's own `fields` take precedence over inherited specs; among
+  parents, earlier entries in `parent_names` outrank later ones. When
+  ancestors disagree on a field's spec, the loser surfaces as a
+  `schema_conflict` advisory warning on `validation_status` — no write
+  blocking, consistent with the rest of the schema-validation model.
+
+  Cache hygiene: the schema-config cache invalidates on `parent_names`
+  changes (in addition to the existing `fields` mutations) since
+  inheritance now walks parent chains.
+
 ## [0.4.1-rc.1] — 2026-05-09
 
 Audit-driven cleanup. The vault MCP surface had two subsystems that

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -3482,6 +3482,94 @@ describe("schema inheritance via parent_names (vault#270)", async () => {
     expect(result.validation_status).toBeUndefined();
   });
 
+  it("`_default` + `tagMatch: 'any'` drops the tag filter entirely (every note matches)", async () => {
+    // Folded from PR #272 review (N1). With OR-semantics, `_default` matches
+    // everything → the disjunction collapses regardless of what else is in
+    // the list. Pre-fold this would have narrowed to `task`-tagged notes.
+    await store.upsertTagRecord("_default", { description: "universal parent" });
+    const a = await store.createNote("alpha", { tags: ["task"] });
+    const b = await store.createNote("beta", { tags: ["project"] });
+    const g = await store.createNote("gamma"); // untagged
+
+    const results = await store.queryNotes({ tags: ["_default", "task"], tagMatch: "any" });
+    const ids = results.map((n) => n.id).sort();
+    expect(ids).toEqual([a.id, b.id, g.id].sort());
+  });
+
+  it("`_default` + `tagMatch: 'all'` drops only `_default` from the AND-set", async () => {
+    // Symmetric guard for N1: AND-semantics should NOT collapse — `_default`
+    // is universally satisfied so it can be dropped, but other tags still
+    // narrow the result set.
+    await store.upsertTagRecord("_default", { description: "universal parent" });
+    const a = await store.createNote("alpha", { tags: ["task"] });
+    await store.createNote("beta", { tags: ["project"] });
+    await store.createNote("gamma"); // untagged
+
+    const results = await store.queryNotes({ tags: ["_default", "task"], tagMatch: "all" });
+    expect(results.length).toBe(1);
+    expect(results[0].id).toBe(a.id);
+  });
+
+  it("`searchNotes` with `_default` returns matches from every note (including untagged)", async () => {
+    // Folded from PR #272 review (N2). FTS-backed search now short-circuits
+    // the tag filter when `_default` is requested, matching `queryNotes`.
+    await store.upsertTagRecord("_default", { description: "universal parent" });
+    const a = await store.createNote("findme alpha", { tags: ["task"] });
+    const b = await store.createNote("findme beta"); // untagged
+
+    const results = await store.searchNotes("findme", { tags: ["_default"] });
+    const ids = results.map((n) => n.id).sort();
+    expect(ids).toEqual([a.id, b.id].sort());
+  });
+
+  it("`schema_conflict` warning carries structured `loser_schema`", async () => {
+    // Folded from PR #272 review (N3). Agents shouldn't have to regex
+    // `message` to find the overridden tag — surface it structurally.
+    await store.upsertTagRecord("task", {
+      fields: { status: { type: "string", enum: ["todo", "done"] } },
+    });
+    await store.upsertTagRecord("publication", {
+      fields: { status: { type: "string", enum: ["draft", "published"] } },
+    });
+    await store.upsertTagRecord("article_task", {
+      parent_names: ["task", "publication"],
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["article_task"],
+      metadata: { status: "todo" },
+    }) as any;
+
+    const conflict = result.validation_status.warnings.find(
+      (w: any) => w.reason === "schema_conflict",
+    );
+    expect(conflict).toBeDefined();
+    expect(conflict.schema).toBe("task"); // winner
+    expect(conflict.loser_schema).toBe("publication"); // overridden
+  });
+
+  it("non-conflict warnings (type/enum mismatch) don't carry `loser_schema`", async () => {
+    // Symmetric guard for N3: `loser_schema` is only meaningful for
+    // schema_conflict; absent on type/enum mismatches.
+    await store.upsertTagSchema("task", {
+      fields: { priority: { type: "string", enum: ["high", "low"] } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["task"],
+      metadata: { priority: "ULTRA" },
+    }) as any;
+
+    expect(result.validation_status.warnings[0].reason).toBe("enum_mismatch");
+    expect(result.validation_status.warnings[0].loser_schema).toBeUndefined();
+  });
+
   it("invalidates schema cache when only parent_names changes (no fields touched)", async () => {
     // Regression guard: pre-vault#270, parent_names changes only invalidated
     // the hierarchy cache. Now they must also invalidate the schema cache,

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -3224,6 +3224,296 @@ describe("schema validation (tags.fields)", async () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Schema inheritance via parent_names + `_default` universal parent — vault#270
+// ---------------------------------------------------------------------------
+
+describe("schema inheritance via parent_names (vault#270)", async () => {
+  it("single-parent: child inherits parent's fields", async () => {
+    await store.upsertTagRecord("work", {
+      fields: { project: { type: "string" } },
+    });
+    await store.upsertTagRecord("task", {
+      parent_names: ["work"],
+      fields: { priority: { type: "string" } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["task"],
+      metadata: { priority: 7, project: 42 }, // both wrong type
+    }) as any;
+
+    expect(result.validation_status.warnings.length).toBe(2);
+    const fields = result.validation_status.warnings.map((w: any) => w.field).sort();
+    expect(fields).toEqual(["priority", "project"]);
+  });
+
+  it("multi-parent: child gets union of parents' fields", async () => {
+    await store.upsertTagRecord("work", {
+      fields: { project: { type: "string" } },
+    });
+    await store.upsertTagRecord("publication", {
+      fields: { venue: { type: "string" } },
+    });
+    await store.upsertTagRecord("paper", {
+      parent_names: ["work", "publication"],
+      fields: { title: { type: "string" } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["paper"],
+      metadata: { title: 1, project: 2, venue: 3 }, // all wrong type
+    }) as any;
+
+    expect(result.validation_status.warnings.length).toBe(3);
+    const fields = result.validation_status.warnings.map((w: any) => w.field).sort();
+    expect(fields).toEqual(["project", "title", "venue"]);
+  });
+
+  it("diamond: A→B, A→C, B→D, C→D — D's field appears once", async () => {
+    await store.upsertTagRecord("D", {
+      fields: { d_field: { type: "string" } },
+    });
+    await store.upsertTagRecord("B", { parent_names: ["D"] });
+    await store.upsertTagRecord("C", { parent_names: ["D"] });
+    await store.upsertTagRecord("A", { parent_names: ["B", "C"] });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["A"],
+      metadata: { d_field: 999 }, // wrong type
+    }) as any;
+
+    expect(result.validation_status.warnings.length).toBe(1);
+    expect(result.validation_status.warnings[0].field).toBe("d_field");
+    expect(result.validation_status.warnings[0].schema).toBe("D");
+  });
+
+  it("cycle: A→B, B→A — no infinite loop, both fields visible", async () => {
+    await store.upsertTagRecord("A", {
+      parent_names: ["B"],
+      fields: { a_field: { type: "string" } },
+    });
+    await store.upsertTagRecord("B", {
+      parent_names: ["A"],
+      fields: { b_field: { type: "string" } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["A"],
+      metadata: { a_field: 1, b_field: 2 }, // both wrong type
+    }) as any;
+
+    expect(result.validation_status.warnings.length).toBe(2);
+    const fields = result.validation_status.warnings.map((w: any) => w.field).sort();
+    expect(fields).toEqual(["a_field", "b_field"]);
+  });
+
+  it("override: child's spec wins over parent's for the same field name", async () => {
+    await store.upsertTagRecord("parent_tag", {
+      fields: { status: { type: "string", enum: ["a", "b"] } },
+    });
+    await store.upsertTagRecord("child_tag", {
+      parent_names: ["parent_tag"],
+      fields: { status: { type: "string", enum: ["x", "y"] } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["child_tag"],
+      metadata: { status: "x" }, // valid under child, invalid under parent
+    }) as any;
+
+    // Child's spec wins → "x" passes the enum check.
+    const enumWarnings = result.validation_status.warnings.filter(
+      (w: any) => w.reason === "enum_mismatch",
+    );
+    expect(enumWarnings.length).toBe(0);
+    // The conflict surfaces as a schema_conflict warning whose `schema` field
+    // names the *winning* tag (child).
+    const conflict = result.validation_status.warnings.find(
+      (w: any) => w.reason === "schema_conflict",
+    );
+    expect(conflict).toBeDefined();
+    expect(conflict.field).toBe("status");
+    expect(conflict.schema).toBe("child_tag");
+  });
+
+  it("conflict warning: two parents declare same field with different specs, first wins", async () => {
+    await store.upsertTagRecord("task", {
+      fields: { status: { type: "string", enum: ["todo", "doing", "done"] } },
+    });
+    await store.upsertTagRecord("publication", {
+      fields: { status: { type: "string", enum: ["draft", "published"] } },
+    });
+    // parent_names order = ["task", "publication"] → task wins.
+    await store.upsertTagRecord("article_task", {
+      parent_names: ["task", "publication"],
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["article_task"],
+      metadata: { status: "todo" }, // valid under task (winner), invalid under publication
+    }) as any;
+
+    const conflict = result.validation_status.warnings.find(
+      (w: any) => w.reason === "schema_conflict",
+    );
+    expect(conflict).toBeDefined();
+    expect(conflict.field).toBe("status");
+    expect(conflict.schema).toBe("task"); // winner
+    // No enum_mismatch — the value is valid under task's enum.
+    const enumMismatch = result.validation_status.warnings.find(
+      (w: any) => w.reason === "enum_mismatch",
+    );
+    expect(enumMismatch).toBeUndefined();
+  });
+
+  it("`_default` universal parent: untagged note picks up `_default`'s schema", async () => {
+    await store.upsertTagRecord("_default", {
+      fields: { author: { type: "string" } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "untagged note",
+      metadata: { author: 42 }, // wrong type
+    }) as any;
+
+    expect(result.validation_status.schemas).toEqual(["_default"]);
+    expect(result.validation_status.warnings.length).toBe(1);
+    expect(result.validation_status.warnings[0].field).toBe("author");
+  });
+
+  it("`_default` universal parent: tagged note gets `_default` + its tag schema", async () => {
+    await store.upsertTagRecord("_default", {
+      fields: { author: { type: "string" } },
+    });
+    await store.upsertTagRecord("task", {
+      fields: { priority: { type: "string" } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["task"],
+      metadata: { author: 1, priority: 2 }, // both wrong type
+    }) as any;
+
+    expect(result.validation_status.warnings.length).toBe(2);
+    const schemas = new Set(
+      result.validation_status.warnings.map((w: any) => w.schema),
+    );
+    expect(schemas.has("_default")).toBe(true);
+    expect(schemas.has("task")).toBe(true);
+  });
+
+  it("`_default` query expansion: query-notes { tag: '_default' } returns every note", async () => {
+    await store.upsertTagRecord("_default", { description: "universal parent" });
+    const a = await store.createNote("alpha", { tags: ["task"] });
+    const b = await store.createNote("beta", { tags: ["project"] });
+    const g = await store.createNote("gamma"); // untagged
+
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = await query.execute({ tag: "_default" }) as any;
+
+    expect(result.length).toBe(3);
+    const ids = (result as { id: string }[]).map((n) => n.id).sort();
+    expect(ids).toEqual([a.id, b.id, g.id].sort());
+  });
+
+  it("missing parent: non-existent name in parent_names is silently skipped", async () => {
+    await store.upsertTagRecord("task", {
+      parent_names: ["nonexistent_tag"],
+      fields: { priority: { type: "string" } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["task"],
+      metadata: { priority: 999 }, // wrong type
+    }) as any;
+
+    // No error. task's own field still validates.
+    expect(result.validation_status.warnings.length).toBe(1);
+    expect(result.validation_status.warnings[0].field).toBe("priority");
+  });
+
+  it("`_default` deleted mid-session: cache invalidates, default behavior goes away", async () => {
+    await store.upsertTagRecord("_default", {
+      fields: { author: { type: "string" } },
+    });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    let result = await create.execute({
+      content: "x",
+      metadata: { author: 42 }, // wrong type
+    }) as any;
+    expect(result.validation_status.warnings.length).toBe(1);
+
+    await store.deleteTag("_default");
+
+    result = await create.execute({
+      content: "y",
+      metadata: { author: 42 },
+    }) as any;
+    expect(result.validation_status).toBeUndefined();
+  });
+
+  it("invalidates schema cache when only parent_names changes (no fields touched)", async () => {
+    // Regression guard: pre-vault#270, parent_names changes only invalidated
+    // the hierarchy cache. Now they must also invalidate the schema cache,
+    // since inheritance walks parent chains at validation time.
+    await store.upsertTagRecord("base", {
+      fields: { tier: { type: "string" } },
+    });
+    await store.upsertTagRecord("derived", { description: "starts orphaned" });
+
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    let result = await create.execute({
+      content: "x",
+      tags: ["derived"],
+      metadata: { tier: 1 },
+    }) as any;
+    expect(result.validation_status).toBeUndefined();
+
+    // Wire up inheritance — fields *not* touched, only parent_names.
+    await store.upsertTagRecord("derived", { parent_names: ["base"] });
+
+    result = await create.execute({
+      content: "y",
+      tags: ["derived"],
+      metadata: { tier: 1 }, // wrong type per base.tier
+    }) as any;
+    expect(result.validation_status.warnings.length).toBe(1);
+    expect(result.validation_status.warnings[0].field).toBe("tier");
+    expect(result.validation_status.warnings[0].schema).toBe("base");
+  });
+});
+
 describe("expandTagsWithDescendants (tag-scoped tokens — patterns/tag-scoped-tokens.md)", async () => {
   it("returns the union of root + every descendant per tags.parent_names", async () => {
     await store.upsertTagRecord("health/food", { parent_names: ["health"] });

--- a/core/src/schema-defaults.ts
+++ b/core/src/schema-defaults.ts
@@ -28,6 +28,10 @@
  *   so "first-in-`parent_names`-array wins" is the operator-controlled
  *   precedence. Conflicts surface as advisory `schema_conflict` warnings; no
  *   write blocking.
+ * - `_default` can technically carry its own `parent_names` and the resolver
+ *   handles it (cycle guard + visited Set), but the resulting interaction is
+ *   non-obvious — `_default` is usually appended last, so its ancestors
+ *   become low-precedence. Treat `_default` as a root tag in normal use.
  *
  * Resolution model:
  * - Lazy: rebuilt on first access, cached on the store.
@@ -75,6 +79,13 @@ export interface ValidationWarning {
    */
   reason: "type_mismatch" | "enum_mismatch" | "schema_conflict";
   message: string;
+  /**
+   * `schema_conflict` only — the tag whose declaration was overridden. Set
+   * when `reason === "schema_conflict"`; absent on type/enum mismatches.
+   * Surfaces structurally so agents don't have to regex `message` to find
+   * the loser.
+   */
+  loser_schema?: string;
 }
 
 export interface ValidationStatus {
@@ -219,6 +230,7 @@ export function resolveNoteSchemas(
       conflicts.push({
         field: fieldName,
         schema: existing.sourceTag,
+        loser_schema: tagName,
         reason: "schema_conflict",
         message: `field '${fieldName}' has conflicting specs in ancestor tags '${existing.sourceTag}' (kept) and '${tagName}' (ignored)`,
       });

--- a/core/src/schema-defaults.ts
+++ b/core/src/schema-defaults.ts
@@ -1,10 +1,11 @@
 /**
- * Schema validation: walk the tags carried by a note, look up each tag's
- * `fields` declaration, and validate the note's metadata against the
- * collected field declarations. Writes are never blocked — schemas are
- * guidance. The MCP/REST layer surfaces a `validation_status` block on
- * create/update responses with any warnings the agent can act on (type
- * mismatch, enum mismatch).
+ * Schema validation: walk the tags carried by a note (plus their ancestors via
+ * `parent_names`), look up each ancestor's `fields` declaration, merge them
+ * (first-in-walk wins on conflict), and validate the note's metadata against
+ * the merged field map. Writes are never blocked — schemas are guidance. The
+ * MCP/REST layer surfaces a `validation_status` block on create/update
+ * responses with any warnings the agent can act on (type mismatch, enum
+ * mismatch, schema conflict).
  *
  * Storage: schemas live as `fields` columns on the `tags` table — same row
  * that already carries description, relationships, and parent_names. Authoring
@@ -15,12 +16,24 @@
  * the path-prefix mapping kind, and tag-mapped schemas were fully redundant
  * with `tags.fields`. The single-axis tag-driven validation lives here.
  *
+ * Inheritance (vault#270, 2026-05-09):
+ * - A note's effective ancestor set = union of {tag ∪ ancestors(tag)} for each
+ *   tag on the note, walking `parent_names` recursively (cycle-safe).
+ * - `_default` is an implicit universal parent: if a tag named `_default`
+ *   exists in the tags table, it's appended to every note's effective ancestor
+ *   set (including untagged notes). The `tags.parent_names` column is never
+ *   auto-mutated — the magic lives at resolve time only.
+ * - Conflict resolution: first-in-walk wins. The walk visits each note tag
+ *   in order, then DFS through its `parent_names` array in declaration order,
+ *   so "first-in-`parent_names`-array wins" is the operator-controlled
+ *   precedence. Conflicts surface as advisory `schema_conflict` warnings; no
+ *   write blocking.
+ *
  * Resolution model:
  * - Lazy: rebuilt on first access, cached on the store.
- * - Invalidated when `tags.fields` is mutated (upsert/delete tag schema or
- *   tag record).
- * - When no tag on the note declares fields, validation is a no-op (status
- *   omitted).
+ * - Invalidated when `tags.fields` or `tags.parent_names` is mutated, when a
+ *   tag is deleted, renamed, or merged.
+ * - When no ancestor declares fields, validation is a no-op (status omitted).
  */
 
 import { Database } from "bun:sqlite";
@@ -36,24 +49,36 @@ export interface SchemaField {
 }
 
 /**
- * Per-tag field map: { tagName: { fieldName: SchemaField } }. Empty when no
- * tag declares any fields.
+ * Tag-record snapshot used by the resolver. Loaded from the `tags` table once
+ * and cached on the store. `allTags` carries every known name (so `_default`
+ * existence checks and query expansion can be answered without a re-read).
  */
 export interface ResolvedSchemas {
+  /** Set of all known tag names (for `_default` magic + presence checks). */
+  allTags: Set<string>;
+  /** Per-tag own fields (only entries with at least one declaration). */
   tagToFields: Map<string, Record<string, SchemaField>>;
+  /** Per-tag `parent_names` (only entries with at least one parent declared). */
+  tagToParents: Map<string, string[]>;
 }
 
 export interface ValidationWarning {
   field: string;
-  /** Tag whose schema declared the violated field. */
+  /** Tag whose schema declared the violated field (or won the conflict). */
   schema: string;
-  /** "type_mismatch" | "enum_mismatch" */
-  reason: "type_mismatch" | "enum_mismatch";
+  /**
+   * `type_mismatch` — value's type contradicts the declared `type`.
+   * `enum_mismatch` — string value not in the declared `enum`.
+   * `schema_conflict` — two ancestors declared the same field with
+   * different specs; first-in-walk wins, the loser surfaces here so the
+   * operator can resolve the disagreement.
+   */
+  reason: "type_mismatch" | "enum_mismatch" | "schema_conflict";
   message: string;
 }
 
 export interface ValidationStatus {
-  /** Tag names whose schemas applied (for transparency). */
+  /** Tag names whose schemas contributed at least one field to the merged map. */
   schemas: string[];
   /** Empty when all checks pass. */
   warnings: ValidationWarning[];
@@ -85,22 +110,34 @@ function parseFieldsJson(raw: string | null): Record<string, SchemaField> {
   return fields;
 }
 
+function parseParentsJson(raw: string | null): string[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return []; }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((x): x is string => typeof x === "string" && x.length > 0);
+}
+
 /**
  * Build a resolution map from the `tags` table. Returns a well-formed
- * `ResolvedSchemas` even when no tag declares fields (empty map).
+ * `ResolvedSchemas` even when no tag declares fields (empty `tagToFields`).
  */
 export function loadSchemaConfig(db: Database): ResolvedSchemas {
+  const allTags = new Set<string>();
   const tagToFields = new Map<string, Record<string, SchemaField>>();
+  const tagToParents = new Map<string, string[]>();
   const rows = db.prepare(
-    `SELECT name, fields FROM tags WHERE fields IS NOT NULL`,
-  ).all() as { name: string; fields: string | null }[];
+    `SELECT name, fields, parent_names FROM tags`,
+  ).all() as { name: string; fields: string | null; parent_names: string | null }[];
   for (const row of rows) {
     if (!row.name) continue;
+    allTags.add(row.name);
     const fields = parseFieldsJson(row.fields);
-    if (Object.keys(fields).length === 0) continue;
-    tagToFields.set(row.name, fields);
+    if (Object.keys(fields).length > 0) tagToFields.set(row.name, fields);
+    const parents = parseParentsJson(row.parent_names);
+    if (parents.length > 0) tagToParents.set(row.name, parents);
   }
-  return { tagToFields };
+  return { allTags, tagToFields, tagToParents };
 }
 
 // ---------------------------------------------------------------------------
@@ -108,24 +145,105 @@ export function loadSchemaConfig(db: Database): ResolvedSchemas {
 // ---------------------------------------------------------------------------
 
 /**
- * Find the tags on this note whose schemas declare at least one field.
- * Returns tag *names* in note-tag order.
+ * Walk-order accumulator for a single note's effective ancestor set. DFS
+ * through `parent_names` in declaration order, cycle-protected via a visited
+ * Set. The output array preserves first-encounter order so the field-merge
+ * pass can apply first-wins precedence.
  */
-export function resolveApplicableSchemas(
+function walkAncestors(
+  startTag: string,
+  resolved: ResolvedSchemas,
+  visited: Set<string>,
+  out: string[],
+): void {
+  if (visited.has(startTag)) return;
+  visited.add(startTag);
+  out.push(startTag);
+  const parents = resolved.tagToParents.get(startTag);
+  if (!parents) return;
+  for (const p of parents) {
+    walkAncestors(p, resolved, visited, out);
+  }
+}
+
+interface MergedField {
+  spec: SchemaField;
+  sourceTag: string;
+}
+
+interface NoteResolution {
+  /** Walk-order tag list whose `fields` contributed at least one entry. */
+  effectiveTags: string[];
+  /** Field name → winning spec + source tag. First-in-walk wins. */
+  mergedFields: Map<string, MergedField>;
+  /** Conflict warnings — same field declared by ≥2 ancestors with diverging specs. */
+  conflicts: ValidationWarning[];
+}
+
+/**
+ * Resolve the effective schema for a note. Walks each note tag through its
+ * `parent_names` chain (cycle-safe), implicitly appends `_default` when the
+ * tag exists, and merges all encountered `fields` declarations with
+ * first-in-walk precedence. A note with no tags still picks up `_default`'s
+ * schema when one is declared.
+ *
+ * Internal — exported for tests. The public entry point is `validateNote`.
+ */
+export function resolveNoteSchemas(
   resolved: ResolvedSchemas,
   note: { tags?: string[] },
-): string[] {
-  const names: string[] = [];
-  const seen = new Set<string>();
-  if (!note.tags) return names;
-  for (const tag of note.tags) {
-    if (seen.has(tag)) continue;
-    if (resolved.tagToFields.has(tag)) {
-      names.push(tag);
-      seen.add(tag);
+): NoteResolution {
+  const visited = new Set<string>();
+  const order: string[] = [];
+
+  for (const tag of note.tags ?? []) {
+    walkAncestors(tag, resolved, visited, order);
+  }
+  if (resolved.allTags.has("_default")) {
+    walkAncestors("_default", resolved, visited, order);
+  }
+
+  const mergedFields = new Map<string, MergedField>();
+  const conflicts: ValidationWarning[] = [];
+
+  for (const tagName of order) {
+    const fields = resolved.tagToFields.get(tagName);
+    if (!fields) continue;
+    for (const [fieldName, spec] of Object.entries(fields)) {
+      const existing = mergedFields.get(fieldName);
+      if (!existing) {
+        mergedFields.set(fieldName, { spec, sourceTag: tagName });
+        continue;
+      }
+      if (fieldSpecsEqual(existing.spec, spec)) continue;
+      conflicts.push({
+        field: fieldName,
+        schema: existing.sourceTag,
+        reason: "schema_conflict",
+        message: `field '${fieldName}' has conflicting specs in ancestor tags '${existing.sourceTag}' (kept) and '${tagName}' (ignored)`,
+      });
     }
   }
-  return names;
+
+  const contributing = new Set<string>();
+  for (const { sourceTag } of mergedFields.values()) contributing.add(sourceTag);
+  const effectiveTags = order.filter((t) => contributing.has(t));
+
+  return { effectiveTags, mergedFields, conflicts };
+}
+
+function fieldSpecsEqual(a: SchemaField, b: SchemaField): boolean {
+  if (a.type !== b.type) return false;
+  if (!stringArraysEqual(a.enum, b.enum)) return false;
+  return true;
+}
+
+function stringArraysEqual(a: string[] | undefined, b: string[] | undefined): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
 }
 
 function valueMatchesType(value: unknown, type: SchemaField["type"]): boolean {
@@ -145,69 +263,52 @@ function valueMatchesType(value: unknown, type: SchemaField["type"]): boolean {
 }
 
 /**
- * Validate a note's metadata against each applicable tag's `fields` and
- * collect warnings. Validation is non-blocking — the caller decides what to
- * do with the warnings (currently: surface them on the create/update
- * response).
+ * Validate a note's metadata against the merged schema. Returns null when no
+ * ancestor declares any fields (so the caller can omit `validation_status`
+ * entirely). Otherwise returns the status with conflict warnings prepended,
+ * followed by per-field type/enum mismatches.
  *
- * Rules per field:
+ * Rules per merged field:
  * - Present and `type` declared and value's type doesn't match → `type_mismatch`
  * - Present and `enum` declared and value not in enum → `enum_mismatch`
  *
- * Fields not declared by any applicable tag's schema are ignored entirely
- * (this isn't a "strict" validator — it's a guide). There is no `required`
- * concept on `tags.fields` (post-v17); declarations are advisory only.
- */
-export function validateMetadata(
-  resolved: ResolvedSchemas,
-  schemaNames: string[],
-  metadata: Record<string, unknown> | undefined,
-): ValidationStatus {
-  const warnings: ValidationWarning[] = [];
-  const m = metadata ?? {};
-
-  for (const name of schemaNames) {
-    const fields = resolved.tagToFields.get(name);
-    if (!fields) continue;
-
-    for (const [fieldName, field] of Object.entries(fields)) {
-      if (!(fieldName in m)) continue;
-      const value = m[fieldName];
-      if (value === undefined || value === null) continue;
-
-      if (field.type && !valueMatchesType(value, field.type)) {
-        warnings.push({
-          field: fieldName,
-          schema: name,
-          reason: "type_mismatch",
-          message: `'${fieldName}' should be ${field.type} (tag '${name}')`,
-        });
-      }
-
-      if (field.enum && field.enum.length > 0 && typeof value === "string" && !field.enum.includes(value)) {
-        warnings.push({
-          field: fieldName,
-          schema: name,
-          reason: "enum_mismatch",
-          message: `'${fieldName}' must be one of [${field.enum.join(", ")}] (tag '${name}')`,
-        });
-      }
-    }
-  }
-
-  return { schemas: schemaNames, warnings };
-}
-
-/**
- * Convenience: combine resolve + validate for a note. Returns null when no
- * tag on the note declares any fields (so the caller can decide whether to
- * omit the field on the response or surface an empty status).
+ * Fields not declared by any ancestor's schema are ignored entirely (this
+ * isn't a "strict" validator — it's a guide). There is no `required` concept
+ * (post-v17); declarations are advisory only.
  */
 export function validateNote(
   resolved: ResolvedSchemas,
   note: { path?: string | null; tags?: string[]; metadata?: Record<string, unknown> },
 ): ValidationStatus | null {
-  const names = resolveApplicableSchemas(resolved, note);
-  if (names.length === 0) return null;
-  return validateMetadata(resolved, names, note.metadata);
+  const resolution = resolveNoteSchemas(resolved, note);
+  if (resolution.mergedFields.size === 0) return null;
+
+  const m = note.metadata ?? {};
+  const warnings: ValidationWarning[] = [...resolution.conflicts];
+
+  for (const [fieldName, { spec, sourceTag }] of resolution.mergedFields) {
+    if (!(fieldName in m)) continue;
+    const value = m[fieldName];
+    if (value === undefined || value === null) continue;
+
+    if (spec.type && !valueMatchesType(value, spec.type)) {
+      warnings.push({
+        field: fieldName,
+        schema: sourceTag,
+        reason: "type_mismatch",
+        message: `'${fieldName}' should be ${spec.type} (tag '${sourceTag}')`,
+      });
+    }
+
+    if (spec.enum && spec.enum.length > 0 && typeof value === "string" && !spec.enum.includes(value)) {
+      warnings.push({
+        field: fieldName,
+        schema: sourceTag,
+        reason: "enum_mismatch",
+        message: `'${fieldName}' must be one of [${spec.enum.join(", ")}] (tag '${sourceTag}')`,
+      });
+    }
+  }
+
+  return { schemas: resolution.effectiveTags, warnings };
 }

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -11,6 +11,7 @@ import {
   loadTagHierarchy,
   getTagDescendants,
   TAG_CONFIG_PREFIX,
+  DEFAULT_TAG_NAME,
   type TagHierarchy,
 } from "./tag-hierarchy.js";
 import {
@@ -217,16 +218,31 @@ export class BunSqliteStore implements Store {
    * each input tag is replaced with `{tag} ∪ descendants(tag)`. The SQL
    * builder uses this to widen the tag join from `name = ?` to
    * `name IN (...)`, so a query for `#manual` matches notes tagged with
-   * any descendant declared via `_tags/*` config notes.
+   * any descendant declared via `tags.parent_names`.
    *
-   * No-op when no `_tags/*` notes exist (empty hierarchy → each tag
-   * expands to just itself, identical to the pre-expansion behavior).
+   * `_default` magic (vault#270): when a `_default` tag row exists in the
+   * vault, it's the implicit parent of every note (tagged or not). A query
+   * filter that names `_default` is therefore equivalent to "no tag filter
+   * at all" — strip it from the tag list so untagged notes also match. If
+   * `_default` was the only tag requested, the tag filter is dropped
+   * entirely; other filters (path, metadata, dates) still apply.
    */
   private expandQueryTags(opts: QueryOpts): QueryOpts {
     if (!opts.tags || opts.tags.length === 0) return opts;
     const hierarchy = this.getTagHierarchy();
+
+    let tags = opts.tags;
+    if (hierarchy.allTags.has(DEFAULT_TAG_NAME) && tags.includes(DEFAULT_TAG_NAME)) {
+      tags = tags.filter((t) => t !== DEFAULT_TAG_NAME);
+      if (tags.length === 0) {
+        const { tags: _drop, ..._rest } = opts;
+        return _rest as QueryOpts;
+      }
+      opts = { ...opts, tags };
+    }
+
     if (hierarchy.childrenOf.size === 0) return opts;
-    const expanded = opts.tags.map((t) => Array.from(getTagDescendants(hierarchy, t)));
+    const expanded = tags.map((t) => Array.from(getTagDescendants(hierarchy, t)));
     return { ...opts, _tagsExpanded: expanded } as QueryOpts;
   }
 
@@ -417,9 +433,19 @@ export class BunSqliteStore implements Store {
   ) {
     const result = tagSchemaOps.upsertTagRecord(this.db, tag, patch);
     if (patch.parent_names !== undefined) {
+      // parent_names drives both query expansion (tag hierarchy) AND, post
+      // vault#270, schema inheritance — bust both caches.
       this._tagHierarchy = null;
+      this._schemaConfig = null;
     }
     if (patch.fields !== undefined) {
+      this._schemaConfig = null;
+    }
+    // First-time creation of a tag row (e.g. an empty `_default` placeholder)
+    // changes the `_default` universal-parent gate even when no fields or
+    // parent_names are touched. Cheap to bust: caches rebuild on next read.
+    if (tag === "_default") {
+      this._tagHierarchy = null;
       this._schemaConfig = null;
     }
     return result;

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -223,9 +223,18 @@ export class BunSqliteStore implements Store {
    * `_default` magic (vault#270): when a `_default` tag row exists in the
    * vault, it's the implicit parent of every note (tagged or not). A query
    * filter that names `_default` is therefore equivalent to "no tag filter
-   * at all" — strip it from the tag list so untagged notes also match. If
-   * `_default` was the only tag requested, the tag filter is dropped
-   * entirely; other filters (path, metadata, dates) still apply.
+   * at all" — but the precise treatment depends on `tagMatch`:
+   *
+   * - `all` (default, AND-semantics): `_default` is universally satisfied,
+   *   so it can be dropped from the tag list. Other tags' AND-semantics
+   *   still apply. If `_default` was the only entry, drop the filter
+   *   entirely so untagged notes match.
+   * - `any` (OR-semantics): `_default` matches every note, so the disjunction
+   *   collapses to "every note." Drop the filter entirely regardless of
+   *   what else was in the list (otherwise we'd narrow to the union of
+   *   the other tags' notes — wrong).
+   *
+   * Other filters (path, metadata, dates) still apply in both cases.
    */
   private expandQueryTags(opts: QueryOpts): QueryOpts {
     if (!opts.tags || opts.tags.length === 0) return opts;
@@ -233,6 +242,11 @@ export class BunSqliteStore implements Store {
 
     let tags = opts.tags;
     if (hierarchy.allTags.has(DEFAULT_TAG_NAME) && tags.includes(DEFAULT_TAG_NAME)) {
+      const match = opts.tagMatch ?? "all";
+      if (match === "any") {
+        const { tags: _drop, ..._rest } = opts;
+        return _rest as QueryOpts;
+      }
       tags = tags.filter((t) => t !== DEFAULT_TAG_NAME);
       if (tags.length === 0) {
         const { tags: _drop, ..._rest } = opts;
@@ -251,9 +265,16 @@ export class BunSqliteStore implements Store {
     // should match notes tagged with any descendant tag. The underlying
     // FTS path already uses `IN (...)` for tags, so we flatten the
     // per-input expansions into a single union (search semantics are
-    // "any tag matches").
+    // "any tag matches"). When `_default` is among the requested tags
+    // (and a `_default` row exists), the OR collapses to "every note" —
+    // drop the tag filter entirely so the search hits the full corpus
+    // and untagged notes are reachable.
     if (opts?.tags && opts.tags.length > 0) {
       const hierarchy = this.getTagHierarchy();
+      if (hierarchy.allTags.has(DEFAULT_TAG_NAME) && opts.tags.includes(DEFAULT_TAG_NAME)) {
+        const { tags: _drop, ..._rest } = opts;
+        return noteOps.searchNotes(this.db, query, _rest);
+      }
       if (hierarchy.childrenOf.size > 0) {
         const expanded = new Set<string>();
         for (const t of opts.tags) {

--- a/core/src/tag-hierarchy.ts
+++ b/core/src/tag-hierarchy.ts
@@ -32,7 +32,22 @@ export interface TagHierarchy {
   childrenOf: Map<string, Set<string>>;
   /** Memoization cache: tag → set including the tag itself plus all transitive descendants. */
   descendantsCache: Map<string, Set<string>>;
+  /**
+   * Every known tag name in the vault. Loaded once at hierarchy build so the
+   * `_default` universal-parent magic in `getTagDescendants` can answer
+   * "expand `_default` → every tag" without a second DB scan.
+   */
+  allTags: Set<string>;
 }
+
+/**
+ * Reserved tag name treated as the implicit universal parent of every other
+ * tag (vault#270). When a row named `_default` exists in the `tags` table,
+ * its schema applies to all notes — tagged or not — and tag-hierarchy queries
+ * for `_default` expand to the full tag list. The `tags.parent_names` column
+ * is never auto-mutated; the universal-parent property lives at resolve time.
+ */
+export const DEFAULT_TAG_NAME = "_default";
 
 /**
  * Pre-v14 path prefix that marked a note as a tag-hierarchy declaration.
@@ -59,16 +74,21 @@ function readParentNames(raw: string | null): string[] {
 /**
  * Scan the `tags` table and build the parent→children adjacency map.
  * Each row's `parent_names` JSON array contributes one edge per parent.
+ * Also collects every known tag name in `allTags` so the `_default`
+ * universal-parent leg in `getTagDescendants` can return the full tag list
+ * without a second scan.
  */
 export function loadTagHierarchy(db: Database): TagHierarchy {
   const rows = db.prepare(
-    `SELECT name, parent_names FROM tags WHERE parent_names IS NOT NULL`,
+    `SELECT name, parent_names FROM tags`,
   ).all() as { name: string; parent_names: string | null }[];
 
   const childrenOf = new Map<string, Set<string>>();
+  const allTags = new Set<string>();
 
   for (const row of rows) {
     if (!row.name) continue;
+    allTags.add(row.name);
     const parents = readParentNames(row.parent_names);
     for (const parent of parents) {
       let children = childrenOf.get(parent);
@@ -80,17 +100,31 @@ export function loadTagHierarchy(db: Database): TagHierarchy {
     }
   }
 
-  return { childrenOf, descendantsCache: new Map() };
+  return { childrenOf, descendantsCache: new Map(), allTags };
 }
 
 /**
  * Return the tag plus all transitive descendants. Always includes the tag
  * itself, so callers can use the result as a drop-in replacement for the
  * input tag when expanding queries.
+ *
+ * Special case: `_default` is treated as the implicit parent of every tag
+ * (vault#270). When a row named `_default` exists in the `tags` table, this
+ * function returns the full set of known tag names — symmetric with the
+ * schema-inheritance model where `_default`'s fields apply to every note.
+ * When `_default` is *not* declared as a tag row, the call falls through to
+ * normal descendant traversal (which yields just `{_default}` since nothing
+ * lists it as a parent).
  */
 export function getTagDescendants(h: TagHierarchy, tag: string): Set<string> {
   const cached = h.descendantsCache.get(tag);
   if (cached) return cached;
+
+  if (tag === DEFAULT_TAG_NAME && h.allTags.has(DEFAULT_TAG_NAME)) {
+    const universal = new Set<string>(h.allTags);
+    h.descendantsCache.set(tag, universal);
+    return universal;
+  }
 
   const result = new Set<string>([tag]);
   const stack = [tag];

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -223,7 +223,14 @@ export interface Store {
   // the first lazy load.
   validateNoteAgainstSchemas(note: { path?: string | null; tags?: string[]; metadata?: Record<string, unknown> }): {
     schemas: string[];
-    warnings: { field: string; schema: string; reason: "type_mismatch" | "enum_mismatch" | "schema_conflict"; message: string }[];
+    warnings: {
+      field: string;
+      schema: string;
+      reason: "type_mismatch" | "enum_mismatch" | "schema_conflict";
+      message: string;
+      /** Set only on `schema_conflict` — the tag whose declaration was overridden. */
+      loser_schema?: string;
+    }[];
   } | null;
 
   // Attachments

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -215,11 +215,15 @@ export interface Store {
 
   // Schema validation (post-v17: backed by `tags.fields` only — the
   // standalone note_schemas + schema_mappings subsystem retired in v17, see
-  // vault#267). Returns null when no tag on the note declares any fields.
-  // The underlying resolver is in-memory after the first lazy load.
+  // vault#267). Post vault#270 the resolver walks `parent_names` so a note's
+  // effective fields include all ancestors' declarations (first-in-walk wins
+  // on conflict, surfaced as `schema_conflict` warnings); a tag named
+  // `_default` is the implicit universal parent. Returns null when no
+  // ancestor declares any fields. The underlying resolver is in-memory after
+  // the first lazy load.
   validateNoteAgainstSchemas(note: { path?: string | null; tags?: string[]; metadata?: Record<string, unknown> }): {
     schemas: string[];
-    warnings: { field: string; schema: string; reason: "type_mismatch" | "enum_mismatch"; message: string }[];
+    warnings: { field: string; schema: string; reason: "type_mismatch" | "enum_mismatch" | "schema_conflict"; message: string }[];
   } | null;
 
   // Attachments

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.1-rc.1",
+  "version": "0.4.1-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Extends `tags.parent_names` from query-only-expansion to **also drive schema inheritance**, and adds `_default` as an implicit universal parent of every tag — its schema applies to all notes regardless of tags. Locks in conflict-resolution semantics for multi-inheritance.

Closes #270. Cross-references: cleanup PR #269 (just merged); follow-up #271 (vault-info expansion) depends on this.

## Design (settled 2026-05-09 with Aaron)

**Schema inheritance via `parent_names`.** A tag's *effective fields* = its own `fields` ∪ all ancestor `fields` (recursive walk through `parent_names`). Multi-inheritance (multiple entries in `parent_names`) merges all parents' fields.

**`_default` as implicit universal parent.** A tag named `_default` is treated as the implicit parent of every other tag, even when not listed in `parent_names`. Modeling: magic at resolve time — the resolver always adds `_default` to the effective ancestor set; `tags.parent_names` is **never auto-mutated**. Removable by deleting the `_default` tag. Notes with no tags also get `_default`'s schema applied directly (the universal-parent property extends to untagged notes).

**Conflict resolution.** First-in-walk wins. The walk visits each note tag in order, then DFS through its `parent_names` array in declaration order — so "first-in-`parent_names`-array wins" is the operator-controlled precedence. Conflicts surface as advisory `schema_conflict` warnings via the existing `validation_status` channel; no write blocking.

**Query expansion.** `getTagDescendants("_default")` returns every tag in the vault. `query-notes { tag: "_default" }` returns every note (including untagged) — implemented by stripping `_default` from the SQL tag-filter when universal-parent magic is active, so the JOIN to `note_tags` doesn't exclude untagged rows.

## Implementation footprint

- `core/src/schema-defaults.ts` — rewrote `loadSchemaConfig` to load `parent_names` + `allTags` alongside `fields`. New `resolveNoteSchemas` walks parent chains (cycle-safe via visited Set), implicitly appends `_default` when present, merges fields first-wins, returns `(effectiveTags, mergedFields, conflicts)`. New `schema_conflict` warning reason.
- `core/src/tag-hierarchy.ts` — added `allTags: Set<string>` to `TagHierarchy`. `getTagDescendants("_default")` returns the full tag list when `_default` is declared; otherwise unchanged. Exported `DEFAULT_TAG_NAME` constant.
- `core/src/store.ts` — invalidate schema-config cache on `parent_names` changes (inheritance now depends on it); strip `_default` from query tag filters when universal-parent magic is active; bust both caches when a `_default` row is upserted (covers the empty-placeholder edge case).
- `core/src/types.ts` — `validation_status` warning union now includes `schema_conflict`.

## Test cases (11; all the ones from the issue body plus a cache-invalidation regression)

1. Single-parent inheritance: child gets parent's fields.
2. Multi-parent: union of both parents' fields.
3. Diamond (A→B, A→C, B→D, C→D): D's fields appear once (Set dedup).
4. Cycle (A↔B): no infinite loop, both fields visible (cycle guard via visited Set).
5. Override: child redeclares field — child's spec wins; conflict warning surfaces winner.
6. Conflict warning: two parents declare same field with different specs, first-in-`parent_names` wins, `schema_conflict` warning emitted naming the winner.
7. `_default` universal parent for **untagged** notes: schema applies, `validation_status.schemas = ["_default"]`.
8. `_default` universal parent for **tagged** notes: `_default` schema applied alongside the tag's schema.
9. `_default` query expansion: `query-notes { tag: "_default" }` returns every note (tagged + untagged).
10. Missing parent: non-existent name in `parent_names` is silently skipped (no error).
11. `_default` deleted mid-session: cache invalidates, default behavior goes away on next validation.
12. (Cache regression) `parent_names`-only mutation invalidates schema cache — pre-#270 only the hierarchy cache was busted.

## Test counts (canonical)

- `bun test ./core/src/` — **395 pass, 0 fail** (was 383)
- `bun test ./src/` — **788 pass, 0 fail** (unchanged)
- `bun run typecheck` — clean

## Versioning

Bumps `0.4.1-rc.1` → `0.4.1-rc.2`. Stays on the `0.4.X-rc.N` chain per pre-1.0 RC discipline.

## Out of scope

- vault#271 (vault-info + server instruction expansion) — separate PR, depends on this one.
- vault#247 (parent_names cascade on rename) — separate, smaller fix.
- vault#240 (full rename cascade) — separate, larger.

## Test plan

- [x] Single-parent inheritance picks up parent fields
- [x] Multi-parent unions field declarations
- [x] Diamond inheritance — D's field appears once
- [x] Cycle in parent_names — no infinite loop
- [x] Override (child wins, conflict warning surfaces)
- [x] First-in-parent_names wins on conflict
- [x] `_default` schema applies to untagged notes
- [x] `_default` + tag schemas combine
- [x] `query-notes { tag: "_default" }` returns every note (tagged + untagged)
- [x] Missing parent silently skipped
- [x] `_default` deletion clears default behavior
- [x] parent_names-only mutation invalidates schema cache
- [x] Full core + server suite passes
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)