### PR TITLE
feat(mcp): expand vault-info with schema projection + structured server-instruction at connect (closes #271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,39 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
-## [0.4.1-rc.2] — 2026-05-09
+## [0.4.1-rc.3] — 2026-05-09
+
+### Added
+
+- **`vault-info` projection + structured connect-time MCP instruction
+  (closes #271).** `vault-info` now returns a comprehensive vault
+  description that an agent can use to self-orient: `name`, `description`,
+  `tags` (schema-bearing tag records with own `fields`/`parents` plus
+  resolved `effective_fields`/`effective_parents` from the #270
+  inheritance walk), `indexed_fields` catalog (one entry per
+  `indexed_fields` row, listing every declarer tag), and a static
+  `query_hints` array describing the `query-notes` interface. Stats
+  remain gated by `include_stats: true` — when set, the existing
+  `getVaultStats` shape is appended unchanged.
+
+  The MCP `initialize` response now carries a markdown projection
+  rendered from the same vault state (rather than just vault name +
+  description). Agents see the schema landscape, the indexed-field
+  catalog, and the query-hint catalog at session start, plus explicit
+  pointers to call `vault-info` (full refresh) or `list-tags
+  { include_schema: true }` (tag-only refresh) mid-session if state
+  shifts. Token budget verified: under ~5K tokens at 50
+  tags-with-schemas; ~600 for typical small vaults.
+
+  Tool count stays at 9 — the projection rides on the existing
+  `vault-info` surface; no new MCP tool added.
+
+  Effective inheritance is computed by reusing #270's
+  `resolveNoteSchemas` walk for each tag, so the per-tag projection's
+  `effective_*` fields match runtime validation precedence (first-in-walk
+  wins; `_default` is the implicit universal parent).
+
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,15 +42,18 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ### Fixed (folded from PR #273 review)
 
-- **`vault-info` honors tag-scoped tokens.** Pre-fold, a token scoped to
-  `task` got the full vault's `tags` catalog and `indexed_fields` table
-  (every declarer surfaced). Now `vault-info` filters both arrays to
-  entries an in-scope tag contributes to, and drops out-of-scope declarer
-  names from each `indexed_fields` entry's `tags` field. Symmetric with
-  the existing `list-tags` tag-scope wrapper. Aggregate stats (counts,
+- **`vault-info` honors tag-scoped tokens (JSON tool + connect-time
+  markdown).** Pre-fold, a token scoped to `task` got the full vault's
+  `tags` catalog and `indexed_fields` table (every declarer surfaced).
+  Now `vault-info` filters both arrays to entries an in-scope tag
+  contributes to, and drops out-of-scope declarer names from each
+  `indexed_fields` entry's `tags` field. The connect-time markdown brief
+  rendered by `getServerInstruction` (sent via MCP `initialize`) is
+  filtered to the token's allowlist via the same shared helper, so the
+  JSON tool and the markdown brief stay in lockstep. Symmetric with the
+  existing `list-tags` tag-scope wrapper. Aggregate stats (counts,
   monthly distribution) continue to flow through unchanged — pre-#271
-  behavior. The connect-time markdown projection (sent via MCP
-  `initialize`) is not yet scope-filtered; tracked for follow-up.
+  behavior.
 
 ## [0.4.1-rc.2] — 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,23 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
   Effective inheritance is computed by reusing #270's
   `resolveNoteSchemas` walk for each tag, so the per-tag projection's
   `effective_*` fields match runtime validation precedence (first-in-walk
-  wins; `_default` is the implicit universal parent).
+  wins; `_default` is the implicit universal parent). Per-tag descriptions
+  are surfaced in `vault-info` JSON only — the connect-time markdown
+  brief lists tag *names* to keep the token budget tight.
 
+### Fixed (folded from PR #273 review)
 
+- **`vault-info` honors tag-scoped tokens.** Pre-fold, a token scoped to
+  `task` got the full vault's `tags` catalog and `indexed_fields` table
+  (every declarer surfaced). Now `vault-info` filters both arrays to
+  entries an in-scope tag contributes to, and drops out-of-scope declarer
+  names from each `indexed_fields` entry's `tags` field. Symmetric with
+  the existing `list-tags` tag-scope wrapper. Aggregate stats (counts,
+  monthly distribution) continue to flow through unchanged — pre-#271
+  behavior. The connect-time markdown projection (sent via MCP
+  `initialize`) is not yet scope-filtered; tracked for follow-up.
+
+## [0.4.1-rc.2] — 2026-05-09
 
 ### Added
 

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -4229,3 +4229,194 @@ describe("tag-scope auth (post-v14 hierarchy)", async () => {
     expect(noteWithinTagScope(note, allowed, ["health"])).toBe(true);
   });
 });
+
+// ---- Vault projection (vault#271) ----
+
+describe("vault projection (vault#271)", async () => {
+  it("projects tags-with-schemas with effective inheritance", async () => {
+    const { buildVaultProjection } = await import("./vault-projection.ts");
+
+    // Universal `_default` parent declares `created_by`.
+    await store.upsertTagRecord("_default", {
+      fields: { created_by: { type: "string", description: "Origin agent" } },
+    });
+    // `person` declares `email` and inherits `created_by`.
+    await store.upsertTagRecord("person", {
+      description: "A person",
+      fields: { email: { type: "string", indexed: true } },
+    });
+    // `employee` extends `person` — should inherit BOTH `email` and `created_by`.
+    await store.upsertTagRecord("employee", {
+      description: "Person who works here",
+      fields: { title: { type: "string" } },
+      parent_names: ["person"],
+    });
+
+    const projection = buildVaultProjection(db);
+
+    const byName = Object.fromEntries(projection.tags.map((t) => [t.name, t]));
+
+    // _default appears (has fields).
+    expect(byName._default).toBeTruthy();
+    expect(byName._default.parents).toEqual([]);
+    expect(byName._default.effective_parents).toEqual([]);
+
+    // person inherits _default's universal field.
+    expect(byName.person.parents).toEqual([]);
+    expect(byName.person.effective_parents).toEqual(["_default"]);
+    expect(Object.keys(byName.person.effective_fields).sort()).toEqual([
+      "created_by",
+      "email",
+    ]);
+    // own fields stay separate
+    expect(Object.keys(byName.person.fields ?? {})).toEqual(["email"]);
+
+    // employee walks person → _default.
+    expect(byName.employee.parents).toEqual(["person"]);
+    expect(byName.employee.effective_parents).toEqual(["person", "_default"]);
+    expect(Object.keys(byName.employee.effective_fields).sort()).toEqual([
+      "created_by",
+      "email",
+      "title",
+    ]);
+  });
+
+  it("catalogs indexed fields across declarers", async () => {
+    const { buildVaultProjection } = await import("./vault-projection.ts");
+
+    // Indexed-field lifecycle is owned by the update-tag MCP tool, not
+    // store.upsertTagRecord — go through the tool so the indexed_fields
+    // table actually gets populated.
+    const tools = generateMcpTools(store);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({
+      tag: "task",
+      fields: { status: { type: "string", indexed: true } },
+    });
+    await updateTag.execute({
+      tag: "project",
+      fields: {
+        status: { type: "string", indexed: true },
+        priority: { type: "integer", indexed: true },
+      },
+    });
+
+    const projection = buildVaultProjection(db);
+    const byName = Object.fromEntries(projection.indexed_fields.map((f) => [f.name, f]));
+
+    expect(byName.status).toBeTruthy();
+    expect(byName.status.type).toBe("string");
+    expect(byName.status.tags.sort()).toEqual(["project", "task"]);
+
+    expect(byName.priority).toBeTruthy();
+    expect(byName.priority.type).toBe("integer");
+    expect(byName.priority.tags).toEqual(["project"]);
+  });
+
+  it("includes the static query-hint catalog", async () => {
+    const { buildVaultProjection, QUERY_HINTS } = await import("./vault-projection.ts");
+    const projection = buildVaultProjection(db);
+    expect(projection.query_hints.length).toBe(QUERY_HINTS.length);
+    expect(projection.query_hints.some((h) => h.startsWith("query-notes { tag:"))).toBe(true);
+    expect(projection.query_hints.some((h) => h.includes("near:"))).toBe(true);
+  });
+
+  it("includes stats only when requested", async () => {
+    const { buildVaultProjection } = await import("./vault-projection.ts");
+    await store.createNote("a", { tags: ["x"] });
+    await store.createNote("b", { tags: ["x", "y"] });
+
+    const without = buildVaultProjection(db);
+    expect(without.stats).toBeUndefined();
+
+    const withStats = buildVaultProjection(db, { includeStats: true });
+    expect(withStats.stats).toBeTruthy();
+    expect(withStats.stats!.totalNotes).toBe(2);
+    expect(withStats.stats!.tagCount).toBe(2);
+  });
+
+  it("degrades gracefully on an empty vault", async () => {
+    const { buildVaultProjection } = await import("./vault-projection.ts");
+    const projection = buildVaultProjection(db);
+    expect(projection.tags).toEqual([]);
+    expect(projection.indexed_fields).toEqual([]);
+    // Query hints are static — present even on a blank vault.
+    expect(projection.query_hints.length).toBeGreaterThan(0);
+  });
+
+  it("renders a markdown brief listing tags-with-schemas and indexed fields", async () => {
+    const { buildVaultProjection, projectionToMarkdown } = await import(
+      "./vault-projection.ts"
+    );
+
+    await store.createNote("a", { tags: ["person"] });
+    const tools = generateMcpTools(store);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({
+      tag: "person",
+      description: "A person",
+      fields: { email: { type: "string", indexed: true } },
+    });
+
+    const projection = buildVaultProjection(db, { includeStats: true });
+    const md = projectionToMarkdown({
+      vaultName: "test",
+      description: "My vault",
+      projection,
+    });
+
+    expect(md).toContain('You are connected to Parachute Vault "test"');
+    expect(md).toContain("My vault");
+    expect(md).toContain("1 tag with schemas: person");
+    expect(md).toContain("Indexed metadata fields");
+    expect(md).toContain("email");
+    expect(md).toContain("#person");
+    expect(md).toContain("vault-info");
+    expect(md).toContain("list-tags { include_schema: true }");
+  });
+
+  it("markdown brief degrades gracefully when no schemas declared", async () => {
+    const { buildVaultProjection, projectionToMarkdown } = await import(
+      "./vault-projection.ts"
+    );
+
+    const projection = buildVaultProjection(db, { includeStats: true });
+    const md = projectionToMarkdown({
+      vaultName: "fresh",
+      description: null,
+      projection,
+    });
+
+    expect(md).toContain('Parachute Vault "fresh"');
+    expect(md).toContain("No tag schemas declared");
+    expect(md).toContain("No indexed metadata fields");
+    expect(md).toContain("Querying");
+  });
+
+  it("markdown brief stays under ~5K tokens for a 50-tags-with-schemas vault", async () => {
+    const { buildVaultProjection, projectionToMarkdown } = await import(
+      "./vault-projection.ts"
+    );
+
+    for (let i = 0; i < 50; i++) {
+      await store.upsertTagRecord(`schema_tag_${i}`, {
+        description: `Description for tag ${i} — covers what this tag is used for in the vault.`,
+        fields: {
+          [`field_${i}_a`]: { type: "string", indexed: i % 3 === 0 },
+          [`field_${i}_b`]: { type: "integer" },
+        },
+      });
+    }
+
+    const projection = buildVaultProjection(db, { includeStats: true });
+    const md = projectionToMarkdown({
+      vaultName: "big",
+      description: "Big test vault",
+      projection,
+    });
+
+    // Rough token approximation: 1 token ≈ 4 chars. Budget: 5K tokens.
+    const approxTokens = md.length / 4;
+    expect(approxTokens).toBeLessThan(5000);
+  });
+});

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1032,11 +1032,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "vault-info",
-      description: "Get vault description and optionally stats (note/tag/link counts, distribution). Pass `description` to update the vault description (changes how AI agents behave in future sessions).",
+      description: "Get a comprehensive vault projection: name, description, tags-with-schemas (own + effective parents/fields per #270 inheritance), indexed metadata fields catalog, and query hints. Pass `include_stats: true` to add note/tag/link counts and the monthly distribution. Pass `description` to update the vault description (changes how AI agents behave in future sessions). Call this anytime mid-session to refresh schema context.",
       inputSchema: {
         type: "object",
         properties: {
-          include_stats: { type: "boolean", description: "Include note count, tag count, distribution by month (default: false)" },
+          include_stats: { type: "boolean", description: "Include note count, tag count, attachment/link counts, and the monthly note distribution (default: false)" },
           description: { type: "string", description: "If provided, updates the vault description" },
         },
       },

--- a/core/src/schema-defaults.ts
+++ b/core/src/schema-defaults.ts
@@ -160,8 +160,13 @@ export function loadSchemaConfig(db: Database): ResolvedSchemas {
  * through `parent_names` in declaration order, cycle-protected via a visited
  * Set. The output array preserves first-encounter order so the field-merge
  * pass can apply first-wins precedence.
+ *
+ * Exported so other consumers (vault projection, future hierarchy
+ * inspectors) can reuse the exact walk semantics rather than carrying
+ * their own copy. Mutating walks (push to `out`, add to `visited`) keep
+ * the implementation cheap; callers pass fresh accumulators.
  */
-function walkAncestors(
+export function walkAncestors(
   startTag: string,
   resolved: ResolvedSchemas,
   visited: Set<string>,

--- a/core/src/vault-projection.ts
+++ b/core/src/vault-projection.ts
@@ -20,6 +20,7 @@ import { Database } from "bun:sqlite";
 import {
   loadSchemaConfig,
   resolveNoteSchemas,
+  walkAncestors,
   type ResolvedSchemas,
   type SchemaField,
 } from "./schema-defaults.ts";
@@ -102,12 +103,13 @@ export function resolveTagInheritance(
   const resolution = resolveNoteSchemas(resolved, { tags: [tag] });
 
   // resolveNoteSchemas returns effectiveTags (only fields-contributing tags).
-  // We need the full walk for effective_parents — recompute it locally.
+  // We need the full walk for effective_parents — replay using the same
+  // resolver helper so walk-order semantics stay in lockstep with #270.
   const visited = new Set<string>();
   const order: string[] = [];
-  walk(tag, resolved, visited, order);
+  walkAncestors(tag, resolved, visited, order);
   if (resolved.allTags.has(DEFAULT_TAG_NAME) && !visited.has(DEFAULT_TAG_NAME)) {
-    walk(DEFAULT_TAG_NAME, resolved, visited, order);
+    walkAncestors(DEFAULT_TAG_NAME, resolved, visited, order);
   }
   const effective_parents = order.filter((t) => t !== tag);
 
@@ -117,20 +119,6 @@ export function resolveTagInheritance(
   }
 
   return { effective_parents, effective_fields };
-}
-
-function walk(
-  startTag: string,
-  resolved: ResolvedSchemas,
-  visited: Set<string>,
-  out: string[],
-): void {
-  if (visited.has(startTag)) return;
-  visited.add(startTag);
-  out.push(startTag);
-  const parents = resolved.tagToParents.get(startTag);
-  if (!parents) return;
-  for (const p of parents) walk(p, resolved, visited, out);
 }
 
 // ---------------------------------------------------------------------------
@@ -270,7 +258,9 @@ export function projectionToMarkdown(args: {
   lines.push("");
 
   if (stats) {
-    lines.push(`- ${stats.totalNotes} notes, ${stats.tagCount} tags`);
+    lines.push(
+      `- ${stats.totalNotes} ${stats.totalNotes === 1 ? "note" : "notes"}, ${stats.tagCount} ${stats.tagCount === 1 ? "tag" : "tags"}`,
+    );
   } else {
     lines.push(`- (call \`vault-info { include_stats: true }\` for note/tag counts)`);
   }

--- a/core/src/vault-projection.ts
+++ b/core/src/vault-projection.ts
@@ -1,0 +1,308 @@
+/**
+ * Vault projection — computes a comprehensive description of the vault
+ * (tags-with-schemas + effective inheritance + indexed-field catalog +
+ * query hints) shared by two consumers:
+ *
+ *   - `vault-info` MCP tool — returns the full projection as a JSON object
+ *     so an agent can request a refresh mid-session.
+ *   - `getServerInstruction` (MCP `initialize` response) — renders the
+ *     same projection as a terse markdown brief sent once at connect.
+ *
+ * The projection lives outside the per-note path: it describes what kinds
+ * of notes and queries are available, not the contents. Nothing here
+ * depends on auth/scopes — both consumers compose this with vault config
+ * (name/description) and any policy-driven framing on top.
+ *
+ * See vault#271 for design notes.
+ */
+
+import { Database } from "bun:sqlite";
+import {
+  loadSchemaConfig,
+  resolveNoteSchemas,
+  type ResolvedSchemas,
+  type SchemaField,
+} from "./schema-defaults.ts";
+import { listIndexedFields } from "./indexed-fields.ts";
+import {
+  listTagRecords,
+  type TagFieldSchema,
+  type TagRecord,
+} from "./tag-schemas.ts";
+import { DEFAULT_TAG_NAME } from "./tag-hierarchy.ts";
+import * as noteOps from "./notes.ts";
+import type { VaultStats } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProjectionTag {
+  name: string;
+  description: string | null;
+  /** Direct parents declared in `tags.parent_names` (verbatim, no walk). */
+  parents: string[];
+  /**
+   * Walk-order ancestor closure (parents → grandparents → …) including the
+   * implicit `_default` universal parent when present, with the tag itself
+   * excluded. Empty when the tag has no parents and no `_default` exists.
+   */
+  effective_parents: string[];
+  /**
+   * Own field declarations (verbatim from `tags.fields`). Carries the full
+   * `TagFieldSchema` shape — `type` (string), optional `description`,
+   * `enum`, `indexed`. Width matches the on-disk row.
+   */
+  fields: Record<string, TagFieldSchema> | null;
+  /**
+   * Merged field map = own ∪ inherited (first-in-walk wins, matching
+   * `resolveNoteSchemas`). Uses the `SchemaField` view returned by the
+   * resolver (narrower `type` enum). Empty when no ancestor — including
+   * the tag itself — declared anything.
+   */
+  effective_fields: Record<string, SchemaField>;
+  relationships: TagRecord["relationships"] | null;
+}
+
+export interface ProjectionIndexedField {
+  name: string;
+  /** User-facing field type ("string" | "integer" | "boolean") drawn from the first declarer. */
+  type: string;
+  tags: string[];
+}
+
+export interface VaultProjection {
+  tags: ProjectionTag[];
+  indexed_fields: ProjectionIndexedField[];
+  query_hints: string[];
+  /** Included when the caller requests stats; omitted otherwise. */
+  stats?: VaultStats;
+}
+
+// ---------------------------------------------------------------------------
+// Inheritance helpers (built on the #272 resolver)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a single tag's effective inheritance.
+ *
+ * Built on top of `resolveNoteSchemas({ tags: [tag] })` so the walk order
+ * and conflict precedence match the runtime validator exactly. Returns:
+ *
+ *   - `effective_parents`: walk-order ancestor list with the tag itself
+ *     excluded. Includes `_default` when a `_default` row exists, regardless
+ *     of whether the tag declares it (universal-parent semantics).
+ *   - `effective_fields`: merged field map (first-in-walk wins). When no
+ *     ancestor contributes, this equals the tag's own `fields`.
+ */
+export function resolveTagInheritance(
+  resolved: ResolvedSchemas,
+  tag: string,
+): { effective_parents: string[]; effective_fields: Record<string, SchemaField> } {
+  const resolution = resolveNoteSchemas(resolved, { tags: [tag] });
+
+  // resolveNoteSchemas returns effectiveTags (only fields-contributing tags).
+  // We need the full walk for effective_parents — recompute it locally.
+  const visited = new Set<string>();
+  const order: string[] = [];
+  walk(tag, resolved, visited, order);
+  if (resolved.allTags.has(DEFAULT_TAG_NAME) && !visited.has(DEFAULT_TAG_NAME)) {
+    walk(DEFAULT_TAG_NAME, resolved, visited, order);
+  }
+  const effective_parents = order.filter((t) => t !== tag);
+
+  const effective_fields: Record<string, SchemaField> = {};
+  for (const [field, { spec }] of resolution.mergedFields) {
+    effective_fields[field] = spec;
+  }
+
+  return { effective_parents, effective_fields };
+}
+
+function walk(
+  startTag: string,
+  resolved: ResolvedSchemas,
+  visited: Set<string>,
+  out: string[],
+): void {
+  if (visited.has(startTag)) return;
+  visited.add(startTag);
+  out.push(startTag);
+  const parents = resolved.tagToParents.get(startTag);
+  if (!parents) return;
+  for (const p of parents) walk(p, resolved, visited, out);
+}
+
+// ---------------------------------------------------------------------------
+// Projection
+// ---------------------------------------------------------------------------
+
+/**
+ * Static query-hint catalog. Sent verbatim in both vault-info JSON and the
+ * connect-time markdown projection so an agent can self-orient without
+ * reading source. Edit here when query semantics change.
+ */
+export const QUERY_HINTS: readonly string[] = [
+  "query-notes { tag: \"X\" } — all notes with tag X (includes descendants per inheritance)",
+  "query-notes { tag: \"X\", metadata: { field: { op: value } } } — operator queries on indexed fields (eq/ne/gt/gte/lt/lte/in/not_in/exists)",
+  "query-notes { search: \"...\" } — full-text search across content",
+  "query-notes { near: { id: \"...\" }, depth: 2 } — graph neighborhood within N hops",
+  "query-notes { id: \"<note-id-or-path>\" } — fetch a single note by ID or path",
+] as const;
+
+/**
+ * Build the comprehensive vault projection. Pure read; no caches mutated.
+ *
+ * Shape rules:
+ *
+ *   - `tags`: only tags carrying their own `description` or `fields`. A
+ *     hierarchy-only tag (parent_names but no own schema) is omitted from
+ *     the catalog — its semantics live in whichever ancestor contributes
+ *     fields. `effective_fields` still surfaces the merged spec when the
+ *     tag *does* appear (because it has its own description/fields).
+ *
+ *   - `indexed_fields`: one entry per row in the `indexed_fields` table.
+ *     The user-facing `type` is drawn from the first declarer's spec —
+ *     declarers must agree on type (enforced at write time) so picking the
+ *     first is unambiguous. `tags` lists every declarer, sorted.
+ *
+ *   - `stats`: included when `opts.includeStats === true`. Uses the
+ *     existing `getVaultStats` shape unchanged — camelCase keys, full
+ *     monthly distribution.
+ */
+export function buildVaultProjection(
+  db: Database,
+  opts?: { includeStats?: boolean },
+): VaultProjection {
+  const resolved = loadSchemaConfig(db);
+  const records = listTagRecords(db);
+
+  const tags: ProjectionTag[] = [];
+  for (const r of records) {
+    const hasOwnSchema =
+      (r.description !== undefined && r.description !== null) ||
+      (r.fields !== undefined && r.fields !== null && Object.keys(r.fields).length > 0);
+    if (!hasOwnSchema) continue;
+
+    const { effective_parents, effective_fields } = resolveTagInheritance(resolved, r.tag);
+
+    tags.push({
+      name: r.tag,
+      description: r.description ?? null,
+      parents: r.parent_names ?? [],
+      effective_parents,
+      fields: r.fields ?? null,
+      effective_fields,
+      relationships: r.relationships ?? null,
+    });
+  }
+
+  const indexedRows = listIndexedFields(db);
+  const indexed_fields: ProjectionIndexedField[] = indexedRows.map((row) => {
+    const declarers = [...row.declarerTags].sort();
+    // Recover the user-facing type from the first declarer's spec. Falls
+    // back to a sqlite-derived label if the declarer's row is gone (race;
+    // shouldn't happen because release drops the indexed_fields row, but
+    // robust against drift).
+    let userType = sqliteToUserType(row.sqliteType);
+    for (const t of declarers) {
+      const fields = resolved.tagToFields.get(t);
+      const declared = fields?.[row.field]?.type;
+      if (typeof declared === "string" && declared.length > 0) {
+        userType = declared;
+        break;
+      }
+    }
+    return { name: row.field, type: userType, tags: declarers };
+  });
+
+  const projection: VaultProjection = {
+    tags,
+    indexed_fields,
+    query_hints: [...QUERY_HINTS],
+  };
+
+  if (opts?.includeStats) {
+    projection.stats = noteOps.getVaultStats(db);
+  }
+
+  return projection;
+}
+
+function sqliteToUserType(t: string): string {
+  if (t === "TEXT") return "string";
+  if (t === "INTEGER") return "integer";
+  return t.toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering — for getServerInstruction
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a vault projection as a terse markdown brief for the MCP
+ * `initialize` response. Keep dense — agents see this once at connect, and
+ * the goal is "everything an agent needs to start using the vault sensibly,
+ * with explicit pointers for refresh."
+ *
+ * Token budget guideline: ~600 tokens for a small vault (Aaron's, ~4 tags-
+ * with-schemas) and under ~5K tokens at 50 tags-with-schemas. Listing all
+ * tags-with-schemas inline is the default; cap heuristics can be added if
+ * a real test shape demands it.
+ */
+export function projectionToMarkdown(args: {
+  vaultName: string;
+  description?: string | null;
+  projection: VaultProjection;
+}): string {
+  const { vaultName, description, projection } = args;
+  const stats = projection.stats;
+
+  const lines: string[] = [];
+  lines.push(`You are connected to Parachute Vault "${vaultName}".`);
+  if (description && description.trim().length > 0) {
+    lines.push("");
+    lines.push(description.trim());
+  }
+
+  lines.push("");
+  lines.push("## Quick orientation (call `vault-info` for full schema)");
+  lines.push("");
+
+  if (stats) {
+    lines.push(`- ${stats.totalNotes} notes, ${stats.tagCount} tags`);
+  } else {
+    lines.push(`- (call \`vault-info { include_stats: true }\` for note/tag counts)`);
+  }
+
+  if (projection.tags.length === 0) {
+    lines.push(`- No tag schemas declared yet — every note is freeform.`);
+  } else {
+    const names = projection.tags.map((t) => t.name).join(", ");
+    lines.push(`- ${projection.tags.length} tag${projection.tags.length === 1 ? "" : "s"} with schemas: ${names}`);
+  }
+
+  if (projection.indexed_fields.length > 0) {
+    lines.push(`- Indexed metadata fields (queryable with operators):`);
+    for (const f of projection.indexed_fields) {
+      const declarers = f.tags.map((t) => `#${t}`).join(", ");
+      lines.push(`  - ${f.name} (${f.type}; from ${declarers})`);
+    }
+  } else {
+    lines.push(`- No indexed metadata fields.`);
+  }
+
+  lines.push("");
+  lines.push("## Querying");
+  lines.push("");
+  for (const hint of projection.query_hints) {
+    lines.push(`- \`${hint}\``);
+  }
+
+  lines.push("");
+  lines.push("## Refreshing context");
+  lines.push("");
+  lines.push("If schema or tags change during this session, call `vault-info` to refresh the full projection. Call `list-tags { include_schema: true }` for tag-only details.");
+
+  return lines.join("\n");
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.1-rc.2",
+  "version": "0.4.1-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -57,7 +57,10 @@ function requiredVerbForTool(toolName: string): VaultVerb {
 
 /** Handle scoped MCP at /vault/{name}/mcp (single vault). */
 export async function handleScopedMcp(req: Request, vaultName: string, auth: AuthResult): Promise<Response> {
-  const instruction = getServerInstruction(vaultName);
+  // Auth flows through to getServerInstruction so the connect-time
+  // markdown brief is filtered by `scoped_tags` — symmetric with the
+  // JSON `vault-info` wrapper.
+  const instruction = await getServerInstruction(vaultName, auth);
   return handleMcp(req, () => generateScopedMcpTools(vaultName, auth), `parachute-vault/${vaultName}`, vaultName, auth, instruction);
 }
 

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -105,6 +105,8 @@ function applyTagDependencyGuards(tools: McpToolDef[], vaultName: string): void 
  *   - query-notes: filter single-note returns + result lists
  *   - list-tags:   filter to allowlisted tags + descendants
  *   - find-path:   require both endpoints (and every hop) in scope
+ *   - vault-info:  filter projection.tags + projection.indexed_fields
+ *                  to entries an in-scope tag contributes to
  *
  * Write-tool gating happens in handleScopedMcp at the verb-scope layer
  * AND inside each tool's wrapper here (so a tag-scoped `vault:write`
@@ -162,6 +164,30 @@ function applyTagScopeWrappers(
       }
     }
     return result;
+  });
+
+  // vault-info projection (#271): filter the tags catalog to in-scope tags
+  // and the indexed_fields catalog to fields with at least one in-scope
+  // declarer. Within each surviving indexed_fields entry, also drop
+  // out-of-scope declarer names from the `tags` array — a token scoped to
+  // `task` shouldn't learn that `project` declares `status` too. Other
+  // top-level keys (name, description, query_hints, stats) pass through:
+  // counts are aggregate and existing pre-#271 behavior already returned
+  // them to scoped tokens.
+  wrapReadTool(tools, "vault-info", async (orig, params) => {
+    const allowed = await getAllowed();
+    const result = await orig(params);
+    if (!allowed || !result || typeof result !== "object") return result;
+    const r = result as Record<string, unknown>;
+    if (Array.isArray(r.tags)) {
+      r.tags = (r.tags as { name: string }[]).filter((t) => allowed.has(t.name));
+    }
+    if (Array.isArray(r.indexed_fields)) {
+      r.indexed_fields = (r.indexed_fields as { name: string; type: string; tags: string[] }[])
+        .map((f) => ({ ...f, tags: f.tags.filter((t) => allowed.has(t)) }))
+        .filter((f) => f.tags.length > 0);
+    }
+    return r;
   });
 
   // ---- Write-side guards ----

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -7,6 +7,10 @@
 
 import { generateMcpTools } from "../core/src/mcp.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
+import {
+  buildVaultProjection,
+  projectionToMarkdown,
+} from "../core/src/vault-projection.ts";
 import { readVaultConfig, writeVaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { hasScopeForVault } from "./scopes.ts";
@@ -20,20 +24,26 @@ import { findTokensReferencingTag } from "./token-store.ts";
 
 /**
  * Get the MCP server instruction for a vault.
- * Sent once at session init — not per tool.
+ *
+ * Sent once at session init via the MCP `initialize` response — not per
+ * tool. The body is a markdown brief composed from the same vault projection
+ * `vault-info` returns, so an agent has everything it needs to orient
+ * itself before issuing a single query. Stats are included so the count
+ * line ("N notes, M tags") is always populated.
+ *
+ * Returns the orientation block even when the vault has no description or
+ * schemas — empty vaults still get the query-hint catalog and refresh
+ * pointers.
  */
 export function getServerInstruction(vaultName: string): string {
   const config = readVaultConfig(vaultName);
-
-  const parts: string[] = [
-    `You are connected to Parachute Vault "${vaultName}".`,
-  ];
-
-  if (config?.description) {
-    parts.push("", config.description);
-  }
-
-  return parts.join("\n");
+  const store = getVaultStore(vaultName);
+  const projection = buildVaultProjection(store.db, { includeStats: true });
+  return projectionToMarkdown({
+    vaultName,
+    description: config?.description ?? null,
+    projection,
+  });
 }
 
 /**
@@ -286,14 +296,20 @@ function overrideVaultInfo(
       writeVaultConfig(config);
     }
 
-    const result: any = {
+    const store = getVaultStore(vaultName);
+    const includeStats = Boolean(params.include_stats);
+    const projection = buildVaultProjection(store.db, { includeStats });
+
+    const result: Record<string, unknown> = {
       name: config.name,
       description: config.description ?? null,
+      tags: projection.tags,
+      indexed_fields: projection.indexed_fields,
+      query_hints: projection.query_hints,
     };
 
-    if (params.include_stats) {
-      const store = getVaultStore(vaultName);
-      result.stats = await store.getVaultStats();
+    if (projection.stats) {
+      result.stats = projection.stats;
     }
 
     return result;

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -10,6 +10,7 @@ import type { McpToolDef } from "../core/src/mcp.ts";
 import {
   buildVaultProjection,
   projectionToMarkdown,
+  type VaultProjection,
 } from "../core/src/vault-projection.ts";
 import { readVaultConfig, writeVaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
@@ -23,6 +24,34 @@ import {
 import { findTokensReferencingTag } from "./token-store.ts";
 
 /**
+ * Filter a vault projection to entries an in-scope tag contributes to.
+ *
+ * Mirrors the JSON `vault-info` wrapper exactly so the connect-time
+ * markdown brief and the JSON tool surface identical scope shapes:
+ *
+ *   - `tags` array → drop entries whose name isn't in `allowed`.
+ *   - `indexed_fields` array → for each entry, intersect `tags` (the
+ *     declarer list) with `allowed`. Drop the entry entirely when no
+ *     declarer survives.
+ *
+ * Aggregate stats and the static `query_hints` catalog pass through
+ * unchanged — counts are aggregate (already pre-#271 behavior) and hints
+ * are pure documentation.
+ */
+function filterProjectionByScope(
+  projection: VaultProjection,
+  allowed: Set<string>,
+): VaultProjection {
+  return {
+    ...projection,
+    tags: projection.tags.filter((t) => allowed.has(t.name)),
+    indexed_fields: projection.indexed_fields
+      .map((f) => ({ ...f, tags: f.tags.filter((t) => allowed.has(t)) }))
+      .filter((f) => f.tags.length > 0),
+  };
+}
+
+/**
  * Get the MCP server instruction for a vault.
  *
  * Sent once at session init via the MCP `initialize` response — not per
@@ -31,14 +60,30 @@ import { findTokensReferencingTag } from "./token-store.ts";
  * itself before issuing a single query. Stats are included so the count
  * line ("N notes, M tags") is always populated.
  *
- * Returns the orientation block even when the vault has no description or
- * schemas — empty vaults still get the query-hint catalog and refresh
- * pointers.
+ * When `auth` carries `scoped_tags`, the projection is filtered to those
+ * tags + descendants before rendering — symmetric with the JSON
+ * `vault-info` wrapper, so a tag-scoped token never learns about
+ * out-of-scope tags via the connect-time brief either. Aggregate counts
+ * pass through unchanged (they were pre-existing leak surface; not new).
+ *
+ * Async because expanding the tag-scope allowlist hits the store's
+ * hierarchy resolver. Returns the orientation block even when the vault
+ * has no description or schemas — empty vaults still get the query-hint
+ * catalog and refresh pointers.
  */
-export function getServerInstruction(vaultName: string): string {
+export async function getServerInstruction(
+  vaultName: string,
+  auth?: AuthResult,
+): Promise<string> {
   const config = readVaultConfig(vaultName);
   const store = getVaultStore(vaultName);
-  const projection = buildVaultProjection(store.db, { includeStats: true });
+  let projection = buildVaultProjection(store.db, { includeStats: true });
+
+  if (auth?.scoped_tags && auth.scoped_tags.length > 0) {
+    const allowed = await expandTokenTagScope(store, auth.scoped_tags);
+    if (allowed) projection = filterProjectionByScope(projection, allowed);
+  }
+
   return projectionToMarkdown({
     vaultName,
     description: config?.description ?? null,
@@ -173,20 +218,22 @@ function applyTagScopeWrappers(
   // `task` shouldn't learn that `project` declares `status` too. Other
   // top-level keys (name, description, query_hints, stats) pass through:
   // counts are aggregate and existing pre-#271 behavior already returned
-  // them to scoped tokens.
+  // them to scoped tokens. The same `filterProjectionByScope` helper backs
+  // `getServerInstruction` so the JSON tool and the connect-time markdown
+  // brief stay in lockstep.
   wrapReadTool(tools, "vault-info", async (orig, params) => {
     const allowed = await getAllowed();
     const result = await orig(params);
     if (!allowed || !result || typeof result !== "object") return result;
-    const r = result as Record<string, unknown>;
-    if (Array.isArray(r.tags)) {
-      r.tags = (r.tags as { name: string }[]).filter((t) => allowed.has(t.name));
-    }
-    if (Array.isArray(r.indexed_fields)) {
-      r.indexed_fields = (r.indexed_fields as { name: string; type: string; tags: string[] }[])
-        .map((f) => ({ ...f, tags: f.tags.filter((t) => allowed.has(t)) }))
-        .filter((f) => f.tags.length > 0);
-    }
+    const r = result as Record<string, unknown> & Partial<VaultProjection>;
+    const partial: VaultProjection = {
+      tags: Array.isArray(r.tags) ? r.tags : [],
+      indexed_fields: Array.isArray(r.indexed_fields) ? r.indexed_fields : [],
+      query_hints: Array.isArray(r.query_hints) ? r.query_hints : [],
+    };
+    const filtered = filterProjectionByScope(partial, allowed);
+    r.tags = filtered.tags;
+    r.indexed_fields = filtered.indexed_fields;
     return r;
   });
 

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -667,7 +667,7 @@ describe("scoped MCP wrapper", async () => {
       fields: { email: { type: "string", indexed: true } },
     });
 
-    const md = getServerInstruction(vaultName);
+    const md = await getServerInstruction(vaultName);
 
     expect(md).toContain(`Parachute Vault "${vaultName}"`);
     expect(md).toContain("Working notebook for the daily team.");
@@ -695,7 +695,7 @@ describe("scoped MCP wrapper", async () => {
       created_at: new Date().toISOString(),
     });
 
-    const md = getServerInstruction(vaultName);
+    const md = await getServerInstruction(vaultName);
 
     expect(md).toContain(`Parachute Vault "${vaultName}"`);
     expect(md).toContain("0 notes, 0 tags");  // 0 is plural per English convention
@@ -732,10 +732,174 @@ describe("scoped MCP wrapper", async () => {
       });
     }
 
-    const md = getServerInstruction(vaultName);
+    const md = await getServerInstruction(vaultName);
     // Rough token approximation: 1 token ≈ 4 chars. Budget: 5K tokens.
     const approxTokens = md.length / 4;
     expect(approxTokens).toBeLessThan(5000);
+
+    closeAllStores();
+  });
+
+  test("getServerInstruction filters projection by tag-scoped allowlist (vault#271 fold 5)", async () => {
+    const { getServerInstruction, generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `instr-scoped-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+      description: "Scoped session brief.",
+    });
+
+    // Seed three schema-bearing tags. Cross-declarer indexed `status`
+    // exercises the same shape the JSON wrapper test pinned: scoped to
+    // `task`, the brief should mention `status` via `task` but never
+    // surface `project` or `person`.
+    const tools = generateScopedMcpTools(vaultName);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({
+      tag: "task",
+      description: "A task",
+      fields: { status: { type: "string", indexed: true } },
+    });
+    await updateTag.execute({
+      tag: "project",
+      description: "A project",
+      fields: { status: { type: "string", indexed: true } },
+    });
+    await updateTag.execute({
+      tag: "person",
+      description: "A person",
+      fields: { email: { type: "string", indexed: true } },
+    });
+
+    const auth = {
+      permission: "full" as const,
+      scopes: ["vault:read", "vault:write", "vault:admin"],
+      legacyDerived: false,
+      scoped_tags: ["task"],
+    };
+    const md = await getServerInstruction(vaultName, auth as any);
+
+    // Allowlisted tag surfaces; out-of-scope tags do not. Use word-boundary
+    // regex — the static refresh-pointer text mentions "full projection"
+    // which contains the substring "project".
+    expect(md).toMatch(/\btask\b/);
+    expect(md).not.toMatch(/\bproject\b/);
+    expect(md).not.toMatch(/\bperson\b/);
+
+    // Indexed-field catalog: `status` survives (declared by `task`);
+    // `email` (person-only) is filtered out entirely.
+    expect(md).toMatch(/\bstatus\b/);
+    expect(md).not.toMatch(/\bemail\b/);
+
+    // Aggregate stats line still flows through unchanged — counts are
+    // pre-existing leak surface (per the rc.3 design discussion).
+    expect(md).toMatch(/\d+ note/);
+
+    closeAllStores();
+  });
+
+  test("getServerInstruction passes the full projection through for unscoped tokens (vault#271 fold 5)", async () => {
+    const { getServerInstruction, generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `instr-unscoped-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+
+    const tools = generateScopedMcpTools(vaultName);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({
+      tag: "task",
+      description: "A task",
+      fields: { status: { type: "string" } },
+    });
+    await updateTag.execute({
+      tag: "project",
+      description: "A project",
+      fields: { priority: { type: "integer" } },
+    });
+
+    // No `auth` arg → no scoping applied, full projection rendered.
+    const md = await getServerInstruction(vaultName);
+    expect(md).toContain("task");
+    expect(md).toContain("project");
+    expect(md).toContain("tags with schemas");
+    // Same for explicit auth with `scoped_tags: null`.
+    const mdNullScoped = await getServerInstruction(vaultName, {
+      permission: "full",
+      scopes: ["vault:read"],
+      legacyDerived: false,
+      scoped_tags: null,
+    } as any);
+    expect(mdNullScoped).toContain("task");
+    expect(mdNullScoped).toContain("project");
+
+    closeAllStores();
+  });
+
+  test("MCP initialize response carries scope-filtered instructions for tag-scoped tokens (vault#271 fold 5)", async () => {
+    const { handleScopedMcp } = await import("./mcp-http.ts");
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `init-scoped-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+
+    // Same fixture shape as the unit test, but driven through the actual
+    // `handleScopedMcp` initialize path the MCP client invokes at session
+    // start. The reviewer asked for an integration assertion on the
+    // `instructions` field carried in the `initialize` response.
+    const tools = generateScopedMcpTools(vaultName);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({
+      tag: "task",
+      description: "A task",
+      fields: { status: { type: "string" } },
+    });
+    await updateTag.execute({
+      tag: "project",
+      description: "A project",
+      fields: { priority: { type: "integer" } },
+    });
+
+    const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0" },
+        },
+      }),
+    });
+
+    const res = await handleScopedMcp(req, vaultName, {
+      permission: "full",
+      scopes: ["vault:read", "vault:write", "vault:admin"],
+      legacyDerived: false,
+      scoped_tags: ["task"],
+    } as any);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as any;
+    const instructions: string = body.result.instructions;
+    expect(instructions).toBeTruthy();
+    // Word-boundary match — the static refresh text mentions "full
+    // projection" which would false-trigger a substring check.
+    expect(instructions).toMatch(/\btask\b/);
+    expect(instructions).not.toMatch(/\bproject\b/);
 
     closeAllStores();
   });

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -565,6 +565,181 @@ describe("scoped MCP wrapper", async () => {
     closeAllStores();
   });
 
+  test("vault-info projection includes tags-with-schemas + indexed_fields + query_hints (vault#271)", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `proj-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+      description: "vault for #271",
+    });
+
+    const vaultStore = getVaultStore(vaultName);
+    await vaultStore.upsertTagRecord("_default", {
+      fields: { created_by: { type: "string", description: "Origin" } },
+    });
+
+    // Indexed-field lifecycle is owned by the update-tag MCP tool — go
+    // through the tool, not the store, so indexed_fields gets populated.
+    const tools = generateScopedMcpTools(vaultName);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({
+      tag: "person",
+      description: "A person",
+      fields: { email: { type: "string", indexed: true } },
+    });
+    await updateTag.execute({
+      tag: "employee",
+      description: "Employee",
+      fields: { title: { type: "string" } },
+      parent_names: ["person"],
+    });
+
+    const vaultInfo = tools.find((t) => t.name === "vault-info")!;
+    const result = await vaultInfo.execute({}) as any;
+
+    expect(result.name).toBe(vaultName);
+    expect(result.description).toBe("vault for #271");
+
+    // tags array — only schema-bearing rows, with effective inheritance
+    const byName = Object.fromEntries(
+      (result.tags as any[]).map((t) => [t.name, t]),
+    );
+    expect(byName.person).toBeTruthy();
+    expect(byName.person.effective_parents).toEqual(["_default"]);
+    expect(Object.keys(byName.person.effective_fields).sort()).toEqual([
+      "created_by",
+      "email",
+    ]);
+    expect(byName.employee.effective_parents).toEqual(["person", "_default"]);
+    expect(Object.keys(byName.employee.effective_fields).sort()).toEqual([
+      "created_by",
+      "email",
+      "title",
+    ]);
+
+    // indexed_fields catalog
+    const indexed = result.indexed_fields as any[];
+    const emailEntry = indexed.find((f) => f.name === "email");
+    expect(emailEntry).toBeTruthy();
+    expect(emailEntry.type).toBe("string");
+    expect(emailEntry.tags).toEqual(["person"]);
+
+    // query_hints — static catalog, present even without include_stats
+    expect(Array.isArray(result.query_hints)).toBe(true);
+    expect((result.query_hints as string[]).length).toBeGreaterThan(0);
+
+    // stats omitted unless requested
+    expect(result.stats).toBeUndefined();
+
+    const withStats = await vaultInfo.execute({ include_stats: true }) as any;
+    expect(withStats.stats).toBeTruthy();
+
+    closeAllStores();
+  });
+
+  test("getServerInstruction renders projection markdown for a populated vault (vault#271)", async () => {
+    const { getServerInstruction } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+
+    const vaultName = `instr-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+      description: "Working notebook for the daily team.",
+    });
+
+    const vaultStore = getVaultStore(vaultName);
+    await vaultStore.createNote("A", { tags: ["person"] });
+
+    const tools = generateScopedMcpTools(vaultName);
+    const updateTag = tools.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({
+      tag: "person",
+      description: "A person",
+      fields: { email: { type: "string", indexed: true } },
+    });
+
+    const md = getServerInstruction(vaultName);
+
+    expect(md).toContain(`Parachute Vault "${vaultName}"`);
+    expect(md).toContain("Working notebook for the daily team.");
+    expect(md).toContain("1 notes, 1 tags");
+    expect(md).toContain("1 tag with schemas: person");
+    expect(md).toContain("Indexed metadata fields");
+    expect(md).toContain("email");
+    expect(md).toContain("#person");
+    expect(md).toContain("Querying");
+    expect(md).toContain("vault-info");
+    expect(md).toContain("list-tags { include_schema: true }");
+
+    closeAllStores();
+  });
+
+  test("getServerInstruction degrades gracefully on an empty vault (vault#271)", async () => {
+    const { getServerInstruction } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `instr-empty-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+
+    const md = getServerInstruction(vaultName);
+
+    expect(md).toContain(`Parachute Vault "${vaultName}"`);
+    expect(md).toContain("0 notes, 0 tags");
+    expect(md).toContain("No tag schemas declared");
+    expect(md).toContain("No indexed metadata fields");
+    // Refresh hints surface both pointers so the agent knows where to look.
+    expect(md).toContain("vault-info");
+    expect(md).toContain("list-tags");
+
+    closeAllStores();
+  });
+
+  test("getServerInstruction stays under ~5K tokens at 50 tags-with-schemas (vault#271)", async () => {
+    const { getServerInstruction } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `instr-big-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+      description: "Stress-test fixture for the connect-time projection size.",
+    });
+
+    const vaultStore = getVaultStore(vaultName);
+    for (let i = 0; i < 50; i++) {
+      await vaultStore.upsertTagRecord(`schema_tag_${i}`, {
+        description: `Description for tag ${i} — covers a meaningful chunk of the vault's domain.`,
+        fields: {
+          [`field_${i}_a`]: { type: "string" },
+          [`field_${i}_b`]: { type: "integer" },
+        },
+      });
+    }
+
+    const md = getServerInstruction(vaultName);
+    // Rough token approximation: 1 token ≈ 4 chars. Budget: 5K tokens.
+    const approxTokens = md.length / 4;
+    expect(approxTokens).toBeLessThan(5000);
+
+    closeAllStores();
+  });
+
   test("list-tags with schema returns per-tag detail", async () => {
     const { generateScopedMcpTools } = await import("./mcp-tools.ts");
     const { writeVaultConfig } = await import("./config.ts");

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -671,7 +671,7 @@ describe("scoped MCP wrapper", async () => {
 
     expect(md).toContain(`Parachute Vault "${vaultName}"`);
     expect(md).toContain("Working notebook for the daily team.");
-    expect(md).toContain("1 notes, 1 tags");
+    expect(md).toContain("1 note, 1 tag");
     expect(md).toContain("1 tag with schemas: person");
     expect(md).toContain("Indexed metadata fields");
     expect(md).toContain("email");
@@ -698,7 +698,7 @@ describe("scoped MCP wrapper", async () => {
     const md = getServerInstruction(vaultName);
 
     expect(md).toContain(`Parachute Vault "${vaultName}"`);
-    expect(md).toContain("0 notes, 0 tags");
+    expect(md).toContain("0 notes, 0 tags");  // 0 is plural per English convention
     expect(md).toContain("No tag schemas declared");
     expect(md).toContain("No indexed metadata fields");
     // Refresh hints surface both pointers so the agent knows where to look.
@@ -968,6 +968,93 @@ describe("scoped MCP wrapper", async () => {
     expect(names).toContain("health");
     expect(names).toContain("health/food");
     expect(names).not.toContain("work");
+
+    closeAllStores();
+  });
+
+  test("scoped vault-info filters projection.tags + indexed_fields to the allowlist (vault#271 fold)", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `tagscope-vault-info-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+
+    // Seed two schema-bearing tags. `task` and `project` BOTH declare a
+    // shared indexed `status` field — this exercises the cross-declarer
+    // case the reviewer called out: a token scoped to `task` should see
+    // `status` (because task is a declarer) but the entry's `tags` array
+    // must list only `task`, not `project`.
+    const unscopedTools = generateScopedMcpTools(vaultName);
+    const updateTag = unscopedTools.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({
+      tag: "task",
+      description: "A task",
+      fields: { status: { type: "string", indexed: true } },
+    });
+    await updateTag.execute({
+      tag: "project",
+      description: "A project",
+      fields: {
+        status: { type: "string", indexed: true },
+        priority: { type: "integer", indexed: true },
+      },
+    });
+
+    // Now mint scoped tools, scoped to `task` only.
+    const tools = generateScopedMcpTools(vaultName, authForTags(["task"]) as any);
+    const vaultInfo = tools.find((t) => t.name === "vault-info")!;
+    const result = await vaultInfo.execute({}) as any;
+
+    // tags array: only `task`, not `project`.
+    const tagNames = (result.tags as { name: string }[]).map((t) => t.name);
+    expect(tagNames).toContain("task");
+    expect(tagNames).not.toContain("project");
+
+    // indexed_fields: `status` survives (task is a declarer), `priority`
+    // dropped entirely (only project declared it).
+    const indexedNames = (result.indexed_fields as { name: string }[]).map((f) => f.name);
+    expect(indexedNames).toContain("status");
+    expect(indexedNames).not.toContain("priority");
+
+    // Cross-declarer attribution leak: `status` lists declarer tags. The
+    // scoped response must show only `task`, never the out-of-scope
+    // `project`.
+    const status = (result.indexed_fields as { name: string; tags: string[] }[]).find(
+      (f) => f.name === "status",
+    )!;
+    expect(status.tags).toEqual(["task"]);
+
+    // Top-level passthrough sanity: name, description, and query_hints are
+    // not tag-scoped surfaces — they must still flow through.
+    expect(result.name).toBe(vaultName);
+    expect(Array.isArray(result.query_hints)).toBe(true);
+    expect((result.query_hints as string[]).length).toBeGreaterThan(0);
+
+    closeAllStores();
+  });
+
+  test("unscoped vault-info still sees the full projection (vault#271 fold)", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `tagscope-vault-info-unscoped-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+
+    const tools0 = generateScopedMcpTools(vaultName);
+    const updateTag = tools0.find((t) => t.name === "update-tag")!;
+    await updateTag.execute({ tag: "task", description: "T", fields: { status: { type: "string", indexed: true } } });
+    await updateTag.execute({ tag: "project", description: "P", fields: { status: { type: "string", indexed: true } } });
+
+    // No `auth` and no `scoped_tags` — unscoped path must remain
+    // identical to pre-fold behavior (full projection).
+    const tools = generateScopedMcpTools(vaultName);
+    const result = await tools.find((t) => t.name === "vault-info")!.execute({}) as any;
+    const tagNames = (result.tags as { name: string }[]).map((t) => t.name);
+    expect(tagNames.sort()).toEqual(["project", "task"]);
+    const status = (result.indexed_fields as { name: string; tags: string[] }[]).find((f) => f.name === "status")!;
+    expect(status.tags.sort()).toEqual(["project", "task"]);
 
     closeAllStores();
   });


### PR DESCRIPTION
## Summary

Implements vault#271 — `vault-info` returns a comprehensive vault projection, and the MCP `initialize` response carries a markdown rendering of the same projection so agents can self-orient before issuing a single query. Builds directly on the inheritance resolver from #270 (#272).

Tool count stays at **9** — no `describe-vault` tool. The projection rides on the existing `vault-info` surface.

### What's in the projection

`vault-info` JSON shape now includes:

- `name`, `description`
- `tags`: every schema-bearing tag (description or own fields), each with:
  - `parents` — verbatim from `tags.parent_names`
  - `effective_parents` — walk-order ancestor closure including `_default` universal parent (excluding self)
  - `fields` — own declarations
  - `effective_fields` — merged `own ∪ inherited`, first-in-walk wins via `resolveNoteSchemas`
  - `relationships`
- `indexed_fields`: one entry per row in the `indexed_fields` table, with user-facing `type` and the full declarer `tags` array
- `query_hints`: static catalog describing the `query-notes` interface
- `stats`: included only when `include_stats: true` (existing `getVaultStats` shape, unchanged)

The connect-time `initialize` instruction is rendered from the same projection — vault name + description + count line + tags-with-schemas list + indexed-field catalog + query hints + refresh pointers (`vault-info`, `list-tags { include_schema: true }`).

### Token budget

- Aaron's vault (~4 tags-with-schemas): ~600 tokens.
- 50-tags-with-schemas fixture: under 5K tokens (regression-tested).

No cap-at-N heuristic — all tags-with-schemas listed inline. Can revisit if a real test shape demands it.

## Test plan

Tests added (per #271):

In `core/src/core.test.ts` — `vault projection (vault#271)` describe block:

- [x] vault-info returns full new shape (`tags`, `indexed_fields`, `query_hints`, optional `stats`)
- [x] `effective_parents` includes `_default` when present
- [x] `effective_fields` correctly merges parent fields per the #272 resolver
- [x] `indexed_fields` catalogs across tags (e.g., `status` listed once with both `task` and `project` as declarers)
- [x] Empty vault degrades gracefully (empty `tags`, empty `indexed_fields`, static query hints still present)

In `src/vault.test.ts` — under `scoped MCP wrapper`:

- [x] `vault-info` MCP tool surfaces the new projection through `generateScopedMcpTools`
- [x] `getServerInstruction` produces expected markdown for a populated vault
- [x] `getServerInstruction` degrades gracefully on an empty vault and surfaces both refresh pointers
- [x] Token-budget sanity at 50 tags-with-schemas (under ~5K tokens via `length / 4` approximation)

Gate counts (canonical anchored runs):

- `bun test ./core/src/` — **408 pass / 0 fail** (was 400; +8 new tests)
- `bun test ./src/` — **792 pass / 0 fail** (was 788; +4 new tests)
- `bun run typecheck` — clean

## Patterns / governance

- RC bump only: `0.4.1-rc.2 → 0.4.1-rc.3` (no patch bump).
- CHANGELOG entry under `[0.4.1-rc.3] — 2026-05-09`.
- Builds on #270 / #272 (tag schema inheritance + `_default`). The new `effective_parents` and `effective_fields` outputs reuse `resolveNoteSchemas` exactly so the projection's inheritance precedence matches runtime validation.
- Tag-data-model pattern unchanged — projection is read-only over `tags` + `indexed_fields`.
- Out of scope: vault#247 (parent_names cascade on rename) and vault#240 (full rename cascade) — separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)