### PR TITLE
fix(projection): distinguish note-usage tags from schema-bearing in vault-info stats line (closes #274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.1-rc.5] — 2026-05-09
+
+### Fixed
+
+- **`vault-info` connect-time stats line distinguishes note-usage tag
+  count from schema-bearing count (closes #274).** Pre-fix, the line
+  read `2280 notes, 100 tags` — conflating "tags any note carries"
+  with "tags with schema declarations." An agent reading "100 tags"
+  next to "5 tags with schemas" had to infer the relationship; in
+  practice, vaults with many ad-hoc tags and few schema-bearing tags
+  read the line as if every tag had a schema.
+
+  New shape: `2280 notes, 100 tags total, 5 with schemas`. The
+  schema-bearing count is dropped when zero (so an empty vault still
+  reads cleanly as `0 notes, 0 tags total`). Pluralization preserved
+  per the rc.3 fix.
+
+  No JSON-schema change to `vault-info` — the stats object still
+  carries `tagCount` (driven by `note_tags`) unchanged. The fix is
+  purely in `projectionToMarkdown`.
+
 ## [0.4.1-rc.4] — 2026-05-09
 
 ### Added

--- a/core/src/vault-projection.ts
+++ b/core/src/vault-projection.ts
@@ -258,9 +258,20 @@ export function projectionToMarkdown(args: {
   lines.push("");
 
   if (stats) {
-    lines.push(
-      `- ${stats.totalNotes} ${stats.totalNotes === 1 ? "note" : "notes"}, ${stats.tagCount} ${stats.tagCount === 1 ? "tag" : "tags"}`,
-    );
+    // Two distinct counts surface here so an agent doesn't conflate
+    // them (vault#274): `tagCount` is "tags ANY note uses" — driven by
+    // note_tags rows. `projection.tags.length` is "tags carrying a
+    // schema declaration" — strictly smaller and the relevant denominator
+    // for the schema-bearing list a few lines down. Showing only one
+    // hid the gap (e.g., 100 tags but only 5 with schemas read as
+    // "100 tags with schemas").
+    const noteCount = stats.totalNotes;
+    const tagCount = stats.tagCount;
+    const withSchemas = projection.tags.length;
+    const noteLabel = noteCount === 1 ? "note" : "notes";
+    const tagLabel = tagCount === 1 ? "tag" : "tags";
+    const tagSuffix = withSchemas > 0 ? `, ${withSchemas} with schemas` : "";
+    lines.push(`- ${noteCount} ${noteLabel}, ${tagCount} ${tagLabel} total${tagSuffix}`);
   } else {
     lines.push(`- (call \`vault-info { include_stats: true }\` for note/tag counts)`);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.1-rc.4",
+  "version": "0.4.1-rc.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -702,9 +702,13 @@ describe("scoped MCP wrapper", async () => {
 
     expect(md).toContain(`Parachute Vault "${vaultName}"`);
     // vault#274: empty vault — no schemas, so the suffix is omitted.
-    // 0 is plural per English convention.
+    // 0 is plural per English convention. The not.toContain guard
+    // pins that "with schemas" doesn't leak through anywhere — when
+    // schemas exist it appears in two places (stats suffix + the
+    // tags-with-schemas list line); on an empty vault both branches
+    // are unreachable, so the phrase shouldn't appear at all.
     expect(md).toContain("0 notes, 0 tags total");
-    expect(md).not.toContain("with schemas,");
+    expect(md).not.toContain("with schemas");
     expect(md).toContain("No tag schemas declared");
     expect(md).toContain("No indexed metadata fields");
     // Refresh hints surface both pointers so the agent knows where to look.

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -671,7 +671,10 @@ describe("scoped MCP wrapper", async () => {
 
     expect(md).toContain(`Parachute Vault "${vaultName}"`);
     expect(md).toContain("Working notebook for the daily team.");
-    expect(md).toContain("1 note, 1 tag");
+    // vault#274: stats line distinguishes total tag count (note-usage)
+    // from schema-bearing count. One note tagged `person`, one tag
+    // overall, that one tag has a schema → "1 tag total, 1 with schemas".
+    expect(md).toContain("1 note, 1 tag total, 1 with schemas");
     expect(md).toContain("1 tag with schemas: person");
     expect(md).toContain("Indexed metadata fields");
     expect(md).toContain("email");
@@ -698,7 +701,10 @@ describe("scoped MCP wrapper", async () => {
     const md = await getServerInstruction(vaultName);
 
     expect(md).toContain(`Parachute Vault "${vaultName}"`);
-    expect(md).toContain("0 notes, 0 tags");  // 0 is plural per English convention
+    // vault#274: empty vault — no schemas, so the suffix is omitted.
+    // 0 is plural per English convention.
+    expect(md).toContain("0 notes, 0 tags total");
+    expect(md).not.toContain("with schemas,");
     expect(md).toContain("No tag schemas declared");
     expect(md).toContain("No indexed metadata fields");
     // Refresh hints surface both pointers so the agent knows where to look.


### PR DESCRIPTION
## Summary

Closes vault#274. Small projection-only fix — the connect-time `vault-info` stats line conflated note-usage tag count with schema-bearing count.

## Before / After

**Before** (rc.4):
```
- 2280 notes, 100 tags
- 5 tags with schemas: person, project, summary/monthly, thread, voice
```

An agent reading `100 tags` next to `5 tags with schemas` had to infer the relationship. In practice, vaults with many ad-hoc tags and few schema-bearing tags read the first line as if every tag had a schema.

**After** (rc.5):
```
- 2280 notes, 100 tags total, 5 with schemas
- 5 tags with schemas: person, project, summary/monthly, thread, voice
```

When zero schemas: `- 0 notes, 0 tags total` (suffix dropped). Pluralization preserved per the rc.3 fix.

## Scope

- Pure projection / markdown-rendering change in `core/src/vault-projection.ts`.
- **No JSON-schema change to `vault-info`** — `stats.tagCount` still represents the `note_tags`-driven count, unchanged.
- Two test fixtures updated in `src/vault.test.ts` (the populated-vault and empty-vault cases that assert on the stats-line shape).
- Bump `0.4.1-rc.4` → `0.4.1-rc.5`.

## Test plan

- [x] `bun test ./core/src/` — **422 pass / 0 fail**
- [x] `bun test ./src/` — **797 pass / 0 fail** (assertions updated for new stats-line shape)
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)