### PR TITLE
feat(auth): consume hub revocation list — scope-guard 0.2.0 (hub#212 Phase 4) (closes #TBD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.1-rc.6] — 2026-05-10
+
+### Changed
+
+- **Hub-issued JWTs are now checked against the hub's revocation list on
+  every request (hub#212 Phase 4).** Bumps `@openparachute/scope-guard`
+  from `^0.1.0` to `^0.2.0`. The new version's `validateHubJwt` consults
+  `<hub-origin>/.well-known/parachute-revocation.json` after sig/iss/aud/
+  expiry pass; revoked jtis surface as `HubJwtError(code: "revoked")` and
+  are rejected at `authenticateVaultRequest` with a 401. Without this,
+  Aaron could revoke a token via the hub's mint API but vault would still
+  honor it — this PR closes that gap from vault's side.
+
+  The existing `pvt_*` opaque-token path is untouched. Phase 6 deprecates
+  `pvt_*` separately.
+
+  Failure semantics (live in scope-guard's revocation cache; vault just
+  consumes the outcome):
+  - 60s TTL matches the hub's `Cache-Control: max-age=60` on the endpoint.
+  - Fail-open with last-good cache during a hub outage — a revoked token
+    may be accepted up to ~60s past revocation when the hub is unreachable,
+    matching the published convergence target.
+  - Fail-closed only on first-fetch-failure (cold start, no last-good).
+    Surfaces as `HubJwtError(code: "revocation_unavailable")` so operators
+    can tell "list couldn't load" from "this token has been retired."
+
+  Client-facing 401 for revoked tokens is sanitized — the jti goes to the
+  server-side audit log via `console.warn`, not into the response body.
+  Other failure modes forward the diagnostic message as before (those
+  carry no jti).
+
+### Internal
+
+- Test fixtures in `auth-hub-jwt.test.ts`, `hub-jwt.test.ts`, and
+  `tokens-routes.test.ts` extended to serve `/.well-known/parachute-revocation.json`
+  alongside the existing `/.well-known/jwks.json` mock. Default response
+  is an empty list; `auth-hub-jwt.test.ts` adds explicit cases for revoked
+  jtis, mixed-list happy path, and cold-start unreachable.
+
+  scope-guard's own unit suite covers the cache mechanics (TTL refresh,
+  fail-open with last-good, single-flight) — vault's tests pin the
+  wire-up and the 401 response shapes.
+
+### Versioning note
+
+Continues the `0.4.1-rc.N` chain (rc.5 → rc.6) per the pre-1.0 rule —
+patch number bumps only on Aaron-confirmed releases.
+
 ## [0.4.1-rc.5] — 2026-05-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,19 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
     Surfaces as `HubJwtError(code: "revocation_unavailable")` so operators
     can tell "list couldn't load" from "this token has been retired."
 
-  Client-facing 401 for revoked tokens is sanitized — the jti goes to the
-  server-side audit log via `console.warn`, not into the response body.
-  Other failure modes forward the diagnostic message as before (those
-  carry no jti).
+  Client-facing 401s for **all revocation-related codes** are sanitized:
+  - `code: "revoked"` → client gets `"token has been revoked"`; the jti
+    goes to the server-side audit log via `console.warn`.
+  - `code: "revocation_unavailable"` → client gets
+    `"token cannot be validated: revocation list unavailable"`; the
+    implementation-detail phrasing (`"no last-good cache"`) goes to the
+    server-side audit log.
+
+  Sets the inheritable pattern across vault/scribe/agent: revocation
+  diagnostics live in operator audit logs, never in the response body.
+  Other failure modes (signature, audience, expired, etc.) forward the
+  diagnostic message as before — they carry no jti and no implementation
+  internals.
 
 ### Internal
 
@@ -47,7 +56,10 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
   scope-guard's own unit suite covers the cache mechanics (TTL refresh,
   fail-open with last-good, single-flight) — vault's tests pin the
-  wire-up and the 401 response shapes.
+  wire-up, the 401 response shapes, and the audit-log invariant
+  (`console.warn` spy in the revoked-jti and cold-start cases asserts
+  the full diagnostic routes server-side even though the client message
+  is sanitized).
 
 ### Versioning note
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "parachute-vault",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@openparachute/scope-guard": "^0.1.0",
+        "@openparachute/scope-guard": "^0.2.0",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode-terminal": "^0.12.0",
@@ -26,7 +26,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
-    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.1.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-zPusPTeNUVzRQebjed8+vuhbdBaIQ6wpmJIwiXu31ybf8xP4+GrUrlFVkz4IhLJq00+TDFKvqVOKSFtx9s64MQ=="],
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.2.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-HbL1ZFBD0Kl/IiEXbEVLEGSQXGKL9sjRltye5RtqVLdwkR7Y9qOM9SSYmxa9np7nqzbRXrwDjEbRRQubKju9xg=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.1-rc.5",
+  "version": "0.4.1-rc.6",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@openparachute/scope-guard": "^0.1.0",
+    "@openparachute/scope-guard": "^0.2.0",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode-terminal": "^0.12.0"

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -10,10 +10,15 @@
  *   - broad `vault:<verb>` scope rejected (forced narrowing per #180)
  *   - `aud=vault.<other>` rejected (audience mismatch)
  *   - JWT path rejected at the global (cross-vault) entrypoint
+ *   - revoked jti rejected (revocation list integration; client-facing
+ *     message is sanitized so the jti doesn't leak)
+ *   - revocation list unavailable on cold start → fail-closed 401
  *
- * Each test owns a fresh `PARACHUTE_HOME` and JWKS fixture, like the auth.test
- * peer file. The JWKS fixture mirrors the one in hub-jwt.test.ts; duplicating
- * ~30 lines is cheaper than introducing a shared test-helper module.
+ * Each test owns a fresh `PARACHUTE_HOME` and a fake hub fixture that serves
+ * BOTH `/.well-known/jwks.json` and `/.well-known/parachute-revocation.json`.
+ * scope-guard's own unit suite covers the cache mechanics (TTL refresh,
+ * fail-open with last-good, single-flight); this file pins the vault-side
+ * wiring and the response-shape contract.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -24,7 +29,7 @@ import { generateKeyPair, exportJWK, SignJWT } from "jose";
 import { writeVaultConfig, readVaultConfig } from "./config.ts";
 import { getVaultStore, clearVaultStoreCache } from "./vault-store.ts";
 import { authenticateVaultRequest, authenticateGlobalRequest } from "./auth.ts";
-import { resetJwksCache } from "./hub-jwt.ts";
+import { resetJwksCache, resetRevocationCache } from "./hub-jwt.ts";
 
 interface Keypair {
   privateKey: CryptoKey;
@@ -42,24 +47,45 @@ async function makeKeypair(kid: string): Promise<Keypair> {
   };
 }
 
-interface JwksFixture {
+interface HubFixture {
   origin: string;
+  /** Drive the revocation list contents; cleared by default. */
+  setRevoked(jtis: string[]): void;
+  /** When true, the revocation endpoint returns 503 — exercises fail-closed. */
+  setRevocationFails(fails: boolean): void;
   stop: () => void;
 }
 
-function startJwksFixture(keys: Keypair[]): JwksFixture {
+function startHubFixture(keys: Keypair[]): HubFixture {
+  let revokedJtis: string[] = [];
+  let revocationFails = false;
   const server = Bun.serve({
     port: 0,
     fetch(req) {
       const url = new URL(req.url);
-      if (url.pathname !== "/.well-known/jwks.json") {
-        return new Response("not found", { status: 404 });
+      if (url.pathname === "/.well-known/jwks.json") {
+        return Response.json({ keys: keys.map((k) => k.publicJwk) });
       }
-      return Response.json({ keys: keys.map((k) => k.publicJwk) });
+      if (url.pathname === "/.well-known/parachute-revocation.json") {
+        if (revocationFails) {
+          return new Response("hub down", { status: 503 });
+        }
+        return Response.json({
+          generated_at: new Date().toISOString(),
+          jtis: revokedJtis,
+        });
+      }
+      return new Response("not found", { status: 404 });
     },
   });
   return {
     origin: `http://127.0.0.1:${server.port}`,
+    setRevoked: (jtis) => {
+      revokedJtis = jtis;
+    },
+    setRevocationFails: (fails) => {
+      revocationFails = fails;
+    },
     stop: () => server.stop(true),
   };
 }
@@ -70,6 +96,8 @@ interface SignOpts {
   scope: string;
   sub?: string;
   ttlSeconds?: number;
+  /** Override the random jti — needed when a test wants to revoke this exact token. */
+  jti?: string;
 }
 
 async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
@@ -82,7 +110,7 @@ async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
     .setAudience(opts.aud)
     .setIssuedAt(iat)
     .setExpirationTime(exp)
-    .setJti(`jti-${Math.random().toString(36).slice(2)}`)
+    .setJti(opts.jti ?? `jti-${Math.random().toString(36).slice(2)}`)
     .sign(kp.privateKey);
 }
 
@@ -95,7 +123,7 @@ function bearer(token: string): Request {
 let tmpHome: string;
 let prevHome: string | undefined;
 let prevHubOrigin: string | undefined;
-let fixture: JwksFixture;
+let fixture: HubFixture;
 let kp: Keypair;
 
 beforeEach(async () => {
@@ -109,10 +137,11 @@ beforeEach(async () => {
   clearVaultStoreCache();
 
   kp = await makeKeypair("k1");
-  fixture = startJwksFixture([kp]);
+  fixture = startHubFixture([kp]);
   prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
   process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
   resetJwksCache();
+  resetRevocationCache();
 });
 
 afterEach(() => {
@@ -226,6 +255,77 @@ describe("authenticateVaultRequest — hub JWT integration", () => {
       const body = (await result.error.json()) as { error: string; message: string };
       expect(body.message).toContain("vault-bound");
       expect(body.message).toContain("/vault/<name>");
+    }
+  });
+
+  test("revoked jti → 401 with sanitized message (jti not leaked to caller)", async () => {
+    seedVault("journal");
+    const revokedJti = "jti-revoked-by-operator";
+    fixture.setRevoked([revokedJti]);
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:read",
+      jti: revokedJti,
+    });
+    const config = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+      const body = (await result.error.json()) as { error: string; message: string };
+      expect(body.error).toBe("Unauthorized");
+      // Client-facing message must NOT carry the jti — that's a server-side
+      // audit-log concern only. See the `code === "revoked"` branch in
+      // authenticateHubJwt for the sanitization.
+      expect(body.message).toBe("token has been revoked");
+      expect(body.message).not.toContain(revokedJti);
+    }
+  });
+
+  test("non-revoked jti against populated list → still honored (happy path with active revocations)", async () => {
+    seedVault("journal");
+    fixture.setRevoked(["some-other-revoked-jti"]);
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:write",
+      jti: "jti-still-good",
+    });
+    const config = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("full");
+      expect(result.scopes).toEqual(["vault:journal:write"]);
+    }
+  });
+
+  test("revocation list unreachable on cold start → fail-closed 401", async () => {
+    seedVault("journal");
+    // Hub is reachable for JWKS but the revocation endpoint 503s. Cold cache
+    // + first-fetch-fail = "unknown" outcome, surfaced as
+    // HubJwtError(code: "revocation_unavailable"). The auth layer forwards
+    // the message verbatim (no jti to leak; safe to surface the diagnostic).
+    fixture.setRevocationFails(true);
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:read",
+    });
+    const config = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+      const body = (await result.error.json()) as { error: string; message: string };
+      expect(body.message).toContain("revocation list unavailable");
     }
   });
 });

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -21,7 +21,7 @@
  * wiring and the response-shape contract.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { mkdirSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -258,7 +258,7 @@ describe("authenticateVaultRequest — hub JWT integration", () => {
     }
   });
 
-  test("revoked jti → 401 with sanitized message (jti not leaked to caller)", async () => {
+  test("revoked jti → 401 sanitized; full diagnostic (with jti) routed to console.warn audit log", async () => {
     seedVault("journal");
     const revokedJti = "jti-revoked-by-operator";
     fixture.setRevoked([revokedJti]);
@@ -271,17 +271,31 @@ describe("authenticateVaultRequest — hub JWT integration", () => {
     const config = readVaultConfig("journal")!;
     const store = getVaultStore("journal");
 
-    const result = await authenticateVaultRequest(bearer(token), config, store.db);
-    expect("error" in result).toBe(true);
-    if ("error" in result) {
-      expect(result.error.status).toBe(401);
-      const body = (await result.error.json()) as { error: string; message: string };
-      expect(body.error).toBe("Unauthorized");
-      // Client-facing message must NOT carry the jti — that's a server-side
-      // audit-log concern only. See the `code === "revoked"` branch in
-      // authenticateHubJwt for the sanitization.
-      expect(body.message).toBe("token has been revoked");
-      expect(body.message).not.toContain(revokedJti);
+    // Spy + suppress so the assertion is the audit-trail invariant for
+    // this scenario, not a stderr inspection. Pattern carries to scribe/agent.
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await authenticateVaultRequest(bearer(token), config, store.db);
+      expect("error" in result).toBe(true);
+      if ("error" in result) {
+        expect(result.error.status).toBe(401);
+        const body = (await result.error.json()) as { error: string; message: string };
+        expect(body.error).toBe("Unauthorized");
+        // Client-facing message must NOT carry the jti — that's a server-side
+        // audit-log concern only. See the `code === "revoked"` branch in
+        // authenticateHubJwt for the sanitization.
+        expect(body.message).toBe("token has been revoked");
+        expect(body.message).not.toContain(revokedJti);
+      }
+      // Audit-log invariant: console.warn fires exactly once with a message
+      // that carries the jti, so an operator chasing a 401 in production logs
+      // can correlate to which token was retired.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnArg = warnSpy.mock.calls[0]![0] as string;
+      expect(warnArg).toContain(revokedJti);
+      expect(warnArg).toContain("revoked");
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 
@@ -305,12 +319,13 @@ describe("authenticateVaultRequest — hub JWT integration", () => {
     }
   });
 
-  test("revocation list unreachable on cold start → fail-closed 401", async () => {
+  test("revocation list unreachable on cold start → fail-closed 401 sanitized; full diagnostic routed to console.warn", async () => {
     seedVault("journal");
     // Hub is reachable for JWKS but the revocation endpoint 503s. Cold cache
     // + first-fetch-fail = "unknown" outcome, surfaced as
-    // HubJwtError(code: "revocation_unavailable"). The auth layer forwards
-    // the message verbatim (no jti to leak; safe to surface the diagnostic).
+    // HubJwtError(code: "revocation_unavailable"). Client gets a code-shaped
+    // sentence; the implementation-detail phrasing ("no last-good cache")
+    // stays in the server-side audit log.
     fixture.setRevocationFails(true);
     const token = await signJwt(kp, {
       iss: fixture.origin,
@@ -320,12 +335,26 @@ describe("authenticateVaultRequest — hub JWT integration", () => {
     const config = readVaultConfig("journal")!;
     const store = getVaultStore("journal");
 
-    const result = await authenticateVaultRequest(bearer(token), config, store.db);
-    expect("error" in result).toBe(true);
-    if ("error" in result) {
-      expect(result.error.status).toBe(401);
-      const body = (await result.error.json()) as { error: string; message: string };
-      expect(body.message).toContain("revocation list unavailable");
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await authenticateVaultRequest(bearer(token), config, store.db);
+      expect("error" in result).toBe(true);
+      if ("error" in result) {
+        expect(result.error.status).toBe(401);
+        const body = (await result.error.json()) as { error: string; message: string };
+        // Client message: code-shaped, no internals.
+        expect(body.message).toBe("token cannot be validated: revocation list unavailable");
+        // The internal phrase "no last-good cache" is a scope-guard
+        // implementation detail and must not leak into the public response.
+        expect(body.message).not.toContain("last-good cache");
+      }
+      // Audit-log invariant: full diagnostic routed to console.warn so
+      // operators can distinguish cold-start from sustained outage.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnArg = warnSpy.mock.calls[0]![0] as string;
+      expect(warnArg).toContain("no last-good cache");
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -275,17 +275,31 @@ async function authenticateHubJwt(
     return { permission, scopes: claims.scopes, legacyDerived: false, scoped_tags: null, vault_name: null };
   } catch (err) {
     if (err instanceof HubJwtError) {
-      // Revoked-token error message carries the jti for operator audit (built
-      // into scope-guard). Log it server-side for the audit trail, but strip
-      // it from the client-facing 401 — the unauthenticated caller doesn't
-      // need to learn which jti was retired. Other HubJwtError codes carry
-      // generic messages and are forwarded as-is (the existing test suite
-      // pins those exact strings).
+      // Revocation-related codes get sanitized client messages: server-side
+      // audit log carries the full diagnostic (jti for `revoked`,
+      // implementation-detail phrasing for `revocation_unavailable`); the
+      // unauthenticated caller gets a code-shaped sentence with no internals.
+      // This is the inheritable pattern across vault/scribe/agent — keep all
+      // revocation-related diagnostics server-side. Other HubJwtError codes
+      // (signature, audience, expired, etc.) carry generic messages and are
+      // forwarded as-is; the existing test suite pins those exact strings.
       if (err.code === "revoked") {
         console.warn(`[auth] hub JWT rejected: ${err.message}`);
         return {
           error: Response.json(
             { error: "Unauthorized", message: "token has been revoked" },
+            { status: 401 },
+          ),
+        };
+      }
+      if (err.code === "revocation_unavailable") {
+        console.warn(`[auth] hub JWT rejected: ${err.message}`);
+        return {
+          error: Response.json(
+            {
+              error: "Unauthorized",
+              message: "token cannot be validated: revocation list unavailable",
+            },
             { status: 401 },
           ),
         };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -275,6 +275,21 @@ async function authenticateHubJwt(
     return { permission, scopes: claims.scopes, legacyDerived: false, scoped_tags: null, vault_name: null };
   } catch (err) {
     if (err instanceof HubJwtError) {
+      // Revoked-token error message carries the jti for operator audit (built
+      // into scope-guard). Log it server-side for the audit trail, but strip
+      // it from the client-facing 401 — the unauthenticated caller doesn't
+      // need to learn which jti was retired. Other HubJwtError codes carry
+      // generic messages and are forwarded as-is (the existing test suite
+      // pins those exact strings).
+      if (err.code === "revoked") {
+        console.warn(`[auth] hub JWT rejected: ${err.message}`);
+        return {
+          error: Response.json(
+            { error: "Unauthorized", message: "token has been revoked" },
+            { status: 401 },
+          ),
+        };
+      }
       return { error: Response.json({ error: "Unauthorized", message: err.message }, { status: 401 }) };
     }
     // Unknown failure shape — surface the message but stay 401.

--- a/src/hub-jwt.test.ts
+++ b/src/hub-jwt.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
 import { generateKeyPair, exportJWK, SignJWT } from "jose";
-import { resetJwksCache, validateHubJwt, looksLikeJwt } from "./hub-jwt.ts";
+import { resetJwksCache, resetRevocationCache, validateHubJwt, looksLikeJwt } from "./hub-jwt.ts";
 
 interface Keypair {
   privateKey: CryptoKey;
@@ -53,11 +53,19 @@ function startJwksFixture(): JwksFixture {
     port: 0,
     fetch(req) {
       const url = new URL(req.url);
-      if (url.pathname !== "/.well-known/jwks.json") {
-        return new Response("not found", { status: 404 });
-      }
       if (down) return new Response("upstream down", { status: 503 });
-      return Response.json({ keys: keys.map((k) => k.publicJwk) });
+      if (url.pathname === "/.well-known/jwks.json") {
+        return Response.json({ keys: keys.map((k) => k.publicJwk) });
+      }
+      // scope-guard 0.2+ consults `/.well-known/parachute-revocation.json` on
+      // every JWT validation (when the token has a jti). Serve an empty list
+      // by default so unrelated tests in this file aren't fail-closed by a
+      // 404 on that endpoint. The integration tests (`auth-hub-jwt.test.ts`)
+      // own the revoked-jti / fail-closed cases separately.
+      if (url.pathname === "/.well-known/parachute-revocation.json") {
+        return Response.json({ generated_at: new Date().toISOString(), jtis: [] });
+      }
+      return new Response("not found", { status: 404 });
     },
   });
   return {
@@ -121,6 +129,9 @@ beforeEach(() => {
   fixture.setUnreachable(false);
   fixture.setKeys([kp]);
   resetJwksCache();
+  // Drop the per-process revocation cache so each test starts cold against
+  // the fixture (an empty list by default; tests opt into populated lists).
+  resetRevocationCache();
 });
 
 describe("looksLikeJwt", () => {

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -75,5 +75,14 @@ export function resetJwksCache(): void {
   guard.resetJwksCache();
 }
 
+/**
+ * Reset the cached revocation list. Tests use this to start from a clean
+ * fail-closed state between cases; production callers shouldn't need it
+ * (the cache refreshes itself on TTL expiry).
+ */
+export function resetRevocationCache(): void {
+  guard.resetRevocationCache();
+}
+
 export { HubJwtError, looksLikeJwt };
 export type { HubJwtClaims, ValidateHubJwtOptions };

--- a/src/tokens-routes.test.ts
+++ b/src/tokens-routes.test.ts
@@ -31,7 +31,7 @@ const { route } = await import("./routing.ts");
 const { writeGlobalConfig, writeVaultConfig } = await import("./config.ts");
 const { clearVaultStoreCache, getVaultStore } = await import("./vault-store.ts");
 const { generateToken, createToken, resolveToken } = await import("./token-store.ts");
-const { resetJwksCache } = await import("./hub-jwt.ts");
+const { resetJwksCache, resetRevocationCache } = await import("./hub-jwt.ts");
 
 interface Keypair {
   privateKey: CryptoKey;
@@ -59,10 +59,16 @@ function startJwksFixture(keys: Keypair[]): JwksFixture {
     port: 0,
     fetch(req) {
       const url = new URL(req.url);
-      if (url.pathname !== "/.well-known/jwks.json") {
-        return new Response("not found", { status: 404 });
+      if (url.pathname === "/.well-known/jwks.json") {
+        return Response.json({ keys: keys.map((k) => k.publicJwk) });
       }
-      return Response.json({ keys: keys.map((k) => k.publicJwk) });
+      // scope-guard 0.2+ consults the revocation list on every JWT validation
+      // (when the token has a jti). Empty list = "clear" outcome; tokens
+      // signed in this suite all pass the revocation check.
+      if (url.pathname === "/.well-known/parachute-revocation.json") {
+        return Response.json({ generated_at: new Date().toISOString(), jtis: [] });
+      }
+      return new Response("not found", { status: 404 });
     },
   });
   return {
@@ -132,6 +138,7 @@ beforeEach(async () => {
   prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
   process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
   resetJwksCache();
+  resetRevocationCache();
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

- Bumps `@openparachute/scope-guard` `^0.1.0` → `^0.2.0`. The new version's `validateHubJwt` consults `<hub-origin>/.well-known/parachute-revocation.json` after sig/iss/aud/expiry pass; revoked jtis surface as `HubJwtError(code: "revoked")` and are rejected at `authenticateVaultRequest` with a 401.
- Without this change, an operator could revoke a hub-issued JWT via the hub's mint API (hub#215, Phase 1) but vault would still honor it. This PR closes that gap from vault's side.
- `pvt_*` opaque-token path is untouched. Phase 6 deprecates `pvt_*` separately.

## Behavior

- **60s TTL** on the revocation cache (matches hub's `Cache-Control: max-age=60` on the endpoint).
- **Fail-open with last-good** cache during a hub outage — a revoked token may be accepted up to ~60s past revocation when the hub is unreachable; matches the published convergence target.
- **Fail-closed only on first-fetch-failure** (cold start, no last-good). Surfaces as `HubJwtError(code: "revocation_unavailable")` so operators can tell "list couldn't load" from "this token has been retired."
- Client-facing 401 for revoked tokens is **sanitized** — the jti goes to the server-side audit log via `console.warn`, not into the response body. Other failure modes forward the diagnostic message as before (those carry no jti).

The cache mechanics (TTL refresh, fail-open with last-good, single-flight, recovery from cold-start) live in scope-guard and are covered by its own unit suite. Vault's tests pin the wire-up and the 401 response shapes.

## Files

- `package.json`, `bun.lock` — dep bump + version `0.4.1-rc.5` → `0.4.1-rc.6` (continues the rc chain).
- `src/hub-jwt.ts` — re-export `resetRevocationCache` (parallel to `resetJwksCache`) for tests.
- `src/auth.ts` — special-case `code: "revoked"` in `authenticateHubJwt`: log server-side, sanitize client message.
- `src/auth-hub-jwt.test.ts` — fixture extended to serve revocation; new cases for revoked jti rejection (with sanitization assertion), mixed-list happy path, cold-start unreachable.
- `src/hub-jwt.test.ts`, `src/tokens-routes.test.ts` — fixtures extended to serve `/.well-known/parachute-revocation.json` (empty list by default) so signature/audience/JWKS-rotation tests aren't fail-closed by the new cache requirement.
- `CHANGELOG.md` — `## [0.4.1-rc.6] — 2026-05-10` entry.

## Test plan

- [x] `bun test ./src/` — 800 pass / 0 fail.
- [x] `bun run typecheck` — clean.
- [x] Verified the new revocation cases:
  - revoked jti → 401 with `message: "token has been revoked"` (no jti leak); server log shows `[auth] hub JWT rejected: hub JWT revoked: jti "..." is in the revocation list`.
  - non-revoked jti against populated list → 200 (cache returns "clear").
  - cold-start with revocation endpoint 503 → 401, `message` contains `"revocation list unavailable"`.
- [ ] Aaron post-merge smoke: mint a hub-issued JWT for a vault scope, immediately revoke its jti via the hub's revocation API (or admin tooling once hub#TBD lands), make a vault request → expect 401.

## Patterns check

- Patterns touched: `parachute-patterns/research/auth-architecture-shape.md` §11 (convergence design — Phase 4 vault-side).
- Conformance: matches the spec — RS consumes hub's revocation list, 60s TTL, fail-open with last-good, fail-closed on first-fetch-failure.
- No new pattern established.

## Versioning

`0.4.1-rc.5` → `0.4.1-rc.6`. The rc chain was already in flight; per the pre-1.0 governance rule, code-touching PRs bump rc.N only — the patch number waits for an Aaron-confirmed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)