### PR TITLE
feat(api): updated_at filter + update-note response-shape opt-out (vault#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.3-rc.1] — 2026-05-10
+
+Two small additive enhancements distilled from the field-input evaluation in
+vault#285. Neither changes existing behavior; both are opt-in conveniences for
+agents and SSGs already hitting vault's query and write surfaces.
+
+### Read path
+
+- **`dateFilter` recognizes `updated_at` (vault#285 friction point 1.5).**
+  Today `dateFilter.field` accepted only `created_at` or an indexed metadata
+  field. `updated_at` joins them as a recognized real column — no indexed-field
+  declaration required, no schema setup. Unblocks the incremental-rebuild
+  pattern an SSG (or any syncing consumer) reaches for: ask vault "what
+  changed since my last build" via
+  `dateFilter: { field: "updated_at", from: lastBuildISO }`. Same API across
+  MCP (`date_filter.field`) and HTTP (`?date_field=updated_at&date_from=…`).
+  No B-tree index on `updated_at` today; a sequential scan is fine for the
+  current sizes (file an issue if a real workload ever shows it).
+
+### Write path
+
+- **`update-note` response-shape opt-out (vault#285 friction point 2.response).**
+  `update-note` accepts a new `include_content: boolean` parameter. Default
+  is `true` for back-compat — existing callers see no change. Set to `false`
+  and the response swaps the full `Note` for the lean `NoteIndex` shape
+  (`id`, `path`, `createdAt`, `updatedAt`, `tags`, `metadata`, `byteSize`,
+  `preview`); `validation_status` is preserved when present. Cuts the
+  response cost on the agent workflow that motivated this — frequent
+  `append` / `content_edit` edits to large notes — by an order of magnitude
+  for big notes. Exposed via MCP `update-note` and HTTP `PATCH /notes/:id`.
+
+### Notes on what stayed put
+
+The wider vault#285 evaluation surfaced six other friction points. None ship
+here; the framing is "small additive only, defer design choices":
+
+- **1.1 path_prefix** — already shipped end-to-end (MCP + HTTP + storage).
+- **1.2 sort by metadata** — already shipped via `order_by` on indexed fields.
+- **1.3 metadata-value filters on HTTP REST** — engine + MCP have it; the
+  HTTP query-string syntax is a design choice still pending.
+- **1.4 tunable preview length** — `NoteIndex` already returns a 120-char
+  preview; a knob is deferred until concretely needed.
+- **1.6 URL-safe slug** — design pending (stability under rename, derive
+  from id vs path); deferred until a renderer needs it.
+- **1.7 Tailscale Funnel** — already documented in README §"Remote access
+  via Tailscale Funnel."
+- **Section 2 section/diff/line-range edits** — speculative; the
+  `append`/`prepend`/`content_edit` primitives that already shipped in
+  #200 cover the originating workflow; the response-side cost is what
+  this release closes.
+
 ## [0.4.2] — 2026-05-10
 
 Six release cuts (`0.4.1-rc.1` through `0.4.1-rc.6`) ship together as

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -1089,6 +1089,58 @@ describe("queryNotes", async () => {
       }) as any[];
       expect(results.map((n) => n.content)).toEqual(["recent email"]);
     });
+
+    // ---- updated_at filter (vault#285 friction point 1.5) ----
+    //
+    // Incremental-rebuild flows ask "what changed since X." Like `created_at`,
+    // `updated_at` is a real column on `notes` (no indexed-field gate), but
+    // it tracks the *last write* rather than ingestion time. SSGs paginate
+    // against it; sync clients use it as a high-watermark cursor.
+    it("dateFilter on updated_at routes to the n.updated_at column (vault#285 1.5)", async () => {
+      // Two notes; only one is later modified. The filter should pick up the
+      // modification time, not the original creation time.
+      const a = await store.createNote("untouched", { created_at: "2026-01-15T00:00:00.000Z" });
+      const b = await store.createNote("modified-later", { created_at: "2026-01-20T00:00:00.000Z" });
+      // Mutate b to bump its updated_at into a window that excludes a.
+      await store.updateNote(b.id, { append: " edit" });
+
+      // Pin each note's updated_at deterministically so the assertion isn't
+      // racing real wall-clock writes from the test harness.
+      db.prepare("UPDATE notes SET updated_at = ? WHERE id = ?")
+        .run("2026-01-15T00:00:00.000Z", a.id);
+      db.prepare("UPDATE notes SET updated_at = ? WHERE id = ?")
+        .run("2026-04-25T00:00:00.000Z", b.id);
+
+      const results = await store.queryNotes({
+        dateFilter: { field: "updated_at", from: "2026-04-01" },
+      });
+      expect(results.map((n) => n.content)).toEqual(["modified-later edit"]);
+    });
+
+    it("dateFilter on updated_at requires no indexed-field declaration", async () => {
+      // `updated_at` is a recognized real column — must not hit the
+      // requireIndexedField gate that fires for arbitrary metadata fields.
+      await store.createNote("x");
+      // Should not throw.
+      const results = await store.queryNotes({
+        dateFilter: { field: "updated_at", from: "1970-01-01" },
+      });
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    it("dateFilter on updated_at honors the upper-bound exclusive `to`", async () => {
+      const a = await store.createNote("inside-window");
+      const b = await store.createNote("after-window");
+      db.prepare("UPDATE notes SET updated_at = ? WHERE id = ?")
+        .run("2026-04-25T00:00:00.000Z", a.id);
+      db.prepare("UPDATE notes SET updated_at = ? WHERE id = ?")
+        .run("2026-05-15T00:00:00.000Z", b.id);
+
+      const results = await store.queryNotes({
+        dateFilter: { field: "updated_at", from: "2026-04-01", to: "2026-05-01" },
+      });
+      expect(results.map((n) => n.content)).toEqual(["inside-window"]);
+    });
   });
 
   it("sorts ascending and descending", async () => {
@@ -1709,6 +1761,96 @@ describe("MCP tools", async () => {
     expect(err.note_id).toBe(note.id);
     expect(err.note_path).toBe("Inbox/x");
     expect((await store.getNote(note.id))!.content).toBe("Test");
+  });
+
+  // ---- include_content response-shape opt-out (vault#285 friction point 2.response) ----
+  //
+  // Default behavior is unchanged: full Note is returned with `content`.
+  // Setting `include_content: false` swaps in the lean NoteIndex shape
+  // (drops content, adds byteSize + preview). Cuts the response cost on
+  // small-edit / large-note workflows.
+  describe("update-note include_content", () => {
+    it("defaults to full Note (back-compat)", async () => {
+      const note = await store.createNote("Original body", { path: "x" });
+      const tools = generateMcpTools(store);
+      const updateNote = tools.find((t) => t.name === "update-note")!;
+      const result = await updateNote.execute({
+        id: note.id,
+        content: "Replaced body",
+        force: true,
+      }) as any;
+      expect(result.content).toBe("Replaced body");
+      // Index-only fields must NOT appear on the back-compat shape.
+      expect(result.byteSize).toBeUndefined();
+      expect(result.preview).toBeUndefined();
+    });
+
+    it("include_content: false returns the lean NoteIndex shape", async () => {
+      const longBody = "a".repeat(5_000);
+      const note = await store.createNote(longBody, { path: "big-note" });
+      const tools = generateMcpTools(store);
+      const updateNote = tools.find((t) => t.name === "update-note")!;
+      const result = await updateNote.execute({
+        id: note.id,
+        append: " edit",
+        include_content: false,
+      }) as any;
+      // No content payload — that's the whole point of the opt-out.
+      expect(result.content).toBeUndefined();
+      // Index fields present.
+      expect(typeof result.byteSize).toBe("number");
+      expect(result.byteSize).toBe(5_000 + 5); // original + " edit"
+      expect(typeof result.preview).toBe("string");
+      expect(result.preview.length).toBeGreaterThan(0);
+      expect(result.id).toBe(note.id);
+      expect(result.path).toBe("big-note");
+      expect(result.updatedAt).toBeTruthy();
+    });
+
+    it("include_content: false applies uniformly across batch responses", async () => {
+      await store.createNote("A", { id: "a", path: "a" });
+      await store.createNote("B", { id: "b", path: "b" });
+      const tools = generateMcpTools(store);
+      const updateNote = tools.find((t) => t.name === "update-note")!;
+      const result = await updateNote.execute({
+        include_content: false,
+        notes: [
+          { id: "a", content: "A v2", force: true },
+          { id: "b", append: " v2" },
+        ],
+      }) as any[];
+      expect(result).toHaveLength(2);
+      for (const item of result) {
+        expect(item.content).toBeUndefined();
+        expect(typeof item.byteSize).toBe("number");
+        expect(typeof item.preview).toBe("string");
+      }
+    });
+
+    it("include_content: false preserves validation_status when present", async () => {
+      // Declare a tag schema with an indexed `priority` field that constrains
+      // values; then write a note whose metadata violates the schema, so
+      // attachValidationStatus has something to surface.
+      await store.upsertTagSchema("task", {
+        description: "tasks",
+        fields: {
+          priority: { type: "string", enum: ["low", "med", "high"], indexed: false },
+        },
+      });
+      await store.createNote("a task", { id: "t1", tags: ["task"] });
+      const tools = generateMcpTools(store);
+      const updateNote = tools.find((t) => t.name === "update-note")!;
+      const result = await updateNote.execute({
+        id: "t1",
+        metadata: { priority: "URGENT" }, // not in enum — generates a warning
+        include_content: false,
+        force: true,
+      }) as any;
+      expect(result.content).toBeUndefined();
+      expect(result.validation_status).toBeTruthy();
+      expect(Array.isArray(result.validation_status.warnings)).toBe(true);
+      expect(result.validation_status.warnings.length).toBeGreaterThan(0);
+    });
   });
 
   it("update-note force:true bypasses precondition and mutates unconditionally", async () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -144,11 +144,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           date_filter: {
             type: "object",
             properties: {
-              field: { type: "string", description: "Field to filter on. Defaults to `created_at` (vault ingestion time). Any other field must be declared `indexed: true` in a tag schema — same contract as metadata operator queries and `order_by`." },
+              field: { type: "string", description: "Field to filter on. Defaults to `created_at` (vault ingestion time). `updated_at` is also recognized as a real column — use it for incremental rebuilds (\"what changed since X\"). Any other field must be declared `indexed: true` in a tag schema — same contract as metadata operator queries and `order_by`." },
               from: { type: "string", description: "Inclusive lower bound (ISO date)." },
               to: { type: "string", description: "Exclusive upper bound (ISO date)." },
             },
-            description: "Generalized date-range filter. Use this when the date that matters is the *content* date (e.g. an email's received date, a meeting's scheduled date), not the vault ingestion time — set `field` to the indexed metadata field that holds it. Mutually exclusive with the top-level `date_from` / `date_to` shorthand.",
+            description: "Generalized date-range filter. Use this when the date that matters is the *content* date (e.g. an email's received date, a meeting's scheduled date) rather than the vault ingestion time, or when paging by `updated_at` for incremental rebuilds. Mutually exclusive with the top-level `date_from` / `date_to` shorthand.",
           },
           near: {
             type: "object",
@@ -468,7 +468,8 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
 - \`links: { add: [{ target, relationship }], remove: [{ target, relationship }] }\` — add/remove links
 - When removing a wikilink-type link, \`[[brackets]]\` are also removed from content.
 - For batch: pass a \`notes\` array, each with an \`id\` field.
-- **Optimistic concurrency is required by default.** Pass \`if_updated_at\` with the \`updated_at\` value you last read — the update is rejected with a conflict error if the note has changed since. Re-read, reconcile, and retry. To skip the safety check (e.g. bulk migration), pass \`force: true\` instead; the update then runs unconditionally. \`append\` / \`prepend\` only updates are exempt from the precondition (no-conflict-by-design).`,
+- **Optimistic concurrency is required by default.** Pass \`if_updated_at\` with the \`updated_at\` value you last read — the update is rejected with a conflict error if the note has changed since. Re-read, reconcile, and retry. To skip the safety check (e.g. bulk migration), pass \`force: true\` instead; the update then runs unconditionally. \`append\` / \`prepend\` only updates are exempt from the precondition (no-conflict-by-design).
+- \`include_content\` (default \`true\`) — set \`false\` to receive a lean index shape (\`id\`, \`path\`, \`createdAt\`, \`updatedAt\`, \`tags\`, \`metadata\`, \`byteSize\`, \`preview\`) instead of full content. Useful for agents making frequent small edits to large notes (e.g. via \`append\` or \`content_edit\`) where re-receiving the body is the dominant cost. \`validation_status\` is preserved on the lean shape when present.`,
       inputSchema: {
         type: "object",
         properties: {
@@ -525,6 +526,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               },
             },
             description: "Links to add/remove",
+          },
+          include_content: {
+            type: "boolean",
+            description: "Response shape opt-out. Default `true` (returns the full Note with content). Set `false` to receive the lean index shape (drops `content`, adds `byteSize` and a whitespace-collapsed `preview`). `validation_status` is preserved on the lean shape when present. Applies uniformly to single and batch responses.",
           },
           // Batch
           notes: {
@@ -737,7 +742,19 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           throw e;
         }
 
-        const final = updated.map((n) => attachValidationStatus(store, db, n));
+        // Response shape: full Note (back-compat default) or lean NoteIndex
+        // (#285 friction point 2.response — opt-out for callers making
+        // frequent small edits to large notes). `validation_status` from
+        // `tags.fields` is preserved across either shape.
+        const includeContent = params.include_content !== false;
+        const final = updated.map((n) => {
+          const validated = attachValidationStatus(store, db, n);
+          if (includeContent) return validated;
+          const lean: any = noteOps.toNoteIndex(validated);
+          const vs = (validated as any).validation_status;
+          if (vs !== undefined) lean.validation_status = vs;
+          return lean;
+        });
         return batch ? final : final[0];
       },
     },

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -512,10 +512,18 @@ export function queryNotes(db: Database, opts: QueryOpts): Note[] {
   //   - Legacy `dateFrom` / `dateTo` — always filters on `n.created_at`
   //     (vault ingestion time).
   //   - Generalized `dateFilter: { field, from, to }` — filters on the
-  //     named field. `created_at` (default) maps to `n.created_at`; any
-  //     other field must be declared `indexed: true` so the SQL targets
-  //     a real B-tree index. The two shapes are mutually exclusive — the
-  //     combination would silently AND, which would be surprising.
+  //     named field. `created_at` (default) and `updated_at` map to the
+  //     real columns on `notes`; any other field must be declared
+  //     `indexed: true` so the SQL targets a real B-tree index. The two
+  //     shapes are mutually exclusive — the combination would silently
+  //     AND, which would be surprising.
+  //
+  // `updated_at` enables incremental-rebuild flows (vault#285 1.5): an
+  // SSG or syncer asks "what changed since my last build" via
+  // `dateFilter: { field: "updated_at", from: lastBuildISO }`. There's
+  // no B-tree on `updated_at` today; a sequential scan is acceptable up
+  // to ~tens of thousands of notes. Add an index if the scan ever shows
+  // up in a real workload.
   const hasLegacyDate = opts.dateFrom !== undefined || opts.dateTo !== undefined;
   const hasDateFilter = opts.dateFilter !== undefined;
   if (hasLegacyDate && hasDateFilter) {
@@ -530,6 +538,8 @@ export function queryNotes(db: Database, opts: QueryOpts): Note[] {
     let column: string;
     if (field === "created_at") {
       column = "n.created_at";
+    } else if (field === "updated_at") {
+      column = "n.updated_at";
     } else {
       // Re-uses the same indexed-field gate as `metadata` operator queries
       // and `orderBy` so the error message and contract are consistent.

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -80,12 +80,14 @@ export interface QueryOpts {
   // as the common path; specifying both this and `dateFilter` rejects.
   dateFrom?: string;    // ISO date
   dateTo?: string;      // ISO date
-  // Generalized date range. `field` defaults to `created_at`; any other
-  // field must be declared `indexed: true` in a tag schema (so the SQL
-  // hits a real B-tree index, same contract as `metadata` operator
-  // queries and `orderBy`). Use this to filter on a *content* date — an
-  // email's received date, a meeting's scheduled date — rather than the
-  // ingestion timestamp.
+  // Generalized date range. `field` defaults to `created_at`; `updated_at`
+  // is also a recognized real column (the incremental-rebuild path —
+  // vault#285 1.5). Any other field must be declared `indexed: true` in a
+  // tag schema (so the SQL hits a real B-tree index, same contract as
+  // `metadata` operator queries and `orderBy`). Use this to filter on a
+  // *content* date — an email's received date, a meeting's scheduled
+  // date — rather than the ingestion timestamp, or on `updated_at` to ask
+  // "what changed since X."
   dateFilter?: {
     field?: string;
     from?: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.2",
+  "version": "0.4.3-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -740,7 +740,14 @@ export async function handleNotes(
         }
       }
 
-      return json(await store.getNote(note.id));
+      // Response shape: full Note (back-compat default) or lean NoteIndex
+      // (vault#285 friction point 2.response — opt-out for callers making
+      // frequent small edits to large notes). Mirror the MCP `update-note`
+      // `include_content` knob exactly.
+      const updatedNote = await store.getNote(note.id);
+      if (updatedNote === null) return json({ error: "Note disappeared" }, 404);
+      const includeContentResp = body.include_content !== false;
+      return json(includeContentResp ? updatedNote : toNoteIndex(updatedNote));
     } catch (e: any) {
       if (e instanceof NotFoundError) return json({ error: e.message }, 404);
       // Duck-type on `code` rather than `instanceof ConflictError`: this

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1550,6 +1550,31 @@ describe("HTTP /notes", async () => {
     expect(body.map((n) => n.content)).toEqual(["plain"]);
   });
 
+  // ---- updated_at filter via date_field (vault#285 friction point 1.5) ----
+  //
+  // HTTP plumbing routes `date_field=updated_at&date_from=…` straight to
+  // the core `dateFilter` resolver, which now recognizes `updated_at` as
+  // a real column. Smoke-tests the end-to-end HTTP path; the engine-side
+  // semantics are exercised in core.test.ts.
+  test("GET /notes?date_field=updated_at filters by last-write time", async () => {
+    const a = await store.createNote("untouched", { id: "ua", path: "ua" });
+    const b = await store.createNote("modified", { id: "ub", path: "ub" });
+    // Bump b's updated_at into the test window, leave a's at its createdAt.
+    db.prepare("UPDATE notes SET updated_at = ? WHERE id = ?")
+      .run("2026-01-15T00:00:00.000Z", a.id);
+    db.prepare("UPDATE notes SET updated_at = ? WHERE id = ?")
+      .run("2026-04-25T00:00:00.000Z", b.id);
+
+    const res = await handleNotes(
+      mkReq("GET", "/notes?date_field=updated_at&date_from=2026-04-01&include_content=true"),
+      store,
+      "",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any[];
+    expect(body.map((n) => n.content)).toEqual(["modified"]);
+  });
+
   test("GET /notes?has_links=false returns only orphaned notes", async () => {
     const a = await store.createNote("src", { id: "qa" });
     const b = await store.createNote("tgt", { id: "qb" });
@@ -2352,6 +2377,39 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect(body.path).toBe("beta");
     // Source note unchanged
     expect((await store.getNote("a"))!.path).toBe("alpha");
+  });
+
+  // ---- include_content response-shape opt-out (vault#285 friction point 2.response) ----
+  test("PATCH defaults to returning the full Note (back-compat)", async () => {
+    await store.createNote("body", { id: "x" });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/x", { content: "updated", force: true }),
+      store,
+      "/x",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.content).toBe("updated");
+    expect(body.byteSize).toBeUndefined();
+    expect(body.preview).toBeUndefined();
+  });
+
+  test("PATCH with include_content: false returns the lean NoteIndex shape", async () => {
+    const longBody = "x".repeat(2_000);
+    await store.createNote(longBody, { id: "big", path: "big" });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/big", { append: " edit", include_content: false }),
+      store,
+      "/big",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.content).toBeUndefined();
+    expect(typeof body.byteSize).toBe("number");
+    expect(body.byteSize).toBe(2_000 + 5);
+    expect(typeof body.preview).toBe("string");
+    expect(body.id).toBe("big");
+    expect(body.path).toBe("big");
   });
 });
 


### PR DESCRIPTION
## Summary

Two small additive enhancements distilled from the vault#285 field-input evaluation. Both are opt-in conveniences with zero behavior change for existing callers.

- **Read path (vault#285 1.5).** `dateFilter` now recognizes `updated_at` as a real column — no indexed-field declaration required. Unblocks the incremental-rebuild pattern: `dateFilter: { field: "updated_at", from: lastBuildISO }` ⇒ "what changed since X." Same API across MCP (`date_filter.field`) and HTTP (`?date_field=updated_at&date_from=…`).
- **Write path (vault#285 2.response).** New `include_content` parameter on `update-note`. Default `true` (back-compat). Set `false` to receive the lean `NoteIndex` shape (drops `content`, keeps `byteSize`/`preview`/`validation_status`). Cuts response cost for the agent workflow of frequent `append`/`content_edit` edits to large notes. Exposed via MCP `update-note` and HTTP `PATCH /notes/:id`.

## Out of scope (per design conversation)

The wider vault#285 evaluation surfaced six other friction points; none ship here. 1.1 path_prefix and 1.2 sort-by-metadata were already shipped end-to-end. 1.3 HTTP-side metadata filters need a syntax design decision. 1.4 tunable preview length, 1.6 slug, 1.7 Funnel discoverability are deferred. Section 2 section/diff/line-range edits are speculative — the originating workflow is mostly addressed by the `append`/`prepend`/`content_edit` primitives shipped in #200; this PR closes the response-side residue.

CHANGELOG entry expands on each deferred item.

## Version

`0.4.2` → `0.4.3-rc.1` (per governance: rc bumps until ready-for-release).

## Test plan

- [x] `bun test ./core/src/` — 429/429 pass
- [x] `bun test ./src/` — 803/803 pass
- [x] Combined: 1232/1232 pass, 3295 expect() calls
- [x] `bunx tsc --noEmit` clean
- [x] Manual review: full Note still returned by default for both MCP `update-note` and HTTP `PATCH /notes/:id`; lean shape only when `include_content: false`
- [x] Manual review: `dateFilter` on `created_at` and indexed metadata fields unchanged; `updated_at` is the only new accepted column

## New tests

- `core/src/core.test.ts`:
  - `dateFilter on updated_at routes to the n.updated_at column`
  - `dateFilter on updated_at requires no indexed-field declaration`
  - `dateFilter on updated_at honors the upper-bound exclusive 'to'`
  - `update-note defaults to full Note (back-compat)`
  - `update-note include_content: false returns the lean NoteIndex shape`
  - `update-note include_content: false applies uniformly across batch responses`
  - `update-note include_content: false preserves validation_status when present`
- `src/vault.test.ts`:
  - `GET /notes?date_field=updated_at filters by last-write time`
  - `PATCH defaults to returning the full Note (back-compat)`
  - `PATCH with include_content: false returns the lean NoteIndex shape`

Refs vault#285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)