### PR TITLE
feat(api): HTTP bracket-style metadata filter (vault#285 1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,87 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.3-rc.2] — 2026-05-11
+
+Closes the HTTP-side gap in vault's metadata-filter surface (vault#285
+friction point 1.3). The engine has always supported the full operator set —
+`eq`/`ne`/`gt`/`gte`/`lt`/`lte`/`in`/`not_in`/`exists` — and MCP exposes it.
+Until this release, the HTTP route declared the surface "not practical in
+query params" and dropped it entirely. Bracket-style filtering plumbs it
+through with a consistent shape.
+
+### Read path
+
+- **Bracket-style metadata filter on `GET /notes` (vault#285 friction point 1.3).**
+  Uses the Stripe / JSON:API / Strapi convention:
+
+  ```
+  ?meta[field][op]=value                 # eq, ne, gt, gte, lt, lte
+  ?meta[field]=value                     # shorthand for eq (JSON-scan fallback;
+                                         # no indexed-field declaration required)
+  ?meta[field][in][]=v1&meta[field][in][]=v2   # array form
+  ?meta[field][in]=v1,v2                 # comma-separated form
+  ?meta[field][exists]=true              # presence check (true|false only)
+  ```
+
+  Multiple `meta[...]` params AND together. Same-field operators (e.g.
+  `meta[score][gte]=5&meta[score][lt]=10`) merge into one operator object.
+  Hand-rolled parser in `src/routes.ts` — vault doesn't ship the `qs`
+  dependency, and the grammar is small enough that one regex + a couple of
+  buckets is cleaner than pulling in a parser library.
+
+- **Bridge for `created_at` / `updated_at` columns.** Bracket-style also
+  accepts the real date columns:
+
+  ```
+  ?meta[created_at][gte]=2026-04-01
+  ?meta[updated_at][gte]=2026-04-01
+  ?meta[created_at][lt]=2026-05-01
+  ```
+
+  These route through `dateFilter` (not through `metadata`) because they're
+  real columns on `notes`, not metadata fields — same exemption as the
+  existing flat-param path. Only `gte` (→ inclusive `from`) and `lt` (→
+  exclusive `to`) are accepted on these fields; other operators reject with
+  a guiding error that names the supported ops. Matches the dateFilter
+  contract exactly — `>= from AND < to` is half-open by design.
+
+- **Tag-authorizes-index gate flows through.** Operator queries on a metadata
+  field still require the field to be declared `indexed: true` in some tag
+  schema (the engine's existing contract at
+  `core/src/indexed-fields.ts:1-17`). Bracket-style errors surface as
+  HTTP 400 with `code: "FIELD_NOT_INDEXED"`. Shorthand `?meta[field]=value`
+  is the exception: it uses the json_extract fallback path and doesn't
+  require an index, mirroring the engine's existing primitive-equality
+  semantics.
+
+### Deprecation
+
+- **Flat date params are deprecated.** `?date_field=`, `?date_from=`,
+  `?date_to=` (and the legacy bare-`date_from`/`date_to` shape) remain
+  functional through the 0.5.x line — no behavior change for existing
+  consumers — but bracket-style is canonical going forward. Planned removal
+  in 0.6.0; tracked at vault#288. On overlap (a request that supplies both
+  forms), bracket wins.
+
+### Test plan
+
+- 18 new HTTP tests in `src/vault.test.ts` covering: every operator, both
+  array forms, shorthand equality, compound AND on one field and across
+  fields, the `created_at`/`updated_at` bridge, deprecation precedence
+  (bracket wins), and all the rejection paths (unsupported date-column op,
+  non-boolean `exists`, non-indexed field, unknown operator).
+- 1250/1250 tests pass.
+
+### Out of scope
+
+- OR composition across `metadata` filters — the engine's `metadata` shape
+  doesn't expose OR; left for a future engine-level decision.
+- CLI bracket-style — CLI uses the MCP shape directly; not affected.
+- Bumping the operator set on date columns past `gte`/`lt` — would require
+  engine-side work and the half-open contract is intentional. Document
+  rather than expand.
+
 ## [0.4.3-rc.1] — 2026-05-10
 
 Two small additive enhancements distilled from the field-input evaluation in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
-## [0.4.3-rc.2] — 2026-05-11
+## [0.4.3-rc.2] — 2026-05-10
 
 Closes the HTTP-side gap in vault's metadata-filter surface (vault#285
 friction point 1.3). The engine has always supported the full operator set —
@@ -69,14 +69,40 @@ through with a consistent shape.
   in 0.6.0; tracked at vault#288. On overlap (a request that supplies both
   forms), bracket wins.
 
+### Parser hardening (review folds on initial implementation)
+
+The parser holds invariants that the engine doesn't enforce on its side,
+because by the time bad input reaches the engine the parser has already
+flattened things. Three classes of silent-data-loss caught in review:
+
+- **Cross-column date filter rejection.** A request mixing
+  `meta[created_at][gte]=…` and `meta[updated_at][lt]=…` previously
+  flattened both onto a single column (whichever was parsed second won),
+  silently applying one column's bound against the wrong column. Now
+  rejects with INVALID_QUERY.
+- **Shorthand-vs-operator on the same field is mutually exclusive.**
+  `meta[field]=v` and `meta[field][gt]=w` in the same request used to
+  silently stomp each other based on URL parameter order (insertion-order
+  iteration). Both directions now reject with INVALID_QUERY.
+- **`[]` array syntax is gated to `in` / `not_in`.** `meta[field][eq][]=v`
+  is a shape error rather than a "happens to be an array passed to a
+  scalar operator" — now caught at the parser layer with a clear message
+  rather than via a generic engine-side INVALID_OPERATOR_VALUE.
+
+Also: refactored the array-bucket keying from `${field}|${op}` string concat
+to a nested `Map<field, Map<op, values>>` so field-name characters can't
+collide with the delimiter.
+
 ### Test plan
 
-- 18 new HTTP tests in `src/vault.test.ts` covering: every operator, both
+- 23 new HTTP tests in `src/vault.test.ts` covering: every operator, both
   array forms, shorthand equality, compound AND on one field and across
   fields, the `created_at`/`updated_at` bridge, deprecation precedence
-  (bracket wins), and all the rejection paths (unsupported date-column op,
-  non-boolean `exists`, non-indexed field, unknown operator).
-- 1250/1250 tests pass.
+  (bracket wins), every rejection path (unsupported date-column op,
+  non-boolean `exists`, non-indexed field, unknown operator), and the
+  three silent-data-loss guards (cross-column date, shorthand+operator
+  mix in both orderings, `[]` on non-array operator).
+- 1255/1255 tests pass.
 
 ### Out of scope
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.3-rc.1",
+  "version": "0.4.3-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -81,6 +81,184 @@ function parseInt10(val: string | null): number | undefined {
 }
 
 /**
+ * Parse bracket-style metadata filters (vault#285 friction point 1.3).
+ *
+ * Maps `?meta[field][op]=value` (Stripe / JSON:API / Strapi convention) to
+ * the engine `metadata` filter shape at `core/src/notes.ts:494-509`. Recognised
+ * forms:
+ *
+ *   - `?meta[field]=value`                 — shorthand equality (JSON-scan;
+ *                                            no indexed-field declaration
+ *                                            required)
+ *   - `?meta[field][op]=value`             — operator query (routes through
+ *                                            the indexed generated column;
+ *                                            engine raises FIELD_NOT_INDEXED
+ *                                            if the field isn't declared)
+ *   - `?meta[field][in][]=v1&[in][]=v2`    — array form for in/not_in
+ *   - `?meta[field][in]=v1,v2`             — comma-separated form for in/not_in
+ *
+ * Supported operators mirror the engine: `eq`, `ne`, `gt`, `gte`, `lt`,
+ * `lte`, `in`, `not_in`, `exists`. `exists` requires `"true"` or `"false"`;
+ * other values reject with INVALID_OPERATOR_VALUE.
+ *
+ * Compound filters AND together: multiple `meta[a][gte]=1&meta[a][lt]=5`
+ * on the same field merge into one operator object; filters on different
+ * fields stack as independent AND clauses (engine semantics).
+ *
+ * **Bridge for the real `n.created_at` / `n.updated_at` columns** — these
+ * route through `dateFilter` (the existing engine path that exempts them
+ * from the indexed-field gate), not through the metadata-filter path. Only
+ * `gte` (→ inclusive `from`) and `lt` (→ exclusive `to`) are accepted on
+ * these fields, matching the dateFilter contract exactly. Other operators
+ * reject with INVALID_QUERY so callers don't think `meta[created_at][eq]=…`
+ * works.
+ *
+ * Returns `{ metadata?, dateFilter?, error? }`. When `error` is set the
+ * caller should return it directly (already shaped as a 400 with
+ * `error` + `code`).
+ */
+function parseMetaBrackets(url: URL): {
+  metadata?: Record<string, unknown>;
+  dateFilter?: { field: string; from?: string; to?: string };
+  error?: Response;
+} {
+  // Real columns on `notes` — exempt from the indexed-field gate, routed
+  // through `dateFilter` instead of `metadata`.
+  const REAL_DATE_COLUMNS = new Set(["created_at", "updated_at"]);
+  // `meta[FIELD]` or `meta[FIELD][OP]` or `meta[FIELD][OP][]`. Field names are
+  // bounded by `FIELD_NAME_RE` at the engine layer; the parser is liberal here
+  // and lets the engine raise the loud error on bad names.
+  const META_RE = /^meta\[([^\]]+)\](?:\[([^\]]+)\](\[\])?)?$/;
+
+  const metadata: Record<string, unknown> = {};
+  const arrayBuckets = new Map<string, string[]>(); // key: `${field}|${op}` → values
+  const dateBucket: { field?: string; from?: string; to?: string } = {};
+
+  function metaOpBucket(field: string): Record<string, unknown> {
+    const existing = metadata[field];
+    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+      return existing as Record<string, unknown>;
+    }
+    // Shorthand `meta[field]=v` first, then `meta[field][op]=w` second would
+    // overwrite the shorthand. That's contradictory input — the bracket form
+    // wins (the more specific shape), but we drop the shorthand silently.
+    // We don't reject here; consumers who hit this can see the bracket op
+    // result and adjust.
+    const bucket: Record<string, unknown> = {};
+    metadata[field] = bucket;
+    return bucket;
+  }
+
+  for (const [key, value] of url.searchParams.entries()) {
+    const m = META_RE.exec(key);
+    if (!m) continue;
+    const field = m[1]!;
+    const op = m[2];
+    const isArray = m[3] === "[]";
+
+    // Bridge: real date columns route to dateFilter, not metadata.
+    if (REAL_DATE_COLUMNS.has(field)) {
+      if (!op) {
+        return {
+          error: json(
+            {
+              error: `bracket-date filter on \`${field}\` requires an operator: meta[${field}][gte]=… (lower bound) or meta[${field}][lt]=… (upper bound, exclusive).`,
+              code: "INVALID_QUERY",
+            },
+            400,
+          ),
+        };
+      }
+      if (op === "gte") {
+        dateBucket.field = field;
+        dateBucket.from = value;
+      } else if (op === "lt") {
+        dateBucket.field = field;
+        dateBucket.to = value;
+      } else {
+        return {
+          error: json(
+            {
+              error: `bracket-date filter on \`${field}\` supports only \`gte\` (inclusive lower bound) and \`lt\` (exclusive upper bound). Got: \`${op}\`. The dateFilter contract uses these two ops because the equivalent flat shape (\`date_field=${field}&date_from=…&date_to=…\`) is half-open by design.`,
+              code: "INVALID_QUERY",
+            },
+            400,
+          ),
+        };
+      }
+      continue;
+    }
+
+    // Regular metadata field.
+    if (!op) {
+      // Shorthand: `?meta[field]=value` → primitive (engine routes through
+      // json_extract; no indexed declaration required).
+      metadata[field] = value;
+      continue;
+    }
+    if (isArray) {
+      // `meta[field][in][]=v1&meta[field][in][]=v2`
+      const bucketKey = `${field}|${op}`;
+      let bucket = arrayBuckets.get(bucketKey);
+      if (!bucket) {
+        bucket = [];
+        arrayBuckets.set(bucketKey, bucket);
+      }
+      bucket.push(value);
+      continue;
+    }
+    if (op === "in" || op === "not_in") {
+      // Comma form: `meta[field][in]=v1,v2`
+      const arr = value.includes(",")
+        ? value.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
+        : [value];
+      metaOpBucket(field)[op] = arr;
+    } else if (op === "exists") {
+      const bool = value === "true" ? true : value === "false" ? false : null;
+      if (bool === null) {
+        return {
+          error: json(
+            {
+              error: `bracket-meta filter: \`exists\` on \`${field}\` requires "true" or "false", got "${value}"`,
+              code: "INVALID_OPERATOR_VALUE",
+            },
+            400,
+          ),
+        };
+      }
+      metaOpBucket(field)[op] = bool;
+    } else {
+      // eq / ne / gt / gte / lt / lte — all primitive, single value. Type
+      // coercion is left to SQLite affinity rules: indexed columns are
+      // declared TEXT or INTEGER, and SQLite will compare a string-shaped
+      // numeric correctly against an INTEGER column. The engine raises
+      // UNKNOWN_OPERATOR if `op` isn't in SUPPORTED_OPS.
+      metaOpBucket(field)[op] = value;
+    }
+  }
+
+  // Roll up `[]`-array buckets onto their fields.
+  for (const [bucketKey, values] of arrayBuckets) {
+    const sep = bucketKey.indexOf("|");
+    const field = bucketKey.slice(0, sep);
+    const op = bucketKey.slice(sep + 1);
+    metaOpBucket(field)[op] = values;
+  }
+
+  const result: {
+    metadata?: Record<string, unknown>;
+    dateFilter?: { field: string; from?: string; to?: string };
+  } = {};
+  if (Object.keys(metadata).length > 0) result.metadata = metadata;
+  if (dateBucket.field) {
+    result.dateFilter = { field: dateBucket.field };
+    if (dateBucket.from !== undefined) result.dateFilter.from = dateBucket.from;
+    if (dateBucket.to !== undefined) result.dateFilter.to = dateBucket.to;
+  }
+  return result;
+}
+
+/**
  * Parse include_metadata query param.
  * - absent/null → undefined (all metadata, default)
  * - "true"/"1" → true (all metadata)
@@ -219,13 +397,32 @@ export async function handleNotes(
 
       // Structured query
       //
-      // Surface asymmetry: REST uses three flat query params
-      // (`date_field`, `date_from`, `date_to`) while MCP takes a nested
-      // `date_filter: { field, from, to }` object. Both lower to the same
-      // store-level `dateFilter` shape — the difference is just that query
-      // strings are flat by nature. This mirrors the broader REST/MCP
-      // pattern across the API and is intentional, not a fix-it-up TODO.
+      // Two filter syntaxes coexist on this endpoint:
+      //
+      //   - **Bracket-style** (canonical, vault#285 friction point 1.3):
+      //     `?meta[field][op]=value` / `?meta[created_at][gte]=…`. Exposes
+      //     the full engine `metadata` filter (eq/ne/gt/gte/lt/lte/in/
+      //     not_in/exists) and the dateFilter bridge through one consistent
+      //     shape. See `parseMetaBrackets` for the grammar.
+      //
+      //   - **Flat date params** (DEPRECATED): `?date_field=created_at&
+      //     date_from=…&date_to=…` and the legacy `?date_from=…&date_to=…`.
+      //     Still functional through 0.5.x; planned removal in 0.6.0
+      //     (vault#288). New consumers should use bracket-style.
+      //
+      // Precedence on overlap: bracket-style wins. If a caller passes both
+      // `meta[created_at][gte]=X` and `date_field=created_at&date_from=Y`,
+      // the bracket form is the dateFilter the engine sees; the flat
+      // params are silently dropped. We don't error — the bracket form is
+      // documented as canonical, and rejecting the overlap would block a
+      // realistic migration path where a caller half-converted their code.
+      //
+      // Surface asymmetry: REST flattens to a query string; MCP takes a
+      // nested `date_filter: { field, from, to }` object directly. Both
+      // lower to the same store-level `dateFilter` shape.
       const tags = parseQueryList(url, "tag");
+      const bracket = parseMetaBrackets(url);
+      if (bracket.error) return bracket.error;
       let results: Note[];
       try {
         results = await store.queryNotes({
@@ -236,23 +433,28 @@ export async function handleNotes(
           hasLinks: parseBoolOrUndef(parseQuery(url, "has_links")),
           path: parseQuery(url, "path") ?? undefined,
           pathPrefix: parseQuery(url, "path_prefix") ?? undefined,
-          metadata: undefined, // metadata filter not practical in query params
-          // `date_field=<name>&date_from=...&date_to=...` activates the
-          // generalized filter (filters on the named indexed field). Without
-          // `date_field`, `date_from`/`date_to` keep their legacy meaning of
-          // filtering on `created_at` (vault ingestion time).
-          ...(parseQuery(url, "date_field")
-            ? {
-                dateFilter: {
-                  field: parseQuery(url, "date_field")!,
-                  from: parseQuery(url, "date_from") ?? undefined,
-                  to: parseQuery(url, "date_to") ?? undefined,
-                },
-              }
-            : {
-                dateFrom: parseQuery(url, "date_from") ?? undefined,
-                dateTo: parseQuery(url, "date_to") ?? undefined,
-              }),
+          metadata: bracket.metadata,
+          // Date-range precedence chain (highest to lowest):
+          //   1. Bracket-style `meta[created_at][gte]=…` (canonical).
+          //   2. Flat `date_field=…&date_from=…&date_to=…` (deprecated).
+          //   3. Legacy `date_from=…&date_to=…` (no date_field, deprecated)
+          //      — filters on `n.created_at` by definition.
+          // The engine rejects combinations of `dateFilter` with the legacy
+          // `dateFrom`/`dateTo`, so we never set both shapes simultaneously.
+          ...(bracket.dateFilter
+            ? { dateFilter: bracket.dateFilter }
+            : parseQuery(url, "date_field")
+              ? {
+                  dateFilter: {
+                    field: parseQuery(url, "date_field")!,
+                    from: parseQuery(url, "date_from") ?? undefined,
+                    to: parseQuery(url, "date_to") ?? undefined,
+                  },
+                }
+              : {
+                  dateFrom: parseQuery(url, "date_from") ?? undefined,
+                  dateTo: parseQuery(url, "date_to") ?? undefined,
+                }),
           sort: (parseQuery(url, "sort") as "asc" | "desc") ?? undefined,
           orderBy: parseQuery(url, "order_by") ?? undefined,
           limit: parseInt10(parseQuery(url, "limit")) ?? 50,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -125,27 +125,48 @@ function parseMetaBrackets(url: URL): {
   // Real columns on `notes` — exempt from the indexed-field gate, routed
   // through `dateFilter` instead of `metadata`.
   const REAL_DATE_COLUMNS = new Set(["created_at", "updated_at"]);
+  // Operators that take an array value. Used for parser-level rejection of
+  // `[]`-array syntax on the wrong operator (e.g. `meta[field][eq][]=value`).
+  const ARRAY_OPS = new Set(["in", "not_in"]);
   // `meta[FIELD]` or `meta[FIELD][OP]` or `meta[FIELD][OP][]`. Field names are
   // bounded by `FIELD_NAME_RE` at the engine layer; the parser is liberal here
   // and lets the engine raise the loud error on bad names.
   const META_RE = /^meta\[([^\]]+)\](?:\[([^\]]+)\](\[\])?)?$/;
 
+  // `metadata[field]` is either a primitive (shorthand `eq` via json_extract)
+  // or a sub-object of operator clauses. The two are *mutually exclusive per
+  // field per request*: mixing them is a silent-data-loss footgun (op set,
+  // then shorthand stomps; or shorthand set, then op stomps) so we reject
+  // loudly. Track each field's chosen form here.
   const metadata: Record<string, unknown> = {};
-  const arrayBuckets = new Map<string, string[]>(); // key: `${field}|${op}` → values
-  const dateBucket: { field?: string; from?: string; to?: string } = {};
+  const shorthandFields = new Set<string>();
+  const opBucketsByField = new Map<string, Map<string, string[]>>(); // field → op → values (array form)
+  const opObjectByField = new Map<string, Record<string, unknown>>(); // field → built op object (single-value ops)
 
-  function metaOpBucket(field: string): Record<string, unknown> {
-    const existing = metadata[field];
-    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-      return existing as Record<string, unknown>;
+  // dateFilter accumulates `from` (gte) and `to` (lt) bounds on a single
+  // column. Spanning both `created_at` AND `updated_at` in one request is
+  // not expressible (the engine takes one `field`), so we reject early
+  // rather than silently corrupting one bound. See vault#289 review F1.
+  let dateField: "created_at" | "updated_at" | null = null;
+  let dateFrom: string | undefined;
+  let dateTo: string | undefined;
+
+  function rejectMixedForms(field: string): Response {
+    return json(
+      {
+        error: `bracket-meta filter: cannot mix shorthand and operator forms for the same field — \`meta[${field}]=…\` and \`meta[${field}][<op>]=…\` are mutually exclusive in one request. Pick one form.`,
+        code: "INVALID_QUERY",
+      },
+      400,
+    );
+  }
+
+  function getOpObject(field: string): Record<string, unknown> {
+    let bucket = opObjectByField.get(field);
+    if (!bucket) {
+      bucket = {};
+      opObjectByField.set(field, bucket);
     }
-    // Shorthand `meta[field]=v` first, then `meta[field][op]=w` second would
-    // overwrite the shorthand. That's contradictory input — the bracket form
-    // wins (the more specific shape), but we drop the shorthand silently.
-    // We don't reject here; consumers who hit this can see the bracket op
-    // result and adjust.
-    const bucket: Record<string, unknown> = {};
-    metadata[field] = bucket;
     return bucket;
   }
 
@@ -169,13 +190,7 @@ function parseMetaBrackets(url: URL): {
           ),
         };
       }
-      if (op === "gte") {
-        dateBucket.field = field;
-        dateBucket.from = value;
-      } else if (op === "lt") {
-        dateBucket.field = field;
-        dateBucket.to = value;
-      } else {
+      if (op !== "gte" && op !== "lt") {
         return {
           error: json(
             {
@@ -186,6 +201,23 @@ function parseMetaBrackets(url: URL): {
           ),
         };
       }
+      // F1: dateFilter takes a single column. Reject the cross-column
+      // case before assigning — otherwise the second column's
+      // assignment would silently override the first.
+      if (dateField !== null && dateField !== field) {
+        return {
+          error: json(
+            {
+              error: `bracket-date filter cannot span both \`created_at\` and \`updated_at\` in one request — issue two queries or use one column per request.`,
+              code: "INVALID_QUERY",
+            },
+            400,
+          ),
+        };
+      }
+      dateField = field as "created_at" | "updated_at";
+      if (op === "gte") dateFrom = value;
+      else dateTo = value;
       continue;
     }
 
@@ -193,26 +225,63 @@ function parseMetaBrackets(url: URL): {
     if (!op) {
       // Shorthand: `?meta[field]=value` → primitive (engine routes through
       // json_extract; no indexed declaration required).
+      // F2: reject if any operator form already wrote a bucket for this
+      // field — the two shapes don't compose and the silent stomp would
+      // drop one form's intent. Mirror check for the reverse order below.
+      if (opObjectByField.has(field) || opBucketsByField.has(field)) {
+        return { error: rejectMixedForms(field) };
+      }
+      shorthandFields.add(field);
       metadata[field] = value;
       continue;
     }
+    // F2: reject if shorthand already wrote a primitive for this field.
+    if (shorthandFields.has(field)) {
+      return { error: rejectMixedForms(field) };
+    }
+    // F4: `[]`-array syntax only makes sense for `in` / `not_in`. Other ops
+    // (eq, gt, exists, …) take a scalar; `meta[field][eq][]=v` is a
+    // shape error — surface it at the parser layer with a clear message
+    // instead of letting the engine raise a generic INVALID_OPERATOR_VALUE
+    // downstream.
+    if (isArray && !ARRAY_OPS.has(op)) {
+      return {
+        error: json(
+          {
+            error: `bracket-meta filter: array form \`meta[${field}][${op}][]=…\` is only valid for \`in\` and \`not_in\`. \`${op}\` takes a single value — use \`meta[${field}][${op}]=value\` instead.`,
+            code: "INVALID_OPERATOR_VALUE",
+          },
+          400,
+        ),
+      };
+    }
     if (isArray) {
-      // `meta[field][in][]=v1&meta[field][in][]=v2`
-      const bucketKey = `${field}|${op}`;
-      let bucket = arrayBuckets.get(bucketKey);
-      if (!bucket) {
-        bucket = [];
-        arrayBuckets.set(bucketKey, bucket);
+      // `meta[field][in][]=v1&meta[field][in][]=v2`. Nested map keeps
+      // field and op as separate dimensions — no string-concat ambiguity
+      // for field names that contain (or might one day be allowed to
+      // contain) the delimiter character. See vault#289 review F5.
+      let fieldBucket = opBucketsByField.get(field);
+      if (!fieldBucket) {
+        fieldBucket = new Map<string, string[]>();
+        opBucketsByField.set(field, fieldBucket);
       }
-      bucket.push(value);
+      let values = fieldBucket.get(op);
+      if (!values) {
+        values = [];
+        fieldBucket.set(op, values);
+      }
+      values.push(value);
       continue;
     }
     if (op === "in" || op === "not_in") {
-      // Comma form: `meta[field][in]=v1,v2`
+      // Comma form: `meta[field][in]=v1,v2`. Mutually exclusive with the
+      // `[]` array form per field+op — last write wins if both are
+      // supplied; we don't reject because the resulting array is well-
+      // defined regardless of which form a caller picked.
       const arr = value.includes(",")
         ? value.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
         : [value];
-      metaOpBucket(field)[op] = arr;
+      getOpObject(field)[op] = arr;
     } else if (op === "exists") {
       const bool = value === "true" ? true : value === "false" ? false : null;
       if (bool === null) {
@@ -226,23 +295,28 @@ function parseMetaBrackets(url: URL): {
           ),
         };
       }
-      metaOpBucket(field)[op] = bool;
+      getOpObject(field)[op] = bool;
     } else {
       // eq / ne / gt / gte / lt / lte — all primitive, single value. Type
       // coercion is left to SQLite affinity rules: indexed columns are
       // declared TEXT or INTEGER, and SQLite will compare a string-shaped
       // numeric correctly against an INTEGER column. The engine raises
       // UNKNOWN_OPERATOR if `op` isn't in SUPPORTED_OPS.
-      metaOpBucket(field)[op] = value;
+      getOpObject(field)[op] = value;
     }
   }
 
-  // Roll up `[]`-array buckets onto their fields.
-  for (const [bucketKey, values] of arrayBuckets) {
-    const sep = bucketKey.indexOf("|");
-    const field = bucketKey.slice(0, sep);
-    const op = bucketKey.slice(sep + 1);
-    metaOpBucket(field)[op] = values;
+  // Roll up `[]`-array buckets onto their op-objects. Done after the main
+  // loop so `in`/`not_in` array-form and comma-form on the same field
+  // collapse into one merged op-object cleanly.
+  for (const [field, opMap] of opBucketsByField) {
+    for (const [op, values] of opMap) {
+      getOpObject(field)[op] = values;
+    }
+  }
+  // Roll up op-objects onto the metadata payload.
+  for (const [field, opObj] of opObjectByField) {
+    metadata[field] = opObj;
   }
 
   const result: {
@@ -250,10 +324,10 @@ function parseMetaBrackets(url: URL): {
     dateFilter?: { field: string; from?: string; to?: string };
   } = {};
   if (Object.keys(metadata).length > 0) result.metadata = metadata;
-  if (dateBucket.field) {
-    result.dateFilter = { field: dateBucket.field };
-    if (dateBucket.from !== undefined) result.dateFilter.from = dateBucket.from;
-    if (dateBucket.to !== undefined) result.dateFilter.to = dateBucket.to;
+  if (dateField) {
+    result.dateFilter = { field: dateField };
+    if (dateFrom !== undefined) result.dateFilter.from = dateFrom;
+    if (dateTo !== undefined) result.dateFilter.to = dateTo;
   }
   return result;
 }

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2288,6 +2288,98 @@ describe("HTTP /notes", async () => {
       expect(body.error).toContain("operator");
     });
 
+    // ---- Mutually-exclusive shapes that would silently corrupt input ----
+
+    test("bracket-date filter spanning created_at AND updated_at in one request rejects (vault#289 F1)", async () => {
+      // Before this guard, the parser flattened both columns onto a single
+      // `dateBucket.field`, so the second column silently won and the first
+      // column's bound was applied against the wrong column.
+      const res = await handleNotes(
+        mkReq(
+          "GET",
+          "/notes?meta[created_at][gte]=2026-04-01&meta[updated_at][lt]=2026-06-01",
+        ),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_QUERY");
+      expect(body.error).toContain("cannot span");
+      expect(body.error).toContain("created_at");
+      expect(body.error).toContain("updated_at");
+    });
+
+    test("two bracket-date params on the same column compose into a range (regression)", async () => {
+      // The F1 guard must reject *different* columns only — same-column
+      // gte+lt is the canonical range case and must keep working.
+      await store.createNote("in-window", { created_at: "2026-04-15T00:00:00.000Z" });
+      await store.createNote("after-window", { created_at: "2026-05-15T00:00:00.000Z" });
+      await store.createNote("before-window", { created_at: "2026-03-15T00:00:00.000Z" });
+      const res = await handleNotes(
+        mkReq(
+          "GET",
+          "/notes?meta[created_at][gte]=2026-04-01&meta[created_at][lt]=2026-05-01&include_content=true",
+        ),
+        store,
+        "",
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["in-window"]);
+    });
+
+    test("shorthand-then-operator on the same field rejects (vault#289 F2)", async () => {
+      // `URLSearchParams` iteration is insertion-order. Before this guard,
+      // shorthand wrote `metadata[field] = primitive`, then the operator
+      // handler called `metaOpBucket` which overwrote it with a fresh op
+      // object — the shorthand was silently dropped.
+      await declareIndexed();
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority]=5&meta[priority][gte]=3"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_QUERY");
+      expect(body.error).toContain("mix shorthand and operator");
+    });
+
+    test("operator-then-shorthand on the same field rejects (vault#289 F2, reverse order)", async () => {
+      // Reverse insertion order. Before this guard, the operator was set
+      // first, then the shorthand wrote `metadata[field] = primitive` and
+      // clobbered the op bucket — operator silently dropped.
+      await declareIndexed();
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][gte]=3&meta[priority]=5"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_QUERY");
+      expect(body.error).toContain("mix shorthand and operator");
+    });
+
+    test("`[]` array form on a non-array operator rejects at the parser layer (vault#289 F4)", async () => {
+      // `meta[field][eq][]=value` is a shape error — `eq` takes a scalar.
+      // The engine would also catch this (the value would be an array
+      // SQLite can't bind), but the parser-level error names the issue
+      // more precisely: "use single-value form for `eq`."
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][eq][]=5"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_OPERATOR_VALUE");
+      expect(body.error).toContain("array form");
+      expect(body.error).toContain("in");
+      expect(body.error).toContain("not_in");
+    });
+
     // ---- Precedence on overlap ----
     test("when both flat and bracket date params overlap, bracket wins", async () => {
       await store.createNote("old", { created_at: "2026-01-15T00:00:00.000Z" });

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2027,6 +2027,286 @@ describe("HTTP /notes", async () => {
       expect(body).toHaveLength(500);
     });
   });
+
+  // ---- Bracket-style metadata filter (vault#285 friction point 1.3) ----
+  //
+  // Exposes vault's engine-level metadata-value filtering to HTTP REST
+  // callers (today: only MCP). Uses `meta[field][op]=value` (Stripe /
+  // JSON:API / Strapi convention). The HTTP layer translates to the engine's
+  // existing `metadata` filter; engine semantics + gates are unchanged.
+  // Bridges `created_at` / `updated_at` through `dateFilter`.
+  describe("bracket-style metadata filter", () => {
+    async function declareIndexed() {
+      const { declareField } = await import("../core/src/indexed-fields.ts");
+      declareField(db, "priority", "INTEGER", "project");
+      declareField(db, "status", "TEXT", "project");
+    }
+
+    test("shorthand `?meta[field]=value` does exact equality (JSON scan, no indexed gate)", async () => {
+      // Deliberately NOT calling declareIndexed — shorthand should work on
+      // any field via the json_extract fallback at core/src/notes.ts:504-507.
+      await store.createNote("matches", { metadata: { kind: "draft" } });
+      await store.createNote("other", { metadata: { kind: "final" } });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[kind]=draft&include_content=true"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["matches"]);
+    });
+
+    test("eq operator on indexed field", async () => {
+      await declareIndexed();
+      await store.createNote("p5", { metadata: { priority: 5 } });
+      await store.createNote("p1", { metadata: { priority: 1 } });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][eq]=5&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["p5"]);
+    });
+
+    test("ne operator returns non-matching rows plus rows without the field", async () => {
+      await declareIndexed();
+      await store.createNote("has-1", { metadata: { priority: 1 } });
+      await store.createNote("has-2", { metadata: { priority: 2 } });
+      await store.createNote("missing");
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][ne]=1&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content).sort()).toEqual(["has-2", "missing"]);
+    });
+
+    test("gt / gte / lt / lte compose into a range query on one field", async () => {
+      await declareIndexed();
+      for (const p of [1, 2, 3, 4, 5]) {
+        await store.createNote(`p${p}`, { metadata: { priority: p } });
+      }
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][gte]=2&meta[priority][lt]=5&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content).sort()).toEqual(["p2", "p3", "p4"]);
+    });
+
+    test("in array form: `?meta[field][in][]=v1&meta[field][in][]=v2`", async () => {
+      await declareIndexed();
+      await store.createNote("a", { metadata: { status: "active" } });
+      await store.createNote("b", { metadata: { status: "exploring" } });
+      await store.createNote("c", { metadata: { status: "done" } });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[status][in][]=active&meta[status][in][]=exploring&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content).sort()).toEqual(["a", "b"]);
+    });
+
+    test("in comma form: `?meta[field][in]=v1,v2`", async () => {
+      await declareIndexed();
+      await store.createNote("a", { metadata: { status: "active" } });
+      await store.createNote("b", { metadata: { status: "exploring" } });
+      await store.createNote("c", { metadata: { status: "done" } });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[status][in]=active,exploring&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content).sort()).toEqual(["a", "b"]);
+    });
+
+    test("not_in via comma form", async () => {
+      await declareIndexed();
+      await store.createNote("a", { metadata: { status: "active" } });
+      await store.createNote("b", { metadata: { status: "done" } });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[status][not_in]=done&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["a"]);
+    });
+
+    test("exists: true / false distinguishes present vs absent field", async () => {
+      await declareIndexed();
+      await store.createNote("has", { metadata: { priority: 3 } });
+      await store.createNote("missing");
+
+      const hasRes = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][exists]=true&include_content=true"),
+        store,
+        "",
+      );
+      const hasBody = await hasRes.json() as any[];
+      expect(hasBody.map((n) => n.content)).toEqual(["has"]);
+
+      const missingRes = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][exists]=false&include_content=true"),
+        store,
+        "",
+      );
+      const missingBody = await missingRes.json() as any[];
+      expect(missingBody.map((n) => n.content)).toEqual(["missing"]);
+    });
+
+    test("exists with non-boolean value rejects with INVALID_OPERATOR_VALUE", async () => {
+      await declareIndexed();
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][exists]=yes"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_OPERATOR_VALUE");
+    });
+
+    test("compound filter across two fields ANDs together", async () => {
+      await declareIndexed();
+      await store.createNote("hit", { metadata: { priority: 5, status: "active" } });
+      await store.createNote("priority-only", { metadata: { priority: 5, status: "done" } });
+      await store.createNote("status-only", { metadata: { priority: 1, status: "active" } });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][gte]=4&meta[status][eq]=active&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["hit"]);
+    });
+
+    test("operator query on a non-indexed field returns 400 with FIELD_NOT_INDEXED", async () => {
+      // Don't declare the field — the engine's indexed-field gate should fire.
+      await store.createNote("x", { metadata: { mood: "great" } });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[mood][eq]=great"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("FIELD_NOT_INDEXED");
+    });
+
+    test("unknown operator returns 400 with UNKNOWN_OPERATOR", async () => {
+      await declareIndexed();
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][bogus]=5"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("UNKNOWN_OPERATOR");
+    });
+
+    // ---- Bridge: created_at / updated_at via brackets route to dateFilter ----
+    test("`meta[created_at][gte]=…` routes to dateFilter (same result as flat date_field)", async () => {
+      await store.createNote("old", { created_at: "2026-01-15T00:00:00.000Z" });
+      await store.createNote("new", { created_at: "2026-04-15T00:00:00.000Z" });
+
+      const bracketRes = await handleNotes(
+        mkReq("GET", "/notes?meta[created_at][gte]=2026-04-01&include_content=true"),
+        store,
+        "",
+      );
+      const bracketBody = await bracketRes.json() as any[];
+      const flatRes = await handleNotes(
+        mkReq("GET", "/notes?date_field=created_at&date_from=2026-04-01&include_content=true"),
+        store,
+        "",
+      );
+      const flatBody = await flatRes.json() as any[];
+      expect(bracketBody.map((n) => n.content)).toEqual(["new"]);
+      expect(bracketBody.map((n) => n.content)).toEqual(flatBody.map((n) => n.content));
+    });
+
+    test("`meta[updated_at][gte]=…` routes to dateFilter on n.updated_at", async () => {
+      const a = await store.createNote("untouched");
+      const b = await store.createNote("modified");
+      db.prepare("UPDATE notes SET updated_at = ? WHERE id = ?")
+        .run("2026-01-15T00:00:00.000Z", a.id);
+      db.prepare("UPDATE notes SET updated_at = ? WHERE id = ?")
+        .run("2026-04-25T00:00:00.000Z", b.id);
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[updated_at][gte]=2026-04-01&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["modified"]);
+    });
+
+    test("`meta[created_at][lt]=…` maps to dateFilter's exclusive upper bound", async () => {
+      await store.createNote("inside", { created_at: "2026-04-15T00:00:00.000Z" });
+      await store.createNote("on-boundary", { created_at: "2026-05-01T00:00:00.000Z" });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[created_at][lt]=2026-05-01&include_content=true"),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      // "on-boundary" excluded because `< to` is half-open by design.
+      expect(body.map((n) => n.content)).toEqual(["inside"]);
+    });
+
+    test("unsupported date-column operator (e.g. gt) rejects with a guiding error", async () => {
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[created_at][gt]=2026-01-01"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_QUERY");
+      // Error must call out the supported ops so callers can self-correct.
+      expect(body.error).toContain("gte");
+      expect(body.error).toContain("lt");
+    });
+
+    test("`meta[created_at]=…` (shorthand, no operator) rejects with a guiding error", async () => {
+      const res = await handleNotes(
+        mkReq("GET", "/notes?meta[created_at]=2026-01-01"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_QUERY");
+      expect(body.error).toContain("operator");
+    });
+
+    // ---- Precedence on overlap ----
+    test("when both flat and bracket date params overlap, bracket wins", async () => {
+      await store.createNote("old", { created_at: "2026-01-15T00:00:00.000Z" });
+      await store.createNote("new", { created_at: "2026-04-15T00:00:00.000Z" });
+      // Bracket says "from 2026-04-01"; flat says "from 2020-01-01". If
+      // flat won, both notes would match. The bracket-wins precedence is
+      // verified by getting back only the post-April note.
+      const res = await handleNotes(
+        mkReq(
+          "GET",
+          "/notes?meta[created_at][gte]=2026-04-01&date_field=created_at&date_from=2020-01-01&include_content=true",
+        ),
+        store,
+        "",
+      );
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["new"]);
+    });
+  });
 });
 
 describe("HTTP GET /notes?format=graph", async () => {


### PR DESCRIPTION
## Summary

Closes the HTTP-side gap in vault's metadata-filter surface (vault#285 friction point 1.3). The engine has always supported `eq`/`ne`/`gt`/`gte`/`lt`/`lte`/`in`/`not_in`/`exists`; MCP exposes them. The HTTP route previously declared the surface "not practical in query params" and dropped it. Bracket-style filtering plumbs it through with the Stripe / JSON:API / Strapi convention.

- **Canonical**: `?meta[field][op]=value`, with `?meta[field]=value` shorthand for equality (JSON-scan fallback; no indexed-field declaration required).
- **Bridge**: `?meta[created_at][gte]=…` / `?meta[updated_at][lt]=…` route through the existing `dateFilter` path (the same real-column exemption as the flat `date_field=` form). Only `gte`/`lt` accepted on these fields — matches `dateFilter`'s `>= from AND < to` contract; other ops reject with a guiding error.
- **Deprecation**: flat `date_field`/`date_from`/`date_to` are still functional through 0.5.x — bracket wins on overlap. Planned removal in 0.6.0, tracked at vault#288.
- **Tag-authorizes-index gate flows through**: operator queries on a metadata field still require declared `indexed: true`; 400 with `code: "FIELD_NOT_INDEXED"` otherwise. Shorthand stays gate-free via json_extract.

Hand-rolled parser (~60 lines, regex + a couple of buckets) — small grammar, doesn't justify pulling `qs` into the dep tree.

## Version

`0.4.3-rc.1` → `0.4.3-rc.2` (per governance: rc bumps until ready-for-release).

## Test plan

- [x] `bun test ./core/src/ ./src/` — 1250/1250 pass, 3324 expect calls
- [x] `bunx tsc --noEmit` clean
- [x] 18 new HTTP tests cover: every operator end-to-end, both array forms (`[]` and comma), shorthand equality (no indexed gate), compound AND on one field and across fields, the `created_at`/`updated_at` bridge, deprecation precedence (bracket wins), and rejection paths.

## New tests (all in `src/vault.test.ts`, `describe(\"bracket-style metadata filter\")`)

- `shorthand ?meta[field]=value does exact equality (JSON scan, no indexed gate)`
- `eq operator on indexed field`
- `ne operator returns non-matching rows plus rows without the field`
- `gt / gte / lt / lte compose into a range query on one field`
- `in array form: ?meta[field][in][]=v1&meta[field][in][]=v2`
- `in comma form: ?meta[field][in]=v1,v2`
- `not_in via comma form`
- `exists: true / false distinguishes present vs absent field`
- `exists with non-boolean value rejects with INVALID_OPERATOR_VALUE`
- `compound filter across two fields ANDs together`
- `operator query on a non-indexed field returns 400 with FIELD_NOT_INDEXED`
- `unknown operator returns 400 with UNKNOWN_OPERATOR`
- `meta[created_at][gte]=… routes to dateFilter (same result as flat date_field)`
- `meta[updated_at][gte]=… routes to dateFilter on n.updated_at`
- `meta[created_at][lt]=… maps to dateFilter's exclusive upper bound`
- `unsupported date-column operator (e.g. gt) rejects with a guiding error`
- `meta[created_at]=… (shorthand, no operator) rejects with a guiding error`
- `when both flat and bracket date params overlap, bracket wins`

## Out of scope

- OR composition across `metadata` filters — engine's `metadata` shape doesn't expose OR; left for a future engine-level decision.
- CLI bracket-style — CLI uses MCP shape directly; not affected.
- Bumping the operator set on date columns past `gte`/`lt` — would require engine-side work; the half-open contract is intentional.
- Removing the deprecated flat params (vault#288, 0.6.0 target).

Refs vault#285, follow-up tracked at vault#288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)