### PR TITLE
chore(release): 0.4.3 + query cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.3] — 2026-05-10
+
+Two release cuts (`0.4.3-rc.1` and `0.4.3-rc.2`) ship together as `0.4.3`
+on `@latest`. Release-RC detail is preserved in the entries below; this
+heading is the operator-facing summary.
+
+Theme: closing the high-priority friction points from the [vault#285
+field-input evaluation](https://github.com/ParachuteComputer/parachute-vault/issues/285).
+Two PRs landed under the rc chain:
+
+- **vault#286 (rc.1)** — `updated_at` filter (1.5) + `update-note`
+  response-shape opt-out (2.response). Two small additive enhancements;
+  no behavior change for existing callers.
+- **vault#289 (rc.2)** — bracket-style HTTP metadata filter (1.3) with
+  bridge for `created_at` / `updated_at` and a deprecation path for the
+  flat date params. Closes the largest HTTP-side surface gap.
+
+### Read path
+
+- **`dateFilter` recognizes `updated_at`** (1.5 / vault#286). SSG
+  incremental-rebuild flows ask "what changed since X" via
+  `dateFilter: { field: "updated_at", from: lastBuildISO }`. No
+  indexed-field declaration required — `updated_at` is a real column on
+  `notes` and joins `created_at` as a recognized exemption from the
+  indexed-field gate.
+- **HTTP bracket-style metadata filter** (1.3 / vault#289). Exposes
+  vault's full engine operator set — `eq` / `ne` / `gt` / `gte` / `lt` /
+  `lte` / `in` / `not_in` / `exists` — to HTTP consumers via
+  `?meta[field][op]=value`. Bracket-style is the canonical shape going
+  forward; the flat `date_field=…&date_from=…&date_to=…` form is
+  deprecated (planned removal 0.6.0, tracked at vault#288).
+
+### Write path
+
+- **`update-note` response-shape opt-out** (2.response / vault#286). New
+  `include_content` parameter (default `true`). Set `false` and the
+  response swaps the full `Note` for the lean `NoteIndex` shape (drops
+  `content`, keeps `byteSize` / `preview` / `validation_status`).
+  Order-of-magnitude smaller responses on big notes — the workflow that
+  surfaced the friction.
+
+### Discoverability
+
+- **Cookbook section in `README.md`.** Patterns for path-subtree queries,
+  sort-by-metadata, preview-only listings, incremental rebuilds, the new
+  bracket-meta filter, surgical `content_edit`, atomic `append`, and the
+  Funnel pointer for CI access. Distilled from the field-input thread.
+
+### Out of scope (still deferred)
+
+- **1.6 URL-safe slug** — design pending (stability under rename, derive
+  from id vs path); deferred until a renderer concretely needs it.
+- **Tunable preview length** — the 120-char default has held; revisit
+  when a real consumer hits a wall.
+- **Section / diff / line-range edits on `update-note`** — speculative
+  given that `content_edit` + `append` cover the originating workflow.
+- **OR composition across metadata filters** — engine doesn't expose OR
+  through the `metadata` shape; future engine-level decision.
+
 ## [0.4.3-rc.2] — 2026-05-10
 
 Closes the HTTP-side gap in vault's metadata-filter surface (vault#285

--- a/README.md
+++ b/README.md
@@ -432,6 +432,137 @@ GET            /vaults/list                                       public: vault 
 GET            /health                                            health check
 ```
 
+## Common queries / cookbook
+
+Patterns that fall out of vault's read and write surfaces. All examples assume your vault is reachable at `http://localhost:1940` and your token is in `$VAULT_TOKEN`. MCP-side examples are how the same operation looks via the tool layer (Claude Code, Claude Desktop, Daily). Each recipe answers a question consumers have asked while building against vault — see [vault#285](https://github.com/ParachuteComputer/parachute-vault/issues/285) for the field-input thread these distilled from.
+
+### Fetch every note under a path subtree
+
+For an SSG or wiki rendering a section of the vault. `path_prefix` matches against the normalized path string — no `.md`, no trailing slash.
+
+```bash
+curl -H "Authorization: Bearer $VAULT_TOKEN" \
+  "http://localhost:1940/vault/default/api/notes?path_prefix=Boulder%20Civics/City%20Council/&include_content=true"
+```
+
+```jsonc
+// MCP
+{ "name": "query-notes", "arguments": { "path_prefix": "Boulder Civics/City Council/", "include_content": true } }
+```
+
+### Sort by a metadata field
+
+Sort by something other than `created_at`. The field must be declared `indexed: true` in some tag schema first — that's what materializes the backing generated column + B-tree index. The "tag authorizes the index" pattern lives in [`core/src/indexed-fields.ts`](./core/src/indexed-fields.ts).
+
+```bash
+curl -H "Authorization: Bearer $VAULT_TOKEN" \
+  "http://localhost:1940/vault/default/api/notes?order_by=meeting_date&sort=desc&include_content=true"
+```
+
+Declare the index via `update-tag`:
+
+```jsonc
+{ "name": "update-tag", "arguments": {
+    "tag": "meeting",
+    "fields": { "meeting_date": { "type": "string", "indexed": true } }
+} }
+```
+
+### Return previews instead of full bodies
+
+Listing pages don't need the whole note. By default `GET /notes` returns the lean shape — 120-char whitespace-collapsed `preview`, `byteSize`, and the usual metadata — with no `content`. Single-note `GET /notes/:id` still returns full content by default; pass `include_content=false` to drop it.
+
+```bash
+curl -H "Authorization: Bearer $VAULT_TOKEN" \
+  "http://localhost:1940/vault/default/api/notes?path_prefix=Posts/"
+# → [{ id, path, byteSize, preview, tags, metadata, ... }, ...]
+```
+
+Caller-tunable preview length is a future enhancement — file an issue if 120 chars isn't enough.
+
+### Incremental rebuilds: "what changed since X"
+
+The SSG / sync pattern. Two equivalent forms — bracket-style is canonical going forward; the flat form is the same shape that ships through the REST/MCP date filter today.
+
+```bash
+# Bracket-style (canonical)
+curl -H "Authorization: Bearer $VAULT_TOKEN" \
+  "http://localhost:1940/vault/default/api/notes?meta[updated_at][gte]=2026-04-01T00:00:00Z"
+
+# Flat form (DEPRECATED in 0.4.3; planned removal 0.6.0 per vault#288)
+curl -H "Authorization: Bearer $VAULT_TOKEN" \
+  "http://localhost:1940/vault/default/api/notes?date_field=updated_at&date_from=2026-04-01T00:00:00Z"
+```
+
+```jsonc
+// MCP — `date_filter` accepts created_at, updated_at, or any indexed metadata field.
+{ "name": "query-notes", "arguments": { "date_filter": { "field": "updated_at", "from": "2026-04-01T00:00:00Z" } } }
+```
+
+### Filter by metadata values (bracket style)
+
+Equality on any metadata field works with no setup:
+
+```bash
+curl -H "Authorization: Bearer $VAULT_TOKEN" \
+  "http://localhost:1940/vault/default/api/notes?meta[meeting-type]=study-session&include_content=true"
+```
+
+Range, `in`, `not_in`, and `exists` operators require the field to be declared `indexed: true` (same gate as `order_by`):
+
+```bash
+# Range — both bounds AND together on one field
+"…/notes?meta[date][gte]=2026-01-01&meta[date][lt]=2026-04-01"
+
+# Membership — `[]` array form OR comma-separated; same result.
+"…/notes?meta[status][in][]=active&meta[status][in][]=exploring"
+"…/notes?meta[status][in]=active,exploring"
+
+# Presence check
+"…/notes?meta[deadline][exists]=true"
+```
+
+Supported operators: `eq` (default when no operator given), `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `exists`. Multiple `meta[…]` filters AND together. Bracket-style and shorthand on the same field in one request reject loudly — pick one form.
+
+### Edit one line in a large note (without re-sending the whole body)
+
+`content_edit` does surgical find-and-replace. Payload is the changed text, not the whole note. `old_text` must occur exactly once; multiple matches or zero matches reject with a "re-read and retry" error.
+
+```jsonc
+// MCP
+{ "name": "update-note", "arguments": {
+    "id": "notes/decisions",
+    "content_edit": {
+      "old_text": "Status: pending",
+      "new_text": "Status: shipped (2026-05-10)"
+    },
+    "if_updated_at": "2026-05-10T12:34:56.789Z"
+} }
+```
+
+```bash
+# REST equivalent
+curl -X PATCH -H "Authorization: Bearer $VAULT_TOKEN" -H "Content-Type: application/json" \
+  -d '{"content_edit":{"old_text":"Status: pending","new_text":"Status: shipped (2026-05-10)"},"if_updated_at":"…"}' \
+  "http://localhost:1940/vault/default/api/notes/notes/decisions"
+```
+
+Set `include_content: false` on the request to cut the response cost too — you get back the lean `NoteIndex` shape instead of the full updated note.
+
+### Append to a note (no concurrency ceremony)
+
+Atomic at the SQL layer: two concurrent appends both land in some order, never clobber. Append-only updates are exempt from the `if_updated_at` precondition that other mutations require.
+
+```jsonc
+{ "name": "update-note", "arguments": { "id": "notes/journal/2026-05-10", "append": "\n\nEvening note: …" } }
+```
+
+If the note opens with YAML frontmatter, `prepend` is automatically injected after the closing fence so parsers still see frontmatter at byte 0.
+
+### CI / public access via Tailscale Funnel
+
+The shortest path to a public HTTPS URL for a vault you control — useful for SSG rebuilds running on GitHub Actions, Vercel, or any runner that isn't on your tailnet. See [Remote access via Tailscale Funnel](#remote-access-via-tailscale-funnel) below for the full setup.
+
 ## Data model
 
 ```

--- a/README.md
+++ b/README.md
@@ -499,6 +499,8 @@ curl -H "Authorization: Bearer $VAULT_TOKEN" \
 { "name": "query-notes", "arguments": { "date_filter": { "field": "updated_at", "from": "2026-04-01T00:00:00Z" } } }
 ```
 
+Only `gte` and `lt` are accepted on `created_at` / `updated_at` (other operators reject with `INVALID_QUERY` — these bracket forms route to the real-column `dateFilter`, not the full metadata operator set, so the half-open `[from, to)` shape is the only expressible range). The full operator set in the next recipe applies to *metadata* fields only.
+
 ### Filter by metadata values (bracket style)
 
 Equality on any metadata field works with no setup:
@@ -551,13 +553,13 @@ Set `include_content: false` on the request to cut the response cost too — you
 
 ### Append to a note (no concurrency ceremony)
 
-Atomic at the SQL layer: two concurrent appends both land in some order, never clobber. Append-only updates are exempt from the `if_updated_at` precondition that other mutations require.
+Atomic at the SQL layer: two concurrent appends both land in some order, never clobber. Append-only and prepend-only updates are exempt from the `if_updated_at` precondition that other mutations require — the SQL-atomic concatenation can't lose data on a stale read, so the precondition would be ceremony for no benefit. Underlying mechanic in [`core/src/notes.ts:295-322`](./core/src/notes.ts).
 
 ```jsonc
 { "name": "update-note", "arguments": { "id": "notes/journal/2026-05-10", "append": "\n\nEvening note: …" } }
 ```
 
-If the note opens with YAML frontmatter, `prepend` is automatically injected after the closing fence so parsers still see frontmatter at byte 0.
+`prepend` is frontmatter-aware: if the note opens with YAML frontmatter, the prepended text is automatically injected *after* the closing `---` fence so parsers that expect frontmatter at byte 0 still find it. Detection is done in the same SQL UPDATE expression, so atomicity is preserved.
 
 ### CI / public access via Tailscale Funnel
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.3-rc.2",
+  "version": "0.4.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Promotes the `0.4.3-rc.1` → `0.4.3-rc.2` chain to stable on `@latest`. Two code-bearing PRs shipped under the rc chain (vault#286, vault#289); this PR bundles them with a new README cookbook section distilled from the vault#285 field-input thread.

## What ships in 0.4.3

- **Read path**
  - `dateFilter` recognizes `updated_at` (vault#285 1.5, vault#286). Unblocks SSG incremental-rebuild patterns.
  - HTTP bracket-style metadata filter exposing the full engine operator set — `eq` / `ne` / `gt` / `gte` / `lt` / `lte` / `in` / `not_in` / `exists` — via `?meta[field][op]=value` (vault#285 1.3, vault#289).
  - Flat `date_field` / `date_from` / `date_to` deprecated; planned removal 0.6.0 (tracked at vault#288). Bracket wins on overlap.
- **Write path**
  - `update-note` `include_content: false` returns the lean `NoteIndex` shape (vault#285 2.response, vault#286). Default `true` keeps existing callers unchanged.
- **Discoverability**
  - New README "Common queries / cookbook" section. Eight field-tested recipes: path-subtree queries, sort by indexed metadata, preview-only listings, incremental rebuilds, bracket-meta filtering, surgical `content_edit`, atomic `append`, and a pointer to the existing Tailscale Funnel section. Each is one-paragraph context + the literal curl/MCP example.

## vault#285 friction points — final status

| Point | Status | Where |
|---|---|---|
| 1.1 path_prefix | Already shipped | Now documented in cookbook |
| 1.2 sort by metadata | Already shipped | Now documented in cookbook |
| 1.3 HTTP metadata filter | Shipped 0.4.3 (vault#289) | Cookbook |
| 1.4 preview-only | Already shipped (default); tunable N deferred | Cookbook |
| 1.5 updated_at | Shipped 0.4.3 (vault#286) | Cookbook |
| 1.6 URL-safe slug | Deferred until a renderer needs it | — |
| 1.7 Tailscale Funnel | Already documented | Cookbook cross-references |
| 2.response | Shipped 0.4.3 (vault#286) | Cookbook |
| 2.section/diff/line-range | Deferred (content_edit + append cover it) | Cookbook documents content_edit + append |

## Version

`0.4.3-rc.2` → `0.4.3`.

## CHANGELOG layout

Follows the 0.4.2 precedent: new `## [0.4.3]` heading with operator-facing summary on top; rc.1 + rc.2 entries preserved below for granular history.

## Test plan

- [x] `bun test ./core/src/ ./src/` — 1255/1255 pass (unchanged from rc.2; no code changes in this PR)
- [x] `bunx tsc --noEmit` clean

## Out of scope

- Cookbook as a separate `parachute-patterns/patterns/` doc — kept in vault README for now per team-lead's call.
- Wider cookbook coverage (tag conventions, schema patterns, OAuth flows) — vault#285 friction points only.

Refs vault#285, vault#286, vault#288, vault#289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)