### PR TITLE
feat(mcp-install): hub-mint default + scope + project-level + multi-vault (Phase A+B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,88 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.4-rc.1] — 2026-05-11
+
+Rework `parachute-vault mcp-install` (Phase A + B of the install-flow audit).
+Hub-mint becomes the canonical install path; `pvt_*` becomes the explicit
+`--legacy-pat` opt-in. New flag surface gives operators control over auth
+source, scope, install location, and target vault.
+
+### New CLI shape
+
+```
+parachute-vault mcp-install
+  [--mint | --token <bearer> | --legacy-pat]    # auth mode (mutually exclusive)
+  [--scope vault:read|vault:write|vault:admin]  # default: vault:read
+  [--install-scope user|project]                # default: user (~/.claude.json)
+  [--vault <name>]                              # default: default_vault
+  [--client claude-code]                        # only claude-code wired up
+```
+
+### Behavior changes
+
+- **Default is now `--mint`** — install reads `~/.parachute/operator.token`,
+  POSTs to `<hub>/api/auth/mint-token` with the requested scope, and writes
+  the returned scope-narrow JWT into `Authorization: Bearer …`. Aligns with
+  the hub-as-AS direction settled in vault#212. Requires the operator token
+  + a configured hub origin; both failure modes have specific remediation
+  messages.
+- **`--token <bearer>`** — paste an existing bearer (any shape: hub JWT,
+  `pvt_*`, legacy YAML key) instead of minting. Skips all token-mint logic.
+- **`--legacy-pat`** — mints a vault-DB `pvt_*` token. Preserved for
+  self-hosted-without-hub setups. Prints a deprecation notice on stderr;
+  the canonical path going forward is hub-mint.
+- **`--scope vault:read|vault:write|vault:admin`** — narrows the minted
+  token's scope. Default `vault:read` (least-privilege). For `--mint`,
+  expands to `vault:<vault-name>:<verb>` so the JWT can't be re-used
+  against other vaults on the same hub. For `--legacy-pat`, narrows the
+  on-disk token's scope set.
+- **`--install-scope user|project`** — `user` writes `~/.claude.json` (old
+  behavior); `project` writes `./.mcp.json` in CWD (Claude Code's
+  project-local config). Doctor checks both locations now.
+- **`--vault <name>`** — targets a specific vault; the entry is keyed as
+  `parachute-vault-<name>` so multi-vault installs coexist. Without
+  `--vault`, the singular `parachute-vault` slot is used (one install
+  per file, default).
+
+### Internals
+
+- `installMcpConfig(apiKey?)` signature → `installMcpConfig(opts)` with
+  `targetPath` / `entryKey` / `vaultName` / `bearer` fields. Init's
+  bootstrap path continues to mint a `pvt_*` so a fresh standalone install
+  still works without a hub; operators with a hub re-run `mcp-install`
+  (now defaulting to hub-mint) to upgrade.
+- `removeMcpConfig` cleans both `~/.claude.json` and `./.mcp.json` and
+  honors the new `parachute-vault-<name>` per-vault keys (plus the legacy
+  `parachute-vault/<name>` slash-form for backward cleanup).
+- `readMcpEntry` (doctor) checks both target files, prefers user-level,
+  and accepts singular + per-vault entry keys. Reports which file +
+  entry-key the check matched.
+- New helpers in `src/mcp-install.ts`: `chooseHubOrigin` (bare origin for
+  hub API calls), `readOperatorToken` (reads `~/.parachute/operator.token`),
+  `mintHubJwt` (test-seamed fetch wrapper for the mint-token endpoint),
+  `resolveInstallTarget` (user/project file resolver).
+
+### Tests
+
+26 new tests in `src/mcp-install.test.ts` cover: hub-mint happy path with
+mocked fetch, every API/network failure mode, operator-token read paths,
+install-target resolution, every flag-parsing rejection (mutually
+exclusive auth modes, bad `--scope`, bad `--install-scope`, bad
+`--client`), missing operator token, no-hub-configured, end-to-end
+`--token` / `--legacy-pat` / `--install-scope project` / `--vault <name>` /
+overwrite-existing-bearer. Doctor tests updated for the new check-name
+shape that includes the source file + entry key. 1281/1281 pass.
+
+### Out of scope (Phase C — deferred)
+
+- **Cross-client support** (Cursor, Claude Desktop, Codex, Zed, Goose,
+  Cline) — `--client` flag accepts only `claude-code` and rejects others
+  with a "Phase C" message so the surface is documented but not yet
+  pluralized.
+- **Client auto-detection** (probe installed clients, suggest defaults).
+- **Interactive picker** when run from a TTY without explicit flags.
+
 ## [0.4.3] — 2026-05-10
 
 Two release cuts (`0.4.3-rc.1` and `0.4.3-rc.2`) ship together as `0.4.3`

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Password and 2FA secrets live in `~/.parachute/vault/config.yaml` at mode 0600 (
 
 Where `{name}` is `default` on a fresh install, or whatever vault you pointed `vault init` at. **First MCP call after `vault init` requires no browser handoff — Claude Code uses the baked-in token and the vault's tools show up in your next session.** This is intentional: for an owner connecting their own machine's vault to their own Claude Code, the token is already there and OAuth would add friction.
 
-To re-point Claude Code at a different vault, change `default_vault` in `~/.parachute/vault/config.yaml` and re-run `parachute-vault init` — which re-mints an API token and re-writes the `~/.claude.json` entry end-to-end. To rotate the token only, edit `~/.claude.json` and replace the `Authorization` header value with a fresh token from `parachute-vault tokens create`. (Running `parachute-vault mcp-install` on its own overwrites the MCP entry *without* an `Authorization` header and is intended for the rare case where you want to drop the token and connect via OAuth instead.)
+To re-point Claude Code at a different vault, change `default_vault` in `~/.parachute/vault/config.yaml` and re-run `parachute-vault init` — which re-mints an API token and re-writes the `~/.claude.json` entry end-to-end. To rotate the token only, run `parachute-vault mcp-install` (defaults to `--mint`, which mints a fresh scope-narrow hub JWT via `~/.parachute/operator.token` and writes it into `~/.claude.json` with an `Authorization: Bearer …` header). See the [cookbook](#install-vault-mcp-into-a-client-config) section below for the full flag surface — token paste, scope narrowing, project-level install, multi-vault.
 
 ### Claude Desktop (OAuth)
 
@@ -190,7 +190,11 @@ parachute-vault uninstall --yes --wipe     # scripted destructive wipe (prints a
 parachute-vault create work                # create a new vault
 parachute-vault list                       # list all vaults (alias: `ls`)
 parachute-vault remove work --yes          # delete a vault (alias: `rm`)
-parachute-vault mcp-install                # (re)write the ~/.claude.json MCP entry for the default vault
+parachute-vault mcp-install                # (re)write the MCP client entry; defaults to --mint (hub-issued JWT)
+parachute-vault mcp-install --token <t>    # paste an existing bearer instead of minting
+parachute-vault mcp-install --legacy-pat   # mint a vault-DB pvt_* (self-hosted-without-hub)
+parachute-vault mcp-install --install-scope project   # write ./.mcp.json instead of ~/.claude.json
+parachute-vault mcp-install --vault work   # target the "work" vault (keyed as parachute-vault-work)
 
 # OAuth — owner password + 2FA
 parachute-vault set-password               # set/change the owner password (OAuth consent page)
@@ -564,6 +568,37 @@ Atomic at the SQL layer: two concurrent appends both land in some order, never c
 ### CI / public access via Tailscale Funnel
 
 The shortest path to a public HTTPS URL for a vault you control — useful for SSG rebuilds running on GitHub Actions, Vercel, or any runner that isn't on your tailnet. See [Remote access via Tailscale Funnel](#remote-access-via-tailscale-funnel) below for the full setup.
+
+### Install vault MCP into a client config
+
+Four common patterns. The standalone `mcp-install` command supports three explicit auth modes plus user-level vs project-level installs.
+
+```bash
+# 1. Default — mint a scope-narrow hub JWT (vault:<vault>:read) via your
+#    operator token, write it into ~/.claude.json. Requires:
+#      - ~/.parachute/operator.token (run `parachute auth rotate-operator` if missing)
+#      - PARACHUTE_HUB_ORIGIN set OR an active `parachute expose` session
+parachute-vault mcp-install
+
+# 2. Project-level install — write ./.mcp.json (Claude Code reads project-
+#    local configs) instead of ~/.claude.json. Pair with --scope vault:write
+#    when the project actually mutates the vault.
+parachute-vault mcp-install --install-scope project --scope vault:write
+
+# 3. Paste an existing token — useful when you already have a pvt_* in hand
+#    or want to re-use a long-lived bearer from another machine. Skips the
+#    mint step entirely.
+parachute-vault mcp-install --token pvt_abc123...
+
+# 4. Self-hosted-without-hub — mint a vault-DB pvt_* token (the legacy
+#    path; preserved so deployments without a hub keep working). Prints a
+#    deprecation notice.
+parachute-vault mcp-install --legacy-pat
+```
+
+**Multi-vault.** `--vault <name>` targets a specific vault and writes the entry under `parachute-vault-<name>` so multiple vaults coexist. Without `--vault`, the singular `parachute-vault` slot is used and one install clobbers another — that's intentional for the common single-vault case.
+
+**Doctor.** `parachute-vault doctor` checks both `~/.claude.json` and `./.mcp.json` and reports which one holds the entry, plus port-match and reachability of the MCP URL.
 
 ## Data model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.3",
+  "version": "0.4.4-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,8 @@
  *   parachute-vault init                    — set up everything, one command
  *   parachute-vault create <name>           — create a new vault
  *   parachute-vault list                    — list all vaults
- *   parachute-vault mcp-install <name>      — add vault MCP to ~/.claude.json
+ *   parachute-vault mcp-install [flags]     — install vault MCP into a client config
+ *                                              (defaults: --mint into ~/.claude.json)
  *   parachute-vault remove <name>           — remove a vault
  *   parachute-vault config                  — show all config
  *   parachute-vault config set <key> <val>  — set a config value
@@ -51,7 +52,14 @@ import {
 import type { VaultConfig } from "./config.ts";
 import { DATA_DIR } from "./config.ts";
 import { installAgent, uninstallAgent, isAgentLoaded, restartAgent } from "./launchd.ts";
-import { chooseMcpUrl } from "./mcp-install.ts";
+import {
+  chooseHubOrigin,
+  chooseMcpUrl,
+  mintHubJwt,
+  readOperatorToken,
+  resolveInstallTarget,
+  type InstallScope,
+} from "./mcp-install.ts";
 import { buildInitSummaryLines } from "./init-summary.ts";
 import {
   runBackup,
@@ -152,7 +160,7 @@ switch (command) {
     cmdList();
     break;
   case "mcp-install":
-    cmdMcpInstall(cmdArgs);
+    await cmdMcpInstall(cmdArgs);
     break;
   case "remove":
   case "rm":
@@ -503,7 +511,19 @@ async function cmdInit(args: string[] = []) {
   }
 
   if (addMcp) {
-    installMcpConfig(apiKey);
+    // Init's bootstrap path stays on the pvt_* shape so a fresh-install
+    // without a hub still works out of the box. Operators with a hub can
+    // re-run `parachute-vault mcp-install` (defaults to hub-mint) to
+    // upgrade. The new `installMcpConfig` opts shape is used here with
+    // the same effective behavior as before.
+    const target = resolveInstallTarget("user");
+    const { url, source } = installMcpConfig({
+      targetPath: target.path,
+      entryKey: "parachute-vault",
+      vaultName: defaultVault,
+      bearer: apiKey,
+    });
+    console.log(`MCP URL: ${url} (${source})`);
     console.log(`  MCP server added to ~/.claude.json`);
   } else {
     console.log("  Skipped adding MCP to ~/.claude.json.");
@@ -880,10 +900,224 @@ function cmdList() {
   }
 }
 
-function cmdMcpInstall(_args: string[]) {
-  installMcpConfig();
-  console.log(`Added MCP server "parachute-vault" to ~/.claude.json`);
-  console.log(`All vaults accessible via the 'vault' parameter on each tool.`);
+/**
+ * Parse a `--flag value` pair from an args array. Returns the value (or
+ * undefined when the flag isn't present) and a flag whether the flag's value
+ * was actually present (catches `--flag` without an argument).
+ */
+function takeArgValue(args: string[], name: string): { value?: string; missingValue?: boolean } {
+  const idx = args.indexOf(name);
+  if (idx === -1) return {};
+  const next = args[idx + 1];
+  if (!next || next.startsWith("--")) return { missingValue: true };
+  return { value: next };
+}
+
+/**
+ * `parachute-vault mcp-install` — install the vault MCP server into an
+ * AI client's config. Three auth modes (mutually exclusive):
+ *
+ *   --mint                (default) Mint a hub JWT via `POST <hub>/api/auth/mint-token`
+ *                         using the local operator token.
+ *   --token <bearer>      Use an existing token (hub JWT, pvt_*, anything).
+ *   --legacy-pat          Mint a vault-DB `pvt_*` token (deprecated;
+ *                         self-hosted-without-hub setups).
+ *
+ * Targeting:
+ *   --scope <verb>        vault:read | vault:write | vault:admin (default: vault:read).
+ *                         For --mint, expands to vault:<vault-name>:<verb>.
+ *   --install-scope <s>   user (default; ~/.claude.json) | project (./.mcp.json).
+ *   --vault <name>        Vault to target (default: default_vault). Multi-vault
+ *                         installs key the entry as `parachute-vault-<name>`.
+ *   --client <name>       Reserved for Phase C. Only `claude-code` accepted.
+ */
+async function cmdMcpInstall(args: string[]): Promise<void> {
+  // --- Auth-mode parsing (mutually exclusive) ---
+  const wantMint = args.includes("--mint");
+  const wantLegacy = args.includes("--legacy-pat");
+  const tokenArg = takeArgValue(args, "--token");
+  if (tokenArg.missingValue) {
+    console.error("--token requires a value (the bearer token to embed).");
+    process.exit(1);
+  }
+  const wantToken = tokenArg.value !== undefined;
+  const modesSet = (wantMint ? 1 : 0) + (wantLegacy ? 1 : 0) + (wantToken ? 1 : 0);
+  if (modesSet > 1) {
+    console.error("--mint, --token, and --legacy-pat are mutually exclusive.");
+    process.exit(1);
+  }
+  const mode: "mint" | "token" | "legacy-pat" =
+    wantToken ? "token" : wantLegacy ? "legacy-pat" : "mint";
+
+  // --- Scope parsing. Default vault:read (least-privilege). ---
+  const scopeArg = takeArgValue(args, "--scope");
+  if (scopeArg.missingValue) {
+    console.error("--scope requires a value: vault:read, vault:write, or vault:admin.");
+    process.exit(1);
+  }
+  const rawScope = scopeArg.value ?? "vault:read";
+  if (!(VAULT_SCOPES as readonly string[]).includes(rawScope)) {
+    console.error(
+      `--scope must be one of: ${VAULT_SCOPES.join(", ")}. Got: ${rawScope}.`,
+    );
+    process.exit(1);
+  }
+  // Verb is the last segment of `vault:<verb>` — used to narrow to
+  // `vault:<vault-name>:<verb>` for the hub-mint path.
+  const verb = rawScope.split(":")[1]!;
+
+  // --- Install scope: user (default) or project. ---
+  const installScopeArg = takeArgValue(args, "--install-scope");
+  if (installScopeArg.missingValue) {
+    console.error("--install-scope requires a value: user or project.");
+    process.exit(1);
+  }
+  const installScopeRaw = installScopeArg.value ?? "user";
+  if (installScopeRaw !== "user" && installScopeRaw !== "project") {
+    console.error(`--install-scope must be "user" or "project". Got: ${installScopeRaw}.`);
+    process.exit(1);
+  }
+  const installScope: InstallScope = installScopeRaw;
+
+  // --- Client (Phase C placeholder). Reject anything other than claude-code. ---
+  // Validated before filesystem-dependent vault-existence so a static flag
+  // typo fails on its own terms ("--client cursor not supported") rather
+  // than getting masked by an unrelated "vault not found" error.
+  const clientArg = takeArgValue(args, "--client");
+  if (clientArg.missingValue) {
+    console.error("--client requires a value.");
+    process.exit(1);
+  }
+  const client = clientArg.value ?? "claude-code";
+  if (client !== "claude-code") {
+    console.error(
+      `--client "${client}" is not yet supported. Only "claude-code" is wired up; ` +
+        `Cursor / Claude Desktop / Codex / Zed are Phase C work.`,
+    );
+    process.exit(1);
+  }
+
+  // --- Vault target. Default = default_vault; validate existence. ---
+  const vaultArg = takeArgValue(args, "--vault");
+  if (vaultArg.missingValue) {
+    console.error("--vault requires a value (the vault name).");
+    process.exit(1);
+  }
+  const globalConfig = readGlobalConfig();
+  const defaultVault = globalConfig.default_vault || "default";
+  const vaultName = vaultArg.value ?? defaultVault;
+  // Was --vault explicitly given? Used to decide entry-key shape — explicit
+  // means "this is one vault among many, key it per-vault"; default means
+  // "the single canonical install, key it as `parachute-vault`."
+  const vaultExplicit = vaultArg.value !== undefined;
+  if (!readVaultConfig(vaultName)) {
+    console.error(`Vault "${vaultName}" not found. Available: ${listVaults().join(", ") || "(none)"}.`);
+    process.exit(1);
+  }
+
+  // --- Resolve target file + entry key. ---
+  const target = resolveInstallTarget(installScope);
+  // Multi-vault installs key the entry as `parachute-vault-<name>` so the
+  // singular `parachute-vault` slot remains the default install. An explicit
+  // `--vault <name>` (even pointing at the default) opts into the per-vault
+  // key shape; without `--vault`, the default install keeps clobbering the
+  // singular slot as before.
+  const entryKey = vaultExplicit ? `parachute-vault-${vaultName}` : "parachute-vault";
+
+  // --- Acquire the bearer per mode. ---
+  let bearer: string | undefined;
+  if (mode === "token") {
+    bearer = tokenArg.value!;
+    console.log(`Using supplied --token (skipping mint).`);
+  } else if (mode === "legacy-pat") {
+    console.error(
+      "Note: --legacy-pat mints a vault-DB pvt_* token. The hub-issued JWT path (--mint, default) " +
+        "is the canonical install going forward; pvt_* support is preserved for self-hosted-without-hub " +
+        "setups but may be removed in a future release.",
+    );
+    const store = getVaultStore(vaultName);
+    const { fullToken } = generateToken();
+    // Narrow the pvt_* to the requested verb's scope set when not full-admin.
+    // `scopes: undefined` leaves the token at full vault permissions
+    // (admin); narrowing to a single-scope array gates it to that verb.
+    const createTokenOpts: Parameters<typeof createToken>[2] = {
+      label: "mcp-install",
+      permission: verb === "read" ? "read" : "full",
+      vault_name: vaultName,
+    };
+    if (verb !== "admin") {
+      createTokenOpts.scopes = [rawScope];
+    }
+    createToken(store.db, fullToken, createTokenOpts);
+    bearer = fullToken;
+  } else {
+    // mode === "mint"
+    const operatorToken = readOperatorToken();
+    if (!operatorToken) {
+      console.error(
+        "No operator token found at ~/.parachute/operator.token. The default install path " +
+          "(--mint) requires a hub-issued operator token to mint scope-narrow JWTs.\n" +
+          "  Fix: run `parachute auth rotate-operator` to create one, then re-run.\n" +
+          "  Or:  use `--token <bearer>` to paste an existing token, or `--legacy-pat` to " +
+          "mint a vault-DB pvt_* token (self-hosted-without-hub).",
+      );
+      process.exit(1);
+    }
+    const port = globalConfig.port || DEFAULT_PORT;
+    const hub = chooseHubOrigin(port);
+    if (hub.source === "loopback") {
+      console.error(
+        "No hub origin configured (PARACHUTE_HUB_ORIGIN unset, no active expose-state). " +
+          "Hub-mint (--mint) needs a real hub URL to call. Either:\n" +
+          "  - Start the hub and set PARACHUTE_HUB_ORIGIN, OR\n" +
+          "  - Bring up an exposure (`parachute expose tailnet`), OR\n" +
+          "  - Use --legacy-pat to mint a vault-DB pvt_* token instead.",
+      );
+      process.exit(1);
+    }
+    // Narrow the mint to `vault:<vault-name>:<verb>` so the JWT can't be
+    // reused against other vaults on the same hub.
+    const narrowScope = `vault:${vaultName}:${verb}`;
+    const result = await mintHubJwt({
+      hubOrigin: hub.url,
+      operatorToken,
+      scope: narrowScope,
+      subject: "parachute-vault-mcp",
+    });
+    if ("kind" in result) {
+      switch (result.kind) {
+        case "no-operator-token":
+          // Shouldn't reach — we already checked above. Defensive branch.
+          console.error("Operator token disappeared between read and mint. Re-run.");
+          break;
+        case "network":
+          console.error(
+            `Hub unreachable at ${result.origin} — ${result.cause}.\n` +
+              `  Fix: verify the hub is running and PARACHUTE_HUB_ORIGIN is set, ` +
+              `or use --legacy-pat to skip hub-mint.`,
+          );
+          break;
+        case "api-error":
+          console.error(
+            `Hub mint-token rejected (HTTP ${result.status}, ${result.error}): ${result.description}`,
+          );
+          break;
+      }
+      process.exit(1);
+    }
+    bearer = result.token;
+    console.log(`Minted hub JWT (jti=${result.jti}, expires ${result.expires_at}, scope ${result.scope}).`);
+  }
+
+  // --- Write the entry. ---
+  const { url, source } = installMcpConfig({
+    targetPath: target.path,
+    entryKey,
+    vaultName,
+    bearer,
+  });
+  console.log(`MCP URL: ${url} (${source})`);
+  console.log(`Added MCP server "${entryKey}" to ${target.path}`);
 }
 
 function cmdRemove(args: string[]) {
@@ -1554,23 +1788,23 @@ async function cmdDoctor() {
     });
   }
 
-  // MCP entry in ~/.claude.json. Split into three separate checks so the
-  // user can see exactly which condition fails: "entry present", "port
-  // matches vault", "daemon reachable over MCP URL". A common failure is
-  // "entry exists but port is stale" after the user changed PORT without
-  // re-running `mcp-install`.
+  // MCP entry in ~/.claude.json or ./.mcp.json. Split into three separate
+  // checks so the user can see exactly which condition fails: "entry
+  // present", "port matches vault", "daemon reachable over MCP URL". A
+  // common failure is "entry exists but port is stale" after the user
+  // changed PORT without re-running `mcp-install`.
   const port = resolveVaultPort();
   const mcpEntry = readMcpEntry();
   if (!mcpEntry.found) {
     checks.push({
-      name: "MCP entry in ~/.claude.json",
+      name: "MCP entry in MCP client config",
       status: "warn",
       detail: mcpEntry.reason,
       fix: "Run `parachute-vault mcp-install` to register the vault with Claude.",
     });
   } else {
     checks.push({
-      name: "MCP entry in ~/.claude.json",
+      name: `MCP entry in ${mcpEntry.locationLabel}`,
       status: "pass",
       detail: mcpEntry.url,
     });
@@ -1734,57 +1968,79 @@ function resolveVaultPort(): number {
 
 type McpEntryLookup =
   | { found: false; reason: string }
-  | { found: true; url: string; port: number | null };
+  | { found: true; url: string; port: number | null; locationLabel: string };
 
 /**
- * Read `~/.claude.json` and return the shape of the `parachute-vault` MCP
- * entry if present. The entry is always an HTTP MCP pointing at the local
- * daemon — `{ type: "http", url: "http://127.0.0.1:<port>/vault/<name>/mcp" }`
- * — so we parse the URL's port for the port-match check.
+ * Read the parachute vault MCP entry from either `~/.claude.json` (user
+ * scope) or `./.mcp.json` (project scope), preferring user-level. Accepts
+ * the singular `parachute-vault` key or any per-vault `parachute-vault-<name>`
+ * key — multi-vault installs key per-vault. The entry is always an HTTP MCP
+ * pointing at the local daemon, so we parse the URL's port for the
+ * port-match check.
  *
- * Invariant: the check is NON-fatal. A missing ~/.claude.json is a warn,
- * not a fail: plenty of users install the vault first and wire it to
- * Claude later. We just make the "is it wired up?" state legible.
+ * Invariant: the check is NON-fatal. A missing entry is a warn, not a fail:
+ * plenty of users install the vault first and wire it to Claude later. We
+ * just make the "is it wired up?" state legible.
  */
 function readMcpEntry(): McpEntryLookup {
-  const claudeJsonPath = resolve(homedir(), ".claude.json");
-  if (!existsSync(claudeJsonPath)) {
-    return { found: false, reason: `${claudeJsonPath} does not exist` };
+  const candidates = [
+    { path: resolve(homedir(), ".claude.json"), label: "~/.claude.json" },
+    { path: resolve(process.cwd(), ".mcp.json"), label: `${process.cwd()}/.mcp.json` },
+  ];
+  const checkedReasons: string[] = [];
+  for (const { path, label } of candidates) {
+    if (!existsSync(path)) {
+      checkedReasons.push(`${label} does not exist`);
+      continue;
+    }
+    let config: any;
+    try {
+      config = JSON.parse(readFileSync(path, "utf-8"));
+    } catch (err: any) {
+      checkedReasons.push(`${label} is not valid JSON: ${String(err?.message ?? err)}`);
+      continue;
+    }
+    const servers = config?.mcpServers ?? {};
+    // Prefer the singular `parachute-vault` slot (canonical default
+    // install); fall back to the first `parachute-vault-<name>` per-vault
+    // entry. Multi-vault installs may have several; the doctor reports on
+    // the one it finds first so the basic "is something wired up?" check
+    // still works without enumerating every vault.
+    let entry = servers["parachute-vault"];
+    let entryKey = "parachute-vault";
+    if (!entry) {
+      for (const key of Object.keys(servers)) {
+        if (key.startsWith("parachute-vault-")) {
+          entry = servers[key];
+          entryKey = key;
+          break;
+        }
+      }
+    }
+    if (!entry) {
+      checkedReasons.push(`no parachute-vault entry in ${label}`);
+      continue;
+    }
+    const url = typeof entry.url === "string" ? entry.url : null;
+    if (!url) {
+      checkedReasons.push(
+        `${label} mcpServers["${entryKey}"] has no \`url\` field (got ${JSON.stringify(entry).slice(0, 80)})`,
+      );
+      continue;
+    }
+    let entryPort: number | null = null;
+    try {
+      const parsed = new URL(url);
+      entryPort = parsed.port ? Number(parsed.port) : null;
+    } catch {
+      entryPort = null;
+    }
+    return { found: true, url, port: entryPort, locationLabel: `${label} (${entryKey})` };
   }
-  let config: any;
-  try {
-    config = JSON.parse(readFileSync(claudeJsonPath, "utf-8"));
-  } catch (err: any) {
-    return {
-      found: false,
-      reason: `${claudeJsonPath} is not valid JSON: ${String(err?.message ?? err)}`,
-    };
-  }
-  const entry = config?.mcpServers?.["parachute-vault"];
-  if (!entry) {
-    return {
-      found: false,
-      reason: `no mcpServers["parachute-vault"] entry in ${claudeJsonPath}`,
-    };
-  }
-  // The entry is always a URL-bearing HTTP MCP. Non-URL shapes are
-  // unexpected (Claude Code would ignore them anyway) but we surface the
-  // raw shape so the user can see what's there.
-  const url = typeof entry.url === "string" ? entry.url : null;
-  if (!url) {
-    return {
-      found: false,
-      reason: `mcpServers["parachute-vault"] has no \`url\` field (got ${JSON.stringify(entry).slice(0, 80)})`,
-    };
-  }
-  let entryPort: number | null = null;
-  try {
-    const parsed = new URL(url);
-    entryPort = parsed.port ? Number(parsed.port) : null;
-  } catch {
-    entryPort = null;
-  }
-  return { found: true, url, port: entryPort };
+  return {
+    found: false,
+    reason: checkedReasons.length > 0 ? checkedReasons.join("; ") : "no MCP config files found",
+  };
 }
 
 /**
@@ -2282,12 +2538,24 @@ function createVault(name: string): string {
   return fullToken;
 }
 
-function installMcpConfig(apiKey?: string) {
-  const claudeJsonPath = resolve(homedir(), ".claude.json");
+interface InstallMcpConfigOpts {
+  /** Absolute path to the MCP client config file. Computed by the caller via `resolveInstallTarget`. */
+  targetPath: string;
+  /** `mcpServers.<entryKey>` slot the entry lands at. Default is `parachute-vault`; multi-vault installs key as `parachute-vault-<name>`. */
+  entryKey: string;
+  /** Vault name to embed in the URL (`/vault/<vaultName>/mcp`). */
+  vaultName: string;
+  /** Bearer token to embed in `Authorization: Bearer …`. Omitted means the entry is unauthenticated — only useful for OAuth-capable clients (Claude Code does discovery). */
+  bearer?: string;
+}
+
+function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: string } {
+  const { targetPath, entryKey, vaultName, bearer } = opts;
+
   let config: any = {};
-  if (existsSync(claudeJsonPath)) {
+  if (existsSync(targetPath)) {
     try {
-      config = JSON.parse(readFileSync(claudeJsonPath, "utf-8"));
+      config = JSON.parse(readFileSync(targetPath, "utf-8"));
     } catch {}
   }
 
@@ -2296,45 +2564,48 @@ function installMcpConfig(apiKey?: string) {
   const globalConfig = readGlobalConfig();
   const port = globalConfig.port || DEFAULT_PORT;
 
-  // Clean up old per-vault stdio entries
-  for (const key of Object.keys(config.mcpServers)) {
-    if (key.startsWith("parachute-vault/")) {
-      delete config.mcpServers[key];
-    }
-  }
-
-  // Single HTTP MCP entry — use per-vault endpoint so pvt_ tokens work.
   // Pick the URL that matches the OAuth issuer vault will advertise, in this
   // order: explicit hub origin env > active tailnet/public exposure >
   // loopback. Otherwise a strict MCP client (Claude Code) hits a loopback URL
   // whose discovery issuer points at the hub and rejects on origin mismatch
   // (RFC 8414).
-  const defaultVault = globalConfig.default_vault || "default";
-  const { url: mcpUrl, source } = chooseMcpUrl(defaultVault, port);
-  console.log(`MCP URL: ${mcpUrl} (${source})`);
+  const { url: mcpUrl, source } = chooseMcpUrl(vaultName, port);
   const mcpEntry: Record<string, unknown> = { type: "http", url: mcpUrl };
-  if (apiKey) {
-    mcpEntry.headers = { Authorization: `Bearer ${apiKey}` };
+  if (bearer) {
+    mcpEntry.headers = { Authorization: `Bearer ${bearer}` };
   }
-  config.mcpServers["parachute-vault"] = mcpEntry;
+  config.mcpServers[entryKey] = mcpEntry;
 
-  writeFileSync(claudeJsonPath, JSON.stringify(config, null, 2) + "\n");
+  writeFileSync(targetPath, JSON.stringify(config, null, 2) + "\n");
+  return { url: mcpUrl, source };
 }
 
 function removeMcpConfig() {
+  // Remove vault entries from both user-level and project-level config
+  // files. Project-level uses CWD — only relevant when uninstall is run
+  // from inside a project that had `mcp-install --install-scope project`
+  // applied; otherwise the project path doesn't exist and we no-op.
   const claudeJsonPath = resolve(homedir(), ".claude.json");
-  if (!existsSync(claudeJsonPath)) return;
-  try {
-    const config = JSON.parse(readFileSync(claudeJsonPath, "utf-8"));
-    delete config.mcpServers?.["parachute-vault"];
-    // Also clean up any old per-vault entries
-    for (const key of Object.keys(config.mcpServers ?? {})) {
-      if (key.startsWith("parachute-vault/")) {
-        delete config.mcpServers[key];
+  const projectMcpJsonPath = resolve(process.cwd(), ".mcp.json");
+  for (const path of [claudeJsonPath, projectMcpJsonPath]) {
+    if (!existsSync(path)) continue;
+    try {
+      const config = JSON.parse(readFileSync(path, "utf-8"));
+      // Drop the singular key and every per-vault `parachute-vault-<name>`
+      // entry. Legacy `parachute-vault/<name>` (slash-form) sub-keys from a
+      // pre-multi-vault pattern still get cleaned up here.
+      for (const key of Object.keys(config.mcpServers ?? {})) {
+        if (
+          key === "parachute-vault" ||
+          key.startsWith("parachute-vault-") ||
+          key.startsWith("parachute-vault/")
+        ) {
+          delete config.mcpServers[key];
+        }
       }
-    }
-    writeFileSync(claudeJsonPath, JSON.stringify(config, null, 2) + "\n");
-  } catch {}
+      writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+    } catch {}
+  }
 }
 
 function usage() {
@@ -2377,7 +2648,25 @@ Vaults:
   parachute-vault create <name> [--json]   Create a new vault (--json: emit { name, token, paths, set_as_default })
   parachute-vault list                     List all vaults
   parachute-vault remove <name> [--yes]    Remove a vault
-  parachute-vault mcp-install              Add vault MCP to Claude
+  parachute-vault mcp-install [--mint|--token <t>|--legacy-pat]
+                              [--scope vault:read|vault:write|vault:admin]
+                              [--install-scope user|project]
+                              [--vault <name>] [--client claude-code]
+                                            Install vault MCP into a client config.
+                                            Default: --mint (hub-issued JWT via
+                                            ~/.parachute/operator.token) into
+                                            ~/.claude.json with vault:read scope.
+                                            --token <t>: paste an existing bearer
+                                            (any shape) instead of minting.
+                                            --legacy-pat: mint a vault-DB pvt_*
+                                            token (deprecated; for self-hosted-
+                                            without-hub setups).
+                                            --install-scope project writes
+                                            ./.mcp.json in CWD instead of
+                                            ~/.claude.json.
+                                            --vault <name> targets a specific
+                                            vault and keys the entry as
+                                            parachute-vault-<name>.
 
 Tokens:
   parachute-vault tokens                          List tokens (every vault)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1033,7 +1033,7 @@ async function cmdMcpInstall(args: string[]): Promise<void> {
     console.error(
       "Note: --legacy-pat mints a vault-DB pvt_* token. The hub-issued JWT path (--mint, default) " +
         "is the canonical install going forward; pvt_* support is preserved for self-hosted-without-hub " +
-        "setups but may be removed in a future release.",
+        "setups, tracked at vault#288, planned removal 0.6.0.",
     );
     const store = getVaultStore(vaultName);
     const { fullToken } = generateToken();
@@ -1086,10 +1086,6 @@ async function cmdMcpInstall(args: string[]): Promise<void> {
     });
     if ("kind" in result) {
       switch (result.kind) {
-        case "no-operator-token":
-          // Shouldn't reach — we already checked above. Defensive branch.
-          console.error("Operator token disappeared between read and mint. Re-run.");
-          break;
         case "network":
           console.error(
             `Hub unreachable at ${result.origin} — ${result.cause}.\n` +

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -156,16 +156,16 @@ describe("vault doctor — extended checks", () => {
     // Isolated HOME with no ~/.claude.json at all — the most common
     // pre-`mcp-install` state for new users.
     const res = runCli(["doctor"], dir, { HOME: dir });
-    expect(res.stdout).toMatch(/! MCP entry in ~\/\.claude\.json/);
-    expect(res.stdout).toMatch(/does not exist|no mcpServers/);
+    expect(res.stdout).toMatch(/! MCP entry in MCP client config/);
+    expect(res.stdout).toMatch(/does not exist|no parachute-vault entry/);
     expect(res.stdout).toMatch(/mcp-install/);
   });
 
   test("warns when ~/.claude.json exists but has no parachute-vault entry", () => {
     writeFileSync(join(dir, ".claude.json"), JSON.stringify({ mcpServers: {} }));
     const res = runCli(["doctor"], dir, { HOME: dir });
-    expect(res.stdout).toMatch(/! MCP entry in ~\/\.claude\.json/);
-    expect(res.stdout).toMatch(/no mcpServers\["parachute-vault"\] entry/);
+    expect(res.stdout).toMatch(/! MCP entry in MCP client config/);
+    expect(res.stdout).toMatch(/no parachute-vault entry/);
   });
 
   test("passes MCP entry + port-match checks when URL points at the configured port", () => {
@@ -174,7 +174,8 @@ describe("vault doctor — extended checks", () => {
     writeFileSync(join(dir, "config.yaml"), "port: 4321\n");
     writeClaudeJson(dir, "http://127.0.0.1:4321/vault/default/mcp");
     const res = runCli(["doctor"], dir, { HOME: dir });
-    expect(res.stdout).toMatch(/✓ MCP entry in ~\/\.claude\.json/);
+    // Doctor now names the source file in the check label.
+    expect(res.stdout).toMatch(/✓ MCP entry in ~\/\.claude\.json \(parachute-vault\)/);
     expect(res.stdout).toMatch(/✓ MCP URL port matches vault\s+\(port 4321\)/);
     // Reachability will warn because nothing is bound to 4321 in the test
     // env — this is the "entry present, port matches, daemon unreachable"
@@ -186,7 +187,7 @@ describe("vault doctor — extended checks", () => {
     writeFileSync(join(dir, "config.yaml"), "port: 4321\n");
     writeClaudeJson(dir, "http://127.0.0.1:9999/vault/default/mcp");
     const res = runCli(["doctor"], dir, { HOME: dir });
-    expect(res.stdout).toMatch(/✓ MCP entry in ~\/\.claude\.json/);
+    expect(res.stdout).toMatch(/✓ MCP entry in ~\/\.claude\.json \(parachute-vault\)/);
     expect(res.stdout).toMatch(/! MCP URL port matches vault/);
     expect(res.stdout).toMatch(/MCP URL port 9999 ≠ vault port 4321/);
   });

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -1,15 +1,67 @@
 /**
- * Tests for the MCP URL picker used by `mcp-install`. The picker must match
- * vault's advertised OAuth issuer for the origin a client will reach it on —
- * otherwise Claude Code (and any strict RFC 8414 client) rejects the
- * discovery response on issuer/origin mismatch.
+ * Tests for `mcp-install` — three concerns:
+ *
+ *   1. Pure helpers in `mcp-install.ts` (URL picking, operator-token reading,
+ *      install-target resolution, hub-mint client with mocked fetch).
+ *   2. CLI flag parsing on `parachute-vault mcp-install` — mutual exclusion,
+ *      validation of `--scope` / `--install-scope` / `--client`.
+ *   3. End-to-end behavior for the modes that don't require a hub: `--token`
+ *      paste, `--legacy-pat` mint, `--install-scope project` write,
+ *      `--vault <name>` per-vault keying. The `--mint` default's happy path
+ *      needs a hub, so we only assert on its failure modes (no operator
+ *      token, no hub configured).
+ *
+ * The URL picker was the only piece with prior coverage; everything else
+ * lands in this PR alongside the cmdMcpInstall rewrite.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { chooseMcpUrl } from "./mcp-install.ts";
+import {
+  chooseHubOrigin,
+  chooseMcpUrl,
+  mintHubJwt,
+  readOperatorToken,
+  resolveInstallTarget,
+} from "./mcp-install.ts";
+
+const CLI = path.resolve(import.meta.dir, "cli.ts");
+
+/**
+ * Spawn the CLI under an isolated `PARACHUTE_HOME` and `HOME`. Cwd defaults
+ * to a tempdir too so `--install-scope project` writes don't leak into the
+ * real working tree.
+ */
+function runCli(
+  args: string[],
+  parachuteHome: string,
+  extraEnv: Record<string, string | undefined> = {},
+  cwd?: string,
+): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync({
+    cmd: ["bun", CLI, ...args],
+    cwd: cwd ?? parachuteHome,
+    env: {
+      ...process.env,
+      PARACHUTE_HOME: parachuteHome,
+      HOME: parachuteHome,
+      ...extraEnv,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: pure helpers
+// ---------------------------------------------------------------------------
 
 describe("chooseMcpUrl", () => {
   let tmpHome: string;
@@ -123,3 +175,381 @@ describe("chooseMcpUrl", () => {
     expect(res.url).toBe("https://hub.example/vault/work/mcp");
   });
 });
+
+describe("chooseHubOrigin", () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    origHome = process.env.PARACHUTE_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "vault-hub-origin-"));
+    process.env.PARACHUTE_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.PARACHUTE_HOME;
+    else process.env.PARACHUTE_HOME = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test("returns the bare origin (no /vault/<name>/mcp suffix)", () => {
+    const res = chooseHubOrigin(1940, { PARACHUTE_HUB_ORIGIN: "https://hub.example" });
+    expect(res).toEqual({ url: "https://hub.example", source: "hub-origin" });
+  });
+
+  test("returns loopback origin when nothing is configured (caller treats as no-hub)", () => {
+    const res = chooseHubOrigin(1940, {});
+    expect(res).toEqual({ url: "http://127.0.0.1:1940", source: "loopback" });
+  });
+});
+
+describe("readOperatorToken", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "vault-op-token-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test("returns null when operator.token doesn't exist", () => {
+    expect(readOperatorToken({ PARACHUTE_HOME: tmpHome })).toBeNull();
+  });
+
+  test("reads and trims the operator.token file when present", () => {
+    fs.writeFileSync(path.join(tmpHome, "operator.token"), "  eyJabc.def.ghi  \n");
+    expect(readOperatorToken({ PARACHUTE_HOME: tmpHome })).toBe("eyJabc.def.ghi");
+  });
+
+  test("returns null for an empty operator.token", () => {
+    fs.writeFileSync(path.join(tmpHome, "operator.token"), "   \n");
+    expect(readOperatorToken({ PARACHUTE_HOME: tmpHome })).toBeNull();
+  });
+});
+
+describe("resolveInstallTarget", () => {
+  test("user scope → ~/.claude.json", () => {
+    const res = resolveInstallTarget("user");
+    expect(res.path).toBe(path.resolve(os.homedir(), ".claude.json"));
+    expect(res.scope).toBe("user");
+  });
+
+  test("project scope → <cwd>/.mcp.json", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vault-target-"));
+    try {
+      const res = resolveInstallTarget("project", tmp);
+      expect(res.path).toBe(path.resolve(tmp, ".mcp.json"));
+      expect(res.scope).toBe("project");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("mintHubJwt", () => {
+  test("happy path returns parsed JWT payload", async () => {
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const mockFetch: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          jti: "jti-abc",
+          token: "eyJ.signed.jwt",
+          expires_at: "2026-08-09T00:00:00.000Z",
+          scope: "vault:default:read",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    const res = await mintHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "operator-bearer",
+      scope: "vault:default:read",
+      fetchImpl: mockFetch,
+    });
+    expect("token" in res).toBe(true);
+    if (!("token" in res)) return; // narrow for TS
+    expect(res.token).toBe("eyJ.signed.jwt");
+    expect(res.scope).toBe("vault:default:read");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("https://hub.example/api/auth/mint-token");
+    const headers = new Headers(calls[0]!.init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer operator-bearer");
+    const body = JSON.parse(String(calls[0]!.init?.body));
+    expect(body.scope).toBe("vault:default:read");
+    expect(body.expires_in).toBeGreaterThan(0);
+  });
+
+  test("network error returns { kind: 'network' } with the origin and cause", async () => {
+    const mockFetch: typeof fetch = async () => {
+      throw new Error("connection refused");
+    };
+    const res = await mintHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "bearer",
+      scope: "vault:default:read",
+      fetchImpl: mockFetch,
+    });
+    expect(res).toEqual({ kind: "network", cause: "connection refused", origin: "https://hub.example" });
+  });
+
+  test("API error surfaces hub error + error_description", async () => {
+    const mockFetch: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({ error: "insufficient_scope", error_description: "bearer lacks parachute:host:auth" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    const res = await mintHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "bearer",
+      scope: "vault:default:read",
+      fetchImpl: mockFetch,
+    });
+    expect(res).toEqual({
+      kind: "api-error",
+      status: 403,
+      error: "insufficient_scope",
+      description: "bearer lacks parachute:host:auth",
+    });
+  });
+
+  test("malformed success response degrades to api-error rather than crashing", async () => {
+    const mockFetch: typeof fetch = async () =>
+      new Response(JSON.stringify({ token: "x" }), { status: 200, headers: { "Content-Type": "application/json" } });
+    const res = await mintHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "bearer",
+      scope: "vault:default:read",
+      fetchImpl: mockFetch,
+    });
+    expect("kind" in res && res.kind === "api-error").toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI flag-parsing tests — these don't need a vault DB
+// ---------------------------------------------------------------------------
+
+describe("mcp-install flag parsing", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-flags-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("rejects mutually exclusive --mint and --token", () => {
+    const res = runCli(["mcp-install", "--mint", "--token", "abc"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/mutually exclusive/);
+  });
+
+  test("rejects mutually exclusive --token and --legacy-pat", () => {
+    const res = runCli(["mcp-install", "--token", "abc", "--legacy-pat"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/mutually exclusive/);
+  });
+
+  test("rejects --token without a value", () => {
+    const res = runCli(["mcp-install", "--token"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/--token requires a value/);
+  });
+
+  test("rejects an unknown --scope value", () => {
+    const res = runCli(["mcp-install", "--scope", "vault:bogus", "--token", "t"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/--scope must be one of/);
+  });
+
+  test("rejects an unknown --install-scope value", () => {
+    const res = runCli(
+      ["mcp-install", "--install-scope", "system-wide", "--token", "t"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/--install-scope must be "user" or "project"/);
+  });
+
+  test("rejects a --client other than claude-code (Phase C is future work)", () => {
+    const res = runCli(
+      ["mcp-install", "--client", "cursor", "--token", "t"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/not yet supported|Phase C/);
+  });
+
+  test("rejects an unknown vault", () => {
+    const res = runCli(
+      ["mcp-install", "--vault", "ghost", "--token", "t"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/Vault "ghost" not found/);
+  });
+
+  test("rejects --mint when there's no operator.token", () => {
+    // Pre-create a vault directory so the existence check passes — the
+    // operator.token check fires before any network hit.
+    setupBareVault(tmp, "default");
+    const res = runCli(["mcp-install"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/No operator token found/);
+    expect(res.stderr).toMatch(/parachute auth rotate-operator/);
+  });
+
+  test("rejects --mint when no hub is configured (loopback-only)", () => {
+    setupBareVault(tmp, "default");
+    fs.writeFileSync(path.join(tmp, "operator.token"), "operator-bearer-stub");
+    // No PARACHUTE_HUB_ORIGIN, no expose-state.json — chooseHubOrigin
+    // returns loopback, which is correctly rejected.
+    const res = runCli(["mcp-install"], tmp, { PARACHUTE_HUB_ORIGIN: "" });
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/No hub origin configured/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: modes that don't need a hub (--token, --legacy-pat,
+// --install-scope project, --vault per-vault keying)
+// ---------------------------------------------------------------------------
+
+describe("mcp-install end-to-end", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-e2e-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("--token writes the supplied bearer into ~/.claude.json", () => {
+    setupBareVault(tmp, "default");
+    const res = runCli(
+      ["mcp-install", "--token", "pasted-bearer"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    const config = readJson(path.join(tmp, ".claude.json"));
+    const entry = config.mcpServers["parachute-vault"];
+    expect(entry.type).toBe("http");
+    expect(entry.headers.Authorization).toBe("Bearer pasted-bearer");
+    expect(entry.url).toContain("/vault/default/mcp");
+  });
+
+  test("--install-scope project writes <cwd>/.mcp.json instead of ~/.claude.json", () => {
+    setupBareVault(tmp, "default");
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-project-"));
+    try {
+      const res = runCli(
+        ["mcp-install", "--install-scope", "project", "--token", "pasted"],
+        tmp,
+        {},
+        projectDir,
+      );
+      expect(res.exitCode).toBe(0);
+      // Wrote into the project, not the user.
+      expect(fs.existsSync(path.join(projectDir, ".mcp.json"))).toBe(true);
+      expect(fs.existsSync(path.join(tmp, ".claude.json"))).toBe(false);
+      const config = readJson(path.join(projectDir, ".mcp.json"));
+      expect(config.mcpServers["parachute-vault"].headers.Authorization).toBe(
+        "Bearer pasted",
+      );
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test("--vault <name> keys the entry as parachute-vault-<name>", () => {
+    setupBareVault(tmp, "default");
+    setupBareVault(tmp, "work");
+    // Install for the second vault — singular slot stays free for the
+    // default. Multi-vault is the motivation.
+    const res = runCli(
+      ["mcp-install", "--vault", "work", "--token", "work-bearer"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    const config = readJson(path.join(tmp, ".claude.json"));
+    expect(config.mcpServers["parachute-vault-work"]).toBeDefined();
+    expect(config.mcpServers["parachute-vault-work"].url).toContain("/vault/work/mcp");
+    expect(config.mcpServers["parachute-vault-work"].headers.Authorization).toBe(
+      "Bearer work-bearer",
+    );
+    // The singular slot is untouched — we'd preserve a pre-existing entry,
+    // but here there was none so it's just absent.
+    expect(config.mcpServers["parachute-vault"]).toBeUndefined();
+  });
+
+  test("--vault without an explicit name uses the default and keys the singular slot", () => {
+    setupBareVault(tmp, "default");
+    const res = runCli(["mcp-install", "--token", "default-bearer"], tmp);
+    expect(res.exitCode).toBe(0);
+    const config = readJson(path.join(tmp, ".claude.json"));
+    expect(config.mcpServers["parachute-vault"]).toBeDefined();
+    // Per-vault key for the default vault is NOT written when --vault wasn't
+    // explicit; the singular slot is the canonical single-install shape.
+    expect(config.mcpServers["parachute-vault-default"]).toBeUndefined();
+  });
+
+  test("--legacy-pat mints a vault-DB pvt_* token and prints deprecation warning", () => {
+    setupBareVault(tmp, "default");
+    const res = runCli(["mcp-install", "--legacy-pat"], tmp);
+    expect(res.exitCode).toBe(0);
+    // Deprecation warning lands on stderr (we used `console.error` for the
+    // notice so it's visible without polluting stdout).
+    expect(res.stderr).toMatch(/--legacy-pat mints a vault-DB pvt_/);
+    expect(res.stderr).toMatch(/canonical install going forward/);
+    const config = readJson(path.join(tmp, ".claude.json"));
+    const bearer = config.mcpServers["parachute-vault"].headers.Authorization;
+    expect(bearer).toMatch(/^Bearer pvt_/);
+  });
+
+  test("subsequent --token install on top of an existing entry overwrites the bearer", () => {
+    setupBareVault(tmp, "default");
+    runCli(["mcp-install", "--token", "first"], tmp);
+    const res = runCli(["mcp-install", "--token", "second"], tmp);
+    expect(res.exitCode).toBe(0);
+    const config = readJson(path.join(tmp, ".claude.json"));
+    expect(config.mcpServers["parachute-vault"].headers.Authorization).toBe("Bearer second");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the minimum vault state that `cmdMcpInstall` validates against:
+ * the vault directory + vault.yaml that `readVaultConfig` reads. Also seeds
+ * `config.yaml` so `default_vault` points at the named vault. Avoids the
+ * full `parachute-vault init` subprocess (slow + heavy) when all we need
+ * is "the vault exists by name."
+ */
+function setupBareVault(parachuteHome: string, name: string): void {
+  // Vault layout: <PARACHUTE_HOME>/vault/data/<name>/vault.yaml.
+  // `readVaultConfig` and `listVaults` both look here.
+  const vaultsDir = path.join(parachuteHome, "vault", "data");
+  fs.mkdirSync(path.join(vaultsDir, name), { recursive: true });
+  fs.writeFileSync(
+    path.join(vaultsDir, name, "vault.yaml"),
+    `name: ${name}\napi_keys: []\n`,
+  );
+  // First vault written becomes default_vault; subsequent vaults leave it
+  // alone. Keeps test setup terse — no separate global config writes.
+  // (The DB file gets created on first open by bun:sqlite, so we don't
+  // pre-seed it; --legacy-pat opens it lazily.)
+  const globalPath = path.join(parachuteHome, "vault", "config.yaml");
+  if (!fs.existsSync(globalPath)) {
+    fs.mkdirSync(path.dirname(globalPath), { recursive: true });
+    fs.writeFileSync(globalPath, `default_vault: ${name}\nport: 1940\n`);
+  }
+}
+
+function readJson(p: string): any {
+  return JSON.parse(fs.readFileSync(p, "utf-8"));
+}

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -201,6 +201,36 @@ describe("chooseHubOrigin", () => {
     const res = chooseHubOrigin(1940, {});
     expect(res).toEqual({ url: "http://127.0.0.1:1940", source: "loopback" });
   });
+
+  test("derives the hub origin from an active expose-state FQDN", () => {
+    // Tailnet/public exposure with no hub env: hub origin uses the
+    // exposure's canonical FQDN (no /vault/<name>/mcp suffix — that's
+    // chooseMcpUrl's job, this returns the bare origin for the
+    // mint-token API call).
+    fs.writeFileSync(
+      path.join(tmpHome, "expose-state.json"),
+      JSON.stringify({
+        version: 1,
+        layer: "tailnet",
+        mode: "path",
+        canonicalFqdn: "parachute.taildf9ce2.ts.net",
+        port: 1940,
+        funnel: false,
+        entries: [],
+      }),
+    );
+    const res = chooseHubOrigin(1940, {});
+    expect(res).toEqual({
+      url: "https://parachute.taildf9ce2.ts.net",
+      source: "expose-state",
+    });
+  });
+
+  test("malformed expose-state.json gracefully falls through to loopback", () => {
+    fs.writeFileSync(path.join(tmpHome, "expose-state.json"), "{ not json");
+    const res = chooseHubOrigin(1940, {});
+    expect(res.source).toBe("loopback");
+  });
 });
 
 describe("readOperatorToken", () => {
@@ -501,9 +531,13 @@ describe("mcp-install end-to-end", () => {
     const res = runCli(["mcp-install", "--legacy-pat"], tmp);
     expect(res.exitCode).toBe(0);
     // Deprecation warning lands on stderr (we used `console.error` for the
-    // notice so it's visible without polluting stdout).
+    // notice so it's visible without polluting stdout). The message names
+    // the tracking issue + planned-removal milestone so operators can
+    // see what they're opting into.
     expect(res.stderr).toMatch(/--legacy-pat mints a vault-DB pvt_/);
     expect(res.stderr).toMatch(/canonical install going forward/);
+    expect(res.stderr).toMatch(/vault#288/);
+    expect(res.stderr).toMatch(/planned removal 0\.6\.0/);
     const config = readJson(path.join(tmp, ".claude.json"));
     const bearer = config.mcpServers["parachute-vault"].headers.Authorization;
     expect(bearer).toMatch(/^Bearer pvt_/);

--- a/src/mcp-install.ts
+++ b/src/mcp-install.ts
@@ -156,13 +156,15 @@ export interface MintedHubJwt {
 
 /**
  * Discriminated failure modes from `mintHubJwt`. Callers turn each into a
- * different operator-facing message — missing operator.token has a specific
- * remediation (`parachute auth rotate-operator`); hub-unreachable has a
- * different one (check `PARACHUTE_HUB_ORIGIN` / start the hub); API-error
- * propagates the hub's own `error_description`.
+ * different operator-facing message — hub-unreachable has its own remediation
+ * (check `PARACHUTE_HUB_ORIGIN` / start the hub); API-error propagates the
+ * hub's own `error_description`.
+ *
+ * Operator-token absence is *not* a `mintHubJwt` failure mode: the caller is
+ * responsible for `readOperatorToken()` before invoking us — by the time we
+ * see `operatorToken: string`, it's guaranteed present.
  */
 export type MintHubJwtError =
-  | { kind: "no-operator-token"; checkedPath: string }
   | { kind: "network"; cause: string; origin: string }
   | { kind: "api-error"; status: number; error: string; description: string };
 

--- a/src/mcp-install.ts
+++ b/src/mcp-install.ts
@@ -1,36 +1,81 @@
 /**
- * URL picker for `parachute-vault mcp-install`. The URL written into
- * `~/.claude.json` must match vault's advertised OAuth issuer for the origin
- * the client will reach the server on — otherwise strict clients (Claude
- * Code's MCP SDK) reject discovery on origin/issuer mismatch (RFC 8414 §3.1).
+ * Helpers for `parachute-vault mcp-install`. Three concerns live here:
  *
- * Selection order:
- *   1. `PARACHUTE_HUB_ORIGIN` env (vault is advertising the hub as issuer).
- *   2. `~/.parachute/expose-state.json` canonical FQDN (active tailnet /
- *      public exposure the CLI brought up).
- *   3. Loopback on the configured port.
+ *   1. **URL pickers.** The MCP URL written into the client config must match
+ *      vault's advertised OAuth issuer for the origin the client will reach
+ *      the server on — otherwise strict clients (Claude Code's MCP SDK)
+ *      reject discovery on origin/issuer mismatch (RFC 8414 §3.1). Two
+ *      pickers: `chooseMcpUrl` returns the full `<origin>/vault/<name>/mcp`
+ *      shape for the entry; `chooseHubOrigin` returns the bare `<origin>` for
+ *      the hub-mint API call.
+ *
+ *   2. **Operator-token reader.** Reads `~/.parachute/operator.token` (or
+ *      `$PARACHUTE_HOME/operator.token`). The hub-mint path uses it as the
+ *      bearer for `POST <hub>/api/auth/mint-token`. Returns null when absent
+ *      or empty — caller decides whether that's a hard error.
+ *
+ *   3. **Hub mint-token client.** `mintHubJwt` posts to
+ *      `<hub>/api/auth/mint-token` with the operator bearer and returns the
+ *      scope-narrow JWT. Test seam for `fetch` injected as an opt so unit
+ *      tests don't need a real hub.
+ *
+ *   4. **Install target resolver.** `resolveInstallTarget` picks between
+ *      `~/.claude.json` (user) and `./.mcp.json` (project) based on the
+ *      `--install-scope` flag.
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 
+// ---------------------------------------------------------------------------
+// URL picking
+// ---------------------------------------------------------------------------
+
 export type McpUrlSource = "hub-origin" | "expose-state" | "loopback";
 
+/**
+ * Pick the URL written into the MCP client's `mcpServers.<key>.url` slot.
+ * Returns the per-vault MCP endpoint (`/vault/<name>/mcp`); see
+ * `chooseHubOrigin` for the bare-origin form used by hub API calls.
+ *
+ * Source order:
+ *   1. `PARACHUTE_HUB_ORIGIN` env (vault is advertising the hub as issuer).
+ *   2. `~/.parachute/expose-state.json` canonical FQDN (active tailnet /
+ *      public exposure the CLI brought up).
+ *   3. Loopback on the configured port.
+ */
 export function chooseMcpUrl(
   vaultName: string,
   port: number,
   env: { PARACHUTE_HUB_ORIGIN?: string | undefined } = process.env as { PARACHUTE_HUB_ORIGIN?: string },
 ): { url: string; source: McpUrlSource } {
+  const origin = chooseHubOrigin(port, env);
+  return { url: `${origin.url}/vault/${vaultName}/mcp`, source: origin.source };
+}
+
+/**
+ * Pick the bare hub origin (no path suffix). Used by hub-mint when posting
+ * to `<origin>/api/auth/mint-token`. Same source order as `chooseMcpUrl`.
+ *
+ * Note: when the source is `loopback`, the origin is *vault's* loopback URL,
+ * not a hub. Hub-mint against a loopback origin will fail at the network
+ * layer (no hub on that port) — the caller catches and surfaces a clear
+ * "no hub configured" error.
+ */
+export function chooseHubOrigin(
+  port: number,
+  env: { PARACHUTE_HUB_ORIGIN?: string | undefined } = process.env as { PARACHUTE_HUB_ORIGIN?: string },
+): { url: string; source: McpUrlSource } {
   const hub = env.PARACHUTE_HUB_ORIGIN?.replace(/\/$/, "");
   if (hub) {
-    return { url: `${hub}/vault/${vaultName}/mcp`, source: "hub-origin" };
+    return { url: hub, source: "hub-origin" };
   }
   const fqdn = readExposedFqdn();
   if (fqdn) {
-    return { url: `https://${fqdn}/vault/${vaultName}/mcp`, source: "expose-state" };
+    return { url: `https://${fqdn}`, source: "expose-state" };
   }
-  return { url: `http://127.0.0.1:${port}/vault/${vaultName}/mcp`, source: "loopback" };
+  return { url: `http://127.0.0.1:${port}`, source: "loopback" };
 }
 
 /**
@@ -57,4 +102,173 @@ function readExposedFqdn(): string | undefined {
     }
   } catch {}
   return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Operator-token reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the operator bearer from `<root>/operator.token`. Root is
+ * `$PARACHUTE_HOME` if set, otherwise `~/.parachute`. Returns null when the
+ * file is absent or empty — caller decides whether that's a hard error.
+ *
+ * We don't enforce the 0600 mode check here (hub's reader does). The CLI
+ * runs locally; if the operator chmod'd it loose, that's already their
+ * footgun, and vault's install command isn't the place to gate on it.
+ */
+export function readOperatorToken(env: NodeJS.ProcessEnv = process.env): string | null {
+  try {
+    const root = env.PARACHUTE_HOME ?? resolve(homedir(), ".parachute");
+    const path = resolve(root, "operator.token");
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, "utf-8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hub mint-token client
+// ---------------------------------------------------------------------------
+
+/**
+ * Default lifetime when `--expires-in` isn't passed. Matches the hub CLI's
+ * default (90 days) — see `parachute-hub/src/api-mint-token.ts`.
+ */
+export const HUB_MINT_DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+/**
+ * Result of a successful hub mint-token call. Shape mirrors the hub HTTP
+ * response so callers can pass `expires_at` through to logs / UX.
+ */
+export interface MintedHubJwt {
+  /** The signed JWT to write into `Authorization: Bearer …`. */
+  token: string;
+  /** JTI for revocation. */
+  jti: string;
+  /** ISO timestamp at which the token expires. */
+  expires_at: string;
+  /** Whitespace-joined scope claim, mirrors the request. */
+  scope: string;
+}
+
+/**
+ * Discriminated failure modes from `mintHubJwt`. Callers turn each into a
+ * different operator-facing message — missing operator.token has a specific
+ * remediation (`parachute auth rotate-operator`); hub-unreachable has a
+ * different one (check `PARACHUTE_HUB_ORIGIN` / start the hub); API-error
+ * propagates the hub's own `error_description`.
+ */
+export type MintHubJwtError =
+  | { kind: "no-operator-token"; checkedPath: string }
+  | { kind: "network"; cause: string; origin: string }
+  | { kind: "api-error"; status: number; error: string; description: string };
+
+export interface MintHubJwtOpts {
+  hubOrigin: string;
+  operatorToken: string;
+  scope: string;
+  subject?: string;
+  expiresInSeconds?: number;
+  /** Test seam — defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * POST to `<hub>/api/auth/mint-token`. The operator-token bearer must carry
+ * `parachute:host:auth` (the admin scope-set covers it). Returns the minted
+ * JWT or a discriminated error the caller turns into a clear message.
+ *
+ * Network errors are caught and returned as `{ kind: "network" }` rather
+ * than bubbling — the CLI doesn't want stack traces, and the operator wants
+ * to know *which* endpoint failed.
+ */
+export async function mintHubJwt(opts: MintHubJwtOpts): Promise<MintedHubJwt | MintHubJwtError> {
+  const url = `${opts.hubOrigin.replace(/\/$/, "")}/api/auth/mint-token`;
+  const body: Record<string, unknown> = {
+    scope: opts.scope,
+    expires_in: opts.expiresInSeconds ?? HUB_MINT_DEFAULT_TTL_SECONDS,
+  };
+  if (opts.subject) body.subject = opts.subject;
+
+  const fetchFn = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${opts.operatorToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    return { kind: "network", cause, origin: opts.hubOrigin };
+  }
+
+  if (!res.ok) {
+    // Hub responses are JSON `{ error, error_description }`. Parse defensively
+    // — a misconfigured hub or a network appliance returning HTML for 502s
+    // shouldn't crash the CLI; we'll surface what we got.
+    let error = "unknown_error";
+    let description = `HTTP ${res.status}`;
+    try {
+      const payload = (await res.json()) as { error?: unknown; error_description?: unknown };
+      if (typeof payload.error === "string") error = payload.error;
+      if (typeof payload.error_description === "string") description = payload.error_description;
+    } catch {}
+    return { kind: "api-error", status: res.status, error, description };
+  }
+
+  const payload = (await res.json()) as Partial<MintedHubJwt>;
+  if (
+    typeof payload.token !== "string" ||
+    typeof payload.jti !== "string" ||
+    typeof payload.expires_at !== "string" ||
+    typeof payload.scope !== "string"
+  ) {
+    return {
+      kind: "api-error",
+      status: res.status,
+      error: "malformed_response",
+      description: "hub mint-token response is missing required fields (token/jti/expires_at/scope)",
+    };
+  }
+  return {
+    token: payload.token,
+    jti: payload.jti,
+    expires_at: payload.expires_at,
+    scope: payload.scope,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Install target resolver
+// ---------------------------------------------------------------------------
+
+export type InstallScope = "user" | "project";
+
+export interface InstallTarget {
+  /** Absolute path the install will write to. */
+  path: string;
+  /** Which scope the path corresponds to (for log lines + doctor). */
+  scope: InstallScope;
+}
+
+/**
+ * Pick the MCP client config file path based on `--install-scope`. Project
+ * scope writes to `<cwd>/.mcp.json` (Claude Code convention); user scope
+ * writes to `~/.claude.json` (legacy + still canonical for user-wide setup).
+ */
+export function resolveInstallTarget(
+  scope: InstallScope,
+  cwd: string = process.cwd(),
+): InstallTarget {
+  if (scope === "project") {
+    return { path: resolve(cwd, ".mcp.json"), scope: "project" };
+  }
+  return { path: resolve(homedir(), ".claude.json"), scope: "user" };
 }


### PR DESCRIPTION
## Summary

Rework `parachute-vault mcp-install` per the install-flow audit. Hub-mint becomes the canonical install path; `pvt_*` becomes the explicit `--legacy-pat` opt-in. Aligns with the hub-as-AS direction settled in vault#212.

## New CLI shape

```
parachute-vault mcp-install
  [--mint | --token <bearer> | --legacy-pat]     # auth mode (mutually exclusive)
  [--scope vault:read|vault:write|vault:admin]   # default: vault:read (least-privilege)
  [--install-scope user|project]                 # default: user (~/.claude.json)
  [--vault <name>]                               # default: default_vault
  [--client claude-code]                         # only claude-code wired (Phase C deferred)
```

## Four common invocations

```bash
# Default — hub-mint scope-narrow JWT into ~/.claude.json
parachute-vault mcp-install

# Project-level + write scope
parachute-vault mcp-install --install-scope project --scope vault:write

# Paste an existing token
parachute-vault mcp-install --token pvt_abc123…

# Self-hosted-without-hub
parachute-vault mcp-install --legacy-pat
```

## Behavior changes

- **`--mint` (default)** reads `~/.parachute/operator.token`, POSTs to `<hub>/api/auth/mint-token`, writes the returned scope-narrow JWT as `Authorization: Bearer …`. Scope is expanded to `vault:<vault-name>:<verb>` so the JWT can't be re-used against other vaults on the same hub. Failure modes (no operator token, no hub configured, mint API error, network) each have specific remediation messages.
- **`--token <bearer>`** skips all mint logic; useful for re-using a long-lived bearer or pasting any token shape.
- **`--legacy-pat`** mints a vault-DB `pvt_*`. Prints a deprecation notice; preserved for self-hosted-without-hub setups.
- **`--scope`** defaults to `vault:read`. For `--legacy-pat`, narrows the on-disk token's scope set (admin gets the full set; read/write narrow).
- **`--install-scope project`** writes `./.mcp.json` in CWD instead of `~/.claude.json` (Claude Code reads project-local configs).
- **`--vault <name>`** keys the entry as `parachute-vault-<name>` so multi-vault installs coexist. Default (no `--vault`) uses the singular `parachute-vault` slot.

## Internals

- `installMcpConfig(apiKey?)` → `installMcpConfig({ targetPath, entryKey, vaultName, bearer })`. Init's bootstrap path keeps minting `pvt_*` so fresh installs work without a hub; operators with a hub re-run `mcp-install` (now defaulting to hub-mint) to upgrade.
- `removeMcpConfig` cleans both `~/.claude.json` and `./.mcp.json`, honors the new `parachute-vault-<name>` per-vault keys, plus the legacy slash-form for backward cleanup.
- `readMcpEntry` (doctor) checks both target files, prefers user-level, accepts singular + per-vault entry keys, reports which file + entry-key matched.
- New helpers in `src/mcp-install.ts`: `chooseHubOrigin`, `readOperatorToken`, `mintHubJwt` (test-seamed fetch wrapper), `resolveInstallTarget`.

## Version

`0.4.3` → `0.4.4-rc.1`.

## Test plan

- [x] `bun test ./core/src/ ./src/` — 1281/1281 pass (3403 expect calls)
- [x] `bunx tsc --noEmit` clean
- [x] 26 new tests across helpers, CLI flag parsing, and end-to-end behavior
- [x] Doctor tests updated for the new check-name shape (includes source file + entry key)
- [x] Init flow preserved — `parachute-vault init` still mints `pvt_*` and writes user-level entry (existing tests cover)

## Out of scope (Phase C)

- **Cross-client support** (Cursor, Claude Desktop, Codex, Zed, Goose, Cline) — `--client` accepts only `claude-code`; others reject with "Phase C" message.
- **Client auto-detection** (probe installed clients, suggest defaults).
- **Interactive picker** when run from a TTY without flags.

Refs vault#212 (hub-as-AS), and the install audit findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)