### PR TITLE
feat(mcp-install): add local install scope + always-prompt for scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,89 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.4-rc.3] — 2026-05-11
+
+Two `parachute-vault mcp-install` fixes from real dogfood feedback —
+operator ran the walkthrough from a plain directory (no `.git`, no
+`package.json`) intending a directory-private install, and the
+walkthrough decided unilaterally for them. Both fixes restore "always
+let the operator pick the scope."
+
+### Fix 1 — Add the `local` install scope
+
+Claude Code has three MCP scopes; vault previously only supported two.
+All three are now first-class:
+
+| Scope | Where the entry lives | Visibility |
+|---|---|---|
+| `user` | `~/.claude.json` top-level `mcpServers` | every project, every directory |
+| `local` | `~/.claude.json` under `projects[<absolute-cwd>].mcpServers` | private to this machine, scoped to this directory |
+| `project` | `<cwd>/.mcp.json` | checked into the repo, shared with the team |
+
+`local` matches Claude Code's own `claude mcp add --scope local` default
+and is the right shape when the operator wants vault available in this
+working directory only, without committing the entry to the repo or
+exposing it from every other project.
+
+Surfaces:
+
+- New `--install-scope local` flag.
+- Walkthrough's install-location prompt now offers all three scopes
+  (see Fix 2).
+- `parachute-vault doctor` reads local entries from `~/.claude.json`
+  under `projects[<cwd>].mcpServers`.
+- `parachute-vault uninstall` cleans local entries from every project
+  slot it finds (not just the current `cwd`'s), so a single uninstall
+  removes the vault server regardless of which directory the operator
+  ran the install from.
+
+### Fix 2 — Drop the marker gate; always prompt for install scope
+
+The interactive walkthrough's install-location step used to silently
+auto-pick **user** scope when no project markers (`.git`, `package.json`,
+…) were detected — the operator never saw the prompt. The premise was
+wrong: Claude Code reads `./.mcp.json` (project scope) and
+`projects[<cwd>]` (local scope) regardless of git/package markers.
+Skipping the prompt buried the operator's actual intent.
+
+The walkthrough now always prompts with the three scopes laid out. The
+default *tilts* on the marker signal — present → `project`, absent →
+`local` — but the operator always sees and can override the choice.
+
+### Breaking — non-interactive default changed from `user` to `local`
+
+`parachute-vault mcp-install` with no `--install-scope` flag previously
+wrote to `~/.claude.json` top-level (user scope). It now writes to
+`~/.claude.json` under `projects[<absolute-cwd>].mcpServers` (local
+scope). This mirrors Claude Code's own `claude mcp add` default. Two
+things to know:
+
+- **Scripted installs**: pass `--install-scope user` explicitly to keep
+  the prior global-install behavior. (We recommend doing this in any
+  automation that runs `mcp-install` non-interactively — the operator-
+  intent prompt isn't there to surface the change.)
+- **Non-interactive `local` install** prints a one-line consequence
+  callout on stdout — "Installed locally for this directory only. To
+  install globally, re-run with `--install-scope user`." — so a
+  first-time operator who hits the new default doesn't wonder why
+  vault works only from one directory.
+
+### Tests
+
+10 new tests across `src/mcp-install.test.ts` and
+`src/mcp-install-interactive.test.ts`:
+
+- `local` scope writer round-trip (writes to `~/.claude.json` under
+  `projects[<cwd>]`, preserves pre-existing top-level entries and
+  pre-existing sibling MCP servers).
+- `--install-scope local` CLI flag accepted; default-when-no-flag
+  changed to `local`; new default writes to the projects-keyed slot.
+- Walkthrough always prompts for scope (no marker-gate skip);
+  default-tilt logic (markers → `project`, no markers → `local`);
+  operator can override either default.
+- `detectExistingEntries` recognises local entries (and ignores
+  local entries at *other* cwds).
+
 ## [0.4.4-rc.2] — 2026-05-11
 
 Interactive default for `parachute-vault mcp-install`. Bare invocation

--- a/README.md
+++ b/README.md
@@ -190,10 +190,12 @@ parachute-vault uninstall --yes --wipe     # scripted destructive wipe (prints a
 parachute-vault create work                # create a new vault
 parachute-vault list                       # list all vaults (alias: `ls`)
 parachute-vault remove work --yes          # delete a vault (alias: `rm`)
-parachute-vault mcp-install                # (re)write the MCP client entry; defaults to --mint (hub-issued JWT)
+parachute-vault mcp-install                # (re)write the MCP client entry; defaults to --mint (hub-issued JWT) at local scope
 parachute-vault mcp-install --token <t>    # paste an existing bearer instead of minting
 parachute-vault mcp-install --legacy-pat   # mint a vault-DB pvt_* (self-hosted-without-hub)
-parachute-vault mcp-install --install-scope project   # write ./.mcp.json instead of ~/.claude.json
+parachute-vault mcp-install --install-scope user      # write ~/.claude.json top-level (every project)
+parachute-vault mcp-install --install-scope local     # write ~/.claude.json projects[<cwd>] (this directory only — default)
+parachute-vault mcp-install --install-scope project   # write ./.mcp.json (checked into the repo)
 parachute-vault mcp-install --vault work   # target the "work" vault (keyed as parachute-vault-work)
 
 # OAuth — owner password + 2FA
@@ -571,27 +573,45 @@ The shortest path to a public HTTPS URL for a vault you control — useful for S
 
 ### Install vault MCP into a client config
 
-Bare `parachute-vault mcp-install` from a terminal **walks you through a short contextual conversation** — picks defaults informed by your environment (how many vaults you have, whether the hub is reachable, whether you're in a project directory, whether vault is already installed somewhere), shows the JSON shape it will write before doing anything, and asks before each non-obvious choice. The four patterns below are the non-interactive shapes — pass any flag (`--mint`, `--token`, `--scope`, `--install-scope`, `--vault`, `--legacy-pat`) and the walkthrough is skipped.
+Bare `parachute-vault mcp-install` from a terminal **walks you through a short contextual conversation** — picks defaults informed by your environment (how many vaults you have, whether the hub is reachable, whether you're in a project directory, whether vault is already installed somewhere), shows the JSON shape it will write before doing anything, and asks before each non-obvious choice. The patterns below are the non-interactive shapes — pass any flag (`--mint`, `--token`, `--scope`, `--install-scope`, `--vault`, `--legacy-pat`) and the walkthrough is skipped.
+
+#### Install scopes
+
+`--install-scope` accepts three values, matching Claude Code's own `claude mcp add --scope`:
+
+| Scope | Where the entry lives | Visibility |
+|---|---|---|
+| `local` *(default)* | `~/.claude.json` under `projects[<absolute-cwd>].mcpServers` | private to your machine, scoped to this directory |
+| `user` | `~/.claude.json` top-level `mcpServers` | every project, every directory on this machine |
+| `project` | `<cwd>/.mcp.json` | checked into the repo, shared with anyone who clones it |
+
+The default is **`local`** — Claude Code only loads the entry when launched from the directory you ran the install from. Pick `user` for a global install (every project sees the vault); pick `project` to commit the entry to the repo so collaborators get it on `git pull`.
+
+#### Cookbook
 
 ```bash
-# 1. Default (non-interactive shape) — mint a scope-narrow hub JWT
-#    (vault:<vault>:read) via your operator token, write it into
-#    ~/.claude.json. Requires:
+# 1. Default — mint a scope-narrow hub JWT (vault:<vault>:read) via your
+#    operator token; write it into ~/.claude.json under projects[<cwd>]
+#    (local scope, this directory only). Requires:
 #      - ~/.parachute/operator.token (run `parachute auth rotate-operator` if missing)
 #      - PARACHUTE_HUB_ORIGIN set OR an active `parachute expose` session
 parachute-vault mcp-install --mint
 
-# 2. Project-level install — write ./.mcp.json (Claude Code reads project-
-#    local configs) instead of ~/.claude.json. Pair with --scope vault:write
-#    when the project actually mutates the vault.
+# 2. Global install — write the entry at top-level ~/.claude.json so
+#    Claude Code loads it from every project, every directory.
+parachute-vault mcp-install --install-scope user
+
+# 3. Project-level install — write ./.mcp.json (committed to the repo,
+#    shared with the team). Pair with --scope vault:write when the
+#    project actually mutates the vault.
 parachute-vault mcp-install --install-scope project --scope vault:write
 
-# 3. Paste an existing token — useful when you already have a pvt_* in hand
+# 4. Paste an existing token — useful when you already have a pvt_* in hand
 #    or want to re-use a long-lived bearer from another machine. Skips the
 #    mint step entirely.
 parachute-vault mcp-install --token pvt_abc123...
 
-# 4. Self-hosted-without-hub — mint a vault-DB pvt_* token (the legacy
+# 5. Self-hosted-without-hub — mint a vault-DB pvt_* token (the legacy
 #    path; preserved so deployments without a hub keep working). Prints a
 #    deprecation notice.
 parachute-vault mcp-install --legacy-pat
@@ -599,7 +619,7 @@ parachute-vault mcp-install --legacy-pat
 
 **Multi-vault.** `--vault <name>` targets a specific vault and writes the entry under `parachute-vault-<name>` so multiple vaults coexist. Without `--vault`, the singular `parachute-vault` slot is used and one install clobbers another — that's intentional for the common single-vault case.
 
-**Doctor.** `parachute-vault doctor` checks both `~/.claude.json` and `./.mcp.json` and reports which one holds the entry, plus port-match and reachability of the MCP URL.
+**Doctor.** `parachute-vault doctor` checks `~/.claude.json` (both top-level and `projects[<cwd>]`) and `./.mcp.json`, and reports which one holds the entry, plus port-match and reachability of the MCP URL.
 
 ## Data model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.4-rc.2",
+  "version": "0.4.4-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -932,7 +932,12 @@ function takeArgValue(args: string[], name: string): { value?: string; missingVa
  * Targeting:
  *   --scope <verb>        vault:read | vault:write | vault:admin (default: vault:read).
  *                         For --mint, expands to vault:<vault-name>:<verb>.
- *   --install-scope <s>   user (default; ~/.claude.json) | project (./.mcp.json).
+ *   --install-scope <s>   local (default) | user | project. local writes to
+ *                         ~/.claude.json under projects[<cwd>].mcpServers
+ *                         (private, this directory only — matches Claude
+ *                         Code's own default). user writes to top-level
+ *                         mcpServers (every project). project writes to
+ *                         ./.mcp.json (check into the repo).
  *   --vault <name>        Vault to target (default: default_vault). Multi-vault
  *                         installs key the entry as `parachute-vault-<name>`.
  *   --client <name>       Reserved for Phase C. Only `claude-code` accepted.
@@ -999,15 +1004,25 @@ async function cmdMcpInstall(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // --- Install scope: user (default) or project. ---
+  // --- Install scope: local (default), user, or project. ---
+  // `local` matches Claude Code's own `claude mcp add` default — entry sits
+  // under `projects[<cwd>].mcpServers` in ~/.claude.json, private to this
+  // machine + this directory. Operators wanting a global install pass
+  // `--install-scope user`; team-shared installs pass `--install-scope project`.
   const installScopeArg = takeArgValue(args, "--install-scope");
   if (installScopeArg.missingValue) {
-    console.error("--install-scope requires a value: user or project.");
+    console.error("--install-scope requires a value: local, user, or project.");
     process.exit(1);
   }
-  const installScopeRaw = installScopeArg.value ?? "user";
-  if (installScopeRaw !== "user" && installScopeRaw !== "project") {
-    console.error(`--install-scope must be "user" or "project". Got: ${installScopeRaw}.`);
+  const installScopeRaw = installScopeArg.value ?? "local";
+  if (
+    installScopeRaw !== "user" &&
+    installScopeRaw !== "project" &&
+    installScopeRaw !== "local"
+  ) {
+    console.error(
+      `--install-scope must be "local", "user", or "project". Got: ${installScopeRaw}.`,
+    );
     process.exit(1);
   }
   const installScope: InstallScope = installScopeRaw;
@@ -1200,9 +1215,16 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
     entryKey,
     vaultName,
     bearer,
+    ...(target.localProjectKey ? { localProjectKey: target.localProjectKey } : {}),
   });
   console.log(`MCP URL: ${url} (${source})`);
-  console.log(`Added MCP server "${entryKey}" to ${target.path}`);
+  if (target.scope === "local") {
+    console.log(`Added MCP server "${entryKey}" to ${target.path} under projects["${target.localProjectKey}"] (local scope).`);
+    console.log(`  Installed locally for this directory only — runs only when Claude Code launches from ${target.localProjectKey}.`);
+    console.log(`  To install globally instead, re-run with --install-scope user.`);
+  } else {
+    console.log(`Added MCP server "${entryKey}" to ${target.path}`);
+  }
 }
 
 function cmdRemove(args: string[]) {
@@ -2068,12 +2090,14 @@ type McpEntryLookup =
  * just make the "is it wired up?" state legible.
  */
 function readMcpEntry(): McpEntryLookup {
-  const candidates = [
+  const cwd = resolve(process.cwd());
+  const candidates: Array<{ path: string; label: string; localProjectKey?: string }> = [
     { path: resolve(homedir(), ".claude.json"), label: "~/.claude.json" },
-    { path: resolve(process.cwd(), ".mcp.json"), label: `${process.cwd()}/.mcp.json` },
+    { path: resolve(homedir(), ".claude.json"), label: `~/.claude.json (projects["${cwd}"])`, localProjectKey: cwd },
+    { path: resolve(cwd, ".mcp.json"), label: `${cwd}/.mcp.json` },
   ];
   const checkedReasons: string[] = [];
-  for (const { path, label } of candidates) {
+  for (const { path, label, localProjectKey } of candidates) {
     if (!existsSync(path)) {
       checkedReasons.push(`${label} does not exist`);
       continue;
@@ -2085,7 +2109,9 @@ function readMcpEntry(): McpEntryLookup {
       checkedReasons.push(`${label} is not valid JSON: ${String(err?.message ?? err)}`);
       continue;
     }
-    const servers = config?.mcpServers ?? {};
+    const servers = localProjectKey
+      ? (config?.projects?.[localProjectKey]?.mcpServers ?? {})
+      : (config?.mcpServers ?? {});
     // Prefer the singular `parachute-vault` slot (canonical default
     // install); fall back to the first `parachute-vault-<name>` per-vault
     // entry. Multi-vault installs may have several; the doctor reports on
@@ -2632,10 +2658,18 @@ interface InstallMcpConfigOpts {
   vaultName: string;
   /** Bearer token to embed in `Authorization: Bearer …`. Omitted means the entry is unauthenticated — only useful for OAuth-capable clients (Claude Code does discovery). */
   bearer?: string;
+  /**
+   * When set, the entry is keyed under `projects[<localProjectKey>].mcpServers`
+   * inside `~/.claude.json` (Claude Code's `local` scope: private to this
+   * machine, scoped to this directory). When unset, keyed at top-level
+   * `mcpServers` (user scope) or written directly to `./.mcp.json`
+   * (project scope — caller passes the project file path).
+   */
+  localProjectKey?: string;
 }
 
 function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: string } {
-  const { targetPath, entryKey, vaultName, bearer } = opts;
+  const { targetPath, entryKey, vaultName, bearer, localProjectKey } = opts;
 
   let config: any = {};
   if (existsSync(targetPath)) {
@@ -2643,8 +2677,6 @@ function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: st
       config = JSON.parse(readFileSync(targetPath, "utf-8"));
     } catch {}
   }
-
-  if (!config.mcpServers) config.mcpServers = {};
 
   const globalConfig = readGlobalConfig();
   const port = globalConfig.port || DEFAULT_PORT;
@@ -2659,7 +2691,21 @@ function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: st
   if (bearer) {
     mcpEntry.headers = { Authorization: `Bearer ${bearer}` };
   }
-  config.mcpServers[entryKey] = mcpEntry;
+
+  if (localProjectKey) {
+    if (!config.projects || typeof config.projects !== "object") config.projects = {};
+    if (!config.projects[localProjectKey] || typeof config.projects[localProjectKey] !== "object") {
+      config.projects[localProjectKey] = {};
+    }
+    const projectEntry = config.projects[localProjectKey];
+    if (!projectEntry.mcpServers || typeof projectEntry.mcpServers !== "object") {
+      projectEntry.mcpServers = {};
+    }
+    projectEntry.mcpServers[entryKey] = mcpEntry;
+  } else {
+    if (!config.mcpServers) config.mcpServers = {};
+    config.mcpServers[entryKey] = mcpEntry;
+  }
 
   writeFileSync(targetPath, JSON.stringify(config, null, 2) + "\n");
   return { url: mcpUrl, source };
@@ -2670,6 +2716,10 @@ function removeMcpConfig() {
   // files. Project-level uses CWD — only relevant when uninstall is run
   // from inside a project that had `mcp-install --install-scope project`
   // applied; otherwise the project path doesn't exist and we no-op.
+  // Local-scope entries (under `projects[<cwd>].mcpServers` in
+  // ~/.claude.json) are cleaned up for every `projects[*]` slot so a
+  // user can uninstall without remembering which directory they ran the
+  // local install from.
   const claudeJsonPath = resolve(homedir(), ".claude.json");
   const projectMcpJsonPath = resolve(process.cwd(), ".mcp.json");
   for (const path of [claudeJsonPath, projectMcpJsonPath]) {
@@ -2679,13 +2729,26 @@ function removeMcpConfig() {
       // Drop the singular key and every per-vault `parachute-vault-<name>`
       // entry. Legacy `parachute-vault/<name>` (slash-form) sub-keys from a
       // pre-multi-vault pattern still get cleaned up here.
-      for (const key of Object.keys(config.mcpServers ?? {})) {
-        if (
-          key === "parachute-vault" ||
-          key.startsWith("parachute-vault-") ||
-          key.startsWith("parachute-vault/")
-        ) {
-          delete config.mcpServers[key];
+      const stripVaultKeys = (servers: Record<string, unknown> | undefined) => {
+        if (!servers) return;
+        for (const key of Object.keys(servers)) {
+          if (
+            key === "parachute-vault" ||
+            key.startsWith("parachute-vault-") ||
+            key.startsWith("parachute-vault/")
+          ) {
+            delete servers[key];
+          }
+        }
+      };
+      stripVaultKeys(config.mcpServers);
+      // Local-scope cleanup: walk every project entry and strip vault keys.
+      if (config.projects && typeof config.projects === "object") {
+        for (const projectKey of Object.keys(config.projects)) {
+          const projectEntry = config.projects[projectKey];
+          if (projectEntry && typeof projectEntry === "object") {
+            stripVaultKeys(projectEntry.mcpServers);
+          }
         }
       }
       writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
@@ -2735,7 +2798,7 @@ Vaults:
   parachute-vault remove <name> [--yes]    Remove a vault
   parachute-vault mcp-install [--mint|--token <t>|--legacy-pat]
                               [--scope vault:read|vault:write|vault:admin]
-                              [--install-scope user|project]
+                              [--install-scope local|user|project]
                               [--vault <name>] [--client claude-code]
                                             Install vault MCP into a client config.
                                             From a terminal with no flags: walks you
@@ -2745,15 +2808,21 @@ Vaults:
                                             the command runs non-interactively.
                                             Default (non-interactive): --mint
                                             (hub-issued JWT via ~/.parachute/operator.token)
-                                            into ~/.claude.json with vault:read scope.
+                                            into ~/.claude.json under
+                                            projects[<cwd>].mcpServers (local scope,
+                                            matches Claude Code's claude-mcp-add
+                                            default) with vault:read scope.
                                             --token <t>: paste an existing bearer
                                             (any shape) instead of minting.
                                             --legacy-pat: mint a vault-DB pvt_*
                                             token (deprecated; for self-hosted-
                                             without-hub setups).
-                                            --install-scope project writes
-                                            ./.mcp.json in CWD instead of
-                                            ~/.claude.json.
+                                            --install-scope local (default) writes
+                                            ~/.claude.json under
+                                            projects[<cwd>].mcpServers (this
+                                            directory only). user writes top-level
+                                            mcpServers (every project). project
+                                            writes ./.mcp.json (check into the repo).
                                             --vault <name> targets a specific
                                             vault and keys the entry as
                                             parachute-vault-<name>.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2090,7 +2090,16 @@ type McpEntryLookup =
  * just make the "is it wired up?" state legible.
  */
 function readMcpEntry(): McpEntryLookup {
+  // Bun's process.cwd() already follows symlinks on macOS, so resolve()
+  // matches the key the install writer used; tests assert with
+  // fs.realpathSync to match the same shape.
   const cwd = resolve(process.cwd());
+  // Two entries point at the same ~/.claude.json file but search different
+  // key namespaces — top-level `mcpServers` (user scope) vs
+  // `projects[<cwd>].mcpServers` (local scope). Intentional duplication: a
+  // single read can't satisfy both without restructuring the search loop,
+  // and the cost of reading the file twice is trivial against the doctor
+  // run's other work.
   const candidates: Array<{ path: string; label: string; localProjectKey?: string }> = [
     { path: resolve(homedir(), ".claude.json"), label: "~/.claude.json" },
     { path: resolve(homedir(), ".claude.json"), label: `~/.claude.json (projects["${cwd}"])`, localProjectKey: cwd },
@@ -2711,7 +2720,7 @@ function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: st
   return { url: mcpUrl, source };
 }
 
-function removeMcpConfig() {
+export function removeMcpConfig() {
   // Remove vault entries from both user-level and project-level config
   // files. Project-level uses CWD — only relevant when uninstall is run
   // from inside a project that had `mcp-install --install-scope project`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,7 @@ import {
   detectInstallContext,
   mintHubJwt,
   readOperatorToken,
+  removeMcpConfig,
   resolveInstallTarget,
   type InstallScope,
 } from "./mcp-install.ts";
@@ -2718,51 +2719,6 @@ function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: st
 
   writeFileSync(targetPath, JSON.stringify(config, null, 2) + "\n");
   return { url: mcpUrl, source };
-}
-
-export function removeMcpConfig() {
-  // Remove vault entries from both user-level and project-level config
-  // files. Project-level uses CWD — only relevant when uninstall is run
-  // from inside a project that had `mcp-install --install-scope project`
-  // applied; otherwise the project path doesn't exist and we no-op.
-  // Local-scope entries (under `projects[<cwd>].mcpServers` in
-  // ~/.claude.json) are cleaned up for every `projects[*]` slot so a
-  // user can uninstall without remembering which directory they ran the
-  // local install from.
-  const claudeJsonPath = resolve(homedir(), ".claude.json");
-  const projectMcpJsonPath = resolve(process.cwd(), ".mcp.json");
-  for (const path of [claudeJsonPath, projectMcpJsonPath]) {
-    if (!existsSync(path)) continue;
-    try {
-      const config = JSON.parse(readFileSync(path, "utf-8"));
-      // Drop the singular key and every per-vault `parachute-vault-<name>`
-      // entry. Legacy `parachute-vault/<name>` (slash-form) sub-keys from a
-      // pre-multi-vault pattern still get cleaned up here.
-      const stripVaultKeys = (servers: Record<string, unknown> | undefined) => {
-        if (!servers) return;
-        for (const key of Object.keys(servers)) {
-          if (
-            key === "parachute-vault" ||
-            key.startsWith("parachute-vault-") ||
-            key.startsWith("parachute-vault/")
-          ) {
-            delete servers[key];
-          }
-        }
-      };
-      stripVaultKeys(config.mcpServers);
-      // Local-scope cleanup: walk every project entry and strip vault keys.
-      if (config.projects && typeof config.projects === "object") {
-        for (const projectKey of Object.keys(config.projects)) {
-          const projectEntry = config.projects[projectKey];
-          if (projectEntry && typeof projectEntry === "object") {
-            stripVaultKeys(projectEntry.mcpServers);
-          }
-        }
-      }
-      writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
-    } catch {}
-  }
 }
 
 function usage() {

--- a/src/mcp-install-interactive.test.ts
+++ b/src/mcp-install-interactive.test.ts
@@ -99,8 +99,9 @@ function baseCtx(overrides: Partial<InstallContext> = {}): InstallContext {
 // ---------------------------------------------------------------------------
 
 describe("runInteractiveInstall — decision tree", () => {
-  test("single vault + no project context + can mint: walkthrough auto-picks vault and installs user-scope mint at vault:read", async () => {
+  test("single vault + no project context + can mint: prompts for install scope (defaults local), then mint at vault:read", async () => {
     const { io, state } = mockIO([
+      null, // accept install-scope default ("local")
       null, // accept "mint" with vault:read scope
       true, // proceed
     ]);
@@ -109,18 +110,20 @@ describe("runInteractiveInstall — decision tree", () => {
     if (result === "abort") return;
     expect(result.mode).toBe("mint");
     expect(result.scope).toBe("vault:read");
-    expect(result.installScope).toBe("user");
+    // No project markers → suggested default is `local` (matches Claude
+    // Code's `claude mcp add` default). The walkthrough always prompts.
+    expect(result.installScope).toBe("local");
     expect(result.vaultName).toBe("default");
     expect(result.vaultExplicit).toBe(false);
-    // Vault prompt is skipped (single vault), install-scope prompt is
-    // skipped (no project markers → user is automatic), and we hit the
-    // auth prompt + final confirm.
-    expect(state.prompts.map((p) => p.kind)).toEqual(["ask", "confirm"]);
+    // Vault prompt skipped (single vault). Install-scope is now an ask
+    // (not a confirm) — always fires. Then auth ask + final confirm.
+    expect(state.prompts.map((p) => p.kind)).toEqual(["ask", "ask", "confirm"]);
   });
 
   test("multi-vault: walkthrough asks which vault and respects the choice", async () => {
     const { io, state } = mockIO([
       "boulder", // pick vault "boulder"
+      null,       // accept install-scope default
       null,       // accept mint with vault:read
       true,       // proceed
     ]);
@@ -138,7 +141,7 @@ describe("runInteractiveInstall — decision tree", () => {
   });
 
   test("multi-vault: pressing Enter accepts the default_vault and is not marked explicit", async () => {
-    const { io } = mockIO([null, null, true]); // accept default vault, accept mint, proceed
+    const { io } = mockIO([null, null, null, true]); // vault, install-scope, mint, proceed
     const result = await runInteractiveInstall(
       baseCtx({ vaults: ["default", "boulder"] }),
       io,
@@ -149,9 +152,9 @@ describe("runInteractiveInstall — decision tree", () => {
     expect(result.vaultExplicit).toBe(false);
   });
 
-  test("project context: walkthrough suggests project-scope install (default Y)", async () => {
+  test("project context: walkthrough suggests project-scope install as the default", async () => {
     const { io, state } = mockIO([
-      null, // accept project-scope default
+      null, // accept install-scope default (project, because markers detected)
       null, // accept mint with vault:read
       true, // proceed
     ]);
@@ -162,16 +165,17 @@ describe("runInteractiveInstall — decision tree", () => {
     expect(result).not.toBe("abort");
     if (result === "abort") return;
     expect(result.installScope).toBe("project");
-    expect(state.prompts[0]!.kind).toBe("confirm");
-    expect(state.prompts[0]!.question).toMatch(/this project/i);
-    expect(state.prompts[0]!.default).toBe(true);
+    // First prompt is the install-scope ask; default tilts to "project"
+    // when project markers are present in cwd.
+    expect(state.prompts[0]!.kind).toBe("ask");
+    expect(state.prompts[0]!.default).toBe("project");
   });
 
-  test("project context but operator declines: install scope falls to user", async () => {
+  test("project context but operator picks user: install scope falls to user", async () => {
     const { io } = mockIO([
-      false, // decline project scope
-      null,  // accept mint
-      true,  // proceed
+      "user", // override the project-scope default → user
+      null,   // accept mint
+      true,   // proceed
     ]);
     const result = await runInteractiveInstall(
       baseCtx({ inProjectContext: true }),
@@ -182,8 +186,57 @@ describe("runInteractiveInstall — decision tree", () => {
     expect(result.installScope).toBe("user");
   });
 
+  test("no project markers: install-scope prompt still fires and defaults to local", async () => {
+    const { io, state } = mockIO([
+      null, // accept install-scope default (local)
+      null, // accept mint
+      true, // proceed
+    ]);
+    const result = await runInteractiveInstall(
+      baseCtx({ inProjectContext: false, cwd: "/Gitcoin" }),
+      io,
+    );
+    expect(result).not.toBe("abort");
+    if (result === "abort") return;
+    // This is the dogfood-feedback case: operator is in a plain
+    // directory (no .git, no package.json). The walkthrough must NOT
+    // silently autopilot to user scope — always prompt.
+    expect(result.installScope).toBe("local");
+    expect(state.prompts.find((p) => p.kind === "ask" && p.default === "local")).toBeDefined();
+  });
+
+  test("no project markers: operator can choose user explicitly", async () => {
+    const { io } = mockIO([
+      "user", // override default
+      null,   // accept mint
+      true,   // proceed
+    ]);
+    const result = await runInteractiveInstall(
+      baseCtx({ inProjectContext: false }),
+      io,
+    );
+    expect(result).not.toBe("abort");
+    if (result === "abort") return;
+    expect(result.installScope).toBe("user");
+  });
+
+  test("install-scope prompt: invalid value re-prompts with help affordance", async () => {
+    const { io, state } = mockIO([
+      "everywhere", // invalid
+      "local",       // valid
+      null,          // accept mint
+      true,          // proceed
+    ]);
+    const result = await runInteractiveInstall(baseCtx(), io);
+    expect(result).not.toBe("abort");
+    if (result === "abort") return;
+    expect(result.installScope).toBe("local");
+    expect(state.logs.some((l) => /expected one of/.test(l))).toBe(true);
+  });
+
   test("hub not reachable: walkthrough offers paste vs legacy (no mint option)", async () => {
     const { io, state } = mockIO([
+      null,     // accept install-scope default
       "legacy", // pick legacy-pat
       null,     // accept default scope (read) on the F2 scope prompt
       true,     // proceed
@@ -202,6 +255,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("hub reachable but no operator.token: also offers paste vs legacy", async () => {
     const { io, state } = mockIO([
+      null,         // accept install-scope default
       "paste",      // pick paste
       "pasted-jwt", // the bearer
       true,         // proceed
@@ -219,6 +273,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("scope widening: typing 'write' produces vault:write mint", async () => {
     const { io } = mockIO([
+      null,    // accept install-scope default
       "write", // widen scope
       true,    // proceed
     ]);
@@ -231,6 +286,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("scope widening: typing 'admin' produces vault:admin mint", async () => {
     const { io } = mockIO([
+      null,    // accept install-scope default
       "admin",
       true,
     ]);
@@ -242,6 +298,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("typing 'paste' at the auth prompt switches to token mode + asks for token", async () => {
     const { io } = mockIO([
+      null,              // accept install-scope default
       "paste",           // switch to paste
       "my-existing-jwt", // the bearer
       true,              // proceed
@@ -255,6 +312,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("typing 'legacy' at the auth prompt switches to legacy-pat with default scope", async () => {
     const { io } = mockIO([
+      null,    // accept install-scope default
       "legacy",
       null,    // accept default scope (read) on the F2 scope prompt
       true,
@@ -268,6 +326,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("legacy-pat path: typing 'write' on the scope prompt widens to vault:write (F2)", async () => {
     const { io, state } = mockIO([
+      null,       // accept install-scope default
       "legacy",   // pick legacy-pat
       "write",    // widen scope
       true,       // proceed
@@ -283,6 +342,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("legacy-pat path (no-hub branch): scope prompt also fires (F2)", async () => {
     const { io } = mockIO([
+      null,      // accept install-scope default
       "legacy",  // pick legacy (no-hub branch)
       "admin",   // widen scope
       true,      // proceed
@@ -296,6 +356,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("paste path: preview clarifies scope is determined by the pasted token (F2)", async () => {
     const { io, state } = mockIO([
+      null,             // accept install-scope default
       "paste",          // pick paste
       "my-existing-jwt", // bearer
       true,              // proceed
@@ -349,6 +410,7 @@ describe("runInteractiveInstall — decision tree", () => {
     };
     const { io } = mockIO([
       false, // decline update
+      null,  // accept install-scope default (local)
       null,  // accept mint
       true,  // proceed
     ]);
@@ -358,12 +420,13 @@ describe("runInteractiveInstall — decision tree", () => {
     );
     expect(result).not.toBe("abort");
     if (result === "abort") return;
-    // Default flow resumed — user scope (no project context), default vault.
-    expect(result.installScope).toBe("user");
+    // Default flow resumed — local scope (no project markers), default vault.
+    expect(result.installScope).toBe("local");
   });
 
   test("aborts cleanly when the operator declines the final confirm", async () => {
     const { io, state } = mockIO([
+      null,  // accept install-scope default
       null,  // accept mint
       false, // decline final confirm
     ]);
@@ -382,6 +445,7 @@ describe("runInteractiveInstall — decision tree", () => {
 
   test("'help' input on the auth prompt re-prompts after showing explanation", async () => {
     const { io, state } = mockIO([
+      null,   // accept install-scope default
       "help", // ask for help
       null,   // then accept mint
       true,   // proceed
@@ -400,6 +464,7 @@ describe("runInteractiveInstall — decision tree", () => {
     const { io, state } = mockIO([
       "ghost",   // unknown vault
       "boulder", // pick a real one
+      null,      // accept install-scope default
       null,      // accept mint
       true,      // proceed
     ]);
@@ -545,6 +610,88 @@ describe("detectExistingEntries", () => {
   test("malformed JSON does not throw — silently skipped", () => {
     fs.writeFileSync(path.join(tmpHome, ".claude.json"), "{ not json");
     expect(detectExistingEntries(tmpCwd)).toEqual({});
+  });
+
+  test("detects local-scope entry under projects[<cwd>].mcpServers", () => {
+    const projectKey = path.resolve(tmpCwd);
+    fs.writeFileSync(
+      path.join(tmpHome, ".claude.json"),
+      JSON.stringify({
+        projects: {
+          [projectKey]: {
+            mcpServers: {
+              "parachute-vault": {
+                type: "http",
+                url: "https://hub.example/vault/default/mcp",
+                headers: { Authorization: "Bearer x" },
+              },
+            },
+          },
+        },
+      }),
+    );
+    const found = detectExistingEntries(tmpCwd);
+    expect(found.local).toBeDefined();
+    expect(found.local!.scope).toBe("local");
+    expect(found.local!.entryKey).toBe("parachute-vault");
+    expect(found.local!.label).toContain(projectKey);
+  });
+
+  test("local-scope entry at a different cwd is not surfaced", () => {
+    // Operator did `mcp-install --install-scope local` from /Other/Project
+    // some time ago. The walkthrough running from tmpCwd today shouldn't
+    // misread that as an "existing here" entry — local scope is per-cwd.
+    fs.writeFileSync(
+      path.join(tmpHome, ".claude.json"),
+      JSON.stringify({
+        projects: {
+          "/Other/Project": {
+            mcpServers: {
+              "parachute-vault": {
+                type: "http",
+                url: "https://hub.example/vault/default/mcp",
+              },
+            },
+          },
+        },
+      }),
+    );
+    const found = detectExistingEntries(tmpCwd);
+    expect(found.local).toBeUndefined();
+  });
+
+  test("user + local + project entries coexist in one detect call", () => {
+    const projectKey = path.resolve(tmpCwd);
+    fs.writeFileSync(
+      path.join(tmpHome, ".claude.json"),
+      JSON.stringify({
+        mcpServers: {
+          "parachute-vault": { type: "http", url: "https://hub.example/vault/u/mcp" },
+        },
+        projects: {
+          [projectKey]: {
+            mcpServers: {
+              "parachute-vault": { type: "http", url: "https://hub.example/vault/l/mcp" },
+            },
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpCwd, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          "parachute-vault": { type: "http", url: "https://hub.example/vault/p/mcp" },
+        },
+      }),
+    );
+    const found = detectExistingEntries(tmpCwd);
+    expect(found.user).toBeDefined();
+    expect(found.local).toBeDefined();
+    expect(found.project).toBeDefined();
+    expect(found.user!.url).toContain("/vault/u/");
+    expect(found.local!.url).toContain("/vault/l/");
+    expect(found.project!.url).toContain("/vault/p/");
   });
 });
 

--- a/src/mcp-install-interactive.ts
+++ b/src/mcp-install-interactive.ts
@@ -119,27 +119,51 @@ export async function runInteractiveInstall(
   }
 
   // 3. Install location. If we're updating, use that location. Otherwise
-  //    suggest project when in a project context, user otherwise.
+  //    always prompt with the three scopes available (local / project /
+  //    user) — Claude Code reads ./.mcp.json regardless of git/package
+  //    markers, so the prior "no markers → autopilot global" branch was
+  //    wrong (silently overrode the operator's intent when they happened
+  //    to be in a plain dir). Default tilts on the same marker signal:
+  //    project markers → suggest `project`, else suggest `local`. The
+  //    suggestion shapes the default; it does NOT decide.
   let installScope: InstallScope;
   if (updateLocation) {
     installScope = updateLocation.scope;
   } else {
-    const suggested: InstallScope = ctx.inProjectContext ? "project" : "user";
-    if (suggested === "project") {
-      io.log(`Looks like you're in a project directory (${pathTail(ctx.cwd)}).`);
-      const useProject = await io.confirm(
-        "Install for this project only (./.mcp.json)?",
-        true,
-      );
-      installScope = useProject ? "project" : "user";
-      io.log(
-        installScope === "project"
-          ? `  → Writing to ${ctx.cwd}/.mcp.json (project-scoped).`
-          : "  → Writing to ~/.claude.json (user-scoped).",
-      );
+    const suggested: InstallScope = ctx.inProjectContext ? "project" : "local";
+    io.log(`Where to install? (CWD: ${pathTail(ctx.cwd)})`);
+    io.log("  local    — ~/.claude.json under projects[<cwd>] (private, this dir only)");
+    io.log("  project  — ./.mcp.json (checked into the repo, shared with team)");
+    io.log("  user     — ~/.claude.json top-level (every project, every dir)");
+    const answer = await askPersistent(
+      io,
+      `Press Enter for "${suggested}", or type local / project / user`,
+      suggested,
+      {
+        help: [
+          "Install scopes (mirrors Claude Code's `claude mcp add --scope`):",
+          "  local    → ~/.claude.json under projects[<cwd>].mcpServers.",
+          "             Private to your machine, scoped to this directory.",
+          "             Claude Code only loads it when launched from here.",
+          "  project  → <cwd>/.mcp.json. Checked into the repo; shared with",
+          "             anyone who clones it. Pick this when the vault",
+          "             integration belongs to the team / project.",
+          "  user     → ~/.claude.json top-level mcpServers. Loaded for",
+          "             every Claude Code session regardless of cwd.",
+        ].join("\n"),
+        validate: (s) => {
+          const ok = ["local", "project", "user"];
+          return ok.includes(s) ? null : `expected one of: ${ok.join(", ")}`;
+        },
+      },
+    );
+    installScope = answer as InstallScope;
+    if (installScope === "local") {
+      io.log(`  → Writing to ~/.claude.json under projects["${ctx.cwd}"].mcpServers (local — this directory only).`);
+    } else if (installScope === "project") {
+      io.log(`  → Writing to ${ctx.cwd}/.mcp.json (project-scoped — shared with the repo).`);
     } else {
-      io.log("Installing globally to ~/.claude.json (no project markers in this directory).");
-      installScope = "user";
+      io.log("  → Writing to ~/.claude.json top-level (user-scoped — every project).");
     }
     io.log("");
   }
@@ -209,7 +233,12 @@ export async function runInteractiveInstall(
   io.log("");
 
   // 5. Preview + final confirm.
-  const targetLabel = installScope === "project" ? `${ctx.cwd}/.mcp.json` : "~/.claude.json";
+  const targetLabel =
+    installScope === "project"
+      ? `${ctx.cwd}/.mcp.json`
+      : installScope === "local"
+        ? `~/.claude.json (projects["${ctx.cwd}"])`
+        : "~/.claude.json";
   const entryKey =
     updateLocation?.entryKey ??
     (vaultExplicit ? `parachute-vault-${vaultName}` : "parachute-vault");
@@ -251,13 +280,15 @@ export async function runInteractiveInstall(
 // ---------------------------------------------------------------------------
 
 /**
- * Pick which existing entry the prompt should lead with. Prefer user-level
- * (the canonical "installed for me everywhere" location) over project-level
- * (which is more often a per-project override that may not represent the
- * operator's primary install).
+ * Pick which existing entry the prompt should lead with. Preference order:
+ *   1. local at this exact CWD — strongest signal the operator was just
+ *      here and updated this very directory before.
+ *   2. user — the global install location, applies to every project.
+ *   3. project — the repo-shared install; lowest priority since it can
+ *      drift independently of the operator's primary install.
  */
 function pickExistingForPrompt(ctx: InstallContext): ExistingMcpEntry | null {
-  return ctx.existing.user ?? ctx.existing.project ?? null;
+  return ctx.existing.local ?? ctx.existing.user ?? ctx.existing.project ?? null;
 }
 
 /**

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -24,6 +24,7 @@ import {
   chooseMcpUrl,
   mintHubJwt,
   readOperatorToken,
+  removeMcpConfig,
   resolveInstallTarget,
 } from "./mcp-install.ts";
 
@@ -725,60 +726,75 @@ describe("mcp-install end-to-end", () => {
     }
   });
 
-  test("uninstall from a different cwd still strips a local-scope entry installed elsewhere", () => {
-    // Pins the cwd-agnostic property of removeMcpConfig's local-scope
-    // walk: an operator who runs `mcp-install --install-scope local`
-    // from one directory and `parachute-vault uninstall` from another
-    // should still see the entry cleaned up. The implementation iterates
-    // every projects[*] slot rather than just the current cwd's; this
-    // test fails fast if a future "optimization" narrows that walk to
-    // only the running-from cwd.
-    setupBareVault(tmp, "default");
-    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-uninstall-install-from-"));
-    const uninstallDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-uninstall-from-"));
+  test("removeMcpConfig walks every projects[*] slot regardless of cwd", () => {
+    // Pins the cwd-agnostic property of removeMcpConfig's local-scope walk.
+    // Called directly rather than via subprocess `uninstall --yes` because
+    // the CLI uninstall also runs `uninstallAgent()` against the real
+    // launchd label `computer.parachute.vault` — not isolated by
+    // PARACHUTE_HOME, so a subprocess test would nuke a real registered
+    // daemon. Direct call keeps the test focused on the cleanup walk,
+    // which is the property the reviewer flagged as untested.
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "vault-rmcfg-home-"));
+    const cwdA = "/Users/imaginary/projectA";
+    const cwdB = "/Users/imaginary/projectB";
+    const claudePath = path.join(fakeHome, ".claude.json");
+    fs.writeFileSync(
+      claudePath,
+      JSON.stringify({
+        mcpServers: { "parachute-vault": { type: "http", url: "user-scope" } },
+        projects: {
+          [cwdA]: {
+            allowedTools: ["Bash(ls:*)"],
+            mcpServers: {
+              "parachute-vault": { type: "http", url: "a" },
+              "some-other-server": { type: "http", url: "kept-a" },
+            },
+          },
+          [cwdB]: {
+            mcpServers: {
+              "parachute-vault-extra": { type: "http", url: "b1" },
+              "parachute-vault/legacy": { type: "http", url: "b2-legacy" },
+              "kept-server": { type: "http", url: "kept-b" },
+            },
+          },
+        },
+      }) + "\n",
+    );
+
+    // Bun's `os.homedir()` reads `process.env.HOME` first — swapping it for
+    // the duration of the call routes the cleanup at fakeHome's .claude.json,
+    // not the real user's. Restored in `finally`.
+    const elsewhere = fs.mkdtempSync(path.join(os.tmpdir(), "vault-rmcfg-cwd-"));
+    const origHome = process.env.HOME;
+    const origCwd = process.cwd();
     try {
-      // 1. Install at installDir with --install-scope local.
-      const installRes = runCli(
-        ["mcp-install", "--install-scope", "local", "--token", "doomed-bearer"],
-        tmp,
-        {},
-        installDir,
-      );
-      expect(installRes.exitCode).toBe(0);
-      const installKey = fs.realpathSync(installDir);
-      let config = readJson(path.join(tmp, ".claude.json"));
-      expect(config.projects[installKey].mcpServers["parachute-vault"]).toBeDefined();
-
-      // 2. Pre-create some unrelated state at the same projects[installDir]
-      //    slot to make sure uninstall's cleanup is surgical — it should
-      //    strip the vault keys but leave siblings + non-mcpServers fields.
-      config.projects[installKey].allowedTools = ["Bash(ls:*)"];
-      config.projects[installKey].mcpServers["some-other-server"] = {
-        type: "http",
-        url: "https://other.example/mcp",
-      };
-      fs.writeFileSync(path.join(tmp, ".claude.json"), JSON.stringify(config, null, 2) + "\n");
-
-      // 3. Run uninstall from a DIFFERENT cwd (uninstallDir). The current
-      //    cwd's projects[*] slot doesn't exist; the install's does.
-      //    `--yes` skips both interactive confirms; we don't pass `--wipe`
-      //    so user data is left alone — only the MCP-entry walk runs.
-      const uninstallRes = runCli(["uninstall", "--yes"], tmp, {}, uninstallDir);
-      expect(uninstallRes.exitCode).toBe(0);
-
-      // 4. The vault entry at installDir should be gone — even though
-      //    that's not where we ran uninstall from.
-      config = readJson(path.join(tmp, ".claude.json"));
-      const installServers = config.projects?.[installKey]?.mcpServers ?? {};
-      expect(installServers["parachute-vault"]).toBeUndefined();
-      // 5. Sibling MCP server preserved.
-      expect(installServers["some-other-server"]).toBeDefined();
-      // 6. Non-mcpServers field at the same slot preserved.
-      expect(config.projects[installKey].allowedTools).toEqual(["Bash(ls:*)"]);
+      process.env.HOME = fakeHome;
+      process.chdir(elsewhere);
+      removeMcpConfig();
     } finally {
-      fs.rmSync(installDir, { recursive: true, force: true });
-      fs.rmSync(uninstallDir, { recursive: true, force: true });
+      process.chdir(origCwd);
+      if (origHome !== undefined) process.env.HOME = origHome;
+      else delete process.env.HOME;
+      fs.rmSync(elsewhere, { recursive: true, force: true });
     }
+
+    const after = JSON.parse(fs.readFileSync(claudePath, "utf-8"));
+
+    // User-scope: stripped.
+    expect(after.mcpServers["parachute-vault"]).toBeUndefined();
+
+    // projectA: vault entry gone, sibling MCP + allowedTools preserved.
+    expect(after.projects[cwdA].mcpServers["parachute-vault"]).toBeUndefined();
+    expect(after.projects[cwdA].mcpServers["some-other-server"]).toBeDefined();
+    expect(after.projects[cwdA].allowedTools).toEqual(["Bash(ls:*)"]);
+
+    // projectB: per-vault `parachute-vault-*` + legacy slash-form gone,
+    // unrelated sibling preserved.
+    expect(after.projects[cwdB].mcpServers["parachute-vault-extra"]).toBeUndefined();
+    expect(after.projects[cwdB].mcpServers["parachute-vault/legacy"]).toBeUndefined();
+    expect(after.projects[cwdB].mcpServers["kept-server"]).toBeDefined();
+
+    fs.rmSync(fakeHome, { recursive: true, force: true });
   });
 });
 

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -724,6 +724,62 @@ describe("mcp-install end-to-end", () => {
       fs.rmSync(projectDir, { recursive: true, force: true });
     }
   });
+
+  test("uninstall from a different cwd still strips a local-scope entry installed elsewhere", () => {
+    // Pins the cwd-agnostic property of removeMcpConfig's local-scope
+    // walk: an operator who runs `mcp-install --install-scope local`
+    // from one directory and `parachute-vault uninstall` from another
+    // should still see the entry cleaned up. The implementation iterates
+    // every projects[*] slot rather than just the current cwd's; this
+    // test fails fast if a future "optimization" narrows that walk to
+    // only the running-from cwd.
+    setupBareVault(tmp, "default");
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-uninstall-install-from-"));
+    const uninstallDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-uninstall-from-"));
+    try {
+      // 1. Install at installDir with --install-scope local.
+      const installRes = runCli(
+        ["mcp-install", "--install-scope", "local", "--token", "doomed-bearer"],
+        tmp,
+        {},
+        installDir,
+      );
+      expect(installRes.exitCode).toBe(0);
+      const installKey = fs.realpathSync(installDir);
+      let config = readJson(path.join(tmp, ".claude.json"));
+      expect(config.projects[installKey].mcpServers["parachute-vault"]).toBeDefined();
+
+      // 2. Pre-create some unrelated state at the same projects[installDir]
+      //    slot to make sure uninstall's cleanup is surgical — it should
+      //    strip the vault keys but leave siblings + non-mcpServers fields.
+      config.projects[installKey].allowedTools = ["Bash(ls:*)"];
+      config.projects[installKey].mcpServers["some-other-server"] = {
+        type: "http",
+        url: "https://other.example/mcp",
+      };
+      fs.writeFileSync(path.join(tmp, ".claude.json"), JSON.stringify(config, null, 2) + "\n");
+
+      // 3. Run uninstall from a DIFFERENT cwd (uninstallDir). The current
+      //    cwd's projects[*] slot doesn't exist; the install's does.
+      //    `--yes` skips both interactive confirms; we don't pass `--wipe`
+      //    so user data is left alone — only the MCP-entry walk runs.
+      const uninstallRes = runCli(["uninstall", "--yes"], tmp, {}, uninstallDir);
+      expect(uninstallRes.exitCode).toBe(0);
+
+      // 4. The vault entry at installDir should be gone — even though
+      //    that's not where we ran uninstall from.
+      config = readJson(path.join(tmp, ".claude.json"));
+      const installServers = config.projects?.[installKey]?.mcpServers ?? {};
+      expect(installServers["parachute-vault"]).toBeUndefined();
+      // 5. Sibling MCP server preserved.
+      expect(installServers["some-other-server"]).toBeDefined();
+      // 6. Non-mcpServers field at the same slot preserved.
+      expect(config.projects[installKey].allowedTools).toEqual(["Bash(ls:*)"]);
+    } finally {
+      fs.rmSync(installDir, { recursive: true, force: true });
+      fs.rmSync(uninstallDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -264,6 +264,7 @@ describe("resolveInstallTarget", () => {
     const res = resolveInstallTarget("user");
     expect(res.path).toBe(path.resolve(os.homedir(), ".claude.json"));
     expect(res.scope).toBe("user");
+    expect(res.localProjectKey).toBeUndefined();
   });
 
   test("project scope → <cwd>/.mcp.json", () => {
@@ -272,6 +273,22 @@ describe("resolveInstallTarget", () => {
       const res = resolveInstallTarget("project", tmp);
       expect(res.path).toBe(path.resolve(tmp, ".mcp.json"));
       expect(res.scope).toBe("project");
+      expect(res.localProjectKey).toBeUndefined();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("local scope → ~/.claude.json with absolute-cwd project key", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vault-target-local-"));
+    try {
+      const res = resolveInstallTarget("local", tmp);
+      // Same file as user scope — what differs is where inside the JSON
+      // the entry lands (top-level vs projects[<cwd>].mcpServers).
+      expect(res.path).toBe(path.resolve(os.homedir(), ".claude.json"));
+      expect(res.scope).toBe("local");
+      // Absolute path → matches Claude Code's own convention.
+      expect(res.localProjectKey).toBe(path.resolve(tmp));
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -401,7 +418,16 @@ describe("mcp-install flag parsing", () => {
       tmp,
     );
     expect(res.exitCode).toBe(1);
-    expect(res.stderr).toMatch(/--install-scope must be "user" or "project"/);
+    expect(res.stderr).toMatch(/--install-scope must be "local", "user", or "project"/);
+  });
+
+  test("accepts --install-scope local", () => {
+    setupBareVault(tmp, "default");
+    const res = runCli(
+      ["mcp-install", "--install-scope", "local", "--token", "t"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
   });
 
   test("rejects a --client other than claude-code (Phase C is future work)", () => {
@@ -457,10 +483,10 @@ describe("mcp-install end-to-end", () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  test("--token writes the supplied bearer into ~/.claude.json", () => {
+  test("--install-scope user writes top-level mcpServers in ~/.claude.json", () => {
     setupBareVault(tmp, "default");
     const res = runCli(
-      ["mcp-install", "--token", "pasted-bearer"],
+      ["mcp-install", "--install-scope", "user", "--token", "pasted-bearer"],
       tmp,
     );
     expect(res.exitCode).toBe(0);
@@ -469,6 +495,36 @@ describe("mcp-install end-to-end", () => {
     expect(entry.type).toBe("http");
     expect(entry.headers.Authorization).toBe("Bearer pasted-bearer");
     expect(entry.url).toContain("/vault/default/mcp");
+    // No projects[*] entry written.
+    expect(config.projects).toBeUndefined();
+  });
+
+  test("default (no --install-scope) writes ~/.claude.json under projects[<cwd>].mcpServers (local)", () => {
+    setupBareVault(tmp, "default");
+    // CLI runs with cwd=tmp (the parachute-home temp dir). Local-scope
+    // default keys the entry under projects[<cwd>] in the same file
+    // user-scope uses (~/.claude.json). On macOS /tmp is a symlink to
+    // /private/tmp, so the spawned process's cwd resolves through —
+    // use fs.realpathSync to compute the same key the CLI will write.
+    const res = runCli(
+      ["mcp-install", "--token", "local-bearer"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    const config = readJson(path.join(tmp, ".claude.json"));
+    // The new default is `local` — top-level mcpServers should be empty
+    // or absent; the entry lives under projects[<absolute-cwd>].
+    const flatEntry = config.mcpServers?.["parachute-vault"];
+    expect(flatEntry).toBeUndefined();
+    const projectKey = fs.realpathSync(tmp);
+    const localServers = config.projects?.[projectKey]?.mcpServers ?? {};
+    expect(localServers["parachute-vault"]).toBeDefined();
+    expect(localServers["parachute-vault"].headers.Authorization).toBe("Bearer local-bearer");
+    expect(localServers["parachute-vault"].url).toContain("/vault/default/mcp");
+    // Stdout surfaces the consequence so operators know the install is
+    // scoped to this directory (and how to widen if they wanted global).
+    expect(res.stdout).toMatch(/this directory only/);
+    expect(res.stdout).toMatch(/--install-scope user/);
   });
 
   test("--install-scope project writes <cwd>/.mcp.json instead of ~/.claude.json", () => {
@@ -494,13 +550,112 @@ describe("mcp-install end-to-end", () => {
     }
   });
 
-  test("--vault <name> keys the entry as parachute-vault-<name>", () => {
+  test("--install-scope local writes ~/.claude.json under projects[<cwd>].mcpServers", () => {
+    setupBareVault(tmp, "default");
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-local-"));
+    try {
+      const res = runCli(
+        ["mcp-install", "--install-scope", "local", "--token", "local-bearer"],
+        tmp,
+        {},
+        projectDir,
+      );
+      expect(res.exitCode).toBe(0);
+      // Local writes to ~/.claude.json under projects[<absolute-cwd>].
+      // Not <cwd>/.mcp.json (that's project scope).
+      expect(fs.existsSync(path.join(projectDir, ".mcp.json"))).toBe(false);
+      expect(fs.existsSync(path.join(tmp, ".claude.json"))).toBe(true);
+      const config = readJson(path.join(tmp, ".claude.json"));
+      const projectKey = fs.realpathSync(projectDir);
+      const entry = config.projects[projectKey].mcpServers["parachute-vault"];
+      expect(entry.type).toBe("http");
+      expect(entry.headers.Authorization).toBe("Bearer local-bearer");
+      expect(entry.url).toContain("/vault/default/mcp");
+      // No top-level entry written for local scope.
+      expect(config.mcpServers?.["parachute-vault"]).toBeUndefined();
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test("--install-scope local preserves an existing top-level entry untouched", () => {
+    setupBareVault(tmp, "default");
+    // Pre-seed ~/.claude.json with a top-level user-scope entry from some
+    // other client. The local install must not clobber it.
+    fs.writeFileSync(
+      path.join(tmp, ".claude.json"),
+      JSON.stringify({
+        mcpServers: {
+          "some-other-server": { type: "http", url: "https://other.example/mcp" },
+        },
+      }),
+    );
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-local-pre-"));
+    try {
+      const res = runCli(
+        ["mcp-install", "--install-scope", "local", "--token", "t"],
+        tmp,
+        {},
+        projectDir,
+      );
+      expect(res.exitCode).toBe(0);
+      const config = readJson(path.join(tmp, ".claude.json"));
+      // Pre-existing top-level entry preserved.
+      expect(config.mcpServers["some-other-server"]).toBeDefined();
+      // New local entry under projects[<cwd>].
+      const projectKey = fs.realpathSync(projectDir);
+      expect(config.projects[projectKey].mcpServers["parachute-vault"]).toBeDefined();
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test("--install-scope local preserves a pre-existing project's other mcp servers", () => {
+    setupBareVault(tmp, "default");
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-local-coexist-"));
+    const projectKey = fs.realpathSync(projectDir);
+    // Pre-seed a projects[cwd] entry with an unrelated MCP server +
+    // additional fields. The install must not blow them away.
+    fs.writeFileSync(
+      path.join(tmp, ".claude.json"),
+      JSON.stringify({
+        projects: {
+          [projectKey]: {
+            allowedTools: ["Bash(ls:*)"],
+            mcpServers: {
+              "glif": { type: "http", url: "https://glif.example/mcp" },
+            },
+          },
+        },
+      }),
+    );
+    try {
+      const res = runCli(
+        ["mcp-install", "--install-scope", "local", "--token", "t"],
+        tmp,
+        {},
+        projectDir,
+      );
+      expect(res.exitCode).toBe(0);
+      const config = readJson(path.join(tmp, ".claude.json"));
+      // Pre-existing sibling preserved.
+      expect(config.projects[projectKey].mcpServers["glif"]).toBeDefined();
+      // Pre-existing non-mcpServers field preserved.
+      expect(config.projects[projectKey].allowedTools).toEqual(["Bash(ls:*)"]);
+      // New entry added.
+      expect(config.projects[projectKey].mcpServers["parachute-vault"]).toBeDefined();
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test("--vault <name> keys the entry as parachute-vault-<name> (user scope)", () => {
     setupBareVault(tmp, "default");
     setupBareVault(tmp, "work");
-    // Install for the second vault — singular slot stays free for the
-    // default. Multi-vault is the motivation.
+    // Install for the second vault under user scope — singular slot
+    // stays free for the default. Multi-vault is the motivation.
     const res = runCli(
-      ["mcp-install", "--vault", "work", "--token", "work-bearer"],
+      ["mcp-install", "--install-scope", "user", "--vault", "work", "--token", "work-bearer"],
       tmp,
     );
     expect(res.exitCode).toBe(0);
@@ -515,9 +670,12 @@ describe("mcp-install end-to-end", () => {
     expect(config.mcpServers["parachute-vault"]).toBeUndefined();
   });
 
-  test("--vault without an explicit name uses the default and keys the singular slot", () => {
+  test("--vault without an explicit name uses the default and keys the singular slot (user scope)", () => {
     setupBareVault(tmp, "default");
-    const res = runCli(["mcp-install", "--token", "default-bearer"], tmp);
+    const res = runCli(
+      ["mcp-install", "--install-scope", "user", "--token", "default-bearer"],
+      tmp,
+    );
     expect(res.exitCode).toBe(0);
     const config = readJson(path.join(tmp, ".claude.json"));
     expect(config.mcpServers["parachute-vault"]).toBeDefined();
@@ -528,7 +686,7 @@ describe("mcp-install end-to-end", () => {
 
   test("--legacy-pat mints a vault-DB pvt_* token and prints deprecation warning", () => {
     setupBareVault(tmp, "default");
-    const res = runCli(["mcp-install", "--legacy-pat"], tmp);
+    const res = runCli(["mcp-install", "--install-scope", "user", "--legacy-pat"], tmp);
     expect(res.exitCode).toBe(0);
     // Deprecation warning lands on stderr (we used `console.error` for the
     // notice so it's visible without polluting stdout). The message names
@@ -543,13 +701,28 @@ describe("mcp-install end-to-end", () => {
     expect(bearer).toMatch(/^Bearer pvt_/);
   });
 
-  test("subsequent --token install on top of an existing entry overwrites the bearer", () => {
+  test("subsequent --token install on top of an existing entry overwrites the bearer (user scope)", () => {
     setupBareVault(tmp, "default");
-    runCli(["mcp-install", "--token", "first"], tmp);
-    const res = runCli(["mcp-install", "--token", "second"], tmp);
+    runCli(["mcp-install", "--install-scope", "user", "--token", "first"], tmp);
+    const res = runCli(["mcp-install", "--install-scope", "user", "--token", "second"], tmp);
     expect(res.exitCode).toBe(0);
     const config = readJson(path.join(tmp, ".claude.json"));
     expect(config.mcpServers["parachute-vault"].headers.Authorization).toBe("Bearer second");
+  });
+
+  test("subsequent --token install in local scope overwrites the bearer at projects[<cwd>]", () => {
+    setupBareVault(tmp, "default");
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-local-update-"));
+    try {
+      runCli(["mcp-install", "--install-scope", "local", "--token", "first"], tmp, {}, projectDir);
+      const res = runCli(["mcp-install", "--install-scope", "local", "--token", "second"], tmp, {}, projectDir);
+      expect(res.exitCode).toBe(0);
+      const config = readJson(path.join(tmp, ".claude.json"));
+      const projectKey = fs.realpathSync(projectDir);
+      expect(config.projects[projectKey].mcpServers["parachute-vault"].headers.Authorization).toBe("Bearer second");
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/mcp-install.ts
+++ b/src/mcp-install.ts
@@ -24,9 +24,61 @@
  *      `--install-scope` flag.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
+
+/**
+ * Strip every vault MCP entry from ~/.claude.json (user-scope + every
+ * local-scope `projects[*].mcpServers`) and ./.mcp.json (project-scope at
+ * cwd). Cleanup walks every `projects[*]` slot so an operator who installed
+ * locally in one directory can uninstall from anywhere without remembering
+ * where. Silent no-op on missing files / malformed JSON.
+ *
+ * Lives in mcp-install.ts (not cli.ts) so tests can call it directly
+ * without triggering cli.ts's top-level dispatch on import.
+ */
+export function removeMcpConfig(): void {
+  // Prefer `process.env.HOME` over cached `homedir()` — Bun caches the OS
+  // userinfo at process start so in-process HOME overrides (tests, exotic
+  // chrooting) don't apply via homedir(). Matches resolveInstallTarget's
+  // home-resolution pattern.
+  const home = process.env.HOME ?? homedir();
+  const claudeJsonPath = resolve(home, ".claude.json");
+  const projectMcpJsonPath = resolve(process.cwd(), ".mcp.json");
+  for (const path of [claudeJsonPath, projectMcpJsonPath]) {
+    if (!existsSync(path)) continue;
+    try {
+      const config = JSON.parse(readFileSync(path, "utf-8"));
+      // Drop the singular key and every per-vault `parachute-vault-<name>`
+      // entry. Legacy `parachute-vault/<name>` (slash-form) sub-keys from a
+      // pre-multi-vault pattern still get cleaned up here.
+      const stripVaultKeys = (servers: Record<string, unknown> | undefined) => {
+        if (!servers) return;
+        for (const key of Object.keys(servers)) {
+          if (
+            key === "parachute-vault" ||
+            key.startsWith("parachute-vault-") ||
+            key.startsWith("parachute-vault/")
+          ) {
+            delete servers[key];
+          }
+        }
+      };
+      stripVaultKeys(config.mcpServers);
+      // Local-scope cleanup: walk every project entry and strip vault keys.
+      if (config.projects && typeof config.projects === "object") {
+        for (const projectKey of Object.keys(config.projects)) {
+          const projectEntry = config.projects[projectKey];
+          if (projectEntry && typeof projectEntry === "object") {
+            stripVaultKeys(projectEntry.mcpServers);
+          }
+        }
+      }
+      writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+    } catch {}
+  }
+}
 
 // ---------------------------------------------------------------------------
 // URL picking

--- a/src/mcp-install.ts
+++ b/src/mcp-install.ts
@@ -251,19 +251,29 @@ export async function mintHubJwt(opts: MintHubJwtOpts): Promise<MintedHubJwt | M
 // Install target resolver
 // ---------------------------------------------------------------------------
 
-export type InstallScope = "user" | "project";
+export type InstallScope = "user" | "project" | "local";
 
 export interface InstallTarget {
   /** Absolute path the install will write to. */
   path: string;
   /** Which scope the path corresponds to (for log lines + doctor). */
   scope: InstallScope;
+  /**
+   * For `local` scope: the absolute CWD the entry is keyed under inside
+   * `~/.claude.json`'s `projects` map. Undefined for `user` and `project`.
+   */
+  localProjectKey?: string;
 }
 
 /**
- * Pick the MCP client config file path based on `--install-scope`. Project
- * scope writes to `<cwd>/.mcp.json` (Claude Code convention); user scope
- * writes to `~/.claude.json` (legacy + still canonical for user-wide setup).
+ * Pick the MCP client config file path based on `--install-scope`. Three
+ * shapes:
+ *
+ *   user    → `~/.claude.json` top-level `mcpServers` (global, every project).
+ *   project → `<cwd>/.mcp.json` (Claude Code convention; check into the repo).
+ *   local   → `~/.claude.json` under `projects[<absolute-cwd>].mcpServers`
+ *             (private to this machine, scoped to this directory). Matches
+ *             Claude's own `claude mcp add` default.
  *
  * `homedir()` from node:os is cached at process start on Bun, so in-process
  * `process.env.HOME` overrides don't propagate to it. We prefer the
@@ -279,7 +289,15 @@ export function resolveInstallTarget(
     return { path: resolve(cwd, ".mcp.json"), scope: "project" };
   }
   const home = process.env.HOME ?? homedir();
-  return { path: resolve(home, ".claude.json"), scope: "user" };
+  const claudeJson = resolve(home, ".claude.json");
+  if (scope === "local") {
+    return {
+      path: claudeJson,
+      scope: "local",
+      localProjectKey: resolve(cwd),
+    };
+  }
+  return { path: claudeJson, scope: "user" };
 }
 
 // ---------------------------------------------------------------------------
@@ -341,10 +359,13 @@ export interface ExistingMcpEntry {
 }
 
 /**
- * Look for an existing parachute-vault entry at the user-level
- * `~/.claude.json` and the project-level `./.mcp.json`. Returns each
- * matching entry independently so the walkthrough can present either
- * (or both, but in practice we pick one).
+ * Look for an existing parachute-vault entry across the three scopes:
+ *   user    — `~/.claude.json` top-level `mcpServers`.
+ *   local   — `~/.claude.json` under `projects[<cwd>].mcpServers`.
+ *   project — `<cwd>/.mcp.json`.
+ *
+ * Returns each matching entry independently so the walkthrough can present
+ * the most relevant one to the operator.
  *
  * `parachute-vault` (singular) wins over `parachute-vault-<name>` at the
  * same file — the singular slot is the canonical default install; per-
@@ -352,24 +373,27 @@ export interface ExistingMcpEntry {
  */
 export function detectExistingEntries(
   cwd: string = process.cwd(),
-): { user?: ExistingMcpEntry; project?: ExistingMcpEntry } {
+): { user?: ExistingMcpEntry; local?: ExistingMcpEntry; project?: ExistingMcpEntry } {
+  const userTarget = resolveInstallTarget("user");
+  const localTarget = resolveInstallTarget("local", cwd);
+  const projectTarget = resolveInstallTarget("project", cwd);
+  const userConfig = readJsonOrNull(userTarget.path);
   return {
-    ...maybeEntry(resolveInstallTarget("user"), "~/.claude.json"),
-    ...maybeEntry(resolveInstallTarget("project", cwd), `${cwd}/.mcp.json`),
+    ...maybeUserEntry(userConfig, userTarget.path),
+    ...maybeLocalEntry(userConfig, localTarget.path, localTarget.localProjectKey!),
+    ...maybeProjectEntry(projectTarget.path, `${cwd}/.mcp.json`),
   };
 
-  function maybeEntry(
-    target: InstallTarget,
-    label: string,
-  ): { user?: ExistingMcpEntry } | { project?: ExistingMcpEntry } | {} {
-    if (!existsSync(target.path)) return {};
-    let config: any;
+  function readJsonOrNull(p: string): any {
+    if (!existsSync(p)) return null;
     try {
-      config = JSON.parse(readFileSync(target.path, "utf-8"));
+      return JSON.parse(readFileSync(p, "utf-8"));
     } catch {
-      return {};
+      return null;
     }
-    const servers: Record<string, any> = config?.mcpServers ?? {};
+  }
+
+  function pickEntry(servers: Record<string, any>): { entry: any; entryKey: string } | null {
     let entry = servers["parachute-vault"];
     let entryKey = "parachute-vault";
     if (!entry) {
@@ -381,16 +405,64 @@ export function detectExistingEntries(
         }
       }
     }
-    if (!entry || typeof entry.url !== "string") return {};
-    const result: ExistingMcpEntry = {
-      path: target.path,
-      label,
-      scope: target.scope,
-      entryKey,
-      url: entry.url,
-      hasAuth: Boolean(entry.headers?.Authorization),
+    if (!entry || typeof entry.url !== "string") return null;
+    return { entry, entryKey };
+  }
+
+  function maybeUserEntry(config: any, p: string): { user?: ExistingMcpEntry } | {} {
+    if (!config) return {};
+    const servers: Record<string, any> = config?.mcpServers ?? {};
+    const picked = pickEntry(servers);
+    if (!picked) return {};
+    return {
+      user: {
+        path: p,
+        label: "~/.claude.json",
+        scope: "user",
+        entryKey: picked.entryKey,
+        url: picked.entry.url,
+        hasAuth: Boolean(picked.entry.headers?.Authorization),
+      },
     };
-    return target.scope === "user" ? { user: result } : { project: result };
+  }
+
+  function maybeLocalEntry(
+    config: any,
+    p: string,
+    projectKey: string,
+  ): { local?: ExistingMcpEntry } | {} {
+    if (!config) return {};
+    const servers: Record<string, any> = config?.projects?.[projectKey]?.mcpServers ?? {};
+    const picked = pickEntry(servers);
+    if (!picked) return {};
+    return {
+      local: {
+        path: p,
+        label: `~/.claude.json (projects["${projectKey}"])`,
+        scope: "local",
+        entryKey: picked.entryKey,
+        url: picked.entry.url,
+        hasAuth: Boolean(picked.entry.headers?.Authorization),
+      },
+    };
+  }
+
+  function maybeProjectEntry(p: string, label: string): { project?: ExistingMcpEntry } | {} {
+    const config = readJsonOrNull(p);
+    if (!config) return {};
+    const servers: Record<string, any> = config?.mcpServers ?? {};
+    const picked = pickEntry(servers);
+    if (!picked) return {};
+    return {
+      project: {
+        path: p,
+        label,
+        scope: "project",
+        entryKey: picked.entryKey,
+        url: picked.entry.url,
+        hasAuth: Boolean(picked.entry.headers?.Authorization),
+      },
+    };
   }
 }
 
@@ -414,8 +486,8 @@ export interface InstallContext {
   inProjectContext: boolean;
   /** Where the walkthrough was invoked from. */
   cwd: string;
-  /** Pre-existing entries at user / project scope, if any. */
-  existing: { user?: ExistingMcpEntry; project?: ExistingMcpEntry };
+  /** Pre-existing entries at user / local / project scope, if any. */
+  existing: { user?: ExistingMcpEntry; local?: ExistingMcpEntry; project?: ExistingMcpEntry };
 }
 
 /**


### PR DESCRIPTION
## Summary

Two `parachute-vault mcp-install` fixes from real dogfood feedback. Operator ran the walkthrough from `/Gitcoin` (a plain personal exploration directory — no `.git`, no `package.json`) intending a directory-private install. The walkthrough decided global user-scope unilaterally and never showed the prompt.

### Fix 1 — Add the `local` install scope

Claude Code has three MCP scopes (`user` / `local` / `project`); vault previously only supported two. All three are now first-class:

| Scope | Entry lives at | Visibility |
|---|---|---|
| `user` | `~/.claude.json` top-level `mcpServers` | every project, every directory |
| `local` | `~/.claude.json` under `projects[<absolute-cwd>].mcpServers` | private, this directory only |
| `project` | `<cwd>/.mcp.json` | checked into the repo, shared with the team |

`local` matches Claude Code's own `claude mcp add --scope local` default (verified via the live `--help`). New CLI flag `--install-scope local`; `parachute-vault doctor` reads local entries from `~/.claude.json` under `projects[<cwd>]`; `parachute-vault uninstall` cleans local entries from every `projects[*]` slot it finds; `detectExistingEntries` surfaces local entries (and correctly ignores local entries at *other* cwds — local scope is per-cwd).

### Fix 2 — Drop the marker gate; always prompt for install scope

`src/mcp-install-interactive.ts` step 3 used to silently auto-pick `user` scope when no project markers (`.git`, `package.json`, …) were detected. The premise was wrong: Claude Code reads `./.mcp.json` (project scope) and `projects[<cwd>]` (local scope) regardless of git/package markers. Skipping the prompt buried the operator's intent.

Walkthrough now always prompts with the three scopes laid out. The default tilts on the marker signal — present → `project`, absent → `local` — but the operator always sees and can override.

### Breaking change — non-interactive default

`parachute-vault mcp-install` with no `--install-scope` flag previously wrote to `~/.claude.json` top-level (`user` scope). It now writes to `~/.claude.json` under `projects[<absolute-cwd>].mcpServers` (`local` scope), matching Claude's own default. Scripted installs relying on the global-write behavior should pass `--install-scope user` explicitly. Non-interactive local installs print a one-line consequence callout on stdout so first-time operators know how to widen:

```
Installed locally for this directory only — runs only when Claude Code launches from /...
To install globally instead, re-run with --install-scope user.
```

## Test plan

- [x] `bun test ./src/` — **903 pass, 1 skip, 0 fail** (up from 893/1/0). 10 new tests across `mcp-install.test.ts` + `mcp-install-interactive.test.ts`.
- [x] `bunx tsc --noEmit` — clean.
- [x] Walkthrough exercised end-to-end via mock IO: local default + override + project tilt + paste + legacy paths.
- [x] CLI exercised end-to-end via `Bun.spawnSync`: `--install-scope local`, default (no flag) writes to `projects[<cwd>]`, `--install-scope user` preserves top-level shape, `--install-scope project` writes `./.mcp.json`, pre-existing top-level / sibling-MCP entries preserved on local install.

## Patterns check

- **Doc-only PR exemption**: N/A — this is code-touching, so RC chain applies. Bumped `0.4.4-rc.2` → `0.4.4-rc.3`.
- **No new patterns**: this PR conforms to existing patterns (install-scope abstraction was already there; we extended it). No new ecosystem-wide convention introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)