### PR TITLE
feat(uninstall): --skip-daemon flag for test isolation (closes #296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.4-rc.5] — 2026-05-12
+
+`parachute-vault uninstall --skip-daemon` test-isolation flag (vault#296).
+
+The CLI's `uninstall` command calls `uninstallAgent()`, which targets the
+hardcoded launchd label `computer.parachute.vault`. That label ignores
+`PARACHUTE_HOME`, so a naive subprocess test of `uninstall --yes` on a
+developer's machine would `launchctl bootout` the real registered
+daemon. We previously dodged this by avoiding subprocess tests entirely
+for the uninstall flow — but that left the full path (wrapper removal,
+MCP cleanup, ordering, exit codes) untested.
+
+### Added
+
+- Undocumented `--skip-daemon` flag on `parachute-vault uninstall`.
+  Bypasses the launchd / systemd / backup-agent uninstall calls;
+  everything else (wrapper removal, MCP cleanup, optional wipe) runs
+  as normal. Tests use this to exercise the full flow against a
+  sandbox `PARACHUTE_HOME` without touching real operator state.
+  Intentionally absent from `usage()` — humans should never need it,
+  and surfacing it would invite "I'll just skip the daemon step"
+  misuse that leaves an orphaned daemon firing on a missing wrapper.
+
+### Tests
+
+- End-to-end uninstall coverage in `src/mcp-install.test.ts`:
+  - wrapper + server-path pointer + MCP entry removed; daemon skip
+    surfaces in stdout for CI log audit.
+  - `--skip-daemon` alone leaves user data alone (no accidental wipe).
+  - `--skip-daemon --wipe --yes` composes correctly — destructive
+    path still removes vault data + .env.
+
+### Docs
+
+- Convention documented in `CLAUDE.md` under "Running".
+
+No operator-visible behavior change in the default uninstall path.
+
 ## [0.4.4-rc.4] — 2026-05-12
 
 `mcp-install` preview-accuracy regression pin (vault#293 follow-up to vault#292).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,10 @@ bun test ./core/src/               # run core tests
 
 `parachute-vault stop` writes a sentinel file at `~/.parachute/vault/stop.signal`. The running server polls for it every 500ms and, when it finds one, deletes it and runs the same drain-and-exit shutdown path used for SIGINT/SIGTERM. Stale sentinels are removed at server startup, so a `stop` written while no server was listening can't pre-empt the next boot. This exists for environments where signals are awkward (Docker exec, foreground runs without a managed PID) — when you have a PID, `kill -TERM` still works and is the more direct path.
 
+### `uninstall --skip-daemon` (test-only)
+
+`parachute-vault uninstall` calls `uninstallAgent()` which targets the hardcoded launchd label `computer.parachute.vault`. That label ignores `PARACHUTE_HOME`, so a naive test that spawns `parachute-vault uninstall --yes` on a developer's machine would `launchctl bootout` the real registered daemon. The undocumented `--skip-daemon` flag bypasses the launchd / systemd / backup-agent uninstall calls — tests use it to exercise the rest of the flow (wrapper removal, MCP cleanup, exit codes, ordering) without touching real operator state. Humans should never need it; it's intentionally absent from `usage()` so it doesn't invite "I'll just skip the daemon step" misuse that orphans a daemon firing on a missing wrapper. See vault#296.
+
 ## Deployment
 
 Self-hosted:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.4-rc.4",
+  "version": "0.4.4-rc.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1725,6 +1725,16 @@ function printErrLogTail(n: number) {
 async function cmdUninstall(argsList: string[]) {
   const wipe = argsList.includes("--wipe");
   const skipPrompts = argsList.includes("--yes") || argsList.includes("-y");
+  // Test-isolation escape hatch (vault#296): skip the launchd / systemd /
+  // backup-agent uninstall calls. Those target hardcoded labels
+  // (`computer.parachute.vault*`) that ignore `PARACHUTE_HOME`, so a test
+  // run on a developer's machine would `launchctl bootout` their real
+  // daemon. With this flag tests can exercise the rest of the uninstall
+  // flow (wrapper removal, MCP cleanup, ordering, exit codes) safely.
+  // Intentionally not documented in `usage()` — humans should never need
+  // it; surfacing it would invite "I'll just skip the daemon step" misuse
+  // that leaves an orphaned daemon firing on a missing wrapper.
+  const skipDaemon = argsList.includes("--skip-daemon");
 
   console.log("Parachute Vault uninstall\n");
   console.log("This removes the daemon registration and wrapper script.");
@@ -1754,7 +1764,9 @@ async function cmdUninstall(argsList: string[]) {
   }
 
   // 1. Stop and remove the daemon registration.
-  if (process.platform === "darwin") {
+  if (skipDaemon) {
+    console.log("Skipping daemon removal (--skip-daemon).");
+  } else if (process.platform === "darwin") {
     console.log("Removing launchd agent...");
     await uninstallAgent();
     // Scheduled backup agent lives in a separate plist — uninstall it too,

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -930,3 +930,106 @@ function setupBareVault(parachuteHome: string, name: string): void {
 function readJson(p: string): any {
   return JSON.parse(fs.readFileSync(p, "utf-8"));
 }
+
+// ---------------------------------------------------------------------------
+// Uninstall flow — end-to-end with --skip-daemon (vault#296)
+// ---------------------------------------------------------------------------
+//
+// `parachute-vault uninstall` calls `uninstallAgent()` which targets the
+// hardcoded launchd label `computer.parachute.vault`. That label ignores
+// `PARACHUTE_HOME`, so a naive subprocess test would `launchctl bootout`
+// the real daemon on the developer's machine. `--skip-daemon` bypasses the
+// launchd / systemd / backup-agent uninstall calls so tests can exercise
+// the rest of the flow (wrapper removal, MCP cleanup, exit codes, ordering)
+// without touching real operator state.
+
+describe("cmdUninstall --skip-daemon (isolation flag for tests)", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vault-uninstall-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("removes wrapper + server-path pointer + MCP entry, never touches real launchd", () => {
+    // Stage the post-init artifacts uninstall is responsible for clearing:
+    //   - start.sh wrapper (would otherwise need `bun:sqlite` + a real init)
+    //   - server-path pointer
+    //   - a vault MCP entry in the sandbox ~/.claude.json
+    const vaultHome = path.join(tmp, "vault");
+    fs.mkdirSync(vaultHome, { recursive: true });
+    fs.writeFileSync(path.join(vaultHome, "start.sh"), "#!/bin/bash\necho stub\n", { mode: 0o755 });
+    fs.writeFileSync(path.join(vaultHome, "server-path"), "/imaginary/server.ts\n");
+    const claudePath = path.join(tmp, ".claude.json");
+    fs.writeFileSync(
+      claudePath,
+      JSON.stringify({
+        mcpServers: { "parachute-vault": { type: "http", url: "stub" } },
+      }) + "\n",
+    );
+
+    const res = runCli(["uninstall", "--yes", "--skip-daemon"], tmp);
+
+    expect(res.exitCode).toBe(0);
+
+    // The flag must surface in stdout so a future maintainer reading a CI
+    // log can tell the daemon step was skipped intentionally (vs. silently
+    // by a future regression).
+    expect(res.stdout).toContain("Skipping daemon removal (--skip-daemon).");
+
+    // Wrapper + pointer gone — that's the "shared across platforms" step
+    // immediately after daemon removal, so this pins the ordering invariant
+    // that --skip-daemon doesn't short-circuit the rest of the flow.
+    expect(fs.existsSync(path.join(vaultHome, "start.sh"))).toBe(false);
+    expect(fs.existsSync(path.join(vaultHome, "server-path"))).toBe(false);
+
+    // MCP cleanup ran — the vault entry is gone from ~/.claude.json.
+    const after = readJson(claudePath);
+    expect(after.mcpServers).toBeDefined();
+    expect(after.mcpServers["parachute-vault"]).toBeUndefined();
+
+    // "Done. To reinstall: `parachute-vault init`." is the closing
+    // confirmation. Its presence means the function ran to completion;
+    // its absence on a future regression would catch an early-return bug.
+    expect(res.stdout).toContain("Done. To reinstall:");
+  });
+
+  test("--skip-daemon leaves user data alone without --wipe", () => {
+    // The wipe-confirm branch is independent of the daemon branch; this
+    // pins that --skip-daemon doesn't accidentally promote to a destructive
+    // wipe. Seed a vaults dir, run uninstall without --wipe, assert it
+    // still exists afterward.
+    const vaultHome = path.join(tmp, "vault");
+    const dataDir = path.join(vaultHome, "data", "default");
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, "vault.db"), "stub\n");
+
+    const res = runCli(["uninstall", "--yes", "--skip-daemon"], tmp);
+
+    expect(res.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(dataDir, "vault.db"))).toBe(true);
+    // No wipe banner should appear.
+    expect(res.stdout).not.toMatch(/User data removed/);
+    expect(res.stdout).toContain("User data (~/.parachute/vault/) is left alone");
+  });
+
+  test("--skip-daemon + --wipe removes vault data (composes with destructive path)", () => {
+    // Pin that --skip-daemon is purely the daemon-call escape hatch — it
+    // does not gate or alter the --wipe semantics. A scripted destructive
+    // test (CI cleanup, fresh-machine setup) must still see --wipe work.
+    const vaultHome = path.join(tmp, "vault");
+    const dataDir = path.join(vaultHome, "data", "default");
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, "vault.db"), "stub\n");
+    fs.writeFileSync(path.join(vaultHome, ".env"), "PORT=1940\n");
+
+    const res = runCli(["uninstall", "--yes", "--wipe", "--skip-daemon"], tmp);
+
+    expect(res.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(vaultHome, "data"))).toBe(false);
+    expect(fs.existsSync(path.join(vaultHome, ".env"))).toBe(false);
+    expect(res.stdout).toMatch(/scripted destructive wipe/);
+    expect(res.stdout).toContain("User data removed");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #296. Adds `--skip-daemon` to `parachute-vault uninstall` so tests can exercise the full uninstall flow without `launchctl bootout`-ing a real daemon.

`uninstallAgent()` targets the hardcoded launchd label `computer.parachute.vault`, which ignores `PARACHUTE_HOME`. A subprocess test of `uninstall --yes` on a developer's machine would therefore nuke the real registered daemon. We previously dodged this by avoiding subprocess coverage of the uninstall flow entirely — leaving the full path (wrapper removal, MCP cleanup, ordering, exit codes) untested. This adds the escape hatch the issue's Option 1 proposed.

- Undocumented `--skip-daemon` flag (intentionally absent from `usage()` — humans should never need it).
- Three end-to-end subprocess tests in `src/mcp-install.test.ts`:
  - wrapper + server-path pointer + MCP entry removed, daemon-skip surfaces in stdout for CI audit.
  - `--skip-daemon` alone leaves user data alone (no accidental wipe promotion).
  - `--skip-daemon --wipe --yes` composes correctly — destructive path still removes vault data + `.env`.
- `CLAUDE.md` documents the convention under "Running".

No operator-visible behavior change in the default uninstall path.

## Test plan

- [x] `bun test ./src/` → 912 pass / 0 fail (was 909/0 pre-change; +3 new uninstall tests).
- [x] `bunx tsc --noEmit` clean.
- [x] Verified the test fails informatively if `--skip-daemon` is removed (manual spot-check).

## Patterns touched

- `patterns/governance.md` rule 2: RC bump `0.4.4-rc.4` → `0.4.4-rc.5`. No new patterns established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)