### PR TITLE
fix(test): exclude web/ui/ from bun test discovery — fix 27 fails on main (closes #294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.4-rc.6] — 2026-05-12
+
+`bun test` from the repo root now returns green (vault#294).
+
+The 27 failures in `web/ui/` tests on `main` were misdiagnosed as a
+`vi.mock` version incompatibility. Root cause: `bun test` walks the
+entire repo for `*.test.*` files, including `web/ui/`'s React SPA
+tests. Those tests import `vitest` and use `vi.mock("path")` in the
+single-arg auto-stub form, which `bun:test` rejects with
+`TypeError: mock(module, fn) requires a function`. The SPA tests are
+written for vitest 4.x (its declared `npm test` runner) and pass
+cleanly there — they were never broken; `bun test` was just trying to
+run them with the wrong runner.
+
+### Fix
+
+- `bunfig.toml` adds `pathIgnorePatterns = ["web/ui/**"]` under
+  `[test]`. `bun test` from the repo root now stops at the
+  server + core boundary; the React SPA's tests stay green under
+  their canonical `vitest run` command.
+
+### Docs
+
+- `CLAUDE.md` "Running" section documents the two-runner split
+  explicitly: `bun test` for server + core, `bunx vitest run` (from
+  `web/ui/`) for the SPA. Future contributors won't trip over the
+  same mis-diagnosis.
+
+### Gates
+
+- `bun test` from repo root → 1341 pass / 3 skip / 0 fail (was
+  1362 pass / 3 skip / 27 fail / 2 errors).
+- `bun test ./src/` → 912 pass / 0 fail (unchanged).
+- `bun test ./core/src/` → 429 pass / 0 fail (unchanged).
+- `cd web/ui && bunx vitest run` → 61 pass / 0 fail (unchanged —
+  always green under vitest).
+
+No code change. Configuration + docs only.
+
 ## [0.4.4-rc.5] — 2026-05-12
 
 `parachute-vault uninstall --skip-daemon` test-isolation flag (vault#296).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,13 @@ bun src/cli.ts vault config        # view/edit config
 bun src/cli.ts vault stop          # graceful shutdown via filesystem sentinel
 bun src/cli.ts vault import <path> # import Obsidian vault
 bun src/cli.ts vault export <path> # export as Obsidian markdown
-bun test ./src/                    # run server tests (anchored — excludes web/ui)
+bun test ./src/                    # run server tests (anchored — also excluded from bare `bun test`)
 bun test ./core/src/               # run core tests
+bun test                           # run server + core (web/ui excluded via bunfig.toml pathIgnorePatterns)
+cd web/ui && bunx vitest run       # run the React SPA's tests (different runner — vi.mock + jsdom)
 ```
+
+The repo holds two test suites with different runners. Server + core run under `bun:test` (Bun-native, `bun:sqlite`-aware). The React admin SPA at `web/ui/` runs under **vitest 4.x** because its tests use `vi.mock("path")` single-arg auto-stubbing, jsdom, and `@testing-library/react` — none of which `bun:test` supports today. `bunfig.toml` excludes `web/ui/**` from `bun test` discovery so the bare `bun test` stays green; the SPA's canonical test command is `vitest run` (its `npm test` script). See vault#294.
 
 ### Graceful shutdown
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,11 @@
 [test]
 preload = ["./core/src/test-preload.ts"]
+# Exclude the React SPA's tests from `bun test` discovery (vault#294). The
+# SPA's *.test.tsx files import `vitest`, mock modules via `vi.mock("path")`
+# (single-arg auto-stub form), and exercise React DOM via @testing-library —
+# all of which vitest 4.x handles but `bun:test` doesn't. The SPA's
+# canonical runner is `vitest run` (see web/ui/package.json `scripts.test`);
+# without this exclusion, `bun test` from the repo root walks into web/ui/
+# and produces 27 spurious failures on a green tree. Anchored test commands
+# (`bun test ./src/`, `bun test ./core/src/`) were already clean.
+pathIgnorePatterns = ["web/ui/**"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.4-rc.5",
+  "version": "0.4.4-rc.6",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Closes #294. The 27 failures in `web/ui/` tests on `main` were misdiagnosed as a `vi.mock` version incompatibility. Root cause: `bun test` walks the entire repo for `*.test.*` files, including `web/ui/`'s React SPA tests. Those tests import `vitest` and use `vi.mock("path")` in the single-arg auto-stub form, which `bun:test` rejects with `TypeError: mock(module, fn) requires a function`. The SPA tests are written for vitest 4.x (its declared `npm test` runner) and pass cleanly there — they were never broken; `bun test` was just trying to run them with the wrong runner.

Fix is a one-liner in `bunfig.toml`:

```toml
[test]
pathIgnorePatterns = ["web/ui/**"]
```

`bun test` from the repo root now stops at the server + core boundary; the React SPA's tests stay green under `bunx vitest run`. `CLAUDE.md`'s "Running" section documents the two-runner split explicitly so future contributors don't repeat the mis-diagnosis.

No code change. Configuration + docs only.

## Test plan

- [x] `bun test` (root) → 1341 pass / 3 skip / **0 fail** (was 1362/3 skip/27 fail/2 errors).
- [x] `bun test ./src/` → 912 pass / 0 fail (unchanged).
- [x] `bun test ./core/src/` → 429 pass / 0 fail (unchanged).
- [x] `cd web/ui && bunx vitest run` → 61 pass / 0 fail (unchanged — always green under vitest).
- [x] `bunx tsc --noEmit` clean.

## Patterns touched

- `patterns/governance.md` rule 2: RC bump `0.4.4-rc.5` → `0.4.4-rc.6`. No new patterns established.

## Note on optional CI gate

The issue mentions an optional CI step to prevent silent regression. The simplest signal is the discrepancy itself: a future test that lands a `*.test.tsx` file inside `web/ui/` will skip from bun's pov but run under vitest. The CLAUDE.md note is the deliberate convention; the bunfig exclusion is the enforcement. A CI matrix that runs both `bun test` and `cd web/ui && bunx vitest run` separately is the natural follow-up — that can ride on the next CI-touching PR rather than expanding this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)