### PR TITLE
refactor(mcp-install): close URL invariant on writer side (closes #302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.4-rc.7] — 2026-05-12
+
+`buildMcpEntryPlan` ⇄ `installMcpConfig` — close the URL invariant on the
+writer side (vault#302, follow-up to vault#301).
+
+vault#301 introduced `buildMcpEntryPlan` as the shared seam for the
+preview ⇄ writer entry-key + URL invariant. But `entryKey` was the only
+half closed: `installMcpConfig` still called `chooseMcpUrl(vaultName,
+port)` directly inside the writer, reading `process.env` rather than the
+`env` threaded through `InstallContext`. In production both branches
+read `process.env`, so they agreed by accident — a future change that
+introduced a non-process-env source (tests with in-memory env, alternate
+config paths, anything using `InstallContext.env` differently) would
+silently diverge between preview and writer.
+
+### Internal
+
+- `InstallMcpConfigOpts` now requires `url` from the caller. The
+  writer is a pure file-writer; the URL decision lives in
+  `buildMcpEntryPlan` alone.
+- `installMcpConfig` returns `void` (was `{ url, source }`). Both
+  call-sites already have `url` and `source` from
+  `buildMcpEntryPlan`'s output — no need to round-trip.
+- `executeMcpInstall` destructures `{ entryKey, url, source }` from
+  `buildMcpEntryPlan` and passes `url` to `installMcpConfig`.
+- The `init --add-mcp` bootstrap path (cli.ts:521) goes through
+  `buildMcpEntryPlan` too, so init and `mcp-install` share the same
+  URL-computation seam — a future URL-shape change can't drift
+  between the two.
+- `chooseMcpUrl` is no longer imported by `cli.ts` (only used inside
+  `buildMcpEntryPlan` now).
+
+### Tests
+
+- `src/mcp-install.test.ts`: new end-to-end test pins that the URL on
+  disk matches `buildMcpEntryPlan({ env: { PARACHUTE_HUB_ORIGIN: ... } })`
+  for a non-default hub origin. A regression that reintroduces the
+  direct `chooseMcpUrl` call inside `installMcpConfig` would drop the
+  caller's env and read `process.env` — this test goes red on that
+  shape.
+
+### Gates
+
+- `bun test` (root) → 1342 pass / 3 skip / 0 fail
+- `bun test ./src/` → 913 pass / 0 fail (was 912)
+- `bun test ./core/src/` → 429 pass / 0 fail
+- `bunx tsc --noEmit` clean
+
+No operator-visible behavior change.
+
 ## [0.4.4-rc.6] — 2026-05-12
 
 `bun test` from the repo root now returns green (vault#294).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.4-rc.6",
+  "version": "0.4.4-rc.7",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,6 @@ import { installAgent, uninstallAgent, isAgentLoaded, restartAgent } from "./lau
 import {
   buildMcpEntryPlan,
   chooseHubOrigin,
-  chooseMcpUrl,
   detectInstallContext,
   mintHubJwt,
   readOperatorToken,
@@ -522,13 +521,19 @@ async function cmdInit(args: string[] = []) {
     // Init's bootstrap path stays on the pvt_* shape so a fresh-install
     // without a hub still works out of the box. Operators with a hub can
     // re-run `parachute-vault mcp-install` (defaults to hub-mint) to
-    // upgrade. The new `installMcpConfig` opts shape is used here with
-    // the same effective behavior as before.
+    // upgrade. Goes through `buildMcpEntryPlan` for entryKey + url so this
+    // path shares the writer-side invariant with `executeMcpInstall` — a
+    // future URL-shape change can't drift between init and mcp-install.
     const target = resolveInstallTarget("user");
-    const { url, source } = installMcpConfig({
-      targetPath: target.path,
-      entryKey: "parachute-vault",
+    const { entryKey, url, source } = buildMcpEntryPlan({
       vaultName: defaultVault,
+      vaultExplicit: false,
+      port: globalConfig.port || DEFAULT_PORT,
+    });
+    installMcpConfig({
+      targetPath: target.path,
+      entryKey,
+      url,
       bearer: apiKey,
     });
     console.log(`MCP URL: ${url} (${source})`);
@@ -1139,9 +1144,10 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
   const verb = rawScope.split(":")[1]!;
   const target = resolveInstallTarget(installScope);
   // Single source of truth shared with the interactive walkthrough's
-  // preview — preview-shows-this-shape ⇒ this-shape-lands-on-disk. See
-  // vault#293.
-  const { entryKey } = buildMcpEntryPlan({
+  // preview — preview-shows-this-shape ⇒ this-shape-lands-on-disk. The
+  // helper closes both halves of the invariant (entryKey + url) — see
+  // vault#293 for the seam, vault#302 for closing the writer-side URL.
+  const { entryKey, url, source } = buildMcpEntryPlan({
     vaultName,
     vaultExplicit,
     port: globalConfig.port || DEFAULT_PORT,
@@ -1230,10 +1236,10 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
     console.log(`Minted hub JWT (jti=${result.jti}, expires ${result.expires_at}, scope ${result.scope}).`);
   }
 
-  const { url, source } = installMcpConfig({
+  installMcpConfig({
     targetPath: target.path,
     entryKey,
-    vaultName,
+    url,
     bearer,
     ...(target.localProjectKey ? { localProjectKey: target.localProjectKey } : {}),
   });
@@ -2695,8 +2701,15 @@ interface InstallMcpConfigOpts {
   targetPath: string;
   /** `mcpServers.<entryKey>` slot the entry lands at. Default is `parachute-vault`; multi-vault installs key as `parachute-vault-<name>`. */
   entryKey: string;
-  /** Vault name to embed in the URL (`/vault/<vaultName>/mcp`). */
-  vaultName: string;
+  /**
+   * URL embedded in the entry's `url` field. The caller is the sole source of
+   * truth — `buildMcpEntryPlan` produces both `entryKey` and `url` together,
+   * and passing them through closes the preview ⇄ writer invariant (the
+   * shape the preview promised is the shape that lands on disk). See
+   * vault#302; #301 introduced the seam for `entryKey`, this closes it for
+   * `url` too.
+   */
+  url: string;
   /** Bearer token to embed in `Authorization: Bearer …`. Omitted means the entry is unauthenticated — only useful for OAuth-capable clients (Claude Code does discovery). */
   bearer?: string;
   /**
@@ -2709,8 +2722,13 @@ interface InstallMcpConfigOpts {
   localProjectKey?: string;
 }
 
-function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: string } {
-  const { targetPath, entryKey, vaultName, bearer, localProjectKey } = opts;
+/**
+ * Write the MCP entry into the target config file. Pure file-writer — the
+ * caller has already decided `entryKey` and `url` (via `buildMcpEntryPlan`).
+ * Returns `void`; the caller already has `url` and `source` for logging.
+ */
+function installMcpConfig(opts: InstallMcpConfigOpts): void {
+  const { targetPath, entryKey, url, bearer, localProjectKey } = opts;
 
   let config: any = {};
   if (existsSync(targetPath)) {
@@ -2719,16 +2737,7 @@ function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: st
     } catch {}
   }
 
-  const globalConfig = readGlobalConfig();
-  const port = globalConfig.port || DEFAULT_PORT;
-
-  // Pick the URL that matches the OAuth issuer vault will advertise, in this
-  // order: explicit hub origin env > active tailnet/public exposure >
-  // loopback. Otherwise a strict MCP client (Claude Code) hits a loopback URL
-  // whose discovery issuer points at the hub and rejects on origin mismatch
-  // (RFC 8414).
-  const { url: mcpUrl, source } = chooseMcpUrl(vaultName, port);
-  const mcpEntry: Record<string, unknown> = { type: "http", url: mcpUrl };
+  const mcpEntry: Record<string, unknown> = { type: "http", url };
   if (bearer) {
     mcpEntry.headers = { Authorization: `Bearer ${bearer}` };
   }
@@ -2749,7 +2758,6 @@ function installMcpConfig(opts: InstallMcpConfigOpts): { url: string; source: st
   }
 
   writeFileSync(targetPath, JSON.stringify(config, null, 2) + "\n");
-  return { url: mcpUrl, source };
 }
 
 function usage() {

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -605,6 +605,48 @@ describe("mcp-install end-to-end", () => {
     }
   });
 
+  test("writer URL on disk matches buildMcpEntryPlan(env) — non-default PARACHUTE_HUB_ORIGIN (vault#302)", () => {
+    // The preview ⇄ writer invariant introduced in vault#301 closed
+    // `entryKey` but left `url` only-coincidentally-coherent: production
+    // both branches read `process.env`, so they agreed by accident.
+    // vault#302 closes the URL half too — `installMcpConfig` now receives
+    // the URL from the caller's `buildMcpEntryPlan({ env, ... })` rather
+    // than re-computing via a direct `chooseMcpUrl(vaultName, port)`. This
+    // test exercises a non-default env so a regression that reintroduces
+    // the direct `chooseMcpUrl` call (which would re-read `process.env`,
+    // possibly without the test's intended override) goes red.
+    setupBareVault(tmp, "default");
+    const hubOrigin = "https://hub-302.example";
+    const res = runCli(
+      ["mcp-install", "--install-scope", "user", "--token", "pasted-302"],
+      tmp,
+      { PARACHUTE_HUB_ORIGIN: hubOrigin },
+    );
+    expect(res.exitCode).toBe(0);
+
+    // Compute what `buildMcpEntryPlan` says the URL should be for the same
+    // env the writer ran under. The writer must land exactly this URL.
+    const plan = buildMcpEntryPlan({
+      vaultName: "default",
+      vaultExplicit: false,
+      port: 1940,
+      env: { PARACHUTE_HUB_ORIGIN: hubOrigin },
+    });
+    expect(plan.url).toBe(`${hubOrigin}/vault/default/mcp`);
+    expect(plan.source).toBe("hub-origin");
+
+    const config = readJson(path.join(tmp, ".claude.json"));
+    const entry = config.mcpServers[plan.entryKey];
+    expect(entry).toBeDefined();
+    expect(entry.url).toBe(plan.url);
+    expect(entry.headers.Authorization).toBe("Bearer pasted-302");
+
+    // Stdout's `MCP URL:` line surfaces the same URL so an operator
+    // reading the log sees what landed (was the same `url` variable
+    // pre-#302 by coincidence; this pins it explicitly).
+    expect(res.stdout).toContain(`MCP URL: ${plan.url}`);
+  });
+
   test("--install-scope local writes ~/.claude.json under projects[<cwd>].mcpServers", () => {
     setupBareVault(tmp, "default");
     const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-local-"));


### PR DESCRIPTION
## Summary

Closes #302. Follow-up to #301 — closes the URL half of the preview ⇄ writer invariant.

#301 introduced `buildMcpEntryPlan` as the shared seam for entry-key + URL across the interactive preview and the writer. But `entryKey` was the only half actually closed: `installMcpConfig` still called `chooseMcpUrl(vaultName, port)` directly inside the writer, reading `process.env` rather than the `env` threaded through `InstallContext`. In production both branches read `process.env` so they agreed by accident — a future change introducing a non-process-env source (tests with in-memory env, alternate config paths, anything using `InstallContext.env` differently) would silently diverge between preview and writer.

- `InstallMcpConfigOpts` now **requires** `url` from the caller. The writer is a pure file-writer; the URL decision lives in `buildMcpEntryPlan` alone.
- `installMcpConfig` returns `void` (was `{ url, source }`) — both call-sites already have those from `buildMcpEntryPlan`.
- `executeMcpInstall` destructures `{ entryKey, url, source }` and passes `url` through.
- The `init --add-mcp` bootstrap path (`cli.ts:521`) now also goes through `buildMcpEntryPlan`, so init and `mcp-install` share the same URL-computation seam.
- `chooseMcpUrl` import removed from `cli.ts` (only used inside `buildMcpEntryPlan` now).

No operator-visible behavior change.

## Test plan

- [x] New end-to-end test in `mcp-install.test.ts`: pins that the URL on disk matches `buildMcpEntryPlan({ env: { PARACHUTE_HUB_ORIGIN: ... } })` for a non-default hub origin. A regression that reintroduces the direct `chooseMcpUrl` call (which would drop the caller's env and read `process.env`) goes red on this test.
- [x] `bun test` (root) → 1342 pass / 3 skip / 0 fail.
- [x] `bun test ./src/` → 913 pass / 0 fail (was 912).
- [x] `bun test ./core/src/` → 429 pass / 0 fail.
- [x] `bunx tsc --noEmit` clean.

## Patterns touched

- `patterns/governance.md` rule 2: RC bump `0.4.4-rc.6` → `0.4.4-rc.7`. No new patterns established; this is a follow-up that completes the seam #301 introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)