### PR TITLE
fix(api): HTTP POST/PATCH /notes attach validation_status — symmetry with MCP (closes #287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,67 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.4-rc.8] — 2026-05-12
+
+HTTP create/update now attach `validation_status` — symmetry with MCP
+(closes vault#287).
+
+The MCP `create-note` and `update-note` tools wrap their responses in
+`attachValidationStatus`: when a tag on the note declares `fields` (a
+type / enum schema) on its `tags` row, the response carries a
+`validation_status` block with the resolved schemas and any warnings
+(type mismatch, enum mismatch). HTTP `POST /api/notes` and `PATCH
+/api/notes/:id` did not — HTTP consumers of schema-validated vaults
+had no signal that their write triggered a warning. They had to
+re-read the note, cross-reference its tags, and replay validation
+client-side. Defeats one of the load-bearing reasons validation runs
+at write time.
+
+### Changed
+
+- `attachValidationStatus` is now exported from `core/src/mcp.ts` so
+  both transports use the same recipe (single source of truth).
+- HTTP `PATCH /api/notes/:idOrPath` attaches `validation_status` to
+  the response, on both the default full-Note shape and the lean
+  (`include_content: false`) shape. The lean-shape preservation
+  mirrors the MCP recipe at `core/src/mcp.ts:751` — `toNoteIndex`
+  drops unknown fields, so the field is re-attached after the
+  conversion.
+- HTTP `POST /api/notes` (single + batch) attaches
+  `validation_status` to each created note. Mirrors the MCP
+  `create-note` attach site at `core/src/mcp.ts:451`.
+
+### Behavior
+
+- No change for vaults without tag schemas: `attachValidationStatus`
+  returns the note unchanged when no tag on it declares fields.
+- No change for MCP — the validation-status surface was already
+  there.
+- HTTP consumers using tag schemas now see `validation_status` on
+  every write response, matching the MCP contract.
+
+### Tests
+
+- 6 new tests in `src/vault.test.ts`:
+  - PATCH attaches `enum_mismatch` warning on a schema-violating
+    metadata update.
+  - PATCH preserves `validation_status` on `include_content: false`
+    (lean shape).
+  - PATCH omits `validation_status` when no tag declares fields
+    (back-compat).
+  - POST attaches `type_mismatch` warning on schema-violating
+    create.
+  - POST batch attaches per-note `validation_status` (mixed
+    valid/invalid entries each carry their own status).
+  - POST omits `validation_status` when no tag declares fields.
+
+### Gates
+
+- `bun test` (root) → 1348 pass / 3 skip / 0 fail
+- `bun test ./src/` → 919 pass / 0 fail (was 913)
+- `bun test ./core/src/` → 429 pass / 0 fail
+- `bunx tsc --noEmit` clean
+
 ## [0.4.4-rc.7] — 2026-05-12
 
 `buildMcpEntryPlan` ⇄ `installMcpConfig` — close the URL invariant on the

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1127,8 +1127,13 @@ function defaultForField(field: { type: string; enum?: string[] }): unknown {
  *
  * Returns the note unchanged when no tag declares fields, so callers
  * without any tag schemas see no behavior change.
+ *
+ * Exported so both transports (MCP `update-note` here, HTTP `PATCH
+ * /api/notes/:id` in `src/routes.ts`) attach the same status field by
+ * the same recipe — see vault#287 for the asymmetry that motivated
+ * exposing it.
  */
-function attachValidationStatus(store: Store, _db: Database, note: Note): Note {
+export function attachValidationStatus(store: Store, _db: Database, note: Note): Note {
   // Short-circuit cheaply: when no tag declares fields, the resolver
   // returns null without us paying a re-read of the note.
   const status = store.validateNoteAgainstSchemas({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.4-rc.7",
+  "version": "0.4.4-rc.8",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,6 +14,7 @@
 import type { Store, Note } from "../core/src/types.ts";
 import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
 import { toNoteIndex, filterMetadata, MAX_BATCH_SIZE } from "../core/src/notes.ts";
+import { attachValidationStatus } from "../core/src/mcp.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
 import {
@@ -733,7 +734,13 @@ export async function handleNotes(
         }
       }
 
-      return json(body.notes ? created : created[0], 201);
+      // Attach `validation_status` so HTTP create-note matches the MCP
+      // surface (vault#287). Mirrors the MCP create-note attach site at
+      // `core/src/mcp.ts:451`. `attachValidationStatus` returns the note
+      // unchanged when no tag declares fields, so vaults without any tag
+      // schemas see no behavior change.
+      const final = created.map((n) => attachValidationStatus(store, db, n));
+      return json(body.notes ? final : final[0], 201);
     }
 
     return json({ error: "Method not allowed" }, 405);
@@ -1019,11 +1026,20 @@ export async function handleNotes(
       // Response shape: full Note (back-compat default) or lean NoteIndex
       // (vault#285 friction point 2.response — opt-out for callers making
       // frequent small edits to large notes). Mirror the MCP `update-note`
-      // `include_content` knob exactly.
+      // `include_content` knob exactly, *and* `validation_status` attachment
+      // (vault#287) so HTTP and MCP consumers see the same schema-validation
+      // signal. Recipe matches `core/src/mcp.ts:751` — attach to the full
+      // Note first, then carry the field across the lean conversion (since
+      // `toNoteIndex` drops unknown fields).
       const updatedNote = await store.getNote(note.id);
       if (updatedNote === null) return json({ error: "Note disappeared" }, 404);
+      const validated = attachValidationStatus(store, db, updatedNote);
       const includeContentResp = body.include_content !== false;
-      return json(includeContentResp ? updatedNote : toNoteIndex(updatedNote));
+      if (includeContentResp) return json(validated);
+      const lean: any = toNoteIndex(validated);
+      const vs = (validated as any).validation_status;
+      if (vs !== undefined) lean.validation_status = vs;
+      return json(lean);
     } catch (e: any) {
       if (e instanceof NotFoundError) return json({ error: e.message }, 404);
       // Duck-type on `code` rather than `instanceof ConflictError`: this

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2783,6 +2783,147 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect(body.id).toBe("big");
     expect(body.path).toBe("big");
   });
+
+  // vault#287 — HTTP must match MCP on validation_status attachment.
+  // Pre-#287 fix: MCP `update-note` attached validation_status; HTTP
+  // PATCH didn't. HTTP consumers using schema-validated vaults had no
+  // way to see schema warnings without re-reading + replaying validation
+  // client-side. These tests pin the symmetry on both response shapes
+  // (`include_content: true` and `false`) and confirm the no-schema
+  // case still returns no validation_status (advisory only — never
+  // forced onto vaults that don't declare fields).
+
+  test("PATCH attaches validation_status with enum_mismatch warning when tag schema is violated", async () => {
+    await store.upsertTagSchema("task287patch", {
+      fields: { priority: { type: "string", enum: ["high", "low"] } },
+    });
+    const note = await store.createNote("body", {
+      id: "p287a",
+      tags: ["task287patch"],
+      metadata: { priority: "high" },
+    });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/p287a", {
+        metadata: { priority: "ULTRA" },
+        if_updated_at: note.updatedAt,
+      }),
+      store,
+      "/p287a",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    // The write still lands — validation is advisory.
+    expect(body.metadata.priority).toBe("ULTRA");
+    // …but the response carries the warning so the HTTP caller knows.
+    expect(body.validation_status).toBeTruthy();
+    expect(body.validation_status.schemas).toContain("task287patch");
+    expect(body.validation_status.warnings.length).toBeGreaterThan(0);
+    expect(body.validation_status.warnings[0].reason).toBe("enum_mismatch");
+    expect(body.validation_status.warnings[0].field).toBe("priority");
+  });
+
+  test("PATCH preserves validation_status on the lean (include_content: false) response", async () => {
+    await store.upsertTagSchema("task287lean", {
+      fields: { priority: { type: "string", enum: ["high", "low"] } },
+    });
+    const note = await store.createNote("body", {
+      id: "p287b",
+      tags: ["task287lean"],
+      metadata: { priority: "high" },
+    });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/p287b", {
+        metadata: { priority: "ULTRA" },
+        include_content: false,
+        if_updated_at: note.updatedAt,
+      }),
+      store,
+      "/p287b",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    // Lean shape: no `content`, has `byteSize` + `preview`.
+    expect(body.content).toBeUndefined();
+    expect(typeof body.byteSize).toBe("number");
+    // …and validation_status survives the lean conversion.
+    expect(body.validation_status).toBeTruthy();
+    expect(body.validation_status.warnings[0].reason).toBe("enum_mismatch");
+  });
+
+  test("PATCH omits validation_status when no tag on the note declares fields", async () => {
+    // No tag schemas configured for this note — the response should look
+    // exactly like the pre-#287 shape (no validation_status). The behavior-
+    // unchanged guarantee for callers that don't use tag schemas.
+    await store.createNote("body", { id: "p287c", tags: ["plain"] });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/p287c", { content: "updated", force: true }),
+      store,
+      "/p287c",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.content).toBe("updated");
+    expect(body.validation_status).toBeUndefined();
+  });
+});
+
+describe("HTTP POST /notes — validation_status attachment (vault#287)", async () => {
+  // Mirror of the PATCH cases for create. The MCP create-note path
+  // attaches validation_status; HTTP POST must match (vault#287).
+
+  test("POST attaches validation_status with type_mismatch warning", async () => {
+    await store.upsertTagSchema("task287post", {
+      fields: { done: { type: "boolean" } },
+    });
+    const res = await handleNotes(
+      mkReq("POST", "/notes", {
+        content: "x",
+        tags: ["task287post"],
+        metadata: { done: "yes" }, // wrong type
+      }),
+      store,
+      "",
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.id).toBeTruthy();
+    expect(body.validation_status).toBeTruthy();
+    expect(body.validation_status.warnings[0].reason).toBe("type_mismatch");
+    expect(body.validation_status.warnings[0].field).toBe("done");
+  });
+
+  test("POST batch attaches validation_status per-note", async () => {
+    await store.upsertTagSchema("task287batch", {
+      fields: { priority: { type: "string", enum: ["high", "low"] } },
+    });
+    const res = await handleNotes(
+      mkReq("POST", "/notes", {
+        notes: [
+          { content: "good", tags: ["task287batch"], metadata: { priority: "high" } },
+          { content: "bad", tags: ["task287batch"], metadata: { priority: "ULTRA" } },
+        ],
+      }),
+      store,
+      "",
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(2);
+    expect(body[0].validation_status.warnings).toEqual([]);
+    expect(body[1].validation_status.warnings[0].reason).toBe("enum_mismatch");
+  });
+
+  test("POST omits validation_status when no tag declares fields (back-compat)", async () => {
+    const res = await handleNotes(
+      mkReq("POST", "/notes", { content: "no schema here", tags: ["plain287"] }),
+      store,
+      "",
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.id).toBeTruthy();
+    expect(body.validation_status).toBeUndefined();
+  });
 });
 
 describe("HTTP /tags", async () => {


### PR DESCRIPTION
## Summary

Closes #287. MCP `create-note` / `update-note` attach `validation_status` to their responses; HTTP `POST /api/notes` and `PATCH /api/notes/:id` did not. HTTP consumers using schema-validated vaults had no signal that their write triggered a schema warning (type / enum mismatch) — they had to re-read the note, cross-reference its tags, and replay validation client-side. Defeats one of the load-bearing reasons validation runs at write time.

- Export `attachValidationStatus` from `core/src/mcp.ts` so both transports use one recipe.
- HTTP `PATCH /api/notes/:idOrPath` attaches `validation_status` on both response shapes (`include_content: true` full Note and `false` lean NoteIndex). Lean-shape preservation mirrors the MCP recipe at `core/src/mcp.ts:751`.
- HTTP `POST /api/notes` (single + batch) attaches per-note `validation_status`. Mirrors MCP at `core/src/mcp.ts:451`.

## Scope note

The issue title is PATCH-specific, but the body's framing ("HTTP consumers using schema-validated vaults can't tell whether their write triggered a schema warning / error") applies equally to create. Fixing both here — coherent ship, parallel surface, and the tests naturally exercise both. Same pattern as #302 → extending the seam-closure to all sites that bypass it.

## No-schema vaults

`attachValidationStatus` returns the note unchanged when no tag on it declares fields. Vaults that don't use tag schemas see no behavior change.

## Test plan

- [x] 6 new HTTP tests in `src/vault.test.ts`:
  - PATCH attaches `enum_mismatch` warning on schema-violating metadata update.
  - PATCH preserves `validation_status` on `include_content: false` (lean shape).
  - PATCH omits `validation_status` when no tag declares fields (back-compat).
  - POST attaches `type_mismatch` warning on schema-violating create.
  - POST batch attaches per-note `validation_status` (mixed valid/invalid entries each carry their own status).
  - POST omits `validation_status` when no tag declares fields.
- [x] `bun test` (root) → 1348 pass / 3 skip / 0 fail (was 1342)
- [x] `bun test ./src/` → 919 pass / 0 fail (was 913)
- [x] `bun test ./core/src/` → 429 pass / 0 fail (unchanged)
- [x] `bunx tsc --noEmit` clean

## Patterns touched

- `patterns/governance.md` rule 2: RC bump `0.4.4-rc.7` → `0.4.4-rc.8`. No new patterns established; this completes the validation-status surface symmetry across transports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)