### PR TITLE
feat(api): Gitcoin sync ergonomics — if_missing on update-note + JSON int coercion (0.4.4-rc.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,82 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.4-rc.12] — 2026-05-13
+
+Gitcoin sync ergonomics — bundled two-commit PR. Both close real
+friction points from `from_parachute_round_2.md`, queued as the
+priorities after vault#308.
+
+### feat(api): `if_missing: "create"` on update-note (closes vault#309)
+
+Pre-fix, Gitcoin's nightly drift-detector loop had to either
+query-first-then-create on 404 (1 extra round trip per item, ~500/night)
+or accept that "update" semantics weren't safe when the note might not
+exist. Now `update-note` accepts an optional `if_missing` field:
+
+- **MCP `update-note`** — new `if_missing: "fail" | "create"` param
+  (default `"fail"`, current behavior). On `"create"`: if the note
+  doesn't exist (`resolveNote` returns null), treat the update payload
+  as a create payload (content/path/tags/metadata become the create
+  fields; `if_updated_at` precondition skipped since there's nothing
+  to conflict with).
+- **REST `PATCH /api/notes/:idOrPath`** — same `if_missing` field in
+  the JSON body. Mirrors MCP semantics.
+- **Response carries `created: true | false`** on every update-note
+  response (both branches). Sync loops read this to know which path
+  fired without a separate query.
+- **Idempotent**: repeated calls with the same id + payload produce
+  the same vault state (first call creates with `created: true`,
+  subsequent calls update with `created: false`).
+- **Tag-schema defaults + validation_status** fire on the create
+  branch identically to `create-note` (the create-path reuses the
+  same `applySchemaDefaults` + `attachValidationStatus` recipe).
+
+ID-vs-path heuristic on the create branch: if the `id` field looks
+path-shaped (contains `/` or doesn't match `^[A-Za-z0-9_-]+$`) and
+`path` isn't explicitly set, use `id` as the path. Otherwise treat as
+opaque id. Matches Gitcoin's sync shape where canonical keys are
+`Inbox/2026-05-13-meeting`-style paths.
+
+Tests:
+- `core/src/core.test.ts`: 6 new MCP tests (create-when-missing,
+  update-when-present, no-if_missing-errors, schema-defaults apply,
+  validation_status surfaces, idempotency).
+- `src/vault.test.ts`: 4 new REST tests (mirror of MCP cases +
+  response-shape pin for the additive `created: false` field).
+
+### fix(schema): coerce JSON number → integer when fractional is zero (closes vault#310)
+
+Pre-fix, every integer-typed metadata field warned `type_mismatch` on
+legitimate values because the validator had no `"integer"` case at
+all — falling through the switch returned `undefined` and the
+`if (spec.type && !valueMatchesType(...))` gate fired. Gitcoin's drift
+detector emits JSON for diffs (and JSON has no separate integer type),
+so every `kpi: 3` triggered a false-positive and buried the real
+warnings in the noise floor.
+
+- `SchemaField.type` union extended with `"integer"`.
+- `valueMatchesType` adds an `"integer"` case using
+  `Number.isInteger(value)`: accepts `5` and `5.0` (zero fractional);
+  rejects `5.5`, `"5"` (string — no string→number coercion),
+  `5.0000000000001` (edge non-zero fractional), `NaN`, `Infinity`.
+- The Gitcoin shape (JSON-decoded integer arriving as JS Number with
+  zero fractional part) now passes validation cleanly.
+
+Tests in `core/src/core.test.ts`:
+- Happy path: `5`, `5.0`, boolean rejection.
+- Strict path: `5.5`, `"5"`, `5.0000000000001`.
+- Inner-boundary: `valueMatchesType` rejects `NaN`/`Infinity` directly
+  (the outer null-short-circuit at the validator level filters them
+  before they reach the type check after JSON.stringify normalization).
+
+### Gates
+
+- `bun test` (root) → 1411 pass / 3 skip / 0 fail (was 1394; +17 tests)
+- `bun test ./src/` → 923 pass / 0 fail (was 919; +4 REST tests)
+- `bun test ./core/src/` → 488 pass / 0 fail (was 475; +6 MCP if_missing + 7 int coercion)
+- `bunx tsc --noEmit` clean
+
 ## [0.4.4-rc.11] — 2026-05-13
 
 Portable markdown knowledge-base format — PR 2 of 2 (closes vault#308 +

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -3678,6 +3678,122 @@ describe("schema validation (tags.fields)", async () => {
     const result = await create.execute({ content: "x", tags: ["task"] }) as any;
     expect(result.validation_status).toBeUndefined();
   });
+
+  // vault#310 — integer type validation. JSON has no separate integer
+  // type, so a JSON number with zero fractional part (`5`, `5.0`) must
+  // pass an `integer`-typed field. Pre-fix, the validator had no
+  // `"integer"` case at all — falling through the switch returned
+  // undefined and every integer-typed field warned `type_mismatch` on
+  // legitimate values. Gitcoin Brain's drift detector emits JSON for
+  // diffs; every `kpi: 3` triggered the false-positive and buried the
+  // real warnings.
+
+  it("integer-typed field: JSON integer (5) passes (vault#310)", async () => {
+    await store.upsertTagSchema("kpi", { fields: { count: { type: "integer" } } });
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["kpi"],
+      metadata: { count: 5 },
+    }) as any;
+    expect(result.validation_status?.warnings ?? []).toEqual([]);
+  });
+
+  it("integer-typed field: JSON `5.0` (zero-fractional) passes (vault#310)", async () => {
+    // 5.0 is the canonical Gitcoin shape — JSON.parse decodes the
+    // emitted JSON number as a JS Number; the JS Number for `5.0` is
+    // identical to `5` so Number.isInteger reports true. This is the
+    // load-bearing assertion for the Gitcoin drift-detector use case.
+    await store.upsertTagSchema("kpi", { fields: { count: { type: "integer" } } });
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["kpi"],
+      metadata: { count: 5.0 },
+    }) as any;
+    expect(result.validation_status?.warnings ?? []).toEqual([]);
+  });
+
+  it("integer-typed field: JSON `5.5` (non-zero fractional) warns type_mismatch (vault#310)", async () => {
+    await store.upsertTagSchema("kpi", { fields: { count: { type: "integer" } } });
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["kpi"],
+      metadata: { count: 5.5 },
+    }) as any;
+    expect(result.validation_status.warnings.length).toBe(1);
+    expect(result.validation_status.warnings[0].reason).toBe("type_mismatch");
+    expect(result.validation_status.warnings[0].field).toBe("count");
+  });
+
+  it("integer-typed field: string `\"5\"` warns type_mismatch (no string→number coercion) (vault#310)", async () => {
+    await store.upsertTagSchema("kpi", { fields: { count: { type: "integer" } } });
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["kpi"],
+      metadata: { count: "5" },
+    }) as any;
+    expect(result.validation_status.warnings.length).toBe(1);
+    expect(result.validation_status.warnings[0].reason).toBe("type_mismatch");
+  });
+
+  it("integer-typed field: edge `5.0000000000001` warns type_mismatch (vault#310)", async () => {
+    await store.upsertTagSchema("kpi", { fields: { count: { type: "integer" } } });
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["kpi"],
+      metadata: { count: 5.0000000000001 },
+    }) as any;
+    expect(result.validation_status.warnings.length).toBe(1);
+    expect(result.validation_status.warnings[0].reason).toBe("type_mismatch");
+  });
+
+  it("integer-typed field: boolean warns type_mismatch (vault#310)", async () => {
+    // Pin that boolean is rejected (Number.isInteger(true) returns
+    // false, but extra coverage in case anyone "improves" the check
+    // with a looser predicate later).
+    await store.upsertTagSchema("kpi", { fields: { count: { type: "integer" } } });
+    const tools = generateMcpTools(store);
+    const create = tools.find((t) => t.name === "create-note")!;
+    const result = await create.execute({
+      content: "x",
+      tags: ["kpi"],
+      metadata: { count: true },
+    }) as any;
+    expect(result.validation_status.warnings.length).toBe(1);
+    expect(result.validation_status.warnings[0].reason).toBe("type_mismatch");
+  });
+
+  // Note on NaN/Infinity: those values pass through
+  // JSON.stringify as `null`, then the validator's null short-circuit
+  // (schema-defaults.ts:327 — "value === null → skip") filters them out
+  // before reaching the type check. We can't observe them in
+  // validation_status from this layer; a dedicated unit test against
+  // `valueMatchesType` would catch the case at the inner boundary.
+  // Pinned at the next layer down:
+
+  it("valueMatchesType('integer', ...) rejects NaN / Infinity (vault#310)", async () => {
+    // Reach the unexported helper indirectly via validateNote on a
+    // hand-built resolved-schemas + metadata where the value is the
+    // actual NaN/Infinity (no JSON round-trip).
+    const { validateNote, loadSchemaConfig } = await import("./schema-defaults.js");
+    // Seed via the public surface, then load the resolved schemas
+    // snapshot.
+    await store.upsertTagSchema("k", { fields: { c: { type: "integer" } } });
+    const resolved = loadSchemaConfig((store as any).db);
+    expect(validateNote(resolved, { tags: ["k"], metadata: { c: Number.NaN } })?.warnings[0]?.reason)
+      .toBe("type_mismatch");
+    expect(validateNote(resolved, { tags: ["k"], metadata: { c: Number.POSITIVE_INFINITY } })?.warnings[0]?.reason)
+      .toBe("type_mismatch");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -3681,6 +3681,122 @@ describe("schema validation (tags.fields)", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// update-note `if_missing: "create"` — idempotent upsert (vault#309)
+// ---------------------------------------------------------------------------
+
+describe("update-note if_missing=create (vault#309)", async () => {
+  let store: SqliteStore;
+  beforeEach(() => {
+    store = new SqliteStore(new Database(":memory:"));
+  });
+
+  it("creates the note when missing + carries created: true", async () => {
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-note")!;
+    const result = await update.execute({
+      id: "Inbox/2026-05-13-meeting",
+      content: "agenda body",
+      tags: ["meeting"],
+      metadata: { priority: "high" },
+      if_missing: "create",
+    }) as any;
+    expect(result.created).toBe(true);
+    expect(result.path).toBe("Inbox/2026-05-13-meeting");
+    expect(result.content).toBe("agenda body");
+    expect(result.tags).toContain("meeting");
+    expect(result.metadata?.priority).toBe("high");
+
+    // And the row landed.
+    const fetched = await store.getNoteByPath("Inbox/2026-05-13-meeting");
+    expect(fetched).not.toBeNull();
+  });
+
+  it("updates the note when present + carries created: false", async () => {
+    await store.createNote("original", { path: "p", metadata: { v: 1 } });
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-note")!;
+    const result = await update.execute({
+      id: "p",
+      content: "updated body",
+      metadata: { v: 2 },
+      if_missing: "create",
+      force: true, // bypass OC since this is an unconditional update
+    }) as any;
+    expect(result.created).toBe(false);
+    expect(result.content).toBe("updated body");
+    expect(result.metadata?.v).toBe(2);
+  });
+
+  it("without if_missing, missing note errors (current behavior — back-compat)", async () => {
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-note")!;
+    await expect(update.execute({
+      id: "nope",
+      content: "x",
+      force: true,
+    })).rejects.toThrow(/Note not found/);
+  });
+
+  it("create branch applies tag-schema defaults when the new tag declares fields", async () => {
+    await store.upsertTagSchema("task", {
+      fields: { priority: { type: "string", enum: ["high", "low"] } },
+    });
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-note")!;
+    const result = await update.execute({
+      id: "Inbox/new-task",
+      content: "do the thing",
+      tags: ["task"],
+      if_missing: "create",
+    }) as any;
+    expect(result.created).toBe(true);
+    // Schema defaults populated metadata.priority on insert.
+    expect(result.metadata?.priority).toBeDefined();
+  });
+
+  it("create branch surfaces validation warnings just like create-note", async () => {
+    await store.upsertTagSchema("task", {
+      fields: { priority: { type: "string", enum: ["high", "low"] } },
+    });
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-note")!;
+    const result = await update.execute({
+      id: "Inbox/bad-task",
+      content: "x",
+      tags: ["task"],
+      metadata: { priority: "ULTRA" },
+      if_missing: "create",
+    }) as any;
+    expect(result.created).toBe(true);
+    expect(result.validation_status?.warnings?.[0]?.reason).toBe("enum_mismatch");
+  });
+
+  it("idempotent: second call with same id + same content updates without error", async () => {
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-note")!;
+    const first = await update.execute({
+      id: "Inbox/sync-target",
+      content: "v1",
+      if_missing: "create",
+    }) as any;
+    expect(first.created).toBe(true);
+
+    const second = await update.execute({
+      id: "Inbox/sync-target",
+      content: "v2",
+      if_missing: "create",
+      force: true,
+    }) as any;
+    expect(second.created).toBe(false);
+    expect(second.content).toBe("v2");
+
+    // Only one row exists.
+    const all = await store.queryNotes({ limit: 100 });
+    expect(all.filter((n) => n.path === "Inbox/sync-target")).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Schema inheritance via parent_names + `_default` universal parent — vault#270
 // ---------------------------------------------------------------------------
 

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -614,11 +614,21 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               //   - `item.content` / `item.path` / `item.tags` /
               //     `item.metadata` / `item.created_at` → forwarded.
               //   - `if_updated_at` / `force` / `content_edit` /
-              //     `append` / `prepend` / `links` are
-              //     update-only — silently ignored on the create branch.
-              //     (Content-edit on a non-existent note is a nonsense
-              //     combination; the caller's intent on missing-note is
-              //     "create the row", not "patch in this section".)
+              //     `append` / `prepend` are update-only — silently
+              //     ignored on the create branch. (Content-edit on a
+              //     non-existent note is a nonsense combination; the
+              //     caller's intent on missing-note is "create the
+              //     row", not "patch in this section".)
+              //   - `links.remove` is also ignored on create (nothing
+              //     to remove on a fresh note).
+              //   - `links.add` IS applied below — the drift sync can
+              //     declare typed links at upsert time and have them
+              //     materialize alongside the create. See vault#320
+              //     reviewer F1 — the prior comment claimed all
+              //     `links` were ignored, but `links.add` was already
+              //     processed and used by Gitcoin's sync; the
+              //     misleading wording is fixed here so a future
+              //     reader doesn't trust it and break the workflow.
               const idOrPath = item.id as string;
               // Heuristic: if `path` isn't set AND the `id` looks like a
               // path (contains "/" or doesn't match a typical opaque-id

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -469,6 +469,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
 - When removing a wikilink-type link, \`[[brackets]]\` are also removed from content.
 - For batch: pass a \`notes\` array, each with an \`id\` field.
 - **Optimistic concurrency is required by default.** Pass \`if_updated_at\` with the \`updated_at\` value you last read — the update is rejected with a conflict error if the note has changed since. Re-read, reconcile, and retry. To skip the safety check (e.g. bulk migration), pass \`force: true\` instead; the update then runs unconditionally. \`append\` / \`prepend\` only updates are exempt from the precondition (no-conflict-by-design).
+- **Idempotent upsert via \`if_missing: "create"\`** — when the note doesn't exist, create it from this same payload (content/path/tags/metadata become the create fields; OC precondition skipped — nothing to conflict with). Response carries \`created: true\`. Useful for nightly sync loops that don't know ahead of time whether the note exists. Default \`"fail"\` (current behavior — missing note errors). See vault#309.
 - \`include_content\` (default \`true\`) — set \`false\` to receive a lean index shape (\`id\`, \`path\`, \`createdAt\`, \`updatedAt\`, \`tags\`, \`metadata\`, \`byteSize\`, \`preview\`) instead of full content. Useful for agents making frequent small edits to large notes (e.g. via \`append\` or \`content_edit\`) where re-receiving the body is the dominant cost. \`validation_status\` is preserved on the lean shape when present.`,
       inputSchema: {
         type: "object",
@@ -491,6 +492,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           created_at: { type: "string", description: "New created_at timestamp" },
           if_updated_at: { type: "string", description: "Optimistic concurrency check: the updated_at value you last read. Rejects with a conflict error if the note has been modified since. Required unless `force: true` is set or the call is `append`/`prepend`-only." },
           force: { type: "boolean", description: "Override the required `if_updated_at` check and run the update unconditionally. Use only for bulk migrations or scripted writes where concurrency is known-safe." },
+          if_missing: { type: "string", enum: ["fail", "create"], description: "What to do when the note (by `id`/path) doesn't exist. `\"fail\"` (default) — error, current behavior. `\"create\"` — create the note from this same payload (content/path/tags/metadata become the create fields; the response carries `created: true`). Skips the `if_updated_at` precondition on the create branch (nothing to conflict with). Idempotent for sync loops that don't know ahead of time whether the note exists. See vault#309." },
           tags: {
             type: "object",
             properties: {
@@ -554,6 +556,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
                 created_at: { type: "string" },
                 if_updated_at: { type: "string", description: "Optimistic concurrency check for this item; rejects with a conflict error if the note has been modified since. Required unless `force: true` is set on this item or the item is `append`/`prepend`-only." },
                 force: { type: "boolean", description: "Override the required `if_updated_at` check for this item." },
+                if_missing: { type: "string", enum: ["fail", "create"], description: "Per-item: see top-level `if_missing` docs. Each batch item carries its own setting." },
                 tags: { type: "object" },
                 links: { type: "object" },
               },
@@ -572,6 +575,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         }
 
         const updated: Note[] = [];
+        // Track which note IDs were freshly created via `if_missing: "create"`
+        // so the response can carry `created: true|false` per-note. The
+        // sync-loop caller (Gitcoin Brain et al) reads this to know which
+        // path fired without doing a separate query. vault#309.
+        const createdIds = new Set<string>();
         // Wrap multi-item batches in a SQLite transaction so any mid-batch
         // failure (precondition error, content_edit miss, ConflictError, …)
         // rolls back every prior mutation in the batch — see #236.
@@ -581,7 +589,77 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         if (batched) db.exec("BEGIN");
         try {
         for (const item of items) {
-          const note = requireNote(db, item.id as string);
+          // Try ID-then-path resolve. If not found AND
+          // `if_missing: "create"` is set, fall through to the create
+          // branch using this same item's payload. Otherwise mirror the
+          // existing `requireNote` behavior (throw "Note not found").
+          // vault#309.
+          const resolved = resolveNote(db, item.id as string);
+          if (!resolved) {
+            if (item.if_missing === "create") {
+              // Treat the update payload as a create payload. Minimum:
+              // content OR a path/id (something the createNote-empty-row
+              // invariant accepts). createNote enforces its own
+              // not-both-empty check — we leave that to the Store and
+              // surface any error to the caller verbatim.
+              //
+              // Field mapping (mirrors the create-note tool surface):
+              //   - `item.id` → both the note's `id` AND a fallback
+              //     `path` when `item.path` isn't set. Treating `id` as
+              //     the path-or-id lookup key matches Gitcoin's nightly
+              //     sync shape where the canonical key is a path string
+              //     like "Inbox/2026-05-13-meeting". If the caller
+              //     supplied an opaque ULID as `id` and no `path`, we
+              //     still create with that as `id` (path stays null).
+              //   - `item.content` / `item.path` / `item.tags` /
+              //     `item.metadata` / `item.created_at` → forwarded.
+              //   - `if_updated_at` / `force` / `content_edit` /
+              //     `append` / `prepend` / `links` are
+              //     update-only — silently ignored on the create branch.
+              //     (Content-edit on a non-existent note is a nonsense
+              //     combination; the caller's intent on missing-note is
+              //     "create the row", not "patch in this section".)
+              const idOrPath = item.id as string;
+              // Heuristic: if `path` isn't set AND the `id` looks like a
+              // path (contains "/" or doesn't match a typical opaque-id
+              // shape), use it as the path too. Otherwise treat it as a
+              // pure id. The shared `id` field for update is ID-or-path
+              // already (see `resolveNote`), so this preserves the
+              // caller's intent.
+              const idLooksLikePath = idOrPath.includes("/") || !/^[A-Za-z0-9_-]+$/.test(idOrPath);
+              const explicitPath = typeof item.path === "string" ? item.path as string : undefined;
+              const createOpts: Parameters<Store["createNote"]>[1] = {
+                ...(idLooksLikePath ? { path: explicitPath ?? idOrPath } : { id: idOrPath, ...(explicitPath !== undefined ? { path: explicitPath } : {}) }),
+                ...(item.tags && Array.isArray((item.tags as any).add)
+                  ? { tags: (item.tags as any).add as string[] }
+                  : Array.isArray(item.tags)
+                    ? { tags: item.tags as string[] }
+                    : {}),
+                ...(item.metadata !== undefined ? { metadata: item.metadata as Record<string, unknown> } : {}),
+                ...(item.created_at !== undefined ? { created_at: item.created_at as string } : {}),
+              };
+              const content = (item.content as string | undefined) ?? "";
+              const created = await store.createNote(content, createOpts);
+              await applySchemaDefaults(store, db, [created.id], created.tags ?? []);
+              // Apply links.add if the caller declared any.
+              const linksAdd = (item.links as any)?.add as { target: string; relationship: string; metadata?: Record<string, unknown> }[] | undefined;
+              if (linksAdd) {
+                for (const link of linksAdd) {
+                  const target = resolveNote(db, link.target);
+                  if (target) await store.createLink(created.id, target.id, link.relationship, link.metadata);
+                }
+              }
+              const fresh = noteOps.getNote(db, created.id) ?? created;
+              updated.push(fresh);
+              createdIds.add(fresh.id);
+              continue;
+            }
+            // Fallthrough: not-found + no if_missing → existing error
+            // contract. Match `requireNote`'s message shape so existing
+            // callers see no behavior change.
+            throw new Error(`Note not found: "${item.id}"`);
+          }
+          const note = resolved;
 
           // --- Validate mutual exclusion of content modes ---
           const hasContent = item.content !== undefined;
@@ -745,14 +823,21 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         // Response shape: full Note (back-compat default) or lean NoteIndex
         // (#285 friction point 2.response — opt-out for callers making
         // frequent small edits to large notes). `validation_status` from
-        // `tags.fields` is preserved across either shape.
+        // `tags.fields` is preserved across either shape. `created: true|false`
+        // (vault#309) is attached to every response so callers using
+        // `if_missing: "create"` can tell which branch fired without a
+        // separate query. `false` for the (overwhelmingly common) update
+        // path; `true` only when this call took the create-on-missing
+        // branch.
         const includeContent = params.include_content !== false;
         const final = updated.map((n) => {
           const validated = attachValidationStatus(store, db, n);
-          if (includeContent) return validated;
+          const created = createdIds.has(n.id);
+          if (includeContent) return { ...validated, created } as Note & { created: boolean };
           const lean: any = noteOps.toNoteIndex(validated);
           const vs = (validated as any).validation_status;
           if (vs !== undefined) lean.validation_status = vs;
+          lean.created = created;
           return lean;
         });
         return batch ? final : final[0];

--- a/core/src/schema-defaults.ts
+++ b/core/src/schema-defaults.ts
@@ -47,7 +47,17 @@ import { Database } from "bun:sqlite";
 // ---------------------------------------------------------------------------
 
 export interface SchemaField {
-  type?: "string" | "number" | "boolean" | "array" | "object";
+  /**
+   * Declared type for the field's metadata value. `"integer"` is distinct
+   * from `"number"` only at validation time — JSON has no separate integer
+   * type, so a JSON number with zero fractional part (`5`, `5.0`,
+   * `Number.isInteger(n) === true`) is accepted as integer and a non-zero
+   * fractional value (`5.5`) is rejected. This matches the indexed-fields
+   * `"integer"` storage type (TYPE_MAP) and removes the false-positive
+   * `type_mismatch` warning that previously fired on every integer-shaped
+   * field because the validator had no `"integer"` case. See vault#310.
+   */
+  type?: "string" | "number" | "integer" | "boolean" | "array" | "object";
   enum?: string[];
   description?: string;
 }
@@ -270,6 +280,14 @@ function valueMatchesType(value: unknown, type: SchemaField["type"]): boolean {
       return typeof value === "string";
     case "number":
       return typeof value === "number" && Number.isFinite(value);
+    case "integer":
+      // JSON has no separate integer type — `5.0` and `5` decode to the
+      // same JS Number. Accept any finite Number whose fractional part is
+      // zero; reject `5.5`, `NaN`, `Infinity`, and non-Number types.
+      // vault#310 (Gitcoin Brain drift detector emits JSON for diffs;
+      // without this case, every integer-typed field warned
+      // `type_mismatch` and buried the real warnings).
+      return typeof value === "number" && Number.isInteger(value);
     case "boolean":
       return typeof value === "boolean";
     case "array":

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.4-rc.11",
+  "version": "0.4.4-rc.12",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -854,15 +854,64 @@ export async function handleNotes(
   // PATCH /notes/:idOrPath — update (content, path, metadata, tags, links)
   if (method === "PATCH") {
     try {
+      // Body is parsed up front so the `if_missing: "create"` branch
+      // (vault#309) can fire when the note doesn't exist. Pre-#309
+      // shape parsed the body only after the not-found check.
+      const body = await req.json() as any;
       const note = await resolveNote(store, idOrPath);
-      if (!note) throw new NotFoundError(`Note not found: "${idOrPath}"`);
+      if (!note) {
+        // vault#309 — `if_missing: "create"` turns this PATCH into a
+        // create using the same payload. POST /notes is the canonical
+        // create surface, but supporting it inline on PATCH lets sync
+        // loops use one endpoint for both branches. Returns the
+        // created note with `created: true` and HTTP 200 (not 201 —
+        // the response shape is "the note as it now exists," same
+        // contract as the update path; `created: true` carries the
+        // signal).
+        if (body.if_missing === "create") {
+          const idOrPathStr = idOrPath;
+          // Tag-scope check on the create branch: the prospective
+          // tag set must still satisfy scope. Compute from body.tags
+          // (create-shape: an array, not the {add,remove} dict).
+          const tagsArr = Array.isArray(body.tags)
+            ? body.tags as string[]
+            : Array.isArray(body.tags?.add) ? body.tags.add as string[] : [];
+          if (tagScope.allowed && !tagsWithinScope(tagsArr, tagScope.allowed, tagScope.raw)) {
+            return tagScopeForbidden(tagScope.raw ?? []);
+          }
+          const idLooksLikePath = idOrPathStr.includes("/") || !/^[A-Za-z0-9_-]+$/.test(idOrPathStr);
+          const explicitPath = typeof body.path === "string" ? body.path as string : undefined;
+          const createOpts: Parameters<Store["createNote"]>[1] = {
+            ...(idLooksLikePath ? { path: explicitPath ?? idOrPathStr } : { id: idOrPathStr, ...(explicitPath !== undefined ? { path: explicitPath } : {}) }),
+            ...(tagsArr.length > 0 ? { tags: tagsArr } : {}),
+            ...(body.metadata !== undefined ? { metadata: body.metadata as Record<string, unknown> } : {}),
+            ...(body.created_at !== undefined ? { created_at: body.created_at as string } : {}),
+            ...(body.createdAt !== undefined ? { created_at: body.createdAt as string } : {}),
+          };
+          const content = (body.content as string | undefined) ?? "";
+          const created = await store.createNote(content, createOpts);
+          if (tagsArr.length > 0) {
+            await applySchemaDefaults(store, db, [created.id], tagsArr);
+          }
+          const final = await store.getNote(created.id);
+          if (!final) return json({ error: "Note disappeared" }, 500);
+          const validated = attachValidationStatus(store, db, final);
+          const includeContentResp = body.include_content !== false;
+          if (includeContentResp) return json({ ...validated, created: true });
+          const lean: any = toNoteIndex(validated);
+          const vs = (validated as any).validation_status;
+          if (vs !== undefined) lean.validation_status = vs;
+          lean.created = true;
+          return json(lean);
+        }
+        throw new NotFoundError(`Note not found: "${idOrPath}"`);
+      }
       // Tag-scope: existing note must be in scope. Mirror the read-side
       // 404-not-403 stance — a token can't see (and therefore can't
       // discover-then-modify) notes outside its allowlist.
       if (!noteWithinTagScope(note, tagScope.allowed, tagScope.raw)) {
         throw new NotFoundError(`Note not found: "${idOrPath}"`);
       }
-      const body = await req.json() as any;
       // Tag-scope: post-update tag set must still satisfy scope. Compute
       // the prospective tag set (existing − removed + added) and reject
       // before any write if it would drift outside the allowlist. This
@@ -1035,10 +1084,15 @@ export async function handleNotes(
       if (updatedNote === null) return json({ error: "Note disappeared" }, 404);
       const validated = attachValidationStatus(store, db, updatedNote);
       const includeContentResp = body.include_content !== false;
-      if (includeContentResp) return json(validated);
+      // `created: false` is appended to every update-path response so
+      // sync-loop callers using `if_missing: "create"` can distinguish
+      // the two branches without a separate query (vault#309). The
+      // create-branch response above carries `created: true`.
+      if (includeContentResp) return json({ ...validated, created: false });
       const lean: any = toNoteIndex(validated);
       const vs = (validated as any).validation_status;
       if (vs !== undefined) lean.validation_status = vs;
+      lean.created = false;
       return json(lean);
     } catch (e: any) {
       if (e instanceof NotFoundError) return json({ error: e.message }, 404);

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2926,6 +2926,80 @@ describe("HTTP POST /notes — validation_status attachment (vault#287)", async 
   });
 });
 
+// vault#309 — HTTP PATCH /notes/:id with if_missing: "create" mirrors
+// the MCP update-note path. Sync loops (Gitcoin Brain et al) use this
+// for idempotent upsert without a separate query-first round trip.
+
+describe("HTTP PATCH /notes/:idOrPath if_missing=create (vault#309)", async () => {
+  test("missing note + if_missing=create creates and returns created: true", async () => {
+    const res = await handleNotes(
+      mkReq("PATCH", `/notes/${encodeURIComponent("Inbox/m309a")}`, {
+        content: "agenda body",
+        tags: ["meeting309"],
+        metadata: { priority: "high" },
+        if_missing: "create",
+      }),
+      store,
+      `/${encodeURIComponent("Inbox/m309a")}`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.created).toBe(true);
+    expect(body.path).toBe("Inbox/m309a");
+    expect(body.content).toBe("agenda body");
+    expect(body.tags).toContain("meeting309");
+    expect(body.metadata.priority).toBe("high");
+    // And the row landed.
+    expect(await store.getNoteByPath("Inbox/m309a")).not.toBeNull();
+  });
+
+  test("existing note + if_missing=create updates and returns created: false", async () => {
+    await store.createNote("original", { path: "m309b", metadata: { v: 1 } });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/m309b", {
+        content: "updated body",
+        metadata: { v: 2 },
+        if_missing: "create",
+        force: true,
+      }),
+      store,
+      "/m309b",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.created).toBe(false);
+    expect(body.content).toBe("updated body");
+    expect(body.metadata.v).toBe(2);
+  });
+
+  test("missing note without if_missing returns 404 (back-compat)", async () => {
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/m309c-nope", {
+        content: "x",
+        force: true,
+      }),
+      store,
+      "/m309c-nope",
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("regular update path now also carries created: false (response shape extended)", async () => {
+    await store.createNote("body", { path: "m309d" });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/m309d", {
+        content: "new body",
+        force: true,
+      }),
+      store,
+      "/m309d",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.created).toBe(false);
+  });
+});
+
 describe("HTTP /tags", async () => {
   test("GET /tags lists all tags", async () => {
     await store.createNote("A", { tags: ["daily"] });


### PR DESCRIPTION
## Summary

**Bundled two-commit PR** under the new cadence (bundle-by-session-theme; one PR with N commits when changes share a theme). Theme: **Gitcoin sync ergonomics** — the next two priorities promised in `from_parachute_round_2.md` after vault#308.

Reviewer steps through each commit independently.

---

### Commit 1 — `feat(api): if_missing="create" on update-note (closes #309)`

Gitcoin's nightly drift-detector loop today does ~500 query-first-then-create round trips per night. New `update-note { if_missing: "create" }` makes update idempotent — the same payload upserts by id-or-path with zero extra round trips.

- **MCP `update-note`** — new optional `if_missing: "fail" | "create"` (default `"fail"`, current behavior). On `"create"` + not-found, treat the update payload as a create payload (content/path/tags/metadata → create fields). `if_updated_at` precondition skipped on the create branch (nothing to conflict with).
- **REST `PATCH /api/notes/:idOrPath`** — same. Body parsed before the not-found check so the create branch can fire.
- **Response `created: true | false`** — appended to every update-note response (both branches; additive, no impact on callers that ignore it). Sync loops read this to distinguish branches without a separate query.
- **ID-vs-path heuristic** on the create branch: path-shaped input (`/`-containing or non-identifier chars) becomes `path`; opaque-id-shaped input becomes `id`. Explicit `path` field wins.
- Tag-schema defaults + validation_status apply on the create branch identically to `create-note`.

Tests: 6 MCP (core.test.ts) + 4 REST (vault.test.ts). Covers create-when-missing, update-when-present, no-if_missing-errors, schema-defaults apply on create branch, validation_status surfaces on create branch, idempotent repeated calls, plus the additive `created: false` pin on regular updates.

### Commit 2 — `fix(schema): coerce JSON number → integer when fractional is zero (closes #310)`

Per Gitcoin Brain `findings_week0_simulation.md` "what was painful" item 1: every integer-typed metadata field warned `type_mismatch` on legitimate values because the validator had no `"integer"` case at all — falling through the switch returned `undefined` and the gate fired. False-positive buried real warnings in the noise floor.

- `SchemaField.type` union extended with `"integer"`.
- `valueMatchesType` adds an `"integer"` case using `Number.isInteger(value)`. Accepts `5`, `5.0`; rejects `5.5`, `"5"` (no string→number coercion), `5.0000000000001`, `NaN`, `Infinity`, booleans.

Tests in core.test.ts: happy path (5, 5.0), rejection path (5.5, "5", edge fractional, boolean), inner-boundary (valueMatchesType direct NaN/Infinity — the outer null short-circuit filters them after JSON.stringify normalization before they hit the type check).

## Test plan

- [x] `bun test` (root) → **1411 pass / 3 skip / 0 fail** (was 1394; +17 tests)
- [x] `bun test ./src/` → 923 pass / 0 fail (was 919; +4 REST)
- [x] `bun test ./core/src/` → 488 pass / 0 fail (was 475; +6 MCP if_missing + 7 int coercion)
- [x] `bunx tsc --noEmit` clean
- [x] Both commits compile + test green independently (commit 1's test counts are interim — commit 2 carries the full rc.12 line in CHANGELOG).

## Patterns touched

- `patterns/governance.md` rule 2: RC bump `0.4.4-rc.11` → `0.4.4-rc.12`. Both commits' work goes under one rc.12 block per team-lead's bundle spec.
- Bundle-by-session-theme cadence: one PR, two commits, separately pushed for reviewer focus.
- Merge-policy precedent from #319's `importPortableVault` comment block: when adding `if_missing`, kept the existing "replace tags wholesale" comment as the precedent; documented `if_missing` in the tool description block at top of update-note rather than re-stating in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)