### PR TITLE
tighten(api): if_missing follow-ups — REST links symmetry + schema-conflict + links.add coverage (0.4.4-rc.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.4-rc.13] — 2026-05-13
+
+`if_missing` tighten-up — vault#321 follow-ups from the vault#320 review.
+Three commits, all under the "if_missing tighten-up" theme. Closes
+vault#321 (F2 + F3 + F4 sub-issues).
+
+### fix(api): REST PATCH if_missing=create applies links.add (vault#321 F2)
+
+Cross-surface inconsistency: MCP's create-on-missing branch processed
+`links.add` (let drift sync declare typed links at upsert time); REST
+PATCH `/notes/:id`'s create-on-missing branch didn't process `links`
+at all. Gitcoin would have tripped on this migrating MCP → REST.
+
+REST now mirrors MCP exactly:
+- `links.add` applied — drift sync materializes typed links alongside
+  the create.
+- `links.remove` ignored (nothing to remove on a fresh note).
+- Missing target notes skip silently.
+- Resolves target via `resolveNote(store, link.target)` — same
+  id-or-path lookup as the update path.
+
+Two new REST integration tests (vault.test.ts):
+- `links.add` creates typed-link rows (id-target + path-target both
+  resolve; metadata round-trips).
+- Missing target → silent skip.
+
+### test(api): schema-conflict warning surfaces on if_missing=create branch (vault#321 F3)
+
+The `attachValidationStatus` path handles schema conflicts (two tags
+declaring the same field with conflicting types) but the create branch
+of `if_missing="create"` reused that path without exercising the case
+in a test. Now pinned on BOTH surfaces for symmetry:
+
+- MCP test in core.test.ts.
+- REST test in vault.test.ts.
+
+Both confirm a `schema_conflict` warning surfaces in
+`validation_status.warnings` when two directly-applied tags declare
+the same field with conflicting specs. First-tag-wins precedence
+(`schema` = winner, `loser_schema` = the dropped declaration).
+
+### test(mcp): links.add applied on if_missing=create branch (vault#321 F4)
+
+`core/src/mcp.ts:644-650` applies `links.add` on the create branch.
+Code was there pre-fold but untested — a future regression breaking
+Gitcoin's upsert-with-typed-links workflow would have slipped through.
+Now pinned: MCP `update-note` + `if_missing: "create"` + `links.add`
+payload → assert link rows materialize with the right targets +
+relationships + metadata.
+
+### Gates
+
+- `bun test` (root) → 1416 pass / 3 skip / 0 fail (was 1411; +5 tests)
+- `bun test ./src/` → 926 pass / 0 fail (was 923; +3 REST tests: 2 F2 + 1 F3)
+- `bun test ./core/src/` → 490 pass / 0 fail (was 488; +2 MCP tests: 1 F3 + 1 F4)
+- `bunx tsc --noEmit` clean
+
 ## [0.4.4-rc.12] — 2026-05-13
 
 Gitcoin sync ergonomics — bundled two-commit PR. Both close real

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -3910,6 +3910,40 @@ describe("update-note if_missing=create (vault#309)", async () => {
     const all = await store.queryNotes({ limit: 100 });
     expect(all.filter((n) => n.path === "Inbox/sync-target")).toHaveLength(1);
   });
+  // vault#321 F3 — schema-conflict warning surfaces on the create
+  // branch. The branch reuses `attachValidationStatus` so the
+  // conflict-detection logic should fire, but pre-fold it wasn't
+  // pinned. Two tags directly applied to the new note, each
+  // declaring the same field with conflicting specs → schema_conflict
+  // warning (the existing `resolveNoteSchemas` walk produces this for
+  // both inheritance chains AND multi-tag direct application).
+  it("schema-conflict warning surfaces on create branch (vault#321 F3)", async () => {
+    await store.upsertTagSchema("kpi", {
+      fields: { count: { type: "integer" } },
+    });
+    await store.upsertTagSchema("metric", {
+      fields: { count: { type: "string" } }, // conflicting spec
+    });
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-note")!;
+    const result = await update.execute({
+      id: "Inbox/conflicting-tags",
+      content: "x",
+      tags: ["kpi", "metric"],
+      metadata: { count: 5 },
+      if_missing: "create",
+    }) as any;
+    expect(result.created).toBe(true);
+    const conflict = result.validation_status.warnings.find(
+      (w: any) => w.reason === "schema_conflict",
+    );
+    expect(conflict).toBeDefined();
+    expect(conflict.field).toBe("count");
+    // First-tag-wins precedence (kpi → integer). The loser_schema
+    // field names metric.
+    expect(conflict.schema).toBe("kpi");
+    expect(conflict.loser_schema).toBe("metric");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -3910,6 +3910,7 @@ describe("update-note if_missing=create (vault#309)", async () => {
     const all = await store.queryNotes({ limit: 100 });
     expect(all.filter((n) => n.path === "Inbox/sync-target")).toHaveLength(1);
   });
+
   // vault#321 F3 — schema-conflict warning surfaces on the create
   // branch. The branch reuses `attachValidationStatus` so the
   // conflict-detection logic should fire, but pre-fold it wasn't
@@ -3943,6 +3944,42 @@ describe("update-note if_missing=create (vault#309)", async () => {
     // field names metric.
     expect(conflict.schema).toBe("kpi");
     expect(conflict.loser_schema).toBe("metric");
+  });
+
+  // vault#321 F4 — links.add on the create branch is applied. The
+  // implementation at mcp.ts:644-650 was present pre-fold; this
+  // test pins it so a future regression breaking Gitcoin's
+  // upsert-with-typed-links workflow goes red.
+  it("links.add applied on create branch (vault#321 F4)", async () => {
+    // Two pre-existing target notes the new source links to.
+    await store.createNote("A", { id: "t-mcp-a-321", path: "Targets/A-mcp" });
+    await store.createNote("B", { id: "t-mcp-b-321", path: "Targets/B-mcp" });
+
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-note")!;
+    const result = await update.execute({
+      id: "Inbox/mcp-source-321",
+      content: "source body",
+      if_missing: "create",
+      links: {
+        add: [
+          { target: "t-mcp-a-321", relationship: "derived-from" },
+          { target: "Targets/B-mcp", relationship: "responds-to", metadata: { weight: 5 } },
+        ],
+      },
+    }) as any;
+    expect(result.created).toBe(true);
+
+    const sourceId = result.id as string;
+    const outboundLinks = await store.getLinks(sourceId, { direction: "outbound" });
+    const derivedFrom = outboundLinks.find((l) => l.relationship === "derived-from");
+    expect(derivedFrom).toBeDefined();
+    expect(derivedFrom!.targetId).toBe("t-mcp-a-321");
+
+    const respondsTo = outboundLinks.find((l) => l.relationship === "responds-to");
+    expect(respondsTo).toBeDefined();
+    expect(respondsTo!.targetId).toBe("t-mcp-b-321");
+    expect(respondsTo!.metadata).toEqual({ weight: 5 });
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.4-rc.12",
+  "version": "0.4.4-rc.13",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -893,6 +893,26 @@ export async function handleNotes(
           if (tagsArr.length > 0) {
             await applySchemaDefaults(store, db, [created.id], tagsArr);
           }
+          // vault#321 F2 — apply `links.add` on the create branch.
+          // MCP's create-on-missing branch already did this
+          // (`core/src/mcp.ts` if_missing=create block); the REST side
+          // was missing it, producing a cross-surface inconsistency
+          // operators (Gitcoin's drift sync) would trip on. Mirror the
+          // MCP recipe exactly:
+          //   - `links.add` IS applied — drift sync can declare typed
+          //     links at upsert time and have them materialize.
+          //   - `links.remove` is ignored (nothing to remove on a
+          //     fresh note).
+          //   - Missing target notes skip silently (mirrors MCP).
+          const linksAdd = (body.links as any)?.add as { target: string; relationship: string; metadata?: Record<string, unknown> }[] | undefined;
+          if (linksAdd) {
+            for (const link of linksAdd) {
+              const target = await resolveNote(store, link.target);
+              if (target) {
+                await store.createLink(created.id, target.id, link.relationship, link.metadata);
+              }
+            }
+          }
           const final = await store.getNote(created.id);
           if (!final) return json({ error: "Note disappeared" }, 500);
           const validated = attachValidationStatus(store, db, final);

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -3063,6 +3063,40 @@ describe("HTTP PATCH /notes/:idOrPath if_missing=create (vault#309)", async () =
     const links = await store.getLinks(body.id, { direction: "outbound" });
     expect(links.filter((l) => l.relationship === "derived-from")).toHaveLength(0);
   });
+
+  // vault#321 F3 — schema-conflict warning on REST create branch
+  // (mirror of the MCP test in core.test.ts). Same conflict-detection
+  // path runs on both surfaces via attachValidationStatus, but we pin
+  // both ends explicitly so a regression on either side surfaces
+  // immediately.
+  test("schema-conflict warning surfaces on REST create branch (vault#321 F3)", async () => {
+    await store.upsertTagSchema("kpi-rest-321", {
+      fields: { count: { type: "integer" } },
+    });
+    await store.upsertTagSchema("metric-rest-321", {
+      fields: { count: { type: "string" } }, // conflicting
+    });
+    const res = await handleNotes(
+      mkReq("PATCH", `/notes/${encodeURIComponent("Inbox/conflict-321")}`, {
+        content: "x",
+        if_missing: "create",
+        tags: ["kpi-rest-321", "metric-rest-321"],
+        metadata: { count: 5 },
+      }),
+      store,
+      `/${encodeURIComponent("Inbox/conflict-321")}`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.created).toBe(true);
+    const conflict = body.validation_status.warnings.find(
+      (w: any) => w.reason === "schema_conflict",
+    );
+    expect(conflict).toBeDefined();
+    expect(conflict.field).toBe("count");
+    expect(conflict.schema).toBe("kpi-rest-321");
+    expect(conflict.loser_schema).toBe("metric-rest-321");
+  });
 });
 
 describe("HTTP /tags", async () => {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2998,6 +2998,71 @@ describe("HTTP PATCH /notes/:idOrPath if_missing=create (vault#309)", async () =
     const body = await res.json() as any;
     expect(body.created).toBe(false);
   });
+
+  // vault#321 F2 — REST create-on-missing branch applies links.add.
+  // MCP's create branch already did; REST was missing the
+  // link-creation pass entirely. Cross-surface inconsistency Gitcoin
+  // would trip on if they migrated from MCP to REST. The new pass
+  // mirrors MCP exactly (links.add applied, links.remove ignored,
+  // missing targets skip silently).
+  test("if_missing=create + links.add creates typed-link rows (vault#321 F2)", async () => {
+    // Two pre-existing target notes (different ids + paths) so the
+    // source can fan out to both.
+    await store.createNote("target A", { id: "t-a-321", path: "Targets/A" });
+    await store.createNote("target B", { id: "t-b-321", path: "Targets/B" });
+
+    const res = await handleNotes(
+      mkReq("PATCH", `/notes/${encodeURIComponent("Inbox/source-321")}`, {
+        content: "source body",
+        if_missing: "create",
+        links: {
+          add: [
+            { target: "t-a-321", relationship: "derived-from" },
+            { target: "Targets/B", relationship: "responds-to", metadata: { weight: 5 } },
+          ],
+        },
+      }),
+      store,
+      `/${encodeURIComponent("Inbox/source-321")}`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.created).toBe(true);
+
+    // Link rows exist + resolved targets correctly. We look up by the
+    // source's note id (the body returned by the create branch).
+    const sourceId = body.id as string;
+    const outboundLinks = await store.getLinks(sourceId, { direction: "outbound" });
+    const derivedFrom = outboundLinks.find((l) => l.relationship === "derived-from");
+    expect(derivedFrom).toBeDefined();
+    expect(derivedFrom!.targetId).toBe("t-a-321");
+
+    const respondsTo = outboundLinks.find((l) => l.relationship === "responds-to");
+    expect(respondsTo).toBeDefined();
+    expect(respondsTo!.targetId).toBe("t-b-321");
+    expect(respondsTo!.metadata).toEqual({ weight: 5 });
+  });
+
+  test("if_missing=create + links.add silently skips when target does not exist (vault#321 F2)", async () => {
+    // Mirrors MCP: missing target → silent skip, no error. Sync loops
+    // that declare links to not-yet-imported notes shouldn't abort
+    // the whole upsert.
+    const res = await handleNotes(
+      mkReq("PATCH", `/notes/${encodeURIComponent("Inbox/source-missing-321")}`, {
+        content: "x",
+        if_missing: "create",
+        links: { add: [{ target: "does-not-exist", relationship: "derived-from" }] },
+      }),
+      store,
+      `/${encodeURIComponent("Inbox/source-missing-321")}`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.created).toBe(true);
+    // The note is created. No links resolved.
+    const links = await store.getLinks(body.id, { direction: "outbound" });
+    expect(links.filter((l) => l.relationship === "derived-from")).toHaveLength(0);
+  });
 });
 
 describe("HTTP /tags", async () => {


### PR DESCRIPTION
## Summary

Closes **vault#321** — the follow-up bundle filed during vault#320 review (F2/F3/F4). Theme: **"if_missing tighten-up."**

Three commits, separately pushed for reviewer focus:

1. `bc1c781 fix(api): REST PATCH if_missing=create applies links.add (vault#321 F2)`
2. `b2a4644 test(api): schema-conflict warning surfaces on if_missing=create branch (vault#321 F3)`
3. `b4339fc test(mcp): links.add applied on if_missing=create branch (vault#321 F4)`

---

### Commit 1 — F2

REST PATCH `/notes/:id`'s create-on-missing branch wasn't processing `links` at all. MCP's was. Cross-surface inconsistency Gitcoin would have tripped on migrating MCP → REST. REST now mirrors MCP exactly (links.add applied; links.remove ignored; missing-target silent skip). Two new REST tests pin both the happy path and the missing-target case.

### Commit 2 — F3

`schema_conflict` warnings on the create branch were untested. Two pins (MCP + REST) added so a regression on either surface goes red. Each test creates a note via `if_missing="create"` with two tags directly applied, each declaring the same field with conflicting types; asserts `validation_status.warnings` carries the `schema_conflict` entry with the right winner/loser.

### Commit 3 — F4

`links.add` on the MCP create branch (`core/src/mcp.ts:644-650`) was implemented pre-vault#320 but untested. A future regression breaking Gitcoin's upsert-with-typed-links workflow would have slipped. Now pinned: `update-note` + `if_missing="create"` + `links.add` → assert link rows materialize with right targets + relationships + metadata.

RC bumped `0.4.4-rc.12` → `0.4.4-rc.13` in this commit, with the CHANGELOG carrying all three sub-sections.

## Test plan

- [x] `bun test` (root) → **1416 pass / 3 skip / 0 fail** (was 1411; +5 tests)
- [x] `bun test ./src/` → 926 pass / 0 fail (was 923; +2 F2 REST + 1 F3 REST)
- [x] `bun test ./core/src/` → 490 pass / 0 fail (was 488; +1 F3 MCP + 1 F4 MCP)
- [x] `bunx tsc --noEmit` clean
- [x] Each commit compiles + tests green standalone (verified via the intermediate-file split technique).

## Patterns touched

- `patterns/governance.md` rule 2: RC bump `rc.12` → `rc.13`. Bundle cadence (one PR, three commits, theme-coherent).
- Same merge-policy comment style as vault#319 fold + vault#320 F1 follow-up: vault#321 F2's REST fix carries an inline comment referencing the MCP recipe so future readers see both sides matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)