### PR TITLE
feat(notes): file-extension support — non-markdown notes with sidecar metadata (vault#328) (0.4.5-rc.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,113 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.5-rc.1] — 2026-05-15
+
+File-extension support — vault#328. Substrate-side feature enabling
+notes whose content is NOT markdown (CSV, YAML, JSON, MDX, plaintext,
+etc.) as first-class. Markdown stays the default; every existing row
+keeps its meaning. Three commits under the vault#328 theme.
+
+### feat(db): add extension column to notes, default 'md' (vault#328)
+
+Schema v17 → v18: `ALTER TABLE notes ADD COLUMN extension TEXT NOT
+NULL DEFAULT 'md'`, and widen the path-uniqueness index from `(path)`
+to `(path, extension)` so two notes can share a path differing only by
+extension (e.g. `Recipes/pasta.md` + `Recipes/pasta.csv`).
+
+Backward-compat by construction — every existing row defaults to "md",
+so the new composite-index uniqueness collapses to the v5 "(path WHERE
+NOT NULL) is unique" behavior on existing data.
+
+Threaded `extension` through `Note`/`NoteSummary`/`NoteIndex`, the
+`Store` interface (`createNote` / `updateNote` / `createNoteRaw`),
+`BulkNoteInput`, and `QueryOpts.extension` (single string or array,
+case-insensitive `LOWER(n.extension) IN (...)` SQL).
+
+Tests: 7 new in `core/src/core.test.ts` covering default 'md',
+explicit persist, v18 migration backfills legacy NULL → 'md',
+`updateNote` changes extension, query filter (single + array shapes),
+case-insensitive match.
+
+### feat(api): extension field on create-note + update-note + query-notes (vault#328)
+
+MCP and REST surfaces gain a symmetric `extension` field:
+
+- **MCP `create-note`**: optional `extension` on single + batch shapes.
+- **MCP `update-note`**: optional `extension`; same validation on both
+  the update branch AND the `if_missing: "create"` branch.
+- **MCP `query-notes`**: `extension` filter accepts a single string or
+  an array.
+- **REST `POST /notes`** + **`PATCH /notes/:id`** (incl.
+  `if_missing=create` branch): symmetric `extension` field, validation,
+  400 `invalid_extension` on bad input with structured
+  `error_type`/`extension`/`reason`.
+- **REST `GET /notes`**: `?extension=csv` (single) or
+  `?extension=csv&extension=yaml` / `?extension=csv,yaml` (array).
+
+Validation: `/^[a-z0-9]{1,16}$/` + reserved `parachute` prefix guard.
+Single source of truth at
+`core/src/notes.ts:validateExtension`, imported by both transports so
+the contract can't drift.
+
+Tests: 7 MCP + 9 REST integration tests — default, persist, validation
+rejections (uppercase, dot, slash, reserved prefix, too long, empty),
+update branch, `if_missing=create` branch, GET filter (single + array).
+
+### feat(export): non-markdown content with sidecar metadata + .mdx as frontmatter-compatible (vault#328)
+
+`core/src/portable-md.ts:supportsInlineFrontmatter(ext)` predicate
+splits extensions into two buckets:
+
+- **Frontmatter-compatible** (`md`, `mdx`): metadata as inline YAML
+  frontmatter at top of content file. Today's behavior, extended to
+  `.mdx` (YAML frontmatter works in MDX identically — and Aaron's
+  planning to use MDX in some notes).
+- **Sidecar-required** (`csv`, `yaml`, `json`, anything else): metadata
+  in `.parachute/notes-meta/<note-id>.yaml`. Content file holds the
+  raw bytes — no frontmatter prepend.
+
+Export emits one sidecar per non-frontmatter-compat note; new
+`ExportStats.sidecars` counter pins the count. Sidecar path-traversal
+guard symmetric with the attachments path: the sidecar lives under
+`.parachute/notes-meta/`, period.
+
+Import builds a `(path, extension) → sidecar` index from the
+`.parachute/notes-meta/` directory at the top of the import pass.
+Walks every content file (not just `.md` — new `walkContentFiles`
+helper) and, for each, parses inline frontmatter (frontmatter-compat
+extensions) or looks up the sidecar (non-frontmatter-compat). Orphaned
+content files (no matching sidecar) are skipped with a warning rather
+than crashing.
+
+`toPortableMarkdown` now returns raw content for sidecar-required
+extensions (no synthetic `---` frontmatter prepend). New
+`toSidecarYaml` emits the metadata-only bytes for the sidecar.
+`portableExportFilePath` honors the note's `extension` (was hardcoded
+`.md`).
+
+**Wikilink ambiguity policy** (vault#328 edge case 3): when two notes
+share a path differing only by extension (`Foo.md` + `Foo.csv`),
+`[[Foo]]` is refused (returns null from `resolveWikilink`) and
+recorded as unresolved. `[[Foo.md]]` / `[[Foo.csv]]` resolve
+unambiguously to their respective notes via the new explicit-extension
+form. The extension-recognition pattern in the wikilink parser mirrors
+`EXTENSION_PATTERN` in `core/src/notes.ts` so the two share the same
+notion of "this looks like an extension."
+
+Frontmatter `extension` field is OMITTED for `md` (the default) so
+pre-vault#328 markdown-only exports produce byte-identical bytes
+before and after the upgrade. The sidecar always includes `extension`
+(the field is the sidecar's reason for existing).
+
+Tests: 10 new in `core/src/portable-md.test.ts` —
+`supportsInlineFrontmatter` true/false matrix, `toPortableMarkdown`
+extension awareness (md, mdx, csv), `toSidecarYaml` shape, full
+round-trip integration over csv/yaml/json/mdx/empty-content/.md
+(export → blow-away import → byte-equiv re-export), orphan-content-
+file rejection, wikilink ambiguity refuse + explicit-extension
+resolve.
+
 ## [0.4.4-rc.14] — 2026-05-15
 
 Round-trip import unblocker — vault#323. Aaron's real default vault

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -1682,6 +1682,91 @@ describe("MCP tools", async () => {
     expect(result[1].tags).toContain("doc");
   });
 
+  it("create-note accepts extension field (vault#328)", async () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    const result = await createNote.execute({
+      content: "month,income\n2026-01,12000",
+      path: "Tabular/budget",
+      extension: "csv",
+    }) as any;
+    expect(result.extension).toBe("csv");
+  });
+
+  it("create-note defaults extension to 'md' when omitted (vault#328)", async () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    const result = await createNote.execute({ content: "plain markdown" }) as any;
+    expect(result.extension).toBe("md");
+  });
+
+  it("create-note rejects invalid extension (uppercase, dot, reserved) (vault#328)", async () => {
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+    // Uppercase
+    expect(createNote.execute({ content: "x", extension: "CSV" })).rejects.toThrow(/invalid extension/);
+    // Dot
+    expect(createNote.execute({ content: "x", extension: "csv.bak" })).rejects.toThrow(/invalid extension/);
+    // Slash
+    expect(createNote.execute({ content: "x", extension: "foo/bar" })).rejects.toThrow(/invalid extension/);
+    // Reserved "parachute" prefix (lowercase — the pattern check passes,
+    // so the reserved-prefix guard is what fires).
+    expect(createNote.execute({ content: "x", extension: "parachute" })).rejects.toThrow(/reserved/);
+    expect(createNote.execute({ content: "x", extension: "parachutex" })).rejects.toThrow(/reserved/);
+    // Too long (>16)
+    expect(createNote.execute({ content: "x", extension: "a".repeat(17) })).rejects.toThrow(/invalid extension/);
+    // Empty
+    expect(createNote.execute({ content: "x", extension: "" })).rejects.toThrow(/non-empty/);
+  });
+
+  it("update-note changes extension (vault#328)", async () => {
+    const note = await store.createNote("hi", { path: "Foo" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = await updateNote.execute({ id: note.id, extension: "mdx", force: true }) as any;
+    expect(result.extension).toBe("mdx");
+  });
+
+  it("update-note validates extension on update branch (vault#328)", async () => {
+    const note = await store.createNote("hi", { path: "Foo" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    expect(
+      updateNote.execute({ id: note.id, extension: "BAD", force: true }),
+    ).rejects.toThrow(/invalid extension/);
+  });
+
+  it("update-note if_missing=create honors extension (vault#328)", async () => {
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = await updateNote.execute({
+      id: "Tabular/new-budget",
+      content: "month,total\n2026-02,9000",
+      extension: "csv",
+      if_missing: "create",
+    }) as any;
+    expect(result.created).toBe(true);
+    expect(result.extension).toBe("csv");
+  });
+
+  it("query-notes filters by extension (vault#328)", async () => {
+    await store.createNote("md note", { path: "a" });
+    await store.createNote("csv note", { path: "b", extension: "csv" });
+    await store.createNote("yaml note", { path: "c", extension: "yaml" });
+    const tools = generateMcpTools(store);
+    const queryNotes = tools.find((t) => t.name === "query-notes")!;
+
+    // Single extension
+    const csv = await queryNotes.execute({ extension: "csv", include_content: true }) as any[];
+    expect(csv).toHaveLength(1);
+    expect(csv[0].path).toBe("b");
+
+    // Array shape
+    const both = await queryNotes.execute({ extension: ["csv", "yaml"], include_content: true }) as any[];
+    expect(both).toHaveLength(2);
+    expect(both.map((n) => n.path).sort()).toEqual(["b", "c"]);
+  });
+
   it("create-note with links resolves targets by path", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -413,6 +413,20 @@ describe("notes.extension (vault#328)", async () => {
     const results = await store.queryNotes({ extension: "CSV" });
     expect(results).toHaveLength(1);
   });
+
+  it("updateNote extension-only collision throws PathConflictError (vault#329 F1)", async () => {
+    // Two notes share `Foo` differing only by extension — legal under
+    // v18's composite (path, extension) uniqueness. Flip the md note's
+    // extension to "csv": that would collide with the existing csv
+    // row. The catch in updateNote must surface PATH_CONFLICT (not a
+    // raw SQLiteError) since the composite index fires UNIQUE on
+    // extension-only updates just like it does on path-only updates.
+    const md = await store.createNote("# md note", { path: "Foo", id: "foo-md" });
+    await store.createNote("a,b\n1,2", { path: "Foo", extension: "csv", id: "foo-csv" });
+    expect(
+      store.updateNote(md.id, { extension: "csv" }),
+    ).rejects.toMatchObject({ code: "PATH_CONFLICT", path: "Foo" });
+  });
 });
 
 // ---- Tags ----

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -322,6 +322,99 @@ describe("updated_at backfill on init", async () => {
   });
 });
 
+// ---- Extension (vault#328 Phase 1: DB + Store) ----
+//
+// Three pinned behaviors:
+//   1. Migrations and inserts default to "md" — every existing row keeps
+//      its meaning after the v17 → v18 ALTER TABLE.
+//   2. Explicit extension on createNote persists end-to-end.
+//   3. queryNotes filters by extension (single string + array shapes).
+
+describe("notes.extension (vault#328)", async () => {
+  it("defaults to 'md' when not specified on createNote", async () => {
+    const note = await store.createNote("hello world");
+    expect(note.extension).toBe("md");
+    const fetched = await store.getNote(note.id);
+    expect(fetched!.extension).toBe("md");
+  });
+
+  it("persists explicit extension on createNote", async () => {
+    const note = await store.createNote("month,income\n2026-01,12000", {
+      path: "Tabular/budget",
+      extension: "csv",
+    });
+    expect(note.extension).toBe("csv");
+    const fetched = await store.getNote(note.id);
+    expect(fetched!.extension).toBe("csv");
+  });
+
+  it("backfills 'md' on existing rows after v17 → v18 migration", () => {
+    // Build a v17-shape vault by hand: create the notes table WITHOUT the
+    // `extension` column, insert a row, then run initSchema and assert
+    // the migration backfills "md".
+    const raw = new Database(":memory:");
+    raw.exec(`
+      CREATE TABLE notes (
+        id TEXT PRIMARY KEY,
+        content TEXT DEFAULT '',
+        path TEXT,
+        metadata TEXT DEFAULT '{}',
+        created_at TEXT NOT NULL,
+        updated_at TEXT
+      )
+    `);
+    raw.prepare(
+      "INSERT INTO notes (id, content, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    ).run("legacy", "old content", "2024-01-01T00:00:00.000Z", "2024-01-01T00:00:00.000Z");
+
+    initSchema(raw); // applies v18 ALTER TABLE
+
+    const row = raw.prepare("SELECT extension FROM notes WHERE id = ?").get("legacy") as {
+      extension: string;
+    };
+    expect(row.extension).toBe("md");
+  });
+
+  it("updateNote changes extension on existing note", async () => {
+    const note = await store.createNote("hello", { path: "Foo" });
+    expect(note.extension).toBe("md");
+    const updated = await store.updateNote(note.id, { extension: "mdx" });
+    expect(updated.extension).toBe("mdx");
+    const fetched = await store.getNote(note.id);
+    expect(fetched!.extension).toBe("mdx");
+  });
+
+  it("queryNotes filters by extension (single string)", async () => {
+    await store.createNote("md note A", { path: "a", extension: "md" });
+    await store.createNote("csv note", { path: "b", extension: "csv" });
+    await store.createNote("md note B", { path: "c" }); // default md
+    const csv = await store.queryNotes({ extension: "csv" });
+    expect(csv).toHaveLength(1);
+    expect(csv[0]!.path).toBe("b");
+    const md = await store.queryNotes({ extension: "md" });
+    expect(md).toHaveLength(2);
+    expect(md.map((n) => n.path).sort()).toEqual(["a", "c"]);
+  });
+
+  it("queryNotes filters by extension (array — IN clause)", async () => {
+    await store.createNote("md note", { path: "a" });
+    await store.createNote("csv note", { path: "b", extension: "csv" });
+    await store.createNote("yaml note", { path: "c", extension: "yaml" });
+    await store.createNote("json note", { path: "d", extension: "json" });
+    const results = await store.queryNotes({ extension: ["csv", "yaml", "json"] });
+    expect(results).toHaveLength(3);
+    const paths = results.map((n) => n.path).sort();
+    expect(paths).toEqual(["b", "c", "d"]);
+  });
+
+  it("queryNotes extension filter is case-insensitive", async () => {
+    await store.createNote("csv note", { path: "b", extension: "csv" });
+    // Caller-supplied case shouldn't matter — stored as "csv", looked up as "CSV".
+    const results = await store.queryNotes({ extension: "CSV" });
+    expect(results).toHaveLength(1);
+  });
+});
+
 // ---- Tags ----
 
 describe("tags", async () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import type { Store, Note } from "./types.js";
 import * as noteOps from "./notes.js";
-import { filterMetadata, MAX_BATCH_SIZE } from "./notes.js";
+import { filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "./notes.js";
 import * as linkOps from "./links.js";
 import * as tagSchemaOps from "./tag-schemas.js";
 import type { TagFieldSchema } from "./tag-schemas.js";
@@ -133,6 +133,13 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           has_links: { type: "boolean", description: "Presence filter: true = only notes with at least one inbound or outbound link; false = only orphaned notes (no links in either direction)." },
           path: { type: "string", description: "Exact path match (case-insensitive)" },
           path_prefix: { type: "string", description: "Path prefix match (e.g., 'Projects/')" },
+          extension: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+            description: "Filter by file extension (vault#328). Pass a single extension (e.g. \"csv\") or an array (e.g. [\"csv\", \"yaml\", \"json\"]). Notes default to \"md\"; case-insensitive match.",
+          },
           search: { type: "string", description: "Full-text search query" },
           metadata: {
             type: "object",
@@ -264,6 +271,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             hasLinks: params.has_links as boolean | undefined,
             path: params.path as string | undefined,
             pathPrefix: params.path_prefix as string | undefined,
+            extension: params.extension as string | string[] | undefined,
             // Push the near-scope into the SQL WHERE so that LIMIT and ORDER
             // BY apply to the neighborhood. Without this, queryNotes would
             // fetch the first `limit` notes by created_at and then post-
@@ -339,6 +347,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           // Single note fields
           content: { type: "string", description: "Note content (markdown). Wikilinks like [[Target]] auto-resolve." },
           path: { type: "string", description: "Note path (e.g., 'Projects/README')" },
+          extension: { type: "string", description: "File extension (vault#328). Default \"md\". Use \"csv\"/\"yaml\"/\"json\"/\"mdx\"/etc. for non-markdown notes. Lowercase alphanumeric, 1–16 chars; no '.' or '/'. The \"parachute\" prefix is reserved." },
           metadata: { type: "object", description: "Metadata fields" },
           tags: { type: "array", items: { type: "string" }, description: "Tags to apply" },
           links: {
@@ -362,6 +371,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               properties: {
                 content: { type: "string" },
                 path: { type: "string" },
+                extension: { type: "string", description: "File extension (vault#328). See top-level docs." },
                 metadata: { type: "object" },
                 tags: { type: "array", items: { type: "string" } },
                 links: { type: "array" },
@@ -392,11 +402,19 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         if (batched) db.exec("BEGIN");
         try {
           for (const item of items) {
+            // Validate extension up front (vault#328). Throwing here while
+            // we're inside the BEGIN block on a batch rolls back the
+            // transaction in the outer catch — the same behavior as a
+            // path conflict mid-batch.
+            const extension = item.extension !== undefined
+              ? validateExtension(item.extension)
+              : undefined;
             const note = await store.createNote(item.content as string ?? "", {
               path: item.path as string | undefined,
               tags: item.tags as string[] | undefined,
               metadata: item.metadata as Record<string, unknown> | undefined,
               created_at: item.created_at as string | undefined,
+              ...(extension !== undefined ? { extension } : {}),
             });
 
             // Create explicit links (not wikilinks — those are automatic)
@@ -467,6 +485,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             description: "Find-and-replace one occurrence. Errors if `old_text` is not found or matches multiple locations. Mutually exclusive with `content` and `append`/`prepend`.",
           },
           path: { type: "string", description: "New path" },
+          extension: { type: "string", description: "Change the note's file extension (vault#328). Allowed but caller-owned — you're responsible for content validity if you switch a non-empty note's extension. Lowercase alphanumeric, 1–16 chars; \"parachute\" prefix reserved." },
           metadata: { type: "object", description: "Metadata to merge (keys are merged, not replaced wholesale)" },
           created_at: { type: "string", description: "New created_at timestamp" },
           if_updated_at: { type: "string", description: "Optimistic concurrency check: the updated_at value you last read. Rejects with a conflict error if the note has been modified since. Required unless `force: true` is set or the call is `append`/`prepend`-only." },
@@ -531,6 +550,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
                   required: ["old_text", "new_text"],
                 },
                 path: { type: "string" },
+                extension: { type: "string", description: "Change the note's file extension (vault#328). See top-level docs." },
                 metadata: { type: "object" },
                 created_at: { type: "string" },
                 if_updated_at: { type: "string", description: "Optimistic concurrency check for this item; rejects with a conflict error if the note has been modified since. Required unless `force: true` is set on this item or the item is `append`/`prepend`-only." },
@@ -617,6 +637,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               // caller's intent.
               const idLooksLikePath = idOrPath.includes("/") || !/^[A-Za-z0-9_-]+$/.test(idOrPath);
               const explicitPath = typeof item.path === "string" ? item.path as string : undefined;
+              // Validate extension before reaching the Store — same
+              // contract as the create-note tool.
+              const createExt = item.extension !== undefined
+                ? validateExtension(item.extension)
+                : undefined;
               const createOpts: Parameters<Store["createNote"]>[1] = {
                 ...(idLooksLikePath ? { path: explicitPath ?? idOrPath } : { id: idOrPath, ...(explicitPath !== undefined ? { path: explicitPath } : {}) }),
                 ...(item.tags && Array.isArray((item.tags as any).add)
@@ -626,6 +651,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
                     : {}),
                 ...(item.metadata !== undefined ? { metadata: item.metadata as Record<string, unknown> } : {}),
                 ...(item.created_at !== undefined ? { created_at: item.created_at as string } : {}),
+                ...(createExt !== undefined ? { extension: createExt } : {}),
               };
               const content = (item.content as string | undefined) ?? "";
               const created = await store.createNote(content, createOpts);
@@ -755,6 +781,9 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             if (item.prepend !== undefined) updates.prepend = item.prepend;
           }
           if (item.path !== undefined) updates.path = item.path;
+          if (item.extension !== undefined) {
+            updates.extension = validateExtension(item.extension);
+          }
           if (item.metadata !== undefined) {
             // Merge metadata (don't replace wholesale)
             const existing = (note.metadata as Record<string, unknown>) ?? {};

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -29,12 +29,16 @@ export function generateId(): string {
 export function createNote(
   db: Database,
   content: string,
-  opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string },
+  opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string; extension?: string },
 ): Note {
   const id = opts?.id ?? generateId();
   const createdAt = opts?.created_at ?? new Date().toISOString();
   const metadata = opts?.metadata ? JSON.stringify(opts.metadata) : "{}";
   const path = normalizePath(opts?.path);
+  // `extension` defaults to "md" so existing callers see no change.
+  // Validation happens at the API surface (MCP/REST) — the Store accepts
+  // whatever the caller passed; importer paths trust the export's shape.
+  const extension = opts?.extension ?? "md";
 
   // Empty content is a valid state (vault#323): skeleton notes, drafts
   // saved before content, organizing-only notes, capture-then-fill flows.
@@ -50,8 +54,8 @@ export function createNote(
   // "user-touched since creation."
   try {
     db.prepare(
-      `INSERT INTO notes (id, content, path, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
-    ).run(id, content, path, metadata, createdAt, createdAt);
+      `INSERT INTO notes (id, content, path, metadata, created_at, updated_at, extension) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(id, content, path, metadata, createdAt, createdAt, extension);
   } catch (err) {
     if (path !== null && isPathUniqueError(err)) {
       throw new PathConflictError(path);
@@ -182,6 +186,7 @@ export function updateNote(
      */
     prepend?: string;
     path?: string;
+    extension?: string;
     metadata?: Record<string, unknown>;
     created_at?: string;
     skipUpdatedAt?: boolean;
@@ -259,6 +264,14 @@ export function updateNote(
   if (updates.path !== undefined) {
     sets.push("path = ?");
     values.push(normalizePath(updates.path));
+  }
+  if (updates.extension !== undefined) {
+    // Allowed but documented as caller-owned (vault#328 edge case 1):
+    // the Store accepts whatever the API surface validated, including
+    // changing extension on a non-empty note. The caller is responsible
+    // for content validity post-change.
+    sets.push("extension = ?");
+    values.push(updates.extension);
   }
   if (updates.metadata !== undefined) {
     sets.push("metadata = ?");
@@ -422,6 +435,26 @@ export function queryNotes(db: Database, opts: QueryOpts): Note[] {
   if (opts.pathPrefix) {
     conditions.push("n.path LIKE ?");
     params.push(opts.pathPrefix + "%");
+  }
+
+  // Extension filter (vault#328). Single string → exact match; array → IN
+  // clause. Compared lower-case so a caller passing "CSV" still hits rows
+  // stored as "csv". An empty array is a no-op (no filter applied) rather
+  // than a "no rows match" short-circuit — matches the spirit of the
+  // existing `tags: []` behavior.
+  if (opts.extension !== undefined) {
+    const exts = Array.isArray(opts.extension) ? opts.extension : [opts.extension];
+    const cleaned = exts
+      .filter((e): e is string => typeof e === "string" && e.length > 0)
+      .map((e) => e.toLowerCase());
+    if (cleaned.length === 1) {
+      conditions.push("LOWER(n.extension) = ?");
+      params.push(cleaned[0]!);
+    } else if (cleaned.length > 1) {
+      const placeholders = cleaned.map(() => "?").join(", ");
+      conditions.push(`LOWER(n.extension) IN (${placeholders})`);
+      params.push(...cleaned);
+    }
   }
 
   // Metadata filters — operator objects route through the indexed generated
@@ -1122,6 +1155,7 @@ export function toNoteIndex(note: Note): NoteIndex {
   return {
     id: note.id,
     path: note.path,
+    extension: note.extension,
     createdAt: note.createdAt,
     updatedAt: note.updatedAt,
     tags: note.tags,
@@ -1229,6 +1263,7 @@ export interface BulkNoteInput {
   tags?: string[];
   metadata?: Record<string, unknown>;
   created_at?: string;
+  extension?: string;
 }
 
 export function createNotes(db: Database, inputs: BulkNoteInput[]): Note[] {
@@ -1244,6 +1279,7 @@ export function createNotes(db: Database, inputs: BulkNoteInput[]): Note[] {
           tags: input.tags,
           metadata: input.metadata,
           created_at: input.created_at,
+          extension: input.extension,
         }),
       );
     }
@@ -1311,6 +1347,7 @@ interface NoteRow {
   metadata: string | null;
   created_at: string;
   updated_at: string | null;
+  extension: string | null;
 }
 
 function rowToNote(row: NoteRow): Note {
@@ -1322,6 +1359,10 @@ function rowToNote(row: NoteRow): Note {
     id: row.id,
     content: row.content,
     path: row.path ?? undefined,
+    // `extension` is NOT NULL DEFAULT 'md' in v18+, but rows under a v17
+    // migration window might briefly read as NULL. Fall back to "md" so
+    // callers never see a missing extension.
+    extension: row.extension ?? "md",
     metadata,
     createdAt: row.created_at,
     // Legacy notes (pre-#70) may have NULL updated_at. Fall back to created_at

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -218,10 +218,11 @@ export function validateExtension(extension: unknown): string {
 }
 
 /**
- * Match bun:sqlite's UNIQUE-constraint error on the notes.path index. The
- * error class is `SQLiteError` but matching on the message is sufficient
- * here — the index name and column are stable parts of the schema, and
- * bun:sqlite has carried this exact message text since 1.0.
+ * Match bun:sqlite's UNIQUE-constraint error on the notes path index.
+ * Post-vault#328 the unique index is composite `(path, extension)`, so
+ * the message text is "UNIQUE constraint failed: notes.path,
+ * notes.extension". Pre-v18 (legacy `(path)` index) emitted just
+ * "notes.path". Match on the common prefix to cover both.
  */
 function isPathUniqueError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -157,6 +157,67 @@ export class PathConflictError extends Error {
 export const MAX_BATCH_SIZE = 500;
 
 /**
+ * Validate a caller-supplied file extension (vault#328). Rules:
+ *   1. Non-empty, lowercase alphanumeric only.
+ *   2. Length 1–16 — long enough for "markdown" etc., short enough to
+ *      bound on-disk filename length.
+ *   3. No dot/slash/uppercase — those would create path-encoding
+ *      ambiguity or collide with filesystem separators.
+ *   4. Reserved: anything matching /^parachute/i is refused because the
+ *      `.parachute/` sidecar dir convention owns that namespace; a note
+ *      with extension `parachute` would write to `<path>.parachute`
+ *      which is ambiguous with a directory entry.
+ *
+ * Throws `ExtensionValidationError` on failure. Both MCP and REST
+ * surfaces import this so the contract can never drift between them.
+ */
+export const EXTENSION_PATTERN = /^[a-z0-9]{1,16}$/;
+
+export class ExtensionValidationError extends Error {
+  code = "INVALID_EXTENSION" as const;
+  extension: string;
+  reason: string;
+
+  constructor(extension: string, reason: string) {
+    super(`invalid extension "${extension}": ${reason}`);
+    this.name = "ExtensionValidationError";
+    this.extension = extension;
+    this.reason = reason;
+  }
+}
+
+export function validateExtension(extension: unknown): string {
+  if (typeof extension !== "string") {
+    throw new ExtensionValidationError(
+      String(extension),
+      `must be a string (got ${typeof extension})`,
+    );
+  }
+  if (extension.length === 0) {
+    throw new ExtensionValidationError(
+      extension,
+      "must be non-empty; omit the field entirely to default to 'md'",
+    );
+  }
+  if (!EXTENSION_PATTERN.test(extension)) {
+    throw new ExtensionValidationError(
+      extension,
+      `must match ${EXTENSION_PATTERN.source} (lowercase alphanumeric, 1–16 chars; no '.', '/', or uppercase)`,
+    );
+  }
+  // Reserved namespace: anything that starts with "parachute" collides
+  // with the .parachute/ sidecar directory convention. The pattern check
+  // above already enforces lowercase, so a literal prefix match is exact.
+  if (extension.startsWith("parachute")) {
+    throw new ExtensionValidationError(
+      extension,
+      "the 'parachute' prefix is reserved for the .parachute/ sidecar dir",
+    );
+  }
+  return extension;
+}
+
+/**
  * Match bun:sqlite's UNIQUE-constraint error on the notes.path index. The
  * error class is `SQLiteError` but matching on the message is sufficient
  * here — the index name and column are stable parts of the schema, and

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -380,8 +380,14 @@ export function updateNote(
       db.prepare(sql).run(...values);
     }
   } catch (err) {
-    if (updates.path !== undefined && isPathUniqueError(err)) {
-      throw new PathConflictError(normalizePath(updates.path) ?? updates.path);
+    // Post-vault#328 the unique index is composite (path, extension), so
+    // an extension-only update can also trip UNIQUE — widen the catch to
+    // surface those as structured PATH_CONFLICT instead of a raw 500.
+    if (isPathUniqueError(err)) {
+      const conflictPath = updates.path !== undefined
+        ? (normalizePath(updates.path) ?? updates.path)
+        : ((db.prepare("SELECT path FROM notes WHERE id = ?").get(id) as { path: string | null } | undefined)?.path ?? "<unknown>");
+      throw new PathConflictError(conflictPath);
     }
     throw err;
   }

--- a/core/src/portable-md.test.ts
+++ b/core/src/portable-md.test.ts
@@ -297,6 +297,25 @@ describe("portableExportFilePath", () => {
       id: "01HABC", content: "", created_at: "2026-05-12T00:00:00.000Z",
     })).toBe("_unpathed/01HABC.md");
   });
+
+  it("honors the note's extension for pathless notes (vault#329 F4)", () => {
+    expect(portableExportFilePath({
+      id: "01HXCSV",
+      content: "a,b\n1,2",
+      created_at: "2026-05-12T00:00:00.000Z",
+      extension: "csv",
+    })).toBe("_unpathed/01HXCSV.csv");
+  });
+
+  it("honors the note's extension for pathed notes (vault#329 F4)", () => {
+    expect(portableExportFilePath({
+      id: "x",
+      content: "",
+      created_at: "2026-05-12T00:00:00.000Z",
+      path: "Inbox/y",
+      extension: "mdx",
+    })).toBe("Inbox/y.mdx");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/core/src/portable-md.test.ts
+++ b/core/src/portable-md.test.ts
@@ -32,7 +32,10 @@ import {
   parseFrontmatter,
   portableExportFilePath,
   SIDECAR_DIR,
+  NOTES_META_DIR,
+  supportsInlineFrontmatter,
   toPortableMarkdown,
+  toSidecarYaml,
   type PortableNote,
 } from "./portable-md.js";
 
@@ -1019,5 +1022,299 @@ note body
     // — must NOT exist. Most importantly NOT at a path higher than destAssets.
     const wouldBeEscape = join(tmpBase, "escape.bin");
     expect(existsSync(wouldBeEscape)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File-extension support — non-markdown notes (vault#328)
+// ---------------------------------------------------------------------------
+//
+// Two pinned behaviors per the design issue:
+//   1. supportsInlineFrontmatter: md + mdx return true; everything else
+//      returns false.
+//   2. Round-trip integration: vault containing csv/yaml/json/mdx/empty
+//      notes survives export → blow-away import → re-export byte-equiv.
+
+describe("supportsInlineFrontmatter (vault#328)", () => {
+  it("returns true for md and mdx", () => {
+    expect(supportsInlineFrontmatter("md")).toBe(true);
+    expect(supportsInlineFrontmatter("mdx")).toBe(true);
+    // Case-insensitive — guard against caller-supplied 'MD'.
+    expect(supportsInlineFrontmatter("MD")).toBe(true);
+  });
+
+  it("returns false for sidecar-required formats", () => {
+    expect(supportsInlineFrontmatter("csv")).toBe(false);
+    expect(supportsInlineFrontmatter("yaml")).toBe(false);
+    expect(supportsInlineFrontmatter("json")).toBe(false);
+    expect(supportsInlineFrontmatter("txt")).toBe(false);
+    expect(supportsInlineFrontmatter("org")).toBe(false); // not yet in the set
+  });
+});
+
+describe("toPortableMarkdown — extension awareness (vault#328)", () => {
+  it(".md note still gets inline frontmatter", () => {
+    const out = toPortableMarkdown({
+      id: "1",
+      path: "Inbox/a",
+      extension: "md",
+      content: "hello\n",
+      created_at: "2026-05-15T00:00:00.000Z",
+    });
+    expect(out.startsWith("---\n")).toBe(true);
+    expect(out).toContain("id: '1'");
+    expect(out).toContain("hello");
+  });
+
+  it(".mdx note also gets inline frontmatter", () => {
+    const out = toPortableMarkdown({
+      id: "1",
+      path: "Components/Card",
+      extension: "mdx",
+      content: "import X from './x';\n\n<X/>\n",
+      created_at: "2026-05-15T00:00:00.000Z",
+    });
+    expect(out.startsWith("---\n")).toBe(true);
+    expect(out).toContain("extension: mdx");
+  });
+
+  it(".csv note returns raw content — no frontmatter prepend", () => {
+    const out = toPortableMarkdown({
+      id: "1",
+      path: "Tabular/budget",
+      extension: "csv",
+      content: "month,total\n2026-01,9000\n",
+      created_at: "2026-05-15T00:00:00.000Z",
+    });
+    expect(out.startsWith("---\n")).toBe(false);
+    expect(out).toBe("month,total\n2026-01,9000\n");
+  });
+
+  it("toSidecarYaml emits the same key set as inline frontmatter, always includes extension", () => {
+    const sidecar = toSidecarYaml({
+      id: "abc",
+      path: "Tabular/budget",
+      extension: "csv",
+      tags: ["budget"],
+      content: "irrelevant — sidecar carries metadata only",
+      metadata: { fiscal_year: 2026 },
+      created_at: "2026-05-15T00:00:00.000Z",
+      updated_at: "2026-05-15T00:00:00.000Z",
+    });
+    expect(sidecar).toContain("id: abc");
+    expect(sidecar).toContain("path: Tabular/budget");
+    expect(sidecar).toContain("extension: csv");
+    expect(sidecar).toContain("tags:");
+    expect(sidecar).toContain("budget");
+    expect(sidecar).toContain("fiscal_year");
+  });
+});
+
+describe("portable-md non-markdown round-trip (vault#328)", async () => {
+  const tmpBase = join(tmpdir(), "parachute-portable-ext");
+  let store: SqliteStore;
+
+  beforeEach(() => {
+    try { rmSync(tmpBase, { recursive: true }); } catch {}
+    mkdirSync(tmpBase, { recursive: true });
+    store = new SqliteStore(new Database(":memory:"));
+  });
+
+  it("csv/yaml/json/mdx/empty notes survive export → blow-away import → byte-equivalent re-export", async () => {
+    // Seed a vault that hits every extension axis the brief calls out:
+    //   - .csv (sidecar-required, non-empty)
+    //   - .yaml (sidecar-required, non-empty)
+    //   - .json (sidecar-required, non-empty)
+    //   - .mdx (frontmatter-compatible, non-empty)
+    //   - .csv empty-content (the vault#323 edge case, vault#328 sidecar path)
+    //   - .md (back-compat baseline — same shape as pre-vault#328)
+    await store.createNote("month,total\n2026-01,9000\n", {
+      id: "csv-1",
+      path: "Tabular/budget",
+      extension: "csv",
+      tags: ["budget"],
+      metadata: { fiscal_year: 2026, currency: "USD" },
+    });
+    await store.createNote("- one\n- two\n", {
+      id: "yaml-1",
+      path: "Config/options",
+      extension: "yaml",
+    });
+    await store.createNote(`{"k":1}\n`, {
+      id: "json-1",
+      path: "Data/sample",
+      extension: "json",
+    });
+    await store.createNote("import X from './x';\n\n<X/>\n", {
+      id: "mdx-1",
+      path: "Components/Card",
+      extension: "mdx",
+      tags: ["component"],
+    });
+    await store.createNote("", {
+      id: "csv-empty",
+      path: "Tabular/skeleton",
+      extension: "csv",
+    });
+    await store.createNote("plain markdown body\n", {
+      id: "md-1",
+      path: "Inbox/note",
+      tags: ["inbox"],
+    });
+
+    // Export A.
+    const outA = join(tmpBase, "outA");
+    const statsA = await exportVaultToDir(store, {
+      outDir: outA,
+      vaultName: "test",
+      exportedAt: "2026-05-15T00:00:00.000Z",
+    });
+    expect(statsA.notes).toBe(6);
+    // Four sidecar-required notes (csv ×2, yaml, json) → four sidecars.
+    // md + mdx carry frontmatter inline so they don't get sidecars.
+    expect(statsA.sidecars).toBe(4);
+
+    // Sidecar files exist with the right basenames (note ids).
+    const sidecarDir = join(outA, SIDECAR_DIR, NOTES_META_DIR);
+    expect(readdirSync(sidecarDir).sort()).toEqual([
+      "csv-1.yaml",
+      "csv-empty.yaml",
+      "json-1.yaml",
+      "yaml-1.yaml",
+    ]);
+
+    // Content files at the user-visible paths with the right suffixes.
+    expect(existsSync(join(outA, "Tabular/budget.csv"))).toBe(true);
+    expect(existsSync(join(outA, "Config/options.yaml"))).toBe(true);
+    expect(existsSync(join(outA, "Data/sample.json"))).toBe(true);
+    expect(existsSync(join(outA, "Components/Card.mdx"))).toBe(true);
+    expect(existsSync(join(outA, "Tabular/skeleton.csv"))).toBe(true);
+    expect(existsSync(join(outA, "Inbox/note.md"))).toBe(true);
+
+    // .csv content is RAW — no `---` frontmatter prepend.
+    const csvFile = readFileSync(join(outA, "Tabular/budget.csv"), "utf-8");
+    expect(csvFile.startsWith("---")).toBe(false);
+    expect(csvFile).toBe("month,total\n2026-01,9000\n");
+
+    // .mdx content has inline frontmatter (same as .md).
+    const mdxFile = readFileSync(join(outA, "Components/Card.mdx"), "utf-8");
+    expect(mdxFile.startsWith("---\n")).toBe(true);
+    expect(mdxFile).toContain("extension: mdx");
+
+    // Blow-away import into a fresh store.
+    const restored = new SqliteStore(new Database(":memory:"));
+    const importStats = await importPortableVault(restored, { inDir: outA, blowAway: true });
+    expect(importStats.notes_created).toBe(6);
+
+    // Verify each note round-tripped its content + extension.
+    const csvRestored = await restored.getNote("csv-1");
+    expect(csvRestored).not.toBeNull();
+    expect(csvRestored!.content).toBe("month,total\n2026-01,9000\n");
+    expect(csvRestored!.extension).toBe("csv");
+    expect(csvRestored!.metadata).toEqual({ fiscal_year: 2026, currency: "USD" });
+    expect(csvRestored!.tags).toContain("budget");
+
+    const emptyCsv = await restored.getNote("csv-empty");
+    expect(emptyCsv!.content).toBe("");
+    expect(emptyCsv!.extension).toBe("csv");
+    expect(emptyCsv!.path).toBe("Tabular/skeleton");
+
+    const mdxRestored = await restored.getNote("mdx-1");
+    expect(mdxRestored!.extension).toBe("mdx");
+    expect(mdxRestored!.content).toBe("import X from './x';\n\n<X/>\n");
+
+    const mdRestored = await restored.getNote("md-1");
+    expect(mdRestored!.extension).toBe("md");
+    expect(mdRestored!.tags).toContain("inbox");
+
+    // Re-export B from the restored store.
+    const outB = join(tmpBase, "outB");
+    await exportVaultToDir(restored, {
+      outDir: outB,
+      vaultName: "test",
+      exportedAt: "2026-05-15T00:00:00.000Z",
+    });
+
+    // Byte-equivalence — every file in outA matches outB.
+    const compareTree = (a: string, b: string, prefix = "") => {
+      const aEntries = readdirSync(a).sort();
+      const bEntries = readdirSync(b).sort();
+      expect(bEntries).toEqual(aEntries);
+      for (const entry of aEntries) {
+        const aPath = join(a, entry);
+        const bPath = join(b, entry);
+        const aStat = statSync(aPath);
+        const bStat = statSync(bPath);
+        expect(bStat.isDirectory()).toBe(aStat.isDirectory());
+        if (aStat.isDirectory()) {
+          compareTree(aPath, bPath, prefix + entry + "/");
+        } else {
+          const aBuf = readFileSync(aPath, "utf-8");
+          const bBuf = readFileSync(bPath, "utf-8");
+          if (aBuf !== bBuf) {
+            // eslint-disable-next-line no-console
+            console.error(`drift at ${prefix}${entry}:\n--- outA ---\n${aBuf}\n--- outB ---\n${bBuf}`);
+          }
+          expect(bBuf).toBe(aBuf);
+        }
+      }
+    };
+    compareTree(outA, outB);
+  });
+
+  it("import refuses content files lacking a sidecar (orphaned non-md file)", async () => {
+    // Build a minimal portable-md directory by hand: a valid vault.yaml
+    // + a .csv content file with NO matching sidecar. The importer
+    // should skip the orphaned file rather than crashing or creating
+    // a sidecar-less note.
+    const outDir = join(tmpBase, "orphan");
+    mkdirSync(join(outDir, SIDECAR_DIR), { recursive: true });
+    writeFileSync(
+      join(outDir, SIDECAR_DIR, "vault.yaml"),
+      "export_format_version: 1\nexported_at: '2026-05-15T00:00:00.000Z'\n",
+    );
+    mkdirSync(join(outDir, "Tabular"), { recursive: true });
+    writeFileSync(join(outDir, "Tabular/orphan.csv"), "a,b\n1,2\n");
+
+    const restored = new SqliteStore(new Database(":memory:"));
+    const stats = await importPortableVault(restored, { inDir: outDir });
+    // No sidecar → no DB row.
+    expect(stats.notes_created).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wikilink ambiguity policy (vault#328)
+// ---------------------------------------------------------------------------
+//
+// When two notes share a path differing only by extension (e.g. `Foo.md`
+// and `Foo.csv`), `[[Foo]]` is ambiguous. The resolver must:
+//   - refuse to resolve the bare form and record it as unresolved
+//   - resolve `[[Foo.md]]` and `[[Foo.csv]]` to their respective notes
+
+describe("wikilink ambiguity across extensions (vault#328)", async () => {
+  it("refuses ambiguous bare-form wikilinks when path collides on extension", async () => {
+    const store = new SqliteStore(new Database(":memory:"));
+    const md = await store.createNote("# MD note", { path: "Foo", id: "foo-md" });
+    const csv = await store.createNote("a,b\n1,2", { path: "Foo", extension: "csv", id: "foo-csv" });
+    // Sanity — both rows landed under the composite uniqueness key.
+    expect(md.path).toBe("Foo");
+    expect(csv.path).toBe("Foo");
+
+    // A third note linking to bare `[[Foo]]` should be UNRESOLVED.
+    await store.createNote("see [[Foo]]", { id: "linker", path: "Linker" });
+    const outboundLinks = await store.getLinks("linker", { direction: "outbound" });
+    expect(outboundLinks).toHaveLength(0);
+  });
+
+  it("resolves explicit-extension wikilinks unambiguously", async () => {
+    const store = new SqliteStore(new Database(":memory:"));
+    await store.createNote("# MD note", { path: "Foo", id: "foo-md" });
+    await store.createNote("a,b\n1,2", { path: "Foo", extension: "csv", id: "foo-csv" });
+
+    await store.createNote("see [[Foo.csv]]", { id: "linker", path: "Linker" });
+    const outbound = await store.getLinks("linker", { direction: "outbound" });
+    expect(outbound).toHaveLength(1);
+    expect(outbound[0]!.targetId).toBe("foo-csv");
   });
 });

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -90,11 +90,42 @@ export const EXPORT_FORMAT_VERSION = 1;
  *  as notes; consumers like Logseq/Foam/Quartz don't see the sidecar. */
 export const SIDECAR_DIR = ".parachute";
 
+/**
+ * Subdirectory under the sidecar where per-note metadata sidecars live
+ * for non-frontmatter-compatible extensions (vault#328). One YAML file
+ * per note, keyed by note id: `.parachute/notes-meta/<note-id>.yaml`.
+ * Mirrors the inline-frontmatter shape so the parser can chew either.
+ */
+export const NOTES_META_DIR = "notes-meta";
+
+/**
+ * Extensions whose serialized form carries metadata as inline YAML
+ * frontmatter at the top of the content file. `.md` is the canonical
+ * case; `.mdx` joins it because MDX's parser accepts the same `---`
+ * delimited preamble (and Aaron's planning to use MDX in notes).
+ * Anything else is sidecar-required — see `core/src/portable-md.ts`
+ * write/read paths.
+ *
+ * Easy to extend later — e.g. `.org` if/when a real workflow demands
+ * it. Today's set is conservative: only formats whose parser semantics
+ * we've explicitly validated.
+ */
+const FRONTMATTER_COMPAT_EXTENSIONS = new Set(["md", "mdx"]);
+
+export function supportsInlineFrontmatter(extension: string): boolean {
+  return FRONTMATTER_COMPAT_EXTENSIONS.has(extension.toLowerCase());
+}
+
 /** Order in which top-level frontmatter keys are emitted. Fixed — required
- *  for byte-identical re-exports of unchanged vault state. */
+ *  for byte-identical re-exports of unchanged vault state. `extension` is
+ *  emitted right after `path` so the suffix story sits with the
+ *  filesystem-location story; emitted only when non-default ("md"
+ *  doesn't get a frontmatter line so the existing `.md`-only corpus
+ *  diffs cleanly against pre-vault#328 exports). */
 const FRONTMATTER_KEY_ORDER = [
   "id",
   "path",
+  "extension",
   "tags",
   "metadata",
   "links",
@@ -107,11 +138,20 @@ const FRONTMATTER_KEY_ORDER = [
 // Types
 // ---------------------------------------------------------------------------
 
-/** Per-note shape written into one .md file (frontmatter + content). */
+/** Per-note shape written into one file (frontmatter + content for
+ *  `.md`/`.mdx`; raw content + sidecar metadata for everything else). */
 export interface PortableNote {
   id: string;
   path?: string;
   content: string;
+  /**
+   * File extension (vault#328). Defaults to "md" when omitted —
+   * back-compat with PR1/PR2 exports that predate the extension axis.
+   * Controls both the file suffix on disk AND whether metadata goes
+   * inline as frontmatter (`md`, `mdx`) or in a sidecar
+   * (`csv`/`yaml`/`json`/etc).
+   */
+  extension?: string;
   metadata?: Record<string, unknown>;
   tags?: string[];
   links?: PortableLink[];
@@ -152,6 +192,13 @@ export interface ExportStats {
   notes: number;
   schemas: number;
   attachments: number;
+  /**
+   * Per-note metadata sidecars written for non-frontmatter-compatible
+   * extensions (vault#328). For `.md`/`.mdx` notes this stays 0 —
+   * metadata is inline. For `.csv`/`.yaml`/`.json` notes, one sidecar
+   * per note.
+   */
+  sidecars: number;
   /** Set when caller passed `since`; counts notes whose `updated_at >= since`. */
   filtered_by_since: boolean;
   /**
@@ -356,6 +403,9 @@ function buildFrontmatter(note: PortableNote): Record<string, unknown> {
   const fm: Record<string, unknown> = {};
   fm.id = note.id;
   if (note.path) fm.path = note.path;
+  // Emit only when non-default ("md") so legacy markdown-only exports
+  // produce byte-identical bytes pre- and post-vault#328.
+  if (note.extension && note.extension !== "md") fm.extension = note.extension;
   if (note.tags && note.tags.length > 0) fm.tags = [...note.tags].sort();
   if (note.metadata && Object.keys(note.metadata).length > 0) fm.metadata = note.metadata;
   if (note.links && note.links.length > 0) fm.links = note.links;
@@ -366,11 +416,29 @@ function buildFrontmatter(note: PortableNote): Record<string, unknown> {
 }
 
 /**
- * Render a note as portable markdown: `--- <frontmatter> --- <content>`.
- * Frontmatter keys in `FRONTMATTER_KEY_ORDER`; nested objects alpha-sorted.
- * Trailing newline preserved from `content` (or one is added if absent).
+ * Render a note's content-file bytes. Behavior depends on the note's
+ * `extension`:
+ *
+ *   - Frontmatter-compatible (`.md`, `.mdx`): emits `--- <frontmatter>
+ *     --- <content>`. Today's behavior, generalized to also handle MDX.
+ *   - Sidecar-required (`.csv`, `.yaml`, `.json`, etc.): emits the
+ *     raw content as-is (no frontmatter prepend). The metadata lives in
+ *     `.parachute/notes-meta/<id>.yaml`; see `toSidecarYaml`.
+ *
+ * Trailing-newline: frontmatter form always ends with `\n`. Raw content
+ * form is returned verbatim — if the note's content has no trailing
+ * newline, the file ends without one. Callers wanting strict
+ * trailing-newline normalization (re-emit invariant) should add it
+ * outside this function.
  */
 export function toPortableMarkdown(note: PortableNote): string {
+  const ext = note.extension ?? "md";
+  if (!supportsInlineFrontmatter(ext)) {
+    // Sidecar-required: content goes out as-is. No frontmatter, no
+    // synthetic trailing newline — the file is whatever the caller
+    // stored as `content`.
+    return note.content;
+  }
   const fm = buildFrontmatter(note);
   let out = "---\n";
   for (const key of FRONTMATTER_KEY_ORDER) {
@@ -393,13 +461,59 @@ export function toPortableMarkdown(note: PortableNote): string {
 }
 
 /**
+ * Render a note's sidecar metadata bytes (vault#328). Same key set as
+ * the inline frontmatter — just lifted out of the content file. Used
+ * for sidecar-required extensions (`.csv`/`.yaml`/`.json`/etc.) where
+ * the content file can't host YAML. Order of keys is fixed
+ * (`FRONTMATTER_KEY_ORDER`) so the sidecar bytes are byte-identical
+ * across re-exports of unchanged vault state.
+ *
+ * Always includes the `extension` field (unlike `buildFrontmatter`,
+ * which omits it for `md` to keep legacy diffs clean) — the sidecar is
+ * a new artifact, the omit-default optimization buys nothing.
+ */
+export function toSidecarYaml(note: PortableNote): string {
+  // Build a "full" frontmatter — same as buildFrontmatter, but always
+  // emit the extension. The sidecar's purpose is exactly to record
+  // the extension that's not in the filename.
+  const fm: Record<string, unknown> = {};
+  fm.id = note.id;
+  if (note.path) fm.path = note.path;
+  fm.extension = note.extension ?? "md";
+  if (note.tags && note.tags.length > 0) fm.tags = [...note.tags].sort();
+  if (note.metadata && Object.keys(note.metadata).length > 0) fm.metadata = note.metadata;
+  if (note.links && note.links.length > 0) fm.links = note.links;
+  if (note.attachments && note.attachments.length > 0) fm.attachments = note.attachments;
+  fm.created_at = note.created_at;
+  if (note.updated_at) fm.updated_at = note.updated_at;
+
+  let out = "";
+  for (const key of FRONTMATTER_KEY_ORDER) {
+    if (!(key in fm)) continue;
+    const value = fm[key];
+    const inline = emitValueInline(value, 1);
+    if (inline !== null) {
+      out += `${key}: ${inline}\n`;
+    } else {
+      out += `${key}:\n`;
+      const block = emitValueBlock(value, 1);
+      if (block !== null) out += `${block}\n`;
+    }
+  }
+  return out;
+}
+
+/**
  * Determine the file path for an exported portable-md note. Notes with a
- * `path` use it; pathless notes use `_unpathed/<id>.md` (no date-prefix
- * coincidence with user content).
+ * `path` use it + their `extension`; pathless notes use
+ * `_unpathed/<id>.<extension>` (no date-prefix coincidence with user
+ * content). Default extension is "md" so pre-vault#328 exports produce
+ * the same filenames.
  */
 export function portableExportFilePath(note: PortableNote): string {
-  if (note.path) return note.path + ".md";
-  return `_unpathed/${note.id}.md`;
+  const ext = note.extension ?? "md";
+  if (note.path) return `${note.path}.${ext}`;
+  return `_unpathed/${note.id}.${ext}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -440,10 +554,16 @@ export async function noteToPortable(
     }))
     .sort((a, b) => a.id.localeCompare(b.id));
 
+  // Default to "md" so old PR1/PR2 callers (or callers that didn't get
+  // the v18 column from a fresh-DB read) keep producing identical
+  // frontmatter shape.
+  const extension = note.extension ?? "md";
+
   const result: PortableNote = {
     id: note.id,
     ...(note.path ? { path: note.path } : {}),
     content: note.content,
+    ...(extension ? { extension } : {}),
     ...(note.metadata && Object.keys(note.metadata).length > 0 ? { metadata: note.metadata } : {}),
     ...(note.tags && note.tags.length > 0 ? { tags: [...note.tags].sort() } : {}),
     ...(typedLinks.length > 0 ? { links: typedLinks } : {}),
@@ -556,8 +676,11 @@ export async function exportVaultToDir(
   const assetsDirResolved = opts.assetsDir ? resolvePath(opts.assetsDir) : undefined;
   const attachmentsRoot = join(sidecar, "attachments");
   const attachmentsRootResolved = resolvePath(attachmentsRoot);
+  const notesMetaRoot = join(sidecar, NOTES_META_DIR);
+  const notesMetaRootResolved = resolvePath(notesMetaRoot);
   let notesWritten = 0;
   let attachmentsWritten = 0;
+  let sidecarsWritten = 0;
   const skipped: { path: string | undefined; reason: string }[] = [];
   const skippedAttachments: { note_id: string; attachment_id: string; path: string; reason: string }[] = [];
   for (const note of allNotes) {
@@ -582,6 +705,28 @@ export async function exportVaultToDir(
     mkdirSync(dirname(fullPath), { recursive: true });
     writeFileSync(fullPath, toPortableMarkdown(portable));
     notesWritten++;
+
+    // Sidecar metadata write for non-frontmatter-compat extensions
+    // (vault#328). The content file holds raw bytes (no YAML); the
+    // sidecar at .parachute/notes-meta/<id>.yaml carries id/path/tags/
+    // metadata/links/attachments/timestamps.
+    const portableExt = portable.extension ?? "md";
+    if (!supportsInlineFrontmatter(portableExt)) {
+      const sidecarFile = join(notesMetaRoot, `${portable.id}.yaml`);
+      const sidecarResolved = resolvePath(sidecarFile);
+      // Path-traversal guard symmetric with the attachments path: the
+      // sidecar lives under the .parachute/notes-meta/ subtree, period.
+      if (!isWithinDir(sidecarResolved, notesMetaRootResolved)) {
+        skipped.push({
+          path: portable.path,
+          reason: `path-traversal: sidecar write target "${sidecarResolved}" escapes notes-meta root "${notesMetaRootResolved}"`,
+        });
+      } else {
+        mkdirSync(notesMetaRoot, { recursive: true });
+        writeFileSync(sidecarResolved, toSidecarYaml(portable));
+        sidecarsWritten++;
+      }
+    }
 
     // Copy attachment binaries when assetsDir is wired. Each attachment
     // is path-traversal-guarded on both ends: source under assetsDir,
@@ -652,6 +797,7 @@ export async function exportVaultToDir(
     notes: notesWritten,
     schemas: schemasWritten,
     attachments: attachmentsWritten,
+    sidecars: sidecarsWritten,
     filtered_by_since: since !== undefined,
     skipped_traversal: skipped.length,
     skipped_notes: skipped,
@@ -837,19 +983,93 @@ export async function importPortableVault(
     }
   }
 
-  // 3. Notes. Walk every .md file under inDir (dot-dirs already
-  // excluded), parse, upsert.
+  // 3. Notes. Walk every content file under inDir (dot-dirs already
+  // excluded). For frontmatter-compatible extensions (md, mdx) parse
+  // inline metadata. For sidecar-required extensions (csv, yaml, json,
+  // etc.) look up metadata in `.parachute/notes-meta/<id>.yaml`.
+  //
+  // The sidecar's `path` + `extension` are the source of truth for the
+  // user-visible filename — but we walk filenames first and INDEX
+  // sidecars by `(path, extension)` for O(1) lookup per content file.
+  // Sidecars with no matching content file are warned about (and
+  // skipped) rather than triggering a write — preserves the
+  // export-bytes-are-truth invariant.
+  const notesMetaDir = join(sidecar, NOTES_META_DIR);
+  const sidecarByKey = new Map<string, Record<string, unknown>>();
+  const sidecarByIdLeftover = new Map<string, Record<string, unknown>>();
+  if (existsSync(notesMetaDir)) {
+    const notesMetaRootResolved = resolvePath(notesMetaDir);
+    for (const entry of readdirSync(notesMetaDir)) {
+      if (!entry.endsWith(".yaml")) continue;
+      if (entry.startsWith(".")) continue;
+      const fullPath = join(notesMetaDir, entry);
+      const resolved = resolvePath(fullPath);
+      if (!isWithinDir(resolved, notesMetaRootResolved)) continue;
+      const text = readFileSync(fullPath, "utf-8");
+      // The sidecar is a bare YAML doc (no `---`); wrap to reuse the
+      // shared frontmatter parser.
+      const wrapped = `---\n${text}${text.endsWith("\n") ? "" : "\n"}---\n`;
+      const { frontmatter } = parseFrontmatter(wrapped);
+      const sidecarId = typeof frontmatter.id === "string" ? frontmatter.id : null;
+      const sidecarPath = typeof frontmatter.path === "string" ? frontmatter.path : null;
+      const sidecarExt = typeof frontmatter.extension === "string" ? frontmatter.extension : null;
+      if (!sidecarId) continue;
+      // Index by both (path, ext) tuple (for pathed notes) and by id
+      // (for unpathed notes whose filename is `_unpathed/<id>.<ext>`).
+      if (sidecarPath && sidecarExt) {
+        sidecarByKey.set(`${sidecarPath.toLowerCase()}|${sidecarExt.toLowerCase()}`, frontmatter);
+      }
+      sidecarByIdLeftover.set(sidecarId, frontmatter);
+    }
+  }
+
   // Track per-import (id → portable) so we can replay typed links
   // after all notes exist.
   const seenNotes = new Map<string, PortableNote>();
-  for (const filePath of walkMarkdownFiles(inDir)) {
+  for (const filePath of walkContentFiles(inDir)) {
     // Containment check — readdirSync should already be safe, but
     // verify the resolved path is inside inDir (symlinks).
     const resolved = resolvePath(filePath);
     if (!isWithinDir(resolved, inDirResolved)) continue;
 
-    const raw = readFileSync(filePath, "utf-8");
-    const { frontmatter, content } = parseFrontmatter(raw);
+    // Derive the file's extension (lowercased, no leading dot) and the
+    // user-visible note path (everything between inDir and the
+    // extension).
+    const extWithDot = extname(filePath); // e.g. ".csv"
+    const fileExt = extWithDot.slice(1).toLowerCase();
+    if (fileExt.length === 0) continue;
+    const relWithExt = relative(inDir, filePath);
+    const relNoExt = relWithExt.slice(0, relWithExt.length - extWithDot.length);
+    // Normalize path separators for cross-platform exports.
+    const userPath = relNoExt.split(pathSep).join("/");
+
+    let frontmatter: Record<string, unknown>;
+    let content: string;
+    if (supportsInlineFrontmatter(fileExt)) {
+      const raw = readFileSync(filePath, "utf-8");
+      const parsed = parseFrontmatter(raw);
+      frontmatter = parsed.frontmatter;
+      content = parsed.content;
+    } else {
+      // Look up sidecar by (path, ext). Lowercase path-key match.
+      const key = `${userPath.toLowerCase()}|${fileExt}`;
+      const found = sidecarByKey.get(key);
+      if (!found) {
+        // No sidecar — log and skip. Importing the raw bytes with no
+        // metadata would orphan the row (no id, no path, no
+        // timestamps). Better to surface the gap than silently lose
+        // shape.
+        // eslint-disable-next-line no-console
+        console.warn(`[import] skipped "${filePath}": no matching sidecar at ${NOTES_META_DIR}/<id>.yaml (path="${userPath}", extension="${fileExt}")`);
+        continue;
+      }
+      frontmatter = found;
+      content = readFileSync(filePath, "utf-8");
+      // Mark this sidecar as consumed so the "stale sidecar" pass
+      // below doesn't double-count.
+      const sidecarId = typeof found.id === "string" ? found.id : null;
+      if (sidecarId) sidecarByIdLeftover.delete(sidecarId);
+    }
 
     const id = typeof frontmatter.id === "string" ? frontmatter.id : null;
     if (!id) {
@@ -863,6 +1083,12 @@ export async function importPortableVault(
     const created_at = typeof frontmatter.created_at === "string" ? frontmatter.created_at : new Date().toISOString();
     const updated_at = typeof frontmatter.updated_at === "string" ? frontmatter.updated_at : created_at;
     const path = typeof frontmatter.path === "string" ? frontmatter.path : undefined;
+    // Trust the frontmatter/sidecar extension first; fall back to the
+    // filename extension. Notes without an explicit extension default
+    // to "md" (back-compat with pre-vault#328 exports).
+    const extension = typeof frontmatter.extension === "string"
+      ? frontmatter.extension
+      : (supportsInlineFrontmatter(fileExt) ? fileExt : fileExt) || "md";
     const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags.filter((t): t is string => typeof t === "string") : undefined;
     const metadata = (frontmatter.metadata && typeof frontmatter.metadata === "object" && !Array.isArray(frontmatter.metadata))
       ? frontmatter.metadata as Record<string, unknown>
@@ -875,6 +1101,7 @@ export async function importPortableVault(
       content,
       created_at,
       updated_at,
+      extension,
       ...(path ? { path } : {}),
       ...(tags && tags.length > 0 ? { tags } : {}),
       ...(metadata ? { metadata } : {}),
@@ -925,6 +1152,7 @@ export async function importPortableVault(
         content,
         ...(path !== undefined ? { path } : {}),
         ...(metadata ? { metadata } : {}),
+        extension,
       });
       // Tags: delete existing, re-tag with imported set.
       if (existing.tags && existing.tags.length > 0) {
@@ -941,6 +1169,7 @@ export async function importPortableVault(
         ...(tags && tags.length > 0 ? { tags } : {}),
         ...(metadata ? { metadata } : {}),
         created_at,
+        extension,
       });
       stats.notes_created++;
     }
@@ -1389,6 +1618,29 @@ export function walkMarkdownFiles(dir: string): string[] {
       const stat = statSync(full);
       if (stat.isDirectory()) walk(full);
       else if (stat.isFile() && extname(entry).toLowerCase() === ".md") results.push(full);
+    }
+  }
+  walk(dir);
+  return results.sort();
+}
+
+/**
+ * Recursively list all content files in a portable-md export (vault#328).
+ * Same dot-dir exclusion as `walkMarkdownFiles` — sidecar metadata under
+ * `.parachute/` is reached separately by the importer. Files with no
+ * extension are skipped (no way to tell what they are; vault doesn't
+ * write extensionless notes by design).
+ */
+export function walkContentFiles(dir: string): string[] {
+  const results: string[] = [];
+  function walk(current: string) {
+    for (const entry of readdirSync(current)) {
+      if (entry.startsWith(".")) continue;
+      if (entry === "node_modules") continue;
+      const full = join(current, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) walk(full);
+      else if (stat.isFile() && extname(entry).length > 0) results.push(full);
     }
   }
   walk(dir);

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -1088,7 +1088,7 @@ export async function importPortableVault(
     // to "md" (back-compat with pre-vault#328 exports).
     const extension = typeof frontmatter.extension === "string"
       ? frontmatter.extension
-      : (supportsInlineFrontmatter(fileExt) ? fileExt : fileExt) || "md";
+      : fileExt || "md";
     const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags.filter((t): t is string => typeof t === "string") : undefined;
     const metadata = (frontmatter.metadata && typeof frontmatter.metadata === "object" && !Array.isArray(frontmatter.metadata))
       ? frontmatter.metadata as Record<string, unknown>

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -808,19 +808,42 @@ function migrateToV17(db: Database): void {
 
 /**
  * Migrate v17 → v18: add `notes.extension TEXT NOT NULL DEFAULT 'md'`
- * (vault#328). Backward-compat by construction — every existing row keeps
- * its meaning (markdown). `extension` is the file-suffix story; MIME-type
- * is a separate axis if we ever need it. Wrapped in BEGIN IMMEDIATE /
- * COMMIT / ROLLBACK per the v14+ pattern; the column add is idempotent
- * via `hasColumn`, the transaction wrap is belt-and-suspenders.
+ * (vault#328) AND widen the path-uniqueness index from `(path)` to
+ * `(path, extension)` so two notes can share a path differing only by
+ * extension (`Recipes/pasta` with both .md and .csv variants).
+ *
+ * Backward-compat by construction — every existing row defaults to "md",
+ * so the new composite-index uniqueness collapses to the v5
+ * "(path WHERE NOT NULL) is unique" behavior on existing data. Wrapped
+ * in BEGIN IMMEDIATE / COMMIT / ROLLBACK per the v14+ pattern.
  */
 function migrateToV18(db: Database): void {
   if (!hasTable(db, "notes")) return;
-  if (hasColumn(db, "notes", "extension")) return;
+
+  // Two responsibilities (column add + index swap) — both idempotent
+  // individually. Wrap in one transaction so an upgrading v17 vault
+  // ends up at exactly v17 or v18, never partial.
+  const needsColumn = !hasColumn(db, "notes", "extension");
+  const indexes = db.prepare(
+    "SELECT name FROM sqlite_master WHERE type='index' AND name IN ('idx_notes_path_unique', 'idx_notes_path_ext_unique')",
+  ).all() as { name: string }[];
+  const hasOldUnique = indexes.some((r) => r.name === "idx_notes_path_unique");
+  const hasNewUnique = indexes.some((r) => r.name === "idx_notes_path_ext_unique");
+  if (!needsColumn && hasNewUnique && !hasOldUnique) return;
 
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.exec("ALTER TABLE notes ADD COLUMN extension TEXT NOT NULL DEFAULT 'md'");
+    if (needsColumn) {
+      db.exec("ALTER TABLE notes ADD COLUMN extension TEXT NOT NULL DEFAULT 'md'");
+    }
+    if (hasOldUnique) {
+      db.exec("DROP INDEX idx_notes_path_unique");
+    }
+    if (!hasNewUnique) {
+      db.exec(
+        "CREATE UNIQUE INDEX idx_notes_path_ext_unique ON notes(path, extension) WHERE path IS NOT NULL",
+      );
+    }
     db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -2,17 +2,25 @@ import { Database } from "bun:sqlite";
 import { normalizePath } from "./paths.js";
 import { rebuildIndexes } from "./indexed-fields.js";
 
-export const SCHEMA_VERSION = 17;
+export const SCHEMA_VERSION = 18;
 
 export const SCHEMA_SQL = `
--- Notes: the universal record
+-- Notes: the universal record.
+--
+-- extension (v18, vault#328) carries the file suffix the note should
+-- exhibit when serialized to disk — "md" by default, "csv"/"yaml"/"json"/
+-- "mdx"/etc. for non-markdown notes. Stored extension-less in the path
+-- column; on-disk uniqueness key is (path, extension). See
+-- core/src/portable-md.ts:supportsInlineFrontmatter for the
+-- frontmatter-vs-sidecar split.
 CREATE TABLE IF NOT EXISTS notes (
   id TEXT PRIMARY KEY,
   content TEXT DEFAULT '',
   path TEXT,
   metadata TEXT DEFAULT '{}',
   created_at TEXT NOT NULL,
-  updated_at TEXT
+  updated_at TEXT,
+  extension TEXT NOT NULL DEFAULT 'md'
 );
 
 -- Tags: first-class identity carrying schema, hierarchy, and typed-link
@@ -265,6 +273,11 @@ export function initSchema(db: Database): void {
   // naming the dropped schemas/mappings so the operator can recreate them
   // as `tags.fields` if needed. See vault#267.
   migrateToV17(db);
+
+  // Migrate v17 → v18: add `notes.extension TEXT NOT NULL DEFAULT 'md'`.
+  // Backward-compat by construction — every existing row defaults to "md"
+  // (markdown), unchanged in meaning. See vault#328.
+  migrateToV18(db);
 
   // Rebuild any generated columns + indexes declared in indexed_fields.
   // No-op for a fresh vault; idempotent on existing vaults.
@@ -790,6 +803,28 @@ function migrateToV17(db: Database): void {
       );
     }
     console.log(lines.join("\n"));
+  }
+}
+
+/**
+ * Migrate v17 → v18: add `notes.extension TEXT NOT NULL DEFAULT 'md'`
+ * (vault#328). Backward-compat by construction — every existing row keeps
+ * its meaning (markdown). `extension` is the file-suffix story; MIME-type
+ * is a separate axis if we ever need it. Wrapped in BEGIN IMMEDIATE /
+ * COMMIT / ROLLBACK per the v14+ pattern; the column add is idempotent
+ * via `hasColumn`, the transaction wrap is belt-and-suspenders.
+ */
+function migrateToV18(db: Database): void {
+  if (!hasTable(db, "notes")) return;
+  if (hasColumn(db, "notes", "extension")) return;
+
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec("ALTER TABLE notes ADD COLUMN extension TEXT NOT NULL DEFAULT 'md'");
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
   }
 }
 

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -92,7 +92,7 @@ export class BunSqliteStore implements Store {
 
   // ---- Notes ----
 
-  async createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Promise<Note> {
+  async createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string; extension?: string }): Promise<Note> {
     const note = noteOps.createNote(this.db, content, opts);
 
     if (content) {
@@ -128,6 +128,7 @@ export class BunSqliteStore implements Store {
       append?: string;
       prepend?: string;
       path?: string;
+      extension?: string;
       metadata?: Record<string, unknown>;
       created_at?: string;
       skipUpdatedAt?: boolean;
@@ -498,7 +499,7 @@ export class BunSqliteStore implements Store {
    * `syncAllWikilinks`, so adding the cache rebuild there is the natural
    * place.)
    */
-  async createNoteRaw(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Promise<Note> {
+  async createNoteRaw(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string; extension?: string }): Promise<Note> {
     return noteOps.createNote(this.db, content, opts);
   }
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -10,6 +10,14 @@ export interface Note {
   id: string;
   content: string;
   path?: string;
+  /**
+   * File extension (sans dot). Defaults to `"md"`. Controls the
+   * serialized file suffix on export — `.md`/`.mdx` carry frontmatter
+   * inline; `.csv`/`.yaml`/`.json`/etc. carry their metadata in a
+   * sidecar at `.parachute/notes-meta/<id>.yaml`. See vault#328 +
+   * `core/src/portable-md.ts:supportsInlineFrontmatter`.
+   */
+  extension?: string;
   metadata?: Record<string, unknown>;
   createdAt: string; // ISO-8601
   updatedAt?: string;
@@ -64,6 +72,13 @@ export interface QueryOpts {
   hasLinks?: boolean;
   path?: string;        // exact path match (case-insensitive)
   pathPrefix?: string;  // e.g., "Projects/Parachute" matches "Projects/Parachute/README"
+  /**
+   * Filter by file extension. Pass a single extension (e.g. `"csv"`) or
+   * an array (e.g. `["csv", "yaml", "json"]`). Extension is compared
+   * lower-case. Notes default to `"md"` so `extension: "md"` matches
+   * the existing markdown corpus. See vault#328.
+   */
+  extension?: string | string[];
   // Restrict results to a specific set of note IDs. The MCP `near` query uses
   // this to push graph-neighborhood scoping into the SQL WHERE clause so that
   // LIMIT and ORDER BY apply to the filtered set, not the whole notes table.
@@ -107,6 +122,7 @@ export interface QueryOpts {
 export interface NoteSummary {
   id: string;
   path?: string;
+  extension?: string;
   metadata?: Record<string, unknown>;
   createdAt: string;
   updatedAt?: string;
@@ -120,6 +136,7 @@ export interface NoteSummary {
 export interface NoteIndex {
   id: string;
   path?: string;
+  extension?: string;
   createdAt: string;
   updatedAt?: string;
   tags?: string[];
@@ -138,11 +155,11 @@ export interface HydratedLink extends Link {
 
 export interface Store {
   // Notes
-  createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string }): Promise<Note>;
+  createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string; extension?: string }): Promise<Note>;
   getNote(id: string): Promise<Note | null>;
   getNoteByPath(path: string): Promise<Note | null>;
   getNotes(ids: string[]): Promise<Note[]>;
-  updateNote(id: string, updates: { content?: string; append?: string; prepend?: string; path?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean; if_updated_at?: string }): Promise<Note>;
+  updateNote(id: string, updates: { content?: string; append?: string; prepend?: string; path?: string; extension?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean; if_updated_at?: string }): Promise<Note>;
   /**
    * Set a note's `created_at` and `updated_at` explicitly. Import-only:
    * used by the portable-md round-trip path to restore timestamps from

--- a/core/src/wikilinks.ts
+++ b/core/src/wikilinks.ts
@@ -110,19 +110,57 @@ function stripCode(content: string): string {
  * Resolve a wikilink target to a note ID.
  *
  * Resolution order:
- * 1. Exact path match (case-insensitive)
- * 2. Basename match — target matches the last segment of a path
- *    (e.g., "README" matches "Projects/Parachute/README")
- *    Only if there's exactly one match (ambiguous = unresolved)
+ * 1. **Explicit-extension target**: `[[Foo.csv]]` matches the note with
+ *    `path: "Foo"` AND `extension: "csv"` (vault#328). Lets a reader
+ *    disambiguate when multiple notes share a path differing only by
+ *    extension. The trailing `.<ext>` must match a known
+ *    alphanumeric pattern (1–16 chars) — otherwise the dot is treated
+ *    as part of the path string and falls through to the existing
+ *    rules.
+ * 2. Exact path match (case-insensitive) — multiple matches resolve to
+ *    a single note when only ONE extension is in play; if `Foo.md` and
+ *    `Foo.csv` both exist, the link refuses to resolve and the caller
+ *    sees an unresolved-wikilink entry (vault#328 ambiguity policy).
+ * 3. Basename match — target matches the last segment of a path
+ *    (e.g., "README" matches "Projects/Parachute/README"). Same
+ *    cross-extension ambiguity policy as #2.
  */
 export function resolveWikilink(db: Database, target: string): string | null {
-  // 1. Exact match (case-insensitive)
+  // 1. Explicit extension form: `[[path.ext]]` where `.ext` is a
+  // pattern-matching tail (lowercase alphanumeric, 1–16 chars).
+  // Mirrors EXTENSION_PATTERN in core/src/notes.ts so the wikilink
+  // parser and the API surface share the same notion of "this looks
+  // like an extension."
+  const extMatch = target.match(/^(.*)\.([a-z0-9]{1,16})$/i);
+  if (extMatch) {
+    const pathPart = extMatch[1]!;
+    const extPart = extMatch[2]!.toLowerCase();
+    const explicit = db.prepare(
+      "SELECT id FROM notes WHERE path = ? COLLATE NOCASE AND LOWER(extension) = ?",
+    ).get(pathPart, extPart) as { id: string } | undefined;
+    if (explicit) return explicit.id;
+    // No match for explicit (path, ext) — fall through to the looser
+    // rules so a literal note named `Recipe.v2` (where `v2` isn't an
+    // extension on a real note) can still resolve under exact-path
+    // match.
+  }
+
+  // 2. Exact match (case-insensitive). When multiple notes share a path
+  // (post-vault#328 this happens when `Foo.md` and `Foo.csv` both
+  // exist, since path is stored extension-less), refuse to resolve.
   const exact = db.prepare(
     "SELECT id FROM notes WHERE path = ? COLLATE NOCASE",
-  ).get(target) as { id: string } | undefined;
-  if (exact) return exact.id;
+  ).all(target) as { id: string }[];
+  if (exact.length === 1) return exact[0]!.id;
+  if (exact.length > 1) {
+    // Ambiguous — refuse-and-require-explicit-extension policy
+    // (vault#328). Returning null routes through the existing
+    // unresolved-wikilinks workflow, so the reader (or the indexer)
+    // sees the conflict.
+    return null;
+  }
 
-  // 2. Basename match — last path segment equals target
+  // 3. Basename match — last path segment equals target.
   // e.g., target "README" matches path "Projects/Parachute/README"
   const basename = db.prepare(`
     SELECT id FROM notes
@@ -150,17 +188,39 @@ export interface WikilinkResolution {
 
 /**
  * Resolve a wikilink target with full detail — single match, ambiguous, or unresolved.
+ * Mirrors `resolveWikilink`'s resolution order, including the explicit-
+ * extension form `[[Foo.csv]]` introduced by vault#328.
  */
 export function resolveWikilinkDetailed(db: Database, target: string): WikilinkResolution {
-  // 1. Exact match (case-insensitive)
-  const exact = db.prepare(
-    "SELECT id, path FROM notes WHERE path = ? COLLATE NOCASE",
-  ).get(target) as { id: string; path: string } | undefined;
-  if (exact) {
-    return { resolved: true, note_id: exact.id, path: exact.path, candidates: [] };
+  // 1. Explicit-extension form: `[[path.ext]]`.
+  const extMatch = target.match(/^(.*)\.([a-z0-9]{1,16})$/i);
+  if (extMatch) {
+    const pathPart = extMatch[1]!;
+    const extPart = extMatch[2]!.toLowerCase();
+    const explicit = db.prepare(
+      "SELECT id, path FROM notes WHERE path = ? COLLATE NOCASE AND LOWER(extension) = ?",
+    ).get(pathPart, extPart) as { id: string; path: string } | undefined;
+    if (explicit) {
+      return { resolved: true, note_id: explicit.id, path: explicit.path, candidates: [] };
+    }
   }
 
-  // 2. Basename match
+  // 2. Exact path match (case-insensitive). Multiple matches → ambiguous.
+  const exact = db.prepare(
+    "SELECT id, path, extension FROM notes WHERE path = ? COLLATE NOCASE",
+  ).all(target) as { id: string; path: string; extension: string }[];
+  if (exact.length === 1) {
+    return { resolved: true, note_id: exact[0]!.id, path: exact[0]!.path, candidates: [] };
+  }
+  if (exact.length > 1) {
+    return {
+      resolved: false,
+      ambiguous: true,
+      candidates: exact.map((r) => ({ note_id: r.id, path: r.path })),
+    };
+  }
+
+  // 3. Basename match
   const basename = db.prepare(`
     SELECT id, path FROM notes
     WHERE path IS NOT NULL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.4-rc.14",
+  "version": "0.4.5-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,7 +13,7 @@
 
 import type { Store, Note } from "../core/src/types.ts";
 import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
-import { toNoteIndex, filterMetadata, MAX_BATCH_SIZE } from "../core/src/notes.ts";
+import { toNoteIndex, filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "../core/src/notes.ts";
 import { attachValidationStatus } from "../core/src/mcp.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
@@ -73,6 +73,25 @@ function parseQuery(url: URL, key: string): string | null {
 function parseQueryList(url: URL, key: string): string[] | undefined {
   const val = url.searchParams.get(key);
   return val ? val.split(",") : undefined;
+}
+
+/**
+ * Parse the extension query parameter (vault#328). Two accepted shapes:
+ *   - `?extension=csv` (single value → string)
+ *   - `?extension=csv&extension=yaml` OR `?extension=csv,yaml`
+ *     (repeated or comma-list → array)
+ * Returns undefined when absent so the queryNotes filter is skipped.
+ * Validation lives at the engine layer — bad strings result in zero
+ * matches rather than 400, mirroring how `path` works.
+ */
+function parseExtensionFilter(url: URL): string | string[] | undefined {
+  const all = url.searchParams.getAll("extension");
+  if (all.length === 0) return undefined;
+  // Flatten comma-lists inside each param.
+  const flat = all.flatMap((v) => v.split(",")).map((s) => s.trim()).filter((s) => s.length > 0);
+  if (flat.length === 0) return undefined;
+  if (flat.length === 1) return flat[0]!;
+  return flat;
 }
 
 function parseInt10(val: string | null): number | undefined {
@@ -508,6 +527,12 @@ export async function handleNotes(
           hasLinks: parseBoolOrUndef(parseQuery(url, "has_links")),
           path: parseQuery(url, "path") ?? undefined,
           pathPrefix: parseQuery(url, "path_prefix") ?? undefined,
+          // Extension filter (vault#328). Accepts repeated `extension=`
+          // params for the array form: `?extension=csv&extension=yaml`.
+          // `parseQueryList` already returns undefined when no params
+          // are present, so the filter is silently skipped on a plain
+          // GET without the extension query.
+          extension: parseExtensionFilter(url),
           metadata: bracket.metadata,
           // Date-range precedence chain (highest to lowest):
           //   1. Bracket-style `meta[created_at][gte]=…` (canonical).
@@ -660,12 +685,19 @@ export async function handleNotes(
       if (batched) db.exec("BEGIN");
       try {
         for (const item of items) {
+          // Validate extension before reaching the Store (vault#328).
+          // Thrown inside the BEGIN block — outer catch rolls the batch
+          // back, same shape as the path-conflict path.
+          const extension = item.extension !== undefined
+            ? validateExtension(item.extension)
+            : undefined;
           const note = await store.createNote(item.content ?? "", {
             id: item.id,
             path: item.path,
             tags: item.tags,
             metadata: item.metadata,
             created_at: item.createdAt ?? item.created_at,
+            ...(extension !== undefined ? { extension } : {}),
           });
 
           // Create explicit links
@@ -686,6 +718,12 @@ export async function handleNotes(
           return json(
             { error_type: "path_conflict", error: "path_conflict", path: e.path, message: e.message },
             409,
+          );
+        }
+        if (e && e.code === "INVALID_EXTENSION") {
+          return json(
+            { error_type: "invalid_extension", error: "invalid_extension", extension: e.extension, reason: e.reason, message: e.message },
+            400,
           );
         }
         throw e;
@@ -845,12 +883,17 @@ export async function handleNotes(
           }
           const idLooksLikePath = idOrPathStr.includes("/") || !/^[A-Za-z0-9_-]+$/.test(idOrPathStr);
           const explicitPath = typeof body.path === "string" ? body.path as string : undefined;
+          // Validate extension before reaching the Store (vault#328).
+          const createExt = body.extension !== undefined
+            ? validateExtension(body.extension)
+            : undefined;
           const createOpts: Parameters<Store["createNote"]>[1] = {
             ...(idLooksLikePath ? { path: explicitPath ?? idOrPathStr } : { id: idOrPathStr, ...(explicitPath !== undefined ? { path: explicitPath } : {}) }),
             ...(tagsArr.length > 0 ? { tags: tagsArr } : {}),
             ...(body.metadata !== undefined ? { metadata: body.metadata as Record<string, unknown> } : {}),
             ...(body.created_at !== undefined ? { created_at: body.created_at as string } : {}),
             ...(body.createdAt !== undefined ? { created_at: body.createdAt as string } : {}),
+            ...(createExt !== undefined ? { extension: createExt } : {}),
           };
           const content = (body.content as string | undefined) ?? "";
           const created = await store.createNote(content, createOpts);
@@ -1019,6 +1062,11 @@ export async function handleNotes(
         if (body.prepend !== undefined) updates.prepend = body.prepend;
       }
       if (body.path !== undefined) updates.path = body.path;
+      if (body.extension !== undefined) {
+        // Validate up front (vault#328). Throws ExtensionValidationError
+        // which the outer catch converts to a 400.
+        updates.extension = validateExtension(body.extension);
+      }
       if (body.metadata !== undefined) {
         const existing = (note.metadata as Record<string, unknown>) ?? {};
         updates.metadata = { ...existing, ...body.metadata };
@@ -1106,6 +1154,12 @@ export async function handleNotes(
         return json(
           { error_type: "path_conflict", error: "path_conflict", path: e.path, message: e.message },
           409,
+        );
+      }
+      if (e && e.code === "INVALID_EXTENSION") {
+        return json(
+          { error_type: "invalid_extension", error: "invalid_extension", extension: e.extension, reason: e.reason, message: e.message },
+          400,
         );
       }
       throw e;

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1702,6 +1702,134 @@ describe("HTTP /notes", async () => {
     expect(body.createdAt).toBe("2025-01-01T00:00:00.000Z");
   });
 
+  // ---- Extension field (vault#328) ----
+
+  test("POST /notes accepts extension and persists it", async () => {
+    const res = await handleNotes(
+      mkReq("POST", "/notes", {
+        content: "month,total\n2026-01,9000",
+        path: "Tabular/budget",
+        extension: "csv",
+      }),
+      store,
+      "",
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.extension).toBe("csv");
+    const fetched = await store.getNote(body.id);
+    expect(fetched!.extension).toBe("csv");
+  });
+
+  test("POST /notes defaults extension to 'md' when omitted", async () => {
+    const res = await handleNotes(
+      mkReq("POST", "/notes", { content: "plain", path: "p" }),
+      store,
+      "",
+    );
+    const body = await res.json() as any;
+    expect(body.extension).toBe("md");
+  });
+
+  test("POST /notes rejects invalid extension with 400 invalid_extension", async () => {
+    const res = await handleNotes(
+      mkReq("POST", "/notes", { content: "x", extension: "CSV" }),
+      store,
+      "",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("invalid_extension");
+    expect(body.extension).toBe("CSV");
+  });
+
+  test("POST /notes rejects reserved 'parachute' prefix with 400", async () => {
+    const res = await handleNotes(
+      mkReq("POST", "/notes", { content: "x", extension: "parachute" }),
+      store,
+      "",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("invalid_extension");
+    expect(body.reason).toMatch(/reserved/);
+  });
+
+  test("PATCH /notes/:id changes extension", async () => {
+    const note = await store.createNote("hi", { id: "ext-patch", path: "p" });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/ext-patch", {
+        extension: "mdx",
+        if_updated_at: note.updatedAt,
+      }),
+      store,
+      "/ext-patch",
+    );
+    expect(res.status).toBe(200);
+    const fetched = await store.getNote("ext-patch");
+    expect(fetched!.extension).toBe("mdx");
+  });
+
+  test("PATCH /notes/:id rejects invalid extension with 400", async () => {
+    const note = await store.createNote("hi", { id: "ext-bad", path: "p" });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/ext-bad", {
+        extension: "foo.bar",
+        if_updated_at: note.updatedAt,
+      }),
+      store,
+      "/ext-bad",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("invalid_extension");
+  });
+
+  test("GET /notes?extension=csv filters by extension", async () => {
+    await store.createNote("md note", { path: "a" });
+    await store.createNote("csv note", { path: "b", extension: "csv" });
+    await store.createNote("yaml note", { path: "c", extension: "yaml" });
+    const res = await handleNotes(
+      mkReq("GET", "/notes?extension=csv&include_content=true"),
+      store,
+      "",
+    );
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(1);
+    expect(body[0].path).toBe("b");
+  });
+
+  test("GET /notes?extension=csv&extension=yaml filters by array of extensions", async () => {
+    await store.createNote("md note", { path: "a" });
+    await store.createNote("csv note", { path: "b", extension: "csv" });
+    await store.createNote("yaml note", { path: "c", extension: "yaml" });
+    const res = await handleNotes(
+      mkReq("GET", "/notes?extension=csv&extension=yaml&include_content=true"),
+      store,
+      "",
+    );
+    const body = await res.json() as any[];
+    expect(body).toHaveLength(2);
+    expect(body.map((n) => n.path).sort()).toEqual(["b", "c"]);
+  });
+
+  test("PATCH /notes/:id if_missing=create honors extension", async () => {
+    const idOrPath = encodeURIComponent("Tabular/new-budget");
+    const res = await handleNotes(
+      mkReq("PATCH", `/notes/${idOrPath}`, {
+        content: "month,total\n2026-02,1000",
+        extension: "csv",
+        if_missing: "create",
+      }),
+      store,
+      `/${idOrPath}`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.created).toBe(true);
+    expect(body.extension).toBe("csv");
+  });
+
   test("POST /notes/:id/attachments accepts mimeType (camelCase) in body", async () => {
     const n = await store.createNote("x", { id: "x" });
     const res = await handleNotes(


### PR DESCRIPTION
## Summary

vault#328 Phase 1: substrate-side file-extension support. Notes can now
carry a `extension` field — markdown remains the default; CSV, YAML, JSON,
MDX, plaintext, etc. become first-class. Bundle of three commits under
one PR per Rule 4. Target: **0.4.5-rc.1** (new minor RC chain).

- **Commit 1** — `feat(db): add extension column to notes, default 'md'`:
  schema v17 → v18, composite `(path, extension)` uniqueness index,
  Store interface threads `extension` through everywhere.
- **Commit 2** — `feat(api): extension field on create-note +
  update-note + query-notes`: symmetric MCP + REST surfaces, shared
  `validateExtension` helper, structured `400 invalid_extension`.
- **Commit 3** — `feat(export): non-markdown content with sidecar
  metadata + .mdx as frontmatter-compatible`: `supportsInlineFrontmatter`
  predicate, sidecar dir `.parachute/notes-meta/<id>.yaml`, round-trip
  integration test, wikilink ambiguity policy.

## Gate counts

- `bunx tsc --noEmit`: clean.
- `bun test ./core/src/ ./src/`: **1452 pass, 0 fail, 4004 expect()**
  (24 new tests — 7 Store/db, 7 MCP, 9 REST, 10 portable-md +
  wikilink).
- Real-vault round-trip smoke: covered by the round-trip test fixture
  inside this PR (vault containing csv/yaml/json/mdx/empty-content/.md
  → export → blow-away → byte-equivalent re-export). End-to-end smoke
  against Aaron's default vault is a release-gate step before promote
  to stable; not a blocker for merging this rc.

## Design decisions

- **Sidecar dir name**: `.parachute/notes-meta/<id>.yaml`. Chose
  `notes-meta` over `metadata` because it reads naturally next to the
  existing `attachments/` and `schemas/` siblings under
  `.parachute/`, and the contents are unambiguously per-note metadata
  (vs. attachment metadata, schema metadata, etc.).
- **Wikilink ambiguity policy**: refuse-and-require-explicit-extension
  when `Foo.md` and `Foo.csv` both exist. `[[Foo]]` → unresolved;
  `[[Foo.md]]` / `[[Foo.csv]]` → resolve. The extension-recognition
  pattern in the wikilink parser mirrors `EXTENSION_PATTERN` from
  `core/src/notes.ts` so the two share the same notion of "this looks
  like an extension."
- **Frontmatter `extension` field omitted for "md"**: so pre-vault#328
  markdown-only exports produce byte-identical bytes before/after the
  upgrade. Sidecars always include `extension` (the field is their
  reason for existing).
- **Path uniqueness changed from `(path)` to `(path, extension)`**:
  required to let `Foo.md` and `Foo.csv` coexist. v18 migration drops
  the old unique index and creates the composite one in one
  transaction; idempotent across fresh and upgrading vaults.

## Out of scope (per issue's Phase 2 list)

- Notes PWA format-aware rendering (separate dispatch to notes tentacle
  after 0.4.5 stabilizes).
- Tag schema content validation ("this CSV must have these columns").
- MDX renderer in the PWA.
- vault#327 case-collision fix (separate PR; the case-collision
  surface for sidecar paths uses note IDs which are immune by
  construction, so this PR doesn't compound the risk).

## Patterns check

Touches: portable-md format (the spec), MCP tool surface, REST API
surface, schema-versioning conventions. All within the conventions
captured in `parachute-patterns/`. No pattern changes needed; the
extension axis is purely additive.

Closes vault#328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)