### PR TITLE
cleanup(notes): 0.4.5 known-limitation closes — case-collision + getNoteByPath ambiguity + sidecar warning + yaml DRY (vault#327, vault#330) (0.4.5-rc.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,77 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.5-rc.2] — 2026-05-15
+
+0.4.5 cleanup — closes known limitations from rc.1 ship. Four commits
+under "0.4.5 cleanup": one substantive (vault#327), three follow-ups
+from the vault#328 reviewer (vault#330 S1/S2/F3). 0.4.5 stable
+promotes from rc.2.
+
+### fix(export): case-collision detection + auto-disambiguation (vault#327)
+
+Aaron's real default vault on macOS APFS had two notes whose paths
+differed only by case silently collapsing into one file on export.
+The fix:
+
+- Probe filesystem case-sensitivity at export time
+  (`probeCaseSensitive`: write a hidden tempfile with a lowercase
+  name, test whether the uppercase variant is reachable). Cleans up
+  its tempfile; defaults to conservative true (case-sensitive,
+  matches today's behavior) on probe failure.
+- On case-insensitive FS, build a lowercased `(path, ext)` index
+  during the export walk. Collisions auto-disambiguate to
+  `<path>__<id-prefix>.<ext>` — deterministic across runs (note IDs
+  are stable, timestamp-prefixed).
+- Note's stored `path` (in inline frontmatter + sidecar) stays
+  canonical. Only on-disk filename is munged. Import recovers
+  truth from frontmatter/sidecar.
+- `ExportStats.case_insensitive_fs` + `disambiguated_paths` audit
+  trail.
+- Import handles both shapes: exact-case canonical match → first
+  remaining bucket entry → id-prefix fallback for disambiguated
+  filenames. `sidecarByKey` is now multi-value Map<key, sidecar[]>
+  so case-collided sidecars coexist.
+- `caseSensitiveOverride: boolean` test seam.
+
+### fix(notes): getNoteByPath ambiguity-aware (vault#330 S1)
+
+`getNoteByPath` was non-deterministic under v18 — two same-path-
+different-extension notes would resolve to one in SQLite's undefined
+row order. Aligns the path-as-key contract with the wikilink
+ambiguity policy: `(path, extension)` is the uniqueness tuple
+everywhere.
+
+- `getNoteByPath(path, extension?)` signature. >1 row with no
+  extension hint → throws new `AmbiguousPathError`
+  (`code=AMBIGUOUS_PATH` + `candidates: [{id, extension}, ...]`).
+- MCP `resolveNote` + REST `resolveNote` both parse trailing
+  `.<ext>` as `(path, extension)` — same explicit-extension form
+  as wikilinks. Falls through to the ambiguity-throwing lookup
+  when no hint is supplied.
+- REST handlers convert `AmbiguousPathError` to structured 409 with
+  `error_type=ambiguous_path` + candidates array.
+
+### fix(import): drain orphaned sidecars into ImportStats.skipped_sidecars (vault#330 S2)
+
+The PR2 import flow built `sidecarByIdLeftover` but never iterated
+it — the comment promising stale-sidecar warnings was a lie. This
+makes the comment honest:
+
+- After the content-file walk, iterate leftover sidecars and record
+  each in `ImportStats.skipped_sidecars` (sidecar_id, expected_path,
+  expected_extension, reason).
+- `console.warn` per entry so CLI / log scrapers can surface the gap.
+- Common cause: operator removed a content file by hand without
+  deleting the matching sidecar.
+
+### refactor(portable-md): unify the frontmatter/sidecar key-emit loop (vault#330 F3)
+
+`toPortableMarkdown` and `toSidecarYaml` had identical per-key emit
+loops with subtly different trailing-newline behaviors. Extracted
+`emitFrontmatterKeys(fm)` so both call paths share one source of
+truth. Pure refactor — round-trip test still pins byte-equivalence.
+
 ## [0.4.5-rc.1] — 2026-05-15
 
 File-extension support — vault#328. Substrate-side feature enabling

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -427,6 +427,35 @@ describe("notes.extension (vault#328)", async () => {
       store.updateNote(md.id, { extension: "csv" }),
     ).rejects.toMatchObject({ code: "PATH_CONFLICT", path: "Foo" });
   });
+
+  it("getNoteByPath throws AmbiguousPathError when path matches multiple extensions (vault#330 S1)", async () => {
+    await store.createNote("# md", { path: "Foo", id: "foo-md" });
+    await store.createNote("a,b\n1,2", { path: "Foo", extension: "csv", id: "foo-csv" });
+    expect(store.getNoteByPath("Foo")).rejects.toMatchObject({
+      code: "AMBIGUOUS_PATH",
+      path: "Foo",
+    });
+  });
+
+  it("getNoteByPath returns the right note when extension is passed (vault#330 S1)", async () => {
+    await store.createNote("# md", { path: "Foo", id: "foo-md" });
+    await store.createNote("a,b\n1,2", { path: "Foo", extension: "csv", id: "foo-csv" });
+    const md = await store.getNoteByPath("Foo", "md");
+    const csv = await store.getNoteByPath("Foo", "csv");
+    expect(md!.id).toBe("foo-md");
+    expect(csv!.id).toBe("foo-csv");
+  });
+
+  it("getNoteByPath returns single match unchanged when no ambiguity (vault#330 S1 back-compat)", async () => {
+    await store.createNote("# only", { path: "Foo", id: "only" });
+    const note = await store.getNoteByPath("Foo");
+    expect(note!.id).toBe("only");
+  });
+
+  it("getNoteByPath returns null for unknown path (vault#330 S1 back-compat)", async () => {
+    const note = await store.getNoteByPath("DoesNotExist");
+    expect(note).toBeNull();
+  });
 });
 
 // ---- Tags ----

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -26,14 +26,33 @@ export interface McpToolDef {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a note identifier — tries ID first, then case-insensitive path match.
- * Works everywhere a note reference is accepted.
+ * Resolve a note identifier — tries ID first, then case-insensitive
+ * path match. Works everywhere a note reference is accepted.
+ *
+ * Path-with-extension form (vault#330 S1): a trailing `.<ext>` matching
+ * the extension pattern (`/^[a-z0-9]{1,16}$/i`) is parsed as
+ * `(path, extension)` to disambiguate notes that share a path
+ * differing only by extension. Mirrors the wikilink ambiguity policy
+ * from vault#328.
+ *
+ * On ambiguous path with no extension hint, `getNoteByPath` throws
+ * `AmbiguousPathError` — `resolveNote` propagates it so MCP / REST
+ * handlers can surface a clear 4xx rather than picking arbitrarily.
  */
 function resolveNote(db: Database, idOrPath: string): Note | null {
   // Try ID match first (fast, indexed)
   const byId = noteOps.getNote(db, idOrPath);
   if (byId) return byId;
-  // Fallback to path match
+  // Path-with-extension form: `Tabular/budget.csv` → (path="Tabular/
+  // budget", extension="csv"). Only kicks in when the suffix looks
+  // like an extension AND a `(path, ext)` row exists. Fall through to
+  // the no-extension lookup if not (so `Recipe.v2` where `v2` isn't a
+  // real extension still finds Recipe.v2 by exact-path).
+  const extMatch = idOrPath.match(/^(.*)\.([a-z0-9]{1,16})$/i);
+  if (extMatch) {
+    const explicit = noteOps.getNoteByPath(db, extMatch[1]!, extMatch[2]!);
+    if (explicit) return explicit;
+  }
   return noteOps.getNoteByPath(db, idOrPath);
 }
 

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1281,8 +1281,10 @@ function normalizeTags(tag: unknown): string[] | undefined {
 }
 
 // Re-exported for backward compat; defined in notes.ts alongside the
-// conditional-UPDATE implementation that raises it.
-export { ConflictError, PathConflictError, MAX_BATCH_SIZE } from "./notes.js";
+// conditional-UPDATE implementation that raises it. AmbiguousPathError
+// joins the set (vault#331 N2) so external callers can `instanceof`
+// it without crossing module boundaries.
+export { ConflictError, PathConflictError, AmbiguousPathError, MAX_BATCH_SIZE } from "./notes.js";
 
 /**
  * Thrown by the `update-note` MCP tool (and the REST PATCH handler) when a

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -79,13 +79,49 @@ export function getNote(db: Database, id: string): Note | null {
   return note;
 }
 
-export function getNoteByPath(db: Database, path: string): Note | null {
-  const row = db.prepare("SELECT * FROM notes WHERE path = ?").get(path) as NoteRow | undefined;
-  if (!row) return null;
+/**
+ * Look up a note by `path`. When `extension` is provided, the lookup
+ * matches the `(path, extension)` tuple — exactly one row, since v18's
+ * composite uniqueness index makes that combo unique. When `extension`
+ * is omitted:
+ *
+ *   - 0 matches → return null (back-compat).
+ *   - 1 match → return it (back-compat).
+ *   - >1 match → throw `AmbiguousPathError` (vault#330 S1). Caller
+ *     must pass `extension` explicitly to disambiguate. Mirrors the
+ *     wikilink ambiguity policy from vault#328 edge case 3 —
+ *     path-as-key lookup is "(path, extension) tuple" everywhere.
+ *
+ * Path match is case-insensitive (`COLLATE NOCASE`) — matches the v5
+ * uniqueness contract and how wikilinks resolve.
+ */
+export function getNoteByPath(db: Database, path: string, extension?: string): Note | null {
+  if (extension !== undefined) {
+    const row = db.prepare(
+      "SELECT * FROM notes WHERE path = ? COLLATE NOCASE AND LOWER(extension) = ?",
+    ).get(path, extension.toLowerCase()) as NoteRow | undefined;
+    if (!row) return null;
+    const note = rowToNote(row);
+    note.tags = getNoteTags(db, note.id);
+    return note;
+  }
 
-  const note = rowToNote(row);
-  note.tags = getNoteTags(db, note.id);
-  return note;
+  // No extension given. The composite-unique index lets two rows share
+  // a path differing only by extension, so we have to look at all matches
+  // before returning.
+  const rows = db.prepare(
+    "SELECT * FROM notes WHERE path = ? COLLATE NOCASE",
+  ).all(path) as NoteRow[];
+  if (rows.length === 0) return null;
+  if (rows.length === 1) {
+    const note = rowToNote(rows[0]!);
+    note.tags = getNoteTags(db, note.id);
+    return note;
+  }
+  throw new AmbiguousPathError(
+    path,
+    rows.map((r) => ({ id: r.id, extension: r.extension ?? "md" })),
+  );
 }
 
 export function getNotes(db: Database, ids: string[]): Note[] {
@@ -144,6 +180,31 @@ export class PathConflictError extends Error {
     super(`path_conflict: another note already uses path "${path}"`);
     this.name = "PathConflictError";
     this.path = path;
+  }
+}
+
+/**
+ * Thrown by `getNoteByPath` when the caller looked up a path that has
+ * multiple notes (post-vault#328: same path, different extensions),
+ * without specifying which extension to disambiguate. Aligns the
+ * path-as-key lookup contract with the wikilink ambiguity policy
+ * (vault#328 edge case 3): refuse-and-require-explicit-extension.
+ *
+ * Surfaces structured fields so callers (MCP `resolveNote`, REST
+ * path-as-id handlers) can convert to a clear 409 / 4xx with the list
+ * of candidate extensions. See vault#330 S1.
+ */
+export class AmbiguousPathError extends Error {
+  code = "AMBIGUOUS_PATH" as const;
+  path: string;
+  candidates: { id: string; extension: string }[];
+
+  constructor(path: string, candidates: { id: string; extension: string }[]) {
+    const list = candidates.map((c) => c.extension).join(", ");
+    super(`ambiguous_path: "${path}" matches ${candidates.length} notes (extensions: ${list}); pass \`extension\` to disambiguate`);
+    this.name = "AmbiguousPathError";
+    this.path = path;
+    this.candidates = candidates;
   }
 }
 

--- a/core/src/portable-md.test.ts
+++ b/core/src/portable-md.test.ts
@@ -1282,6 +1282,52 @@ describe("portable-md non-markdown round-trip (vault#328)", async () => {
     compareTree(outA, outB);
   });
 
+  it("records orphan sidecars in ImportStats.skipped_sidecars (vault#330 S2)", async () => {
+    // Build a portable-md export by hand with an orphan sidecar: a
+    // sidecar YAML at .parachute/notes-meta/<id>.yaml whose
+    // (path, extension) doesn't point to any real content file on
+    // disk. Import should record it in skipped_sidecars without
+    // crashing.
+    const outDir = join(tmpBase, "orphan-sidecar");
+    mkdirSync(join(outDir, SIDECAR_DIR, NOTES_META_DIR), { recursive: true });
+    writeFileSync(
+      join(outDir, SIDECAR_DIR, "vault.yaml"),
+      "export_format_version: 1\nexported_at: '2026-05-15T00:00:00.000Z'\n",
+    );
+    writeFileSync(
+      join(outDir, SIDECAR_DIR, NOTES_META_DIR, "orphan-1.yaml"),
+      "id: orphan-1\npath: Tabular/missing\nextension: csv\ncreated_at: '2026-05-15T00:00:00.000Z'\nupdated_at: '2026-05-15T00:00:00.000Z'\n",
+    );
+
+    const restored = new SqliteStore(new Database(":memory:"));
+    const stats = await importPortableVault(restored, { inDir: outDir });
+    expect(stats.notes_created).toBe(0);
+    expect(stats.skipped_sidecars).toHaveLength(1);
+    expect(stats.skipped_sidecars[0]!.sidecar_id).toBe("orphan-1");
+    expect(stats.skipped_sidecars[0]!.expected_path).toBe("Tabular/missing");
+    expect(stats.skipped_sidecars[0]!.expected_extension).toBe("csv");
+    expect(stats.skipped_sidecars[0]!.reason).toMatch(/no content file/);
+  });
+
+  it("skipped_sidecars stays empty on a clean export-then-import", async () => {
+    // Sanity pin: when every sidecar pairs with a content file, the
+    // leftover-drain produces no entries.
+    await store.createNote("month,total\n2026-01,9000", {
+      id: "csv-1",
+      path: "Tabular/budget",
+      extension: "csv",
+    });
+    const outDir = join(tmpBase, "clean-sidecars");
+    await exportVaultToDir(store, {
+      outDir,
+      vaultName: "test",
+      exportedAt: "2026-05-15T00:00:00.000Z",
+    });
+    const restored = new SqliteStore(new Database(":memory:"));
+    const stats = await importPortableVault(restored, { inDir: outDir, blowAway: true });
+    expect(stats.skipped_sidecars).toEqual([]);
+  });
+
   it("import refuses content files lacking a sidecar (orphaned non-md file)", async () => {
     // Build a minimal portable-md directory by hand: a valid vault.yaml
     // + a .csv content file with NO matching sidecar. The importer

--- a/core/src/portable-md.test.ts
+++ b/core/src/portable-md.test.ts
@@ -31,6 +31,7 @@ import {
   noteToPortable,
   parseFrontmatter,
   portableExportFilePath,
+  probeCaseSensitive,
   SIDECAR_DIR,
   NOTES_META_DIR,
   supportsInlineFrontmatter,
@@ -1335,5 +1336,173 @@ describe("wikilink ambiguity across extensions (vault#328)", async () => {
     const outbound = await store.getLinks("linker", { direction: "outbound" });
     expect(outbound).toHaveLength(1);
     expect(outbound[0]!.targetId).toBe("foo-csv");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case-collision detection + auto-disambiguation (vault#327)
+// ---------------------------------------------------------------------------
+//
+// macOS APFS-default + Windows NTFS-default + FAT/exFAT are case-
+// insensitive — two notes whose paths differ only by case collapse
+// into one file on naive export. The fix probes the filesystem then
+// either ships as-is (case-sensitive) or disambiguates with an
+// `__<id-short>` filename suffix (case-insensitive). The note's
+// stored `path` stays canonical; only the on-disk filename is suffixed.
+
+describe("case-collision detection (vault#327)", async () => {
+  const tmpBase = join(tmpdir(), "parachute-portable-case");
+  let store: SqliteStore;
+
+  beforeEach(() => {
+    try { rmSync(tmpBase, { recursive: true }); } catch {}
+    mkdirSync(tmpBase, { recursive: true });
+    store = new SqliteStore(new Database(":memory:"));
+  });
+
+  it("probeCaseSensitive runs cleanly and returns a boolean", () => {
+    // Documenting behavior rather than asserting a specific value:
+    // macOS dev environments + most Linux CI runners produce different
+    // results. We just pin that the probe is well-formed (doesn't throw,
+    // returns boolean, cleans up its tempfile).
+    const result = probeCaseSensitive(tmpBase);
+    expect(typeof result).toBe("boolean");
+    // After the probe runs the dir should contain no leftover probe files.
+    const leftovers = readdirSync(tmpBase).filter((e) => e.includes("_parachute_cs_probe_"));
+    expect(leftovers).toEqual([]);
+  });
+
+  it("ships as-is when FS is case-sensitive (override=true)", async () => {
+    // Two notes with case-only-differing paths. With the case-sensitive
+    // override, both files land at their canonical paths — no
+    // disambiguation, no collisions in stats.
+    await store.createNote("# in Balance", {
+      id: "2025-05-26-09-15-42-aaaaaa",
+      path: "Journal/2025-05-26 Technology in Balance",
+    });
+    await store.createNote("# in balance", {
+      id: "2025-05-26-09-15-42-bbbbbb",
+      path: "Journal/2025-05-26 Technology in balance",
+    });
+
+    const outDir = join(tmpBase, "cs-on");
+    const stats = await exportVaultToDir(store, {
+      outDir,
+      vaultName: "test",
+      exportedAt: "2026-05-15T00:00:00.000Z",
+      caseSensitiveOverride: true,
+    });
+    expect(stats.notes).toBe(2);
+    expect(stats.case_insensitive_fs).toBe(false);
+    expect(stats.disambiguated_paths).toHaveLength(0);
+  });
+
+  it("disambiguates colliding paths on case-insensitive FS (override=false)", async () => {
+    // Same fixture as above; force the case-insensitive code path. The
+    // second note (deterministic order: queryNotes sorts ASC on
+    // created_at — the IDs sort lexicographically so 'aaaaaa' lands
+    // first, 'bbbbbb' second) gets its filename suffixed.
+    await store.createNote("# in Balance", {
+      id: "2025-05-26-09-15-42-aaaaaa",
+      path: "Journal/2025-05-26 Technology in Balance",
+    });
+    await store.createNote("# in balance", {
+      id: "2025-05-26-09-15-42-bbbbbb",
+      path: "Journal/2025-05-26 Technology in balance",
+    });
+
+    const outDir = join(tmpBase, "ci-on");
+    const stats = await exportVaultToDir(store, {
+      outDir,
+      vaultName: "test",
+      exportedAt: "2026-05-15T00:00:00.000Z",
+      caseSensitiveOverride: false,
+    });
+    expect(stats.notes).toBe(2);
+    expect(stats.case_insensitive_fs).toBe(true);
+    expect(stats.disambiguated_paths).toHaveLength(1);
+    expect(stats.disambiguated_paths[0]!.note_id).toBe("2025-05-26-09-15-42-bbbbbb");
+    expect(stats.disambiguated_paths[0]!.disambiguated_filename).toMatch(/__2025-05-/);
+
+    // Both files exist on disk under their respective filenames.
+    expect(existsSync(join(outDir, "Journal/2025-05-26 Technology in Balance.md"))).toBe(true);
+    expect(existsSync(join(outDir, stats.disambiguated_paths[0]!.disambiguated_filename))).toBe(true);
+
+    // The disambiguated file's inline frontmatter still carries the
+    // canonical (original) path, NOT the disambiguated filename — that
+    // way an import on a case-sensitive filesystem (or a future re-
+    // export on a case-sensitive FS) recovers the truth.
+    const disambigFile = readFileSync(
+      join(outDir, stats.disambiguated_paths[0]!.disambiguated_filename),
+      "utf-8",
+    );
+    expect(disambigFile).toContain("path: Journal/2025-05-26 Technology in balance");
+  });
+
+  it("disambiguated content round-trips through import (md inline frontmatter path)", async () => {
+    await store.createNote("# upper", {
+      id: "2025-05-26-09-15-42-aaaaaa",
+      path: "Journal/Same-Case Different",
+    });
+    await store.createNote("# lower", {
+      id: "2025-05-26-09-15-42-bbbbbb",
+      path: "Journal/same-case different",
+    });
+
+    const outDir = join(tmpBase, "rt-md");
+    const stats = await exportVaultToDir(store, {
+      outDir,
+      vaultName: "test",
+      exportedAt: "2026-05-15T00:00:00.000Z",
+      caseSensitiveOverride: false,
+    });
+    expect(stats.disambiguated_paths).toHaveLength(1);
+
+    const restored = new SqliteStore(new Database(":memory:"));
+    const importStats = await importPortableVault(restored, { inDir: outDir, blowAway: true });
+    expect(importStats.notes_created).toBe(2);
+
+    // Both notes recovered their canonical paths from the frontmatter.
+    const upper = await restored.getNote("2025-05-26-09-15-42-aaaaaa");
+    const lower = await restored.getNote("2025-05-26-09-15-42-bbbbbb");
+    expect(upper!.path).toBe("Journal/Same-Case Different");
+    expect(lower!.path).toBe("Journal/same-case different");
+  });
+
+  it("disambiguated sidecar-required content round-trips (csv with sidecar lookup fallback)", async () => {
+    // The disambig fallback in the import loop kicks in: the sidecar
+    // is keyed by canonical (path, ext) so the walker's
+    // `<base>__<id8>.csv` filename doesn't match the index — but the
+    // id-prefix lookup recovers the sidecar.
+    await store.createNote("month,total\n2026-01,9000", {
+      id: "2025-05-26-09-15-42-aaaaaa",
+      path: "Tabular/Budget-2026",
+      extension: "csv",
+    });
+    await store.createNote("month,total\n2026-01,1", {
+      id: "2025-05-26-09-15-42-bbbbbb",
+      path: "Tabular/budget-2026",
+      extension: "csv",
+    });
+
+    const outDir = join(tmpBase, "rt-csv");
+    const stats = await exportVaultToDir(store, {
+      outDir,
+      vaultName: "test",
+      exportedAt: "2026-05-15T00:00:00.000Z",
+      caseSensitiveOverride: false,
+    });
+    expect(stats.disambiguated_paths).toHaveLength(1);
+
+    const restored = new SqliteStore(new Database(":memory:"));
+    const importStats = await importPortableVault(restored, { inDir: outDir, blowAway: true });
+    expect(importStats.notes_created).toBe(2);
+
+    const upper = await restored.getNote("2025-05-26-09-15-42-aaaaaa");
+    const lower = await restored.getNote("2025-05-26-09-15-42-bbbbbb");
+    expect(upper!.path).toBe("Tabular/Budget-2026");
+    expect(upper!.content).toBe("month,total\n2026-01,9000");
+    expect(lower!.path).toBe("Tabular/budget-2026");
+    expect(lower!.content).toBe("month,total\n2026-01,1");
   });
 });

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -434,6 +434,34 @@ function buildFrontmatter(note: PortableNote): Record<string, unknown> {
 }
 
 /**
+ * Emit a frontmatter-shape object using `FRONTMATTER_KEY_ORDER`: each
+ * present key gets one or more lines (inline form for scalars + empty
+ * collections, block form otherwise). Every line ends in `\n`. The
+ * output does NOT include the `---` wrapper — that's the caller's
+ * concern (only `toPortableMarkdown` wraps; `toSidecarYaml` doesn't).
+ *
+ * Single source of truth for the per-key emit loop shared by
+ * `toPortableMarkdown` and `toSidecarYaml` (vault#330 F3 — pure
+ * refactor, behavior unchanged).
+ */
+function emitFrontmatterKeys(fm: Record<string, unknown>): string {
+  let out = "";
+  for (const key of FRONTMATTER_KEY_ORDER) {
+    if (!(key in fm)) continue;
+    const value = fm[key];
+    const inline = emitValueInline(value, 1);
+    if (inline !== null) {
+      out += `${key}: ${inline}\n`;
+    } else {
+      out += `${key}:\n`;
+      const block = emitValueBlock(value, 1);
+      if (block !== null) out += `${block}\n`;
+    }
+  }
+  return out;
+}
+
+/**
  * Render a note's content-file bytes. Behavior depends on the note's
  * `extension`:
  *
@@ -459,18 +487,7 @@ export function toPortableMarkdown(note: PortableNote): string {
   }
   const fm = buildFrontmatter(note);
   let out = "---\n";
-  for (const key of FRONTMATTER_KEY_ORDER) {
-    if (!(key in fm)) continue;
-    const value = fm[key];
-    const inline = emitValueInline(value, 1);
-    if (inline !== null) {
-      out += `${key}: ${inline}\n`;
-    } else {
-      out += `${key}:\n`;
-      const block = emitValueBlock(value, 1);
-      if (block !== null) out += `${block}\n`;
-    }
-  }
+  out += emitFrontmatterKeys(fm);
   out += "---\n";
   // Preserve content as-is; ensure exactly one trailing newline if missing.
   out += note.content;
@@ -505,20 +522,7 @@ export function toSidecarYaml(note: PortableNote): string {
   fm.created_at = note.created_at;
   if (note.updated_at) fm.updated_at = note.updated_at;
 
-  let out = "";
-  for (const key of FRONTMATTER_KEY_ORDER) {
-    if (!(key in fm)) continue;
-    const value = fm[key];
-    const inline = emitValueInline(value, 1);
-    if (inline !== null) {
-      out += `${key}: ${inline}\n`;
-    } else {
-      out += `${key}:\n`;
-      const block = emitValueBlock(value, 1);
-      if (block !== null) out += `${block}\n`;
-    }
-  }
-  return out;
+  return emitFrontmatterKeys(fm);
 }
 
 /**

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -1022,6 +1022,14 @@ export interface ImportStats {
   skipped_links: Array<{ source_id: string; target_id: string; relationship: string; reason: string }>;
   /** Per-skipped-attachment detail. */
   skipped_attachments: Array<{ note_id: string; attachment_id: string; reason: string }>;
+  /**
+   * Sidecars under `.parachute/notes-meta/` with no matching content
+   * file on disk (vault#330 S2). Each entry records the sidecar's id +
+   * the expected `(path, extension)` it claimed so the operator can
+   * see what's orphaned. Empty when every sidecar paired with a
+   * content file during the walk.
+   */
+  skipped_sidecars: Array<{ sidecar_id: string; expected_path: string | null; expected_extension: string | null; reason: string }>;
   /** Set when the caller passed `blowAway: true`; counts notes removed. */
   notes_wiped: number;
 }
@@ -1069,6 +1077,7 @@ export async function importPortableVault(
     attachments_restored: 0,
     skipped_links: [],
     skipped_attachments: [],
+    skipped_sidecars: [],
     notes_wiped: 0,
   };
 
@@ -1368,6 +1377,27 @@ export async function importPortableVault(
     //   2. update path bumped updated_at to now(); we want to peg it
     //      back to the exported value.
     await store.restoreNoteTimestamps(id, created_at, updated_at);
+  }
+
+  // 3b. Drain remaining sidecars (vault#330 S2). Any entry still in
+  // `sidecarByIdLeftover` after the content-file walk is orphaned —
+  // its expected content file wasn't on disk. Record the gap in
+  // `skipped_sidecars` so programmatic callers can surface or repair.
+  // Common cause: an operator removed a content file by hand without
+  // deleting the matching sidecar.
+  for (const [sidecarId, sidecar] of sidecarByIdLeftover) {
+    const expectedPath = typeof sidecar.path === "string" ? sidecar.path : null;
+    const expectedExt = typeof sidecar.extension === "string" ? sidecar.extension : null;
+    stats.skipped_sidecars.push({
+      sidecar_id: sidecarId,
+      expected_path: expectedPath,
+      expected_extension: expectedExt,
+      reason: expectedPath
+        ? `no content file at "${expectedPath}.${expectedExt ?? "md"}"`
+        : "sidecar has no `path:` field; orphaned by construction",
+    });
+    // eslint-disable-next-line no-console
+    console.warn(`[import] orphaned sidecar "${sidecarId}.yaml": ${stats.skipped_sidecars[stats.skipped_sidecars.length - 1]!.reason}`);
   }
 
   // 4. Typed links — replay only now that all notes exist. Wikilinks

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -201,11 +201,11 @@ export interface ExportStats {
   sidecars: number;
   /**
    * True when the export ran on a case-insensitive filesystem (macOS
-   * APFS default, Windows NTFS, FAT/exFAT) and detected at least one
-   * lower-cased `(path, extension)` collision in the note set — i.e.
-   * `disambiguated_paths.length > 0` (vault#327). Programmatic callers
-   * (`parachute-vault import` etc.) inspect this to decide whether to
-   * surface the disambiguation in CLI output.
+   * APFS default, Windows NTFS, FAT/exFAT) — whether or not any
+   * collision actually occurred. The probe runs once per export
+   * regardless of the note set; this field reflects the probe's
+   * outcome. To detect actual collisions, check
+   * `disambiguated_paths.length > 0`. See vault#327.
    */
   case_insensitive_fs: boolean;
   /**
@@ -973,6 +973,20 @@ export function probeCaseSensitive(dir: string): boolean {
  * The original path is preserved in the note's frontmatter/sidecar
  * `path:` field — import recovers the canonical path from there, not
  * from the disambiguated filename.
+ *
+ * **Assumption** (vault#331 N4): two notes created in the same month
+ * share the first 8 chars of the id-prefix (`YYYY-MM-`). For import,
+ * this is harmless because the resolver runs three tiers in order
+ * (exact-case canonical path → leftover-bucket pick → id-prefix
+ * scan), and sidecars are removed from the leftover map as they're
+ * consumed. By the time the id-prefix scan runs for a disambiguated
+ * filename, the only sidecars that could match are still-orphaned,
+ * so there's at most one candidate per scan. If two notes in the
+ * same month BOTH had disambiguated filenames AND the resolver had
+ * to fall through to the prefix scan for both, the first match wins
+ * deterministically (sorted dir walk). Bumping the slice to 12 or 14
+ * chars would tighten this further but adds noise to filenames —
+ * skip it until a real workload demands the change.
  */
 function disambiguateFilename(path: string, extension: string, noteId: string): string {
   const idShort = noteId.slice(0, 8);

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -72,7 +72,7 @@
  * See vault#308.
  */
 
-import { readdirSync, readFileSync, statSync, mkdirSync, writeFileSync, copyFileSync, existsSync } from "fs";
+import { readdirSync, readFileSync, statSync, mkdirSync, writeFileSync, copyFileSync, existsSync, rmSync } from "fs";
 import { basename, join, relative, extname, dirname, resolve as resolvePath, sep as pathSep } from "path";
 import type { Store, Note, Link, Attachment } from "./types.js";
 import type { TagRecord } from "./tag-schemas.js";
@@ -199,6 +199,24 @@ export interface ExportStats {
    * per note.
    */
   sidecars: number;
+  /**
+   * True when the export ran on a case-insensitive filesystem (macOS
+   * APFS default, Windows NTFS, FAT/exFAT) and detected at least one
+   * lower-cased `(path, extension)` collision in the note set — i.e.
+   * `disambiguated_paths.length > 0` (vault#327). Programmatic callers
+   * (`parachute-vault import` etc.) inspect this to decide whether to
+   * surface the disambiguation in CLI output.
+   */
+  case_insensitive_fs: boolean;
+  /**
+   * Per-note disambiguation detail when the export's case-insensitive
+   * filesystem would otherwise silently collapse notes whose paths
+   * differ only by case (vault#327). Each entry records the original
+   * path + the suffixed on-disk filename so the operator can audit.
+   * Empty on case-sensitive filesystems and on case-insensitive
+   * filesystems with no collisions.
+   */
+  disambiguated_paths: Array<{ note_id: string; original_path: string; disambiguated_filename: string }>;
   /** Set when caller passed `since`; counts notes whose `updated_at >= since`. */
   filtered_by_since: boolean;
   /**
@@ -600,6 +618,15 @@ export interface ExportOptions {
    * stays pure (no dep on server-side path resolution).
    */
   assetsDir?: string;
+  /**
+   * Override the filesystem case-sensitivity probe (vault#327). Pass
+   * `false` to force the case-insensitive code path (with auto-
+   * disambiguation) regardless of the real filesystem; pass `true` to
+   * force the case-sensitive code path. Test seam — lets the round-trip
+   * suite exercise both branches on whatever FS the test happens to
+   * run on. When unset (the production default), the probe runs.
+   */
+  caseSensitiveOverride?: boolean;
 }
 
 /**
@@ -683,10 +710,56 @@ export async function exportVaultToDir(
   let sidecarsWritten = 0;
   const skipped: { path: string | undefined; reason: string }[] = [];
   const skippedAttachments: { note_id: string; attachment_id: string; path: string; reason: string }[] = [];
+  const disambiguatedPaths: ExportStats["disambiguated_paths"] = [];
+
+  // Case-collision detection (vault#327). On case-insensitive
+  // filesystems (macOS APFS-default, Windows NTFS-default, FAT/exFAT),
+  // two notes whose paths differ only by case collapse into one file
+  // on write — silent data loss. We probe the export dir's filesystem
+  // once, then either ship as-is (case-sensitive) or build a lowercase
+  // `(path, extension)` index during the walk and disambiguate
+  // colliding notes with an `__<id-short>` filename suffix.
+  //
+  // The note's stored `path` (in frontmatter + sidecar) stays canonical;
+  // only the on-disk filename is suffixed. Import recovers the
+  // canonical path from frontmatter/sidecar, not from the filename.
+  const caseSensitive = opts.caseSensitiveOverride ?? probeCaseSensitive(outDir);
+  // Lowercased `<path>|<ext>` → first-write note-id. Subsequent matches
+  // on the same key trigger disambiguation. Only populated on
+  // case-insensitive filesystems.
+  const seenLowerKeys = new Map<string, string>();
+
   for (const note of allNotes) {
     if (since && !shouldIncludeForSince(note, since)) continue;
     const portable = await noteToPortable(note, store);
-    const relPath = portableExportFilePath(portable);
+    let relPath = portableExportFilePath(portable);
+
+    // Decide whether this note's filename needs disambiguation
+    // (vault#327). Only meaningful when the FS is case-insensitive AND
+    // a prior note's (path, ext) tuple already claimed the same
+    // lowercased filename slot. Pathless notes (`_unpathed/<id>.<ext>`)
+    // are immune by construction — their filename embeds the id, which
+    // is case-stable already.
+    if (!caseSensitive && portable.path) {
+      const ext = portable.extension ?? "md";
+      const key = `${portable.path.toLowerCase()}|${ext.toLowerCase()}`;
+      const prior = seenLowerKeys.get(key);
+      if (prior !== undefined && prior !== portable.id) {
+        // Collision: emit the disambiguated form. The frontmatter /
+        // sidecar `path:` still holds the canonical (original) path so
+        // import recovers the truth.
+        const disambig = disambiguateFilename(portable.path, ext, portable.id);
+        relPath = disambig;
+        disambiguatedPaths.push({
+          note_id: portable.id,
+          original_path: portable.path,
+          disambiguated_filename: disambig,
+        });
+      } else if (prior === undefined) {
+        seenLowerKeys.set(key, portable.id);
+      }
+    }
+
     const fullPath = join(outDir, relPath);
     // vault#317 F3 — path-traversal guard. A note with
     // `path: "../../.ssh/authorized_keys"` would otherwise write outside
@@ -798,6 +871,8 @@ export async function exportVaultToDir(
     schemas: schemasWritten,
     attachments: attachmentsWritten,
     sidecars: sidecarsWritten,
+    case_insensitive_fs: !caseSensitive,
+    disambiguated_paths: disambiguatedPaths,
     filtered_by_since: since !== undefined,
     skipped_traversal: skipped.length,
     skipped_notes: skipped,
@@ -833,6 +908,71 @@ function sanitizeTagFilename(tag: string): string {
 function isWithinDir(candidate: string, root: string): boolean {
   if (candidate === root) return true;
   return candidate.startsWith(root + pathSep);
+}
+
+/**
+ * Probe whether `dir` lives on a case-sensitive filesystem (vault#327).
+ *
+ * The check writes a hidden tempfile, then tests whether the same file
+ * is reachable via its uppercased name. macOS APFS-default and Windows
+ * NTFS-default are case-insensitive (the file IS reachable); Linux
+ * ext4 and macOS APFS-CS are case-sensitive (the file is NOT). Other
+ * platforms (FAT32, exFAT, network shares to either) collapse to the
+ * same probe result.
+ *
+ * Returns true when the filesystem distinguishes case, false otherwise.
+ * Defaults to true (case-sensitive — current export behavior) if the
+ * probe fails for any reason — we'd rather ship without disambiguation
+ * than fail-closed on an unexpected I/O error mid-export.
+ *
+ * The probe cleans up after itself: tempfile is removed before return.
+ * Tempfile name uses a UUID-ish suffix so concurrent probes don't
+ * collide in shared directories.
+ */
+export function probeCaseSensitive(dir: string): boolean {
+  const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  const lowerName = `._parachute_cs_probe_${suffix}`;
+  const upperName = `._PARACHUTE_CS_PROBE_${suffix.toUpperCase()}`;
+  const lowerPath = join(dir, lowerName);
+  const upperPath = join(dir, upperName);
+  try {
+    writeFileSync(lowerPath, "");
+    // On a case-insensitive FS, `existsSync(upperPath)` returns true
+    // because upperPath references the same inode. On a case-sensitive
+    // FS, the file at upperPath doesn't exist.
+    const caseInsensitive = existsSync(upperPath);
+    return !caseInsensitive;
+  } catch {
+    // Probe failed — assume case-sensitive (the conservative default
+    // that matches today's export behavior).
+    return true;
+  } finally {
+    try { rmSync(lowerPath, { force: true }); } catch {}
+    // Defensive: if some FS variant created a distinct file at
+    // upperPath, clean that too. No-op when it was the same inode.
+    try { rmSync(upperPath, { force: true }); } catch {}
+  }
+}
+
+/**
+ * Compute the disambiguated filename for a colliding note (vault#327).
+ * Appends `__<id-short>` to the path's basename, before the extension.
+ * The id-short is the first 8 chars of the note ID — short enough to
+ * stay readable, unique enough to avoid secondary collisions in
+ * practice (vault IDs are timestamp-prefixed YYYY-MM-DD-HH-MM-SS-ffffff,
+ * so the first 8 chars include the year + month + day).
+ *
+ * Example: `Journal/2025-05-26 Technology in Balance` (path) with
+ * extension `md` + id `2025-05-26-09-15-42-123456` becomes
+ * `Journal/2025-05-26 Technology in Balance__2025-05-.md`.
+ *
+ * The original path is preserved in the note's frontmatter/sidecar
+ * `path:` field — import recovers the canonical path from there, not
+ * from the disambiguated filename.
+ */
+function disambiguateFilename(path: string, extension: string, noteId: string): string {
+  const idShort = noteId.slice(0, 8);
+  return `${path}__${idShort}.${extension}`;
 }
 
 function shouldIncludeForSince(note: Note, since: string): boolean {
@@ -994,8 +1134,14 @@ export async function importPortableVault(
   // Sidecars with no matching content file are warned about (and
   // skipped) rather than triggering a write — preserves the
   // export-bytes-are-truth invariant.
+  // Sidecar index: keyed by lowercased `<path>|<ext>` so the walker's
+  // filename-derived key (also lowered) matches. The bucket holds the
+  // full sidecar(s) — multiple entries occur when two notes share a
+  // case-insensitive path (vault#327 collisions). The lookup logic
+  // picks the right sidecar from the bucket using the walker's
+  // case-preserved filename + the disambiguated-id-suffix heuristic.
   const notesMetaDir = join(sidecar, NOTES_META_DIR);
-  const sidecarByKey = new Map<string, Record<string, unknown>>();
+  const sidecarByKey = new Map<string, Record<string, unknown>[]>();
   const sidecarByIdLeftover = new Map<string, Record<string, unknown>>();
   if (existsSync(notesMetaDir)) {
     const notesMetaRootResolved = resolvePath(notesMetaDir);
@@ -1014,10 +1160,14 @@ export async function importPortableVault(
       const sidecarPath = typeof frontmatter.path === "string" ? frontmatter.path : null;
       const sidecarExt = typeof frontmatter.extension === "string" ? frontmatter.extension : null;
       if (!sidecarId) continue;
-      // Index by both (path, ext) tuple (for pathed notes) and by id
-      // (for unpathed notes whose filename is `_unpathed/<id>.<ext>`).
+      // Index by (path, ext) tuple lowered so case-insensitive walks
+      // match. Multi-value bucket lets two case-collided sidecars coexist
+      // until the per-file lookup picks the right one.
       if (sidecarPath && sidecarExt) {
-        sidecarByKey.set(`${sidecarPath.toLowerCase()}|${sidecarExt.toLowerCase()}`, frontmatter);
+        const key = `${sidecarPath.toLowerCase()}|${sidecarExt.toLowerCase()}`;
+        const bucket = sidecarByKey.get(key);
+        if (bucket) bucket.push(frontmatter);
+        else sidecarByKey.set(key, [frontmatter]);
       }
       sidecarByIdLeftover.set(sidecarId, frontmatter);
     }
@@ -1051,9 +1201,48 @@ export async function importPortableVault(
       frontmatter = parsed.frontmatter;
       content = parsed.content;
     } else {
-      // Look up sidecar by (path, ext). Lowercase path-key match.
+      // Resolve which sidecar this content file belongs to. Two
+      // sources of ambiguity to handle:
+      //   1. vault#327 case-collisions on a case-insensitive FS —
+      //      multiple sidecars share the same lowered (path, ext) key.
+      //   2. Disambiguated filenames — `<base>__<id-prefix>.<ext>` —
+      //      where the walker's path doesn't match any sidecar's
+      //      canonical path.
+      // Resolution order: exact-case match within the bucket → id-prefix
+      // match against the disambiguation suffix → first remaining
+      // sidecar in the bucket → fall through to id-prefix scan of all
+      // leftovers.
+      let found: Record<string, unknown> | undefined;
       const key = `${userPath.toLowerCase()}|${fileExt}`;
-      const found = sidecarByKey.get(key);
+      const bucket = sidecarByKey.get(key);
+      if (bucket && bucket.length > 0) {
+        // Try exact-case match on canonical path first — distinguishes
+        // case-collided notes when the FS preserves filename case but
+        // not equality.
+        found = bucket.find((s) => typeof s.path === "string" && s.path === userPath);
+        if (!found) {
+          // No exact-case match. Pick a sidecar from the bucket whose
+          // id is still in `leftover` (i.e. not yet consumed by a prior
+          // file in the walk). This keeps two case-collided notes on a
+          // case-sensitive replay from claiming the same sidecar twice.
+          found = bucket.find((s) => typeof s.id === "string" && sidecarByIdLeftover.has(s.id));
+        }
+      }
+      if (!found) {
+        // Disambiguated filename fallback: `<base>__<id-prefix>.<ext>`.
+        // Strip the suffix, then find a leftover sidecar whose id
+        // starts with that prefix.
+        const disambigMatch = userPath.match(/^(.*)__([A-Za-z0-9-]{6,})$/);
+        if (disambigMatch) {
+          const idPrefix = disambigMatch[2]!;
+          for (const [sidecarId, sidecar] of sidecarByIdLeftover) {
+            if (sidecarId.startsWith(idPrefix)) {
+              found = sidecar;
+              break;
+            }
+          }
+        }
+      }
       if (!found) {
         // No sidecar — log and skip. Importing the raw bytes with no
         // metadata would orphan the row (no id, no path, no
@@ -1065,8 +1254,8 @@ export async function importPortableVault(
       }
       frontmatter = found;
       content = readFileSync(filePath, "utf-8");
-      // Mark this sidecar as consumed so the "stale sidecar" pass
-      // below doesn't double-count.
+      // Mark this sidecar as consumed so subsequent files (and the
+      // stale-sidecar pass) don't double-count.
       const sidecarId = typeof found.id === "string" ? found.id : null;
       if (sidecarId) sidecarByIdLeftover.delete(sidecarId);
     }

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -113,8 +113,8 @@ export class BunSqliteStore implements Store {
     return noteOps.getNote(this.db, id);
   }
 
-  async getNoteByPath(path: string): Promise<Note | null> {
-    return noteOps.getNoteByPath(this.db, path);
+  async getNoteByPath(path: string, extension?: string): Promise<Note | null> {
+    return noteOps.getNoteByPath(this.db, path, extension);
   }
 
   async getNotes(ids: string[]): Promise<Note[]> {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -157,7 +157,14 @@ export interface Store {
   // Notes
   createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string; extension?: string }): Promise<Note>;
   getNote(id: string): Promise<Note | null>;
-  getNoteByPath(path: string): Promise<Note | null>;
+  /**
+   * Look up a note by path. Pass `extension` to disambiguate when
+   * multiple notes share a path differing only by extension (post-
+   * vault#328). When omitted and >1 row matches, throws
+   * `AmbiguousPathError` instead of silently picking one. See
+   * vault#330 S1.
+   */
+  getNoteByPath(path: string, extension?: string): Promise<Note | null>;
   getNotes(ids: string[]): Promise<Note[]>;
   updateNote(id: string, updates: { content?: string; append?: string; prepend?: string; path?: string; extension?: string; metadata?: Record<string, unknown>; created_at?: string; skipUpdatedAt?: boolean; if_updated_at?: string }): Promise<Note>;
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.5-rc.1",
+  "version": "0.4.5-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/published.test.ts
+++ b/src/published.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "bun:test";
+import { Database } from "bun:sqlite";
 import { handleViewNote } from "./routes.ts";
+import { SqliteStore } from "../core/src/store.ts";
 
 // Redirect URL builder — mirrors the logic in server.ts
 function buildRedirectUrl(reqUrl: string, noteId: string, prefix = ""): string {
@@ -210,5 +212,20 @@ describe("handleViewNote", async () => {
     });
     const resp = await handleViewNote(store, "n1", { publishedTag: "public" });
     expect(resp.status).toBe(404);
+  });
+
+  it("returns 409 ambiguous_path when bare path resolves to multiple notes (vault#331 N1)", async () => {
+    // Real SqliteStore so the v18 composite (path, extension) uniqueness
+    // index lets two notes coexist at the same path with different
+    // extensions — the scenario AmbiguousPathError is built for.
+    const store = new SqliteStore(new Database(":memory:"));
+    await store.createNote("# md", { id: "vn-md", path: "Foo", tags: ["publish"] });
+    await store.createNote("a,b\n1,2", { id: "vn-csv", path: "Foo", extension: "csv", tags: ["publish"] });
+    const resp = await handleViewNote(store, "Foo", { authenticated: true });
+    expect(resp.status).toBe(409);
+    const body = await resp.json() as any;
+    expect(body.error_type).toBe("ambiguous_path");
+    expect(body.path).toBe("Foo");
+    expect(body.candidates).toHaveLength(2);
   });
 });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -427,6 +427,27 @@ class NotFoundError extends Error {
 // Notes — GET/POST/PATCH/DELETE /api/notes[/:idOrPath]
 // ---------------------------------------------------------------------------
 
+/**
+ * Convert a thrown `AmbiguousPathError` (vault#330 S1) into a structured
+ * 409 JSON response. Shared by every handler that calls `resolveNote`
+ * with a user-supplied path — handleNotes, handleFindPath,
+ * handleViewNote. Returns null when the error isn't an
+ * AmbiguousPathError so the caller can re-throw / fall through.
+ */
+function ambiguousPathResponse(e: any): Response | null {
+  if (!e || e.code !== "AMBIGUOUS_PATH") return null;
+  return json(
+    {
+      error_type: "ambiguous_path",
+      error: "ambiguous_path",
+      path: e.path,
+      candidates: e.candidates,
+      message: e.message,
+    },
+    409,
+  );
+}
+
 export async function handleNotes(
   req: Request,
   store: Store,
@@ -437,21 +458,8 @@ export async function handleNotes(
   try {
     return await handleNotesInner(req, store, subpath, vault, tagScope);
   } catch (e: any) {
-    // AmbiguousPathError (vault#330 S1) — convert to a structured 409
-    // anywhere it surfaces in the notes routes. Carries the candidate
-    // extensions so the caller knows what to disambiguate with.
-    if (e && e.code === "AMBIGUOUS_PATH") {
-      return json(
-        {
-          error_type: "ambiguous_path",
-          error: "ambiguous_path",
-          path: e.path,
-          candidates: e.candidates,
-          message: e.message,
-        },
-        409,
-      );
-    }
+    const ambig = ambiguousPathResponse(e);
+    if (ambig) return ambig;
     throw e;
   }
 }
@@ -1541,6 +1549,11 @@ export async function handleFindPath(
     return json(result);
   } catch (e: any) {
     if (e instanceof NotFoundError) return json({ error: e.message }, 404);
+    // vault#331 N1 — surface AmbiguousPathError from resolveNote as 409
+    // mirroring the handleNotes path. Without this, an ambiguous source/
+    // target path on /api/find-path bubbled to a server-level 500.
+    const ambig = ambiguousPathResponse(e);
+    if (ambig) return ambig;
     throw e;
   }
 }
@@ -1733,7 +1746,19 @@ export async function handleViewNote(
   options: { authenticated?: boolean; publishedTag?: string } = {},
 ): Promise<Response> {
   const { authenticated = false, publishedTag = "publish" } = options;
-  const note = await resolveNote(store, idOrPath);
+  let note: Note | null;
+  try {
+    note = await resolveNote(store, idOrPath);
+  } catch (e: any) {
+    // vault#331 N1 — surface AmbiguousPathError as 409. The HTML view
+    // route doesn't otherwise return JSON, but the structured body is
+    // the right shape for the API contract; a human reader hitting
+    // this URL gets the JSON inline (rare — the bare path form is
+    // mostly an API consumer's mistake).
+    const ambig = ambiguousPathResponse(e);
+    if (ambig) return ambig;
+    throw e;
+  }
   if (!note) {
     return new Response("Not Found", { status: 404, headers: { "Content-Type": "text/plain" } });
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -392,11 +392,21 @@ function parseExpandParams(
 
 
 /**
- * Resolve a note by ID or path. Tries ID first, then case-insensitive path.
+ * Resolve a note by ID or path. Tries ID first, then case-insensitive
+ * path. A trailing `.<ext>` matching the extension pattern is parsed
+ * as `(path, extension)` to disambiguate notes sharing a path
+ * differing only by extension (vault#330 S1). When the path is
+ * ambiguous and no extension hint is supplied, `getNoteByPath` throws
+ * `AmbiguousPathError` — REST handlers catch it and return 409.
  */
 async function resolveNote(store: Store, idOrPath: string): Promise<Note | null> {
   const byId = await store.getNote(idOrPath);
   if (byId) return byId;
+  const extMatch = idOrPath.match(/^(.*)\.([a-z0-9]{1,16})$/i);
+  if (extMatch) {
+    const explicit = await store.getNoteByPath(extMatch[1]!, extMatch[2]!);
+    if (explicit) return explicit;
+  }
   return await store.getNoteByPath(idOrPath);
 }
 
@@ -418,6 +428,35 @@ class NotFoundError extends Error {
 // ---------------------------------------------------------------------------
 
 export async function handleNotes(
+  req: Request,
+  store: Store,
+  subpath: string,
+  vault?: string,
+  tagScope: TagScopeCtx = NO_TAG_SCOPE,
+): Promise<Response> {
+  try {
+    return await handleNotesInner(req, store, subpath, vault, tagScope);
+  } catch (e: any) {
+    // AmbiguousPathError (vault#330 S1) — convert to a structured 409
+    // anywhere it surfaces in the notes routes. Carries the candidate
+    // extensions so the caller knows what to disambiguate with.
+    if (e && e.code === "AMBIGUOUS_PATH") {
+      return json(
+        {
+          error_type: "ambiguous_path",
+          error: "ambiguous_path",
+          path: e.path,
+          candidates: e.candidates,
+          message: e.message,
+        },
+        409,
+      );
+    }
+    throw e;
+  }
+}
+
+async function handleNotesInner(
   req: Request,
   store: Store,
   subpath: string,

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1830,6 +1830,34 @@ describe("HTTP /notes", async () => {
     expect(body.extension).toBe("csv");
   });
 
+  test("GET /notes?id=<path> returns 409 ambiguous_path when path matches multiple extensions (vault#330 S1)", async () => {
+    await store.createNote("# md", { path: "Foo", id: "foo-md" });
+    await store.createNote("a,b\n1,2", { path: "Foo", extension: "csv", id: "foo-csv" });
+    const res = await handleNotes(
+      mkReq("GET", "/notes?id=Foo"),
+      store,
+      "",
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("ambiguous_path");
+    expect(body.path).toBe("Foo");
+    expect(body.candidates).toHaveLength(2);
+  });
+
+  test("GET /notes?id=Foo.csv resolves the explicit-extension form (vault#330 S1)", async () => {
+    await store.createNote("# md", { path: "Foo", id: "foo-md" });
+    await store.createNote("a,b\n1,2", { path: "Foo", extension: "csv", id: "foo-csv" });
+    const res = await handleNotes(
+      mkReq("GET", "/notes?id=Foo.csv"),
+      store,
+      "",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.id).toBe("foo-csv");
+  });
+
   test("POST /notes/:id/attachments accepts mimeType (camelCase) in body", async () => {
     const n = await store.createNote("x", { id: "x" });
     const res = await handleNotes(

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -3435,6 +3435,25 @@ describe("HTTP /find-path", async () => {
     const res = await handleFindPath(mkReq("GET", "/find-path?source=a"), store);
     expect(res.status).toBe(400);
   });
+
+  test("returns 409 ambiguous_path when source path is ambiguous (vault#331 N1)", async () => {
+    // Two notes share path "Foo" differing by extension. handleFindPath's
+    // resolveNote(source) would otherwise non-deterministically pick
+    // one; post-#331 it throws AmbiguousPathError and the handler's
+    // catch surfaces a structured 409 (same shape as handleNotes).
+    await store.createNote("# md", { id: "foo-md", path: "Foo" });
+    await store.createNote("a,b\n1,2", { id: "foo-csv", path: "Foo", extension: "csv" });
+    await store.createNote("target", { id: "target" });
+    const res = await handleFindPath(
+      mkReq("GET", "/find-path?source=Foo&target=target"),
+      store,
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("ambiguous_path");
+    expect(body.path).toBe("Foo");
+    expect(body.candidates).toHaveLength(2);
+  });
 });
 
 describe("stateless MCP transport", async () => {


### PR DESCRIPTION
## Summary

0.4.5 cleanup bundle — closes known limitations from rc.1 before stable
promotion. Four commits under "0.4.5 cleanup": one substantive
(vault#327), three follow-ups from the vault#328 reviewer
(vault#330 S1/S2/F3).

- **Commit 1** — `fix(export): case-collision detection +
  auto-disambiguation (vault#327)`: probe FS case-sensitivity at
  export, auto-disambiguate colliding paths with `__<id-prefix>`
  filename suffix on case-insensitive filesystems. Closes vault#327.
- **Commit 2** — `fix(notes): getNoteByPath ambiguity-aware
  (vault#330 S1)`: aligns path-as-key lookup with wikilink ambiguity
  policy. `getNoteByPath(path, ext?)` throws `AmbiguousPathError` when
  ambiguous. Closes vault#330 S1.
- **Commit 3** — `fix(import): drain orphaned sidecars into
  ImportStats.skipped_sidecars (vault#330 S2)`: makes the
  "stale-sidecar warning" comment honest. Closes vault#330 S2.
- **Commit 4** — `refactor(portable-md): unify the frontmatter/sidecar
  key-emit loop (vault#330 F3)`: extracts shared `emitFrontmatterKeys`.
  Pure refactor; round-trip byte-equivalence preserved. Closes
  vault#330 F3.

Closes vault#327, closes vault#330.

## Gate counts

- `bunx tsc --noEmit`: clean.
- `bun test ./core/src/ ./src/`: **1468 pass, 0 fail, 4048 expect()**
  (13 new tests since 0.4.5-rc.1 — 5 for case-collision, 4 for
  getNoteByPath ambiguity, 2 for orphan sidecars, 2 REST integration).

## Design decisions

- **Disambiguation suffix format**: `<path>__<id-prefix-8>.<ext>`.
  Note IDs are timestamp-prefixed (`YYYY-MM-DD-HH-MM-SS-ffffff`), so
  the first 8 chars include `YYYY-MM-`. Readable + well-distributed
  + deterministic across runs (note IDs are stable).
- **Probe approach**: write a hidden tempfile with lowercase name,
  check whether `existsSync` of the uppercase variant returns true.
  Cleans up after itself; defaults to case-sensitive (conservative,
  matches today's behavior) on probe failure.
- **`caseSensitiveOverride` test seam**: ExportOptions field lets the
  round-trip suite exercise both branches on whatever filesystem the
  test runs on. CI is usually Linux ext4 (case-sensitive); Aaron's
  local is macOS APFS (case-insensitive). Both code paths get covered
  on both environments.
- **AmbiguousPathError vs reusing PATH_CONFLICT**: distinct error
  class. The two share a "two notes claim the same path slot" shape
  but differ in semantics: PATH_CONFLICT is "your write would
  collide", AMBIGUOUS_PATH is "your read can't pick one". Mapping
  AMBIGUOUS_PATH to its own 409 surface (with `candidates` array)
  lets clients display the disambiguation choice.
- **Multi-value sidecar bucket**: `sidecarByKey: Map<key,
  sidecar[]>`. Case-collided sidecars coexist in the index;
  per-content-file lookup picks via exact-case-on-canonical-path
  → leftover-bucket-entry → disambiguation-suffix scan.

## Patterns check

Touches: portable-md format (the spec), Store interface, MCP/REST
resolveNote shape, error-class taxonomy. All within the conventions
captured in `parachute-patterns/`. No pattern changes needed; the
fixes are additive and align with existing principles (`(path,
extension)` is the uniqueness tuple, surface ambiguity rather than
silently picking, structured error codes).

## Real-vault smoke (Aaron's queue)

After merge: Aaron's real default vault should re-export cleanly with
the case-collision detection — the two `Journal/2025-05-26 Technology
in Balance` / `... in balance` notes will both survive the round-trip
this time (one canonical filename + one disambiguated). The
`disambiguated_paths` stats array will list the suffix Aaron sees on
disk so he can audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)