### PR TITLE
release: 0.4.5 stable (rc chain → @latest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com) and 
 
 ## [Unreleased]
 
+## [0.4.5] — 2026-05-15
+
+Stable release. Promotes from `0.4.5-rc.2` after real-vault smoke validation
+on a 2296-note default vault (zero silent loss, byte-equivalent round-trip
+across markdown + CSV + sidecar). Same code as rc.2; only the version suffix
+drops. Headline arc since 0.4.4:
+
+- **File-extension support** (vault#328) — non-markdown notes as first-class
+  citizens. CSV / YAML / JSON / MDX / .txt / etc. carry `extension` field;
+  metadata lives in inline frontmatter for frontmatter-compatible formats
+  (.md, .mdx), in `.parachute/notes-meta/<id>.yaml` sidecars for everything
+  else. Wikilink ambiguity policy: explicit-extension required when
+  `Foo.md` and `Foo.csv` both exist. Path uniqueness is now `(path, extension)`.
+- **Gitcoin sync ergonomics** (vault#309, vault#310, vault#321) —
+  `update-note if_missing: "create"` saves a query-then-create round trip
+  per missing note on nightly sync. JSON int coercion accepts `5.0` for
+  integer-typed fields. REST + MCP create-branch link handling is now
+  symmetric.
+- **Case-collision auto-disambiguation** (vault#327) — exports probe
+  filesystem case-sensitivity; on case-insensitive disks (macOS APFS,
+  Windows NTFS), colliding notes get on-disk filename suffixes while
+  canonical paths in frontmatter stay unchanged. Cross-FS replay recovers
+  via three-tier sidecar resolution.
+- **AmbiguousPathError** — distinct from `PathConflictError`. Carries
+  `candidates` field listing matching `(path, extension)` pairs.
+  REST 409 with `error_type: "ambiguous_path"`. Three surfaces
+  (`handleNotes`, `handleFindPath`, `handleViewNote`) share an
+  `ambiguousPathResponse` helper.
+- **Sidecar leftover tracking** — orphan sidecars (sidecar present,
+  content file missing on import) land in `ImportStats.skipped_sidecars`.
+- **Empty notes are a valid state** (vault#323) — dropped the
+  `EMPTY_NOTE` guard. Skeleton notes, drafts saved-before-content,
+  organizing-only notes all create + round-trip cleanly.
+
 ## [0.4.5-rc.2] — 2026-05-15
 
 0.4.5 cleanup — closes known limitations from rc.1 ship. Four commits

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.5-rc.2",
+  "version": "0.4.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Promotes the `0.4.5-rc.N` chain to stable. Same code as rc.2; only the version suffix drops from `0.4.5-rc.2` → `0.4.5`. Real-vault smoke against a 2296-note default vault validates clean (zero silent loss, byte-equivalent round-trip including a CSV note with sidecar).

## Arc since 0.4.4

- **File-extension support** (#328) — non-markdown notes as first-class. CSV/YAML/JSON/MDX/etc. with sidecar metadata for non-frontmatter-compat formats.
- **Gitcoin sync ergonomics** (#309 + #310 + #321) — `update-note if_missing: "create"`, JSON int coercion, REST+MCP create-branch link symmetry.
- **Case-collision auto-disambiguation** (#327) — filesystem case-sensitivity probe + on-disk filename suffix + canonical path preservation in frontmatter/sidecar.
- **AmbiguousPathError** — distinct from PathConflictError, carries `candidates` list, 409 with `error_type: "ambiguous_path"` across `handleNotes`, `handleFindPath`, `handleViewNote`.
- **Sidecar leftover tracking** (#330 S2) — orphan sidecars land in `ImportStats.skipped_sidecars`.
- **Empty notes valid** (#323) — dropped `EMPTY_NOTE` guard.

## Test plan

- [x] Real-vault smoke: 2296 notes / 12 schemas / 298 attachments exported + imported + re-exported byte-equivalent (modulo documented attachment-id-remint).
- [x] CSV note round-trip with sidecar — content + sidecar yaml byte-identical across export → import → re-export.
- [x] `bun test`: 1470 pass / 0 fail / 4056 expect() (rc.2 head state).
- [x] `bunx tsc --noEmit` clean.

## Patterns check

- **Touches**: `package.json`, `CHANGELOG.md`.
- **Conforms**: yes — governance rule 2 (drop `-rc.N` suffix → publish stable, same patch number as the rc chain). Same `0.4.5` patch number as the rc.1/rc.2 chain.
- **Establishes / changes**: no governance change. Standard rc → stable promote.

## Post-merge

\`npm publish --tag latest\` from \`parachute-vault\` repo root (after merging this PR). That puts \`@openparachute/vault@0.4.5\` on the \`@latest\` dist-tag for consumers.