### PR TITLE
docs: 0.2.4 → 0.4.5 upgrade guide + CHANGELOG npm-vs-published meta-note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,40 +4,89 @@ All notable changes to Parachute Vault are documented here.
 
 This project loosely follows [Keep a Changelog](https://keepachangelog.com) and [Semantic Versioning](https://semver.org).
 
+## A note on versioning between launch (0.2.4) and 0.4.5
+
+CHANGELOG entries between `0.2.4` and `0.4.5` narrate development work,
+but not every entry corresponds to a published version on npm. The
+entries starting at `0.3.6-rc.1` (2026-04-26) chronicle internal RC
+version bumps in `package.json` during active development; only a subset
+were pushed to the npm registry:
+
+| Listed in CHANGELOG                       | Actually published to npm                    |
+| ----------------------------------------- | -------------------------------------------- |
+| `0.3.6-rc.1` through `0.3.6-rc.39`        | `0.3.0-rc.1`, `0.3.0`, `0.3.1`, `0.3.3`      |
+| `0.4.0-rc.1`, `rc.2`, `0.4.0` stable      | `0.4.0` only                                 |
+| `0.4.1` chain through `0.4.2`             | (none published)                             |
+| `0.4.3-rc.1`, `rc.2`, `0.4.3` stable      | `0.4.3` only                                 |
+| `0.4.4-rc.1` through `rc.14` + stable     | `0.4.4-rc.11`, `rc.12`, `rc.14` only         |
+| `0.4.5-rc.1`, `rc.2`, `0.4.5` stable      | `0.4.5` only                                 |
+
+Most beta users running an `npm install`-style upgrade between launch
+and 0.4.5 ended up on one of: `0.2.4` (no upgrade), `0.3.0`, `0.3.1`,
+`0.3.3`, `0.4.0`, `0.4.3`, or `0.4.5`. The "0.3.6" series in the
+chronological CHANGELOG below never had a corresponding npm version.
+
+The versioning discipline now codified in
+[`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md)
+(Rule 2 — RC versioning) was instituted as a response to this drift,
+around the 0.4.4 cycle. Going forward each CHANGELOG entry on a
+code-touching PR bumps the `rc.N` suffix and gets published to npm
+under the `@rc` dist-tag; stable promotes drop the suffix and publish
+to `@latest`.
+
 ## [Unreleased]
 
 ## [0.4.5] — 2026-05-15
 
-Stable release. Promotes from `0.4.5-rc.2` after real-vault smoke validation
-on a 2296-note default vault (zero silent loss, byte-equivalent round-trip
-across markdown + CSV + sidecar). Same code as rc.2; only the version suffix
-drops. Headline arc since 0.4.4:
+0.4.5 closes the substrate cycle that started with the launch &
+ecosystem-fit phase in late April 2026 — the load-bearing phase where
+vault stopped being a self-contained server and became a pure OAuth
+resource server inside the Parachute Computer ecosystem (URL migration,
+CLI rename, filesystem restructure, hub-issued JWT validation, scope
+enforcement, indexed metadata fields, atomic tag rename/merge,
+server-side transcription). Across roughly four weeks, vault moved
+from a working single-host prototype into a substrate-grade module
+that round-trips losslessly to git, handles non-markdown content as
+first-class, and lives behind a hub that issues, scopes, and revokes
+its tokens. Stable promotes from `0.4.5-rc.2` after real-vault smoke
+validation on a 2296-note default vault (zero silent loss,
+byte-equivalent round-trip across markdown + CSV + sidecar). Same code
+as rc.2; only the version suffix drops.
 
-- **File-extension support** (vault#328) — non-markdown notes as first-class
-  citizens. CSV / YAML / JSON / MDX / .txt / etc. carry `extension` field;
-  metadata lives in inline frontmatter for frontmatter-compatible formats
-  (.md, .mdx), in `.parachute/notes-meta/<id>.yaml` sidecars for everything
-  else. Wikilink ambiguity policy: explicit-extension required when
-  `Foo.md` and `Foo.csv` both exist. Path uniqueness is now `(path, extension)`.
-- **Gitcoin sync ergonomics** (vault#309, vault#310, vault#321) —
-  `update-note if_missing: "create"` saves a query-then-create round trip
-  per missing note on nightly sync. JSON int coercion accepts `5.0` for
+**Coming from 0.2.4?** See [UPGRADING.md](./UPGRADING.md) for the
+operator migration guide — the direct upgrade is correctness-safe
+(schema and filesystem migrations auto-run on first post-upgrade
+boot), and the active-change list is short: CLI rename, URL prefix,
+token audience binding, and one priv-esc audit.
+
+Headline arc since 0.4.4:
+
+- **File-extension support** (vault#328) — non-markdown notes as
+  first-class citizens. CSV / YAML / JSON / MDX / .txt / etc. carry an
+  `extension` field; metadata is inline for frontmatter-compatible
+  formats (.md, .mdx) or in `.parachute/notes-meta/<id>.yaml` sidecars
+  otherwise. Wikilinks to ambiguous bare paths (`[[Foo]]` when both
+  `Foo.md` and `Foo.csv` exist) are refused; use the explicit form.
+  Path uniqueness is now `(path, extension)`.
+- **Sync ergonomics** (vault#309, vault#310, vault#321) — `update-note
+  if_missing: "create"` saves the query-then-create round trip on
+  every missing-note sync. JSON int coercion accepts `5.0` for
   integer-typed fields. REST + MCP create-branch link handling is now
   symmetric.
 - **Case-collision auto-disambiguation** (vault#327) — exports probe
   filesystem case-sensitivity; on case-insensitive disks (macOS APFS,
   Windows NTFS), colliding notes get on-disk filename suffixes while
-  canonical paths in frontmatter stay unchanged. Cross-FS replay recovers
-  via three-tier sidecar resolution.
+  canonical paths in frontmatter stay unchanged. Cross-FS replay
+  recovers via three-tier sidecar resolution.
 - **AmbiguousPathError** — distinct from `PathConflictError`. Carries
-  `candidates` field listing matching `(path, extension)` pairs.
-  REST 409 with `error_type: "ambiguous_path"`. Three surfaces
+  a `candidates` array listing matching `(path, extension)` pairs.
+  REST returns 409 with `error_type: "ambiguous_path"`. Three handlers
   (`handleNotes`, `handleFindPath`, `handleViewNote`) share an
   `ambiguousPathResponse` helper.
 - **Sidecar leftover tracking** — orphan sidecars (sidecar present,
   content file missing on import) land in `ImportStats.skipped_sidecars`.
 - **Empty notes are a valid state** (vault#323) — dropped the
-  `EMPTY_NOTE` guard. Skeleton notes, drafts saved-before-content,
+  `EMPTY_NOTE` guard. Skeleton notes, drafts saved-before-content, and
   organizing-only notes all create + round-trip cleanly.
 
 ## [0.4.5-rc.2] — 2026-05-15

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -55,6 +55,20 @@ to *actively* change.
    per-vault audience `aud: vault.<name>` and narrowed scopes
    `vault:<name>:<verb>`.
 
+### Two readers, one doc
+
+*This doc serves two readers:*
+
+*__The human upgrading__: read the TL;DR and the seven numbered
+active changes above. ~5min.*
+
+*__An agent helping the human (or building on parachute)__: read
+everything. The detailed sections cite specific issues
+(`vault#N`), PRs (`#NNN`), commits (`SHA`), and code paths
+(`file.ts:line`). An AI fed this whole doc will understand what
+shipped, what changed shape, what's still in flight, and where to
+look in the codebase for ground truth.*
+
 ### Step-by-step
 
 1. **Stop the daemon** before upgrading:
@@ -222,34 +236,15 @@ Two defaults changed:
 
 ### What if I happen to be on an intermediate version?
 
-The CHANGELOG narrates development RCs that were never published to
-npm. What actually shipped on npm between 0.2.4 and 0.4.5 was:
-`0.3.0-rc.1`, `0.3.0`, `0.3.1`, `0.3.3`, `0.4.0`, `0.4.3`,
-`0.4.4-rc.11`, `0.4.4-rc.12`, `0.4.4-rc.14`, `0.4.5`. See the
-[CHANGELOG meta-note](./CHANGELOG.md) for the full table.
-
-- **On `0.3.0` / `0.3.1` / `0.3.3`**: you're past CLI rename, URL
-  migration, and filesystem restructure. Schema migrations
-  `v12 → v18` run automatically. The active-change list above
-  shrinks to: token audience binding (only if you script JWT
-  minting), the `mcp-install` default flips (if you script
-  installs), the priv-esc audit, and the smaller items in §7.
-- **On `0.4.0`**: schema `v12` or higher. Token audience, JWT scope
-  narrowing, and per-vault token binding all landed here. From 0.4.0
-  the remaining 0.4.5 changes are mostly additive (file extensions,
-  case-collision handling, sync ergonomics, lossless export). The
-  priv-esc fix landed during the 0.4.0 chain — audit
-  `config.yaml` as documented above.
-- **On `0.4.3`**: most ground covered. Remaining: extension column
-  (`vault#328`), case-collision auto-disambig (`vault#327`), upsert
-  on `update-note if_missing: "create"` (`vault#309`), portable
-  export PR-2 polish (attachments, blow-away).
-- **On `0.4.4-rc.11/rc.12/rc.14`**: you're a brave soul; you're at
-  schema `v17` or `v18`. The only meaningful delta to 0.4.5 stable
-  is case-collision auto-disambig (`vault#327`),
-  `AmbiguousPathError` distinct from `PathConflictError`
-  (`vault#330 S1`), and the sidecar leftover tracking
-  (`vault#330 S2`).
+*__If you're not on 0.2.4__ (you installed at some point in the 0.3
+or 0.4 window): the schema and filesystem migrations still apply on
+first boot from any prior version — they're idempotent and only
+execute what's needed. The active changes that affect you depend on
+when you installed. The CHANGELOG meta-note at the top of the
+[CHANGELOG.md](./CHANGELOG.md) maps installed-version-to-schema-version.
+If your upgrade surfaces anything confusing or breaking,
+[reach out on GitHub](https://github.com/ParachuteComputer/parachute-vault/issues)
+— happy to help in real time.*
 
 ### One paragraph on shipped-then-changed-mid-arc
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,387 @@
+# Upgrading Parachute Vault
+
+Operator-facing migration guidance. For the full chronological CHANGELOG,
+see [CHANGELOG.md](./CHANGELOG.md) — note the meta-note at the top about
+what's actually been published to npm.
+
+## 0.2.4 → 0.4.5
+
+**Most beta users are on `0.2.4`** (the launch version, 2026-04-18).
+The current stable is `0.4.5` (2026-05-15). This is the direct upgrade
+path; everything in between can be skipped safely.
+
+### Migration is automatic
+
+Schema migrations and filesystem migrations both run on first
+post-upgrade boot. They're **idempotent**, **target-wins on conflict**,
+and handle the full `v9 → v18` jump in one init — no incremental hops
+required.
+
+- **Schema migrations** (every `v3 → v18`): wrapped in
+  `BEGIN IMMEDIATE` transactions, log each step to the boot output. A
+  `0.2.4` baseline is at schema `v9`; on first post-upgrade boot the
+  store walks `v10 → v18` in order. Re-running is a no-op.
+- **Filesystem migrations** (run on every CLI command):
+  `~/.parachute/<stuff>` → `~/.parachute/vault/<stuff>`, then
+  `vault/vaults/<name>/` → `vault/data/<name>/` and daemon logs into
+  `vault/logs/`. Each move is logged. EXDEV (cross-mount-boundary)
+  failures surface a clear hint.
+- **One data-loss carve-out worth knowing about**: the v17 migration
+  drops the `note_schemas` + `schema_mappings` tables. For 0.2.4 →
+  0.4.5 direct upgraders, this is harmless — those tables were
+  transiently present in development RCs between 0.3.x and 0.4.1
+  that **never published to npm**, so no real installer had them. If
+  the migration finds rows it logs a warning naming the dropped
+  schemas + mappings so you can recreate them as `tags.fields`
+  declarations on the relevant `tags` rows.
+
+So the operator-visible work is short. The rest of this guide is what
+to *actively* change.
+
+### TL;DR — what you have to actively do
+
+1. **Stop the daemon, install, restart.** Schema + filesystem
+   migrations run automatically.
+2. **Rename CLI references** in shell aliases, shebangs, CI scripts,
+   README files: `parachute` → `parachute-vault`.
+3. **Re-install your MCP integration** with `parachute-vault
+   mcp-install` so `~/.claude.json` rewrites the URL surface. OAuth
+   clients re-handshake.
+4. **Audit `~/.parachute/vault/config.yaml`** for `api_keys[].scope:
+   read` rows — those silently escalated to full access pre-fix
+   (vault#233). Upgrading is the fix; the audit confirms whether you
+   were affected.
+5. **Update scripted JWT minting** (only if you have it) to use
+   per-vault audience `aud: vault.<name>` and narrowed scopes
+   `vault:<name>:<verb>`.
+
+### Step-by-step
+
+1. **Stop the daemon** before upgrading:
+
+   ```
+   parachute stop vault          # if you have the new dispatcher
+   # or, on 0.2.4:
+   parachute daemon stop
+   ```
+
+   If neither command is recognized (some 0.2.4 sub-versions only had
+   `parachute serve` as the foreground run surface), kill the process
+   directly — `pkill -f parachute` or `launchctl bootout` the launchd
+   label.
+2. **Pull the new package**:
+
+   ```
+   npm install -g @openparachute/vault@latest
+   ```
+3. **Restart the daemon**:
+
+   ```
+   parachute-vault serve         # or: parachute start vault
+   ```
+4. **Verify**. The boot log shows automatic schema bumps `v9 → v18`
+   and the filesystem moves. `parachute-vault status` reports running
+   version + state.
+5. **Re-install MCP integration** (see the URL prefix change below):
+
+   ```
+   parachute-vault mcp-install
+   ```
+
+### Active changes
+
+These are the operator-visible changes 0.2.4 → 0.4.5 in order of
+likely impact.
+
+#### 1. CLI binary renamed `parachute` → `parachute-vault`
+
+The `parachute` name was freed for the `@openparachute/hub`
+dispatcher. When the dispatcher is installed it transparently forwards
+`parachute vault <cmd>` to `parachute-vault <cmd>`; the vault CLI's
+own arg-parser also accepts a leading `vault` prefix
+(`parachute-vault vault init`), so existing launchd/systemd wrappers
+continue working.
+
+**Action**: update shell aliases, shebangs, CI scripts, and README
+references. The canonical command an operator types becomes
+`parachute-vault`.
+
+#### 2. API URL prefix migrated `/vaults/<name>/...` → `/vault/<name>/...`
+
+Every vault-touching route changed: API at `/vault/<name>/api/...`,
+MCP at `/vault/<name>/mcp`, OAuth at
+`/vault/<name>/oauth/{register,authorize,token}`, discovery at
+`/vault/<name>/.well-known/oauth-*`, published-note view at
+`/vault/<name>/view/:id`. The unscoped `/api`, `/mcp`, `/oauth/*`,
+`/view/*` paths (single-vault auto-default) retired, as did the
+plural `/vaults/<name>/...` prefix and the unified cross-vault MCP
+endpoint (each MCP session now pins to one vault by URL).
+`list-vaults` MCP tool retired alongside.
+
+**Action**, by client:
+
+- **Claude Code**: run `parachute-vault mcp-install` to rewrite
+  `~/.claude.json`. The new install also picks up hub-mint auth and
+  the `local` scope default — pass `--legacy-pat` or
+  `--install-scope user` if you want the prior behavior.
+- **OAuth clients** (Claude Desktop, Parachute Daily, custom
+  integrations): remove the existing integration and re-add it
+  pointing at the new URL — the issuer URL changed, OAuth must
+  re-handshake.
+- **`curl` scripts**: rewrite hardcoded URLs.
+  `/vaults/work/api/notes` → `/vault/work/api/notes`.
+- **Published-note permalinks**: `/view/<id>` and
+  `/vaults/<name>/view/<id>` both become
+  `/vault/<name>/view/<id>`.
+
+Cross-vault endpoints (`GET /vaults`, `/vaults/list`, `/health`) are
+unchanged. Tokens themselves keep working — only the addressing
+changes.
+
+#### 3. Token audience binding — per-vault `aud: vault.<name>`
+
+JWT audience switched from hardcoded `"hub"` to per-vault
+`aud: vault.<name>`. Tokens minted for `vault.work` can't replay
+against `vault.personal`. Cross-vault routes reject hub JWTs (no
+single audience to bind). Hub-issued JWTs also reject broad
+`vault:<verb>` scopes — they must pick a vault:
+`vault:<name>:<verb>`.
+
+**Action**: only matters if you have scripted JWT minting against a
+multi-vault setup. Narrow scopes to `vault:<name>:<verb>` and set
+`aud: vault.<name>`. `pvt_*` tokens are unaffected. The old
+`aud: "hub"` claims validated during a now-closed rolling-update
+window.
+
+#### 4. Privilege-escalation fix — audit `config.yaml` (vault#233)
+
+The global `config.yaml` `api_keys` parser previously dropped the
+`scope` field. The auth check `globalKey.scope === "read"` then
+resolved `undefined` to "full" — silently escalating any
+user-authored `scope: read` global key to full access. Upgrading is
+the fix; the parser now mirrors the vault-level one.
+
+**Action**: audit `~/.parachute/vault/config.yaml` (or older
+`~/.parachute/config.yaml` if your filesystem migration is mid-flight)
+for `api_keys[].scope: read` entries. Pre-upgrade they may have been
+silently inflated. Impact scan on Aaron's own deployment found zero
+affected keys, but the fix exists because the bug existed.
+
+#### 5. Scope enforcement is now real
+
+Pre-0.4.0, `parachute-vault tokens create --read` produced a token
+documented as read-only but advisory at the boundary. Post-0.4.0,
+scopes are enforced. Reads require `vault:read`, mutations
+`vault:write`, `/.parachute/config` `vault:admin`. Inheritance:
+`admin ⊇ write ⊇ read`. MCP `tools/list` returns only read tools for
+read-scoped tokens; mutation `tools/call` returns 403
+`insufficient_scope`.
+
+**Action**: audit any caller using `--read` tokens that performs
+writes. Pre-`v12` NULL-scope rows fall back to
+`legacyPermissionToScopes(permission)` for one release with a
+deprecation warning; new mints write scopes explicitly.
+
+#### 6. `mcp-install` script defaults
+
+Two defaults changed:
+
+- **Install scope** flipped from `user` (global `~/.claude.json`) to
+  `local` (`projects[<absolute-cwd>].mcpServers` in
+  `~/.claude.json`). Scripted installs that want the old behavior
+  add `--install-scope user`. Interactive walkthrough always prompts.
+- **Auth mode** flipped from minting a vault-DB `pvt_*` to requesting
+  a hub-issued JWT. `--mint` (now the default) reads
+  `~/.parachute/operator.token` and POSTs to
+  `<hub>/api/auth/mint-token`. `--legacy-pat` falls back to `pvt_*`
+  with a deprecation notice. Self-hosted-without-hub deployments
+  should pass `--legacy-pat` explicitly.
+
+#### 7. Smaller automatic-but-worth-noting changes
+
+- **Loopback bind by default**: server bound `0.0.0.0`; now binds
+  `127.0.0.1`. Set `VAULT_BIND=0.0.0.0` if your topology relies on a
+  wide bind (Docker bridge networking, LAN exposure).
+- **`update-note` requires `if_updated_at` or `force: true`**: the
+  optimistic-concurrency check is now mandatory. Callers omitting
+  both receive MCP `InvalidParams` / REST 428
+  `precondition_required`. `query-notes` and `create-note` return
+  `updatedAt` so callers have the token to echo.
+- **Tag rename returns 200 with cascade stats** (was 409
+  `tag_in_use_by_tokens`). Cascade rewrites tags, sub-tags,
+  `note_tags`, `parent_names`, `tokens.scoped_tags`,
+  `indexed_fields.declarer_tags`, body refs, and
+  `_tags/<name>` paths in one transaction.
+- **Per-vault token binding**: new `pvt_*` mints bind to the
+  minting vault (schema `v16`). Pre-`v16` NULL-bound tokens stay
+  server-wide (legacy compat). Pass `--all` on `tokens create` to
+  opt back in to server-wide with a warning.
+- **Path uniqueness widened `(path)` → `(path, extension)`**: lets
+  `Foo.md` and `Foo.csv` coexist. Wikilinks to ambiguous bare paths
+  (`[[Foo]]`) are refused; use the explicit `[[Foo.csv]]` form.
+
+### What if I happen to be on an intermediate version?
+
+The CHANGELOG narrates development RCs that were never published to
+npm. What actually shipped on npm between 0.2.4 and 0.4.5 was:
+`0.3.0-rc.1`, `0.3.0`, `0.3.1`, `0.3.3`, `0.4.0`, `0.4.3`,
+`0.4.4-rc.11`, `0.4.4-rc.12`, `0.4.4-rc.14`, `0.4.5`. See the
+[CHANGELOG meta-note](./CHANGELOG.md) for the full table.
+
+- **On `0.3.0` / `0.3.1` / `0.3.3`**: you're past CLI rename, URL
+  migration, and filesystem restructure. Schema migrations
+  `v12 → v18` run automatically. The active-change list above
+  shrinks to: token audience binding (only if you script JWT
+  minting), the `mcp-install` default flips (if you script
+  installs), the priv-esc audit, and the smaller items in §7.
+- **On `0.4.0`**: schema `v12` or higher. Token audience, JWT scope
+  narrowing, and per-vault token binding all landed here. From 0.4.0
+  the remaining 0.4.5 changes are mostly additive (file extensions,
+  case-collision handling, sync ergonomics, lossless export). The
+  priv-esc fix landed during the 0.4.0 chain — audit
+  `config.yaml` as documented above.
+- **On `0.4.3`**: most ground covered. Remaining: extension column
+  (`vault#328`), case-collision auto-disambig (`vault#327`), upsert
+  on `update-note if_missing: "create"` (`vault#309`), portable
+  export PR-2 polish (attachments, blow-away).
+- **On `0.4.4-rc.11/rc.12/rc.14`**: you're a brave soul; you're at
+  schema `v17` or `v18`. The only meaningful delta to 0.4.5 stable
+  is case-collision auto-disambig (`vault#327`),
+  `AmbiguousPathError` distinct from `PathConflictError`
+  (`vault#330 S1`), and the sidecar leftover tracking
+  (`vault#330 S2`).
+
+### One paragraph on shipped-then-changed-mid-arc
+
+For the niche set of users who tracked development RCs (rather than
+published-to-npm versions): three items shipped and then changed
+shape inside the arc. The `synthesize-notes` MCP tool shipped in
+`vault#198` and retired in `vault#268` (`v17`). The `_tags/<name>`
+and `_schemas/<name>` notes-as-config convention shipped in
+`vault#204` and migrated to first-class tables (`vault#245`,
+`vault#249`) ~5 days later — the legacy notes are left in place as
+inert audit trail. Empty-note rejection shipped in `vault#235` and
+reversed in `vault#324` after a real-vault round-trip smoke proved
+skeletons / drafts / organizing notes are valid state (the 500-cap
+on batches stays). None of these affect operators who upgraded
+directly between published-to-npm versions.
+
+### What you can now do
+
+Ranked by impact for operators upgrading from 0.2.4. Adoption is
+opt-in unless otherwise noted.
+
+- **Lossless portable export.** `parachute-vault export <dir>` writes
+  git-tractable markdown (`.parachute/vault.yaml` + per-tag schemas
+  + notes with frontmatter + attachment binaries). `parachute-vault
+  import <dir>` is the lossless inverse. `--blow-away` wipes and
+  replays for disaster recovery (confirm defaults NO). `--since
+  <iso>` for incremental exports. Round-trip is byte-identical on
+  unchanged vault state. (Caveat: attachment IDs re-mint on import.
+  Note-level round-trip is byte-identical; `attachments[].id`
+  values differ between original and re-imported. Frontmatter refs
+  resolve correctly via `(note_id, path)`. Tracked as a follow-up.)
+- **Non-markdown notes as first-class.** Pass `extension: "csv"`
+  (or yaml / json / mdx / txt / etc.) on `create-note`.
+  Frontmatter-compatible formats (md, mdx) carry metadata inline;
+  the rest get a sidecar at `.parachute/notes-meta/<id>.yaml`.
+  Filter by extension via `query-notes extension: ["csv", "yaml"]`
+  or REST `?extension=csv&extension=yaml` (vault#328).
+- **Upsert-on-update.** Pass `if_missing: "create"` on `update-note`
+  (MCP) or `PATCH /notes/:id` (REST). Eliminates the
+  query-then-create round trip on nightly syncs. Response carries
+  `created: true|false` so sync loops branch without a follow-up
+  query (vault#309).
+- **`update-note` operations bundle.** SQL-atomic `append` /
+  `prepend` (concurrent appends never overwrite each other);
+  `content_edit: { old_text, new_text }` for surgical
+  find-and-replace with multi-match guard; frontmatter-aware
+  prepend that skips the YAML block. `update-note` elevated from
+  blunt full-document replacement to a real edit surface.
+- **Indexed metadata + operator-object queries.** Declare a tag
+  field as indexed via `update-tag fields.<name>.indexed: true` —
+  vault adds a generated column + B-tree index universal across all
+  notes. Then query with operators:
+  `query-notes metadata: {priority: {gte: 3, lt: 10}, status: {in:
+  ["open"]}}`. Full set: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`,
+  `in`, `not_in`, `exists`. HTTP catches up with
+  `?meta[field][op]=value` bracket-style. Also: `has_tags` /
+  `has_links` presence filters, `order_by` on indexed fields,
+  `dateFilter` recognizes `updated_at` for incremental rebuilds.
+  *Bonus fix:* `query-notes near` (graph neighborhood) now returns
+  all results — a silent SQL `WHERE` bug previously dropped
+  neighborhoods beyond the first N rows.
+- **JSON integer coercion.** `update-tag fields.<name>.type:
+  "integer"` accepts both `5` and `5.0` (zero fractional), rejects
+  `5.5`, `"5"`, `NaN`, `Infinity`. Fixes false-positive
+  `type_mismatch` warnings from JSON-emitting drift detectors.
+- **Tag schema inheritance.** Tags can declare `parent_names`; a
+  child's effective fields = its own ∪ all ancestors'. `_default`
+  is the implicit universal parent. First-in-walk-wins conflict
+  resolution with advisory `schema_conflict` warnings.
+- **Atomic tag rename + merge.** `POST /api/tags/{name}/rename`
+  rewrites the tag across every reference surface in one
+  transaction; `POST /api/tags/merge` retags every note carrying
+  any source onto the target.
+- **Hub-minted auth with revocation enforcement.** Hub-issued JWTs
+  are the canonical auth path. JWTs are revocation-checked every
+  request with 60s caching, fail-open during hub outage, fail-closed
+  only on cold start. Tag-scoped tokens narrow a single `pvt_*` to
+  a root-tag allowlist.
+- **Scripted token management via REST.** `POST /vault/<name>/tokens`
+  to mint, `GET` to list, `DELETE` to revoke. Same surface the
+  Admin SPA uses; useful for orchestrators or CI without shell
+  access. Hub-JWT `vault:<name>:admin` auth required.
+- **Server-side transcription.** `POST
+  /api/notes/{id}/attachments {transcribe: true}` queues audio for
+  the scribe worker (set `SCRIBE_URL` env to enable). Event-driven
+  via the `attachment:created` hook. Vault becomes the canonical
+  scribe context provider via `transcription.context` in
+  `vault.yaml`. Audio retention configurable per-vault.
+- **Interactive `mcp-install`.** Bare `parachute-vault mcp-install`
+  from a TTY walks through vault choice, install location, auth
+  mode, and previews the exact JSON before any network call.
+- **Graceful stop via filesystem sentinel.** `parachute-vault stop`
+  writes `~/.parachute/vault/stop.signal`; the running server polls
+  every 500ms and runs the drain-and-exit path. Useful in
+  environments where signals are awkward (Docker exec, foreground
+  runs without a managed PID).
+- **Case-collision safety.** Exports probe filesystem
+  case-sensitivity and auto-disambiguate colliding filenames on
+  macOS APFS / Windows NTFS while keeping canonical paths in
+  frontmatter. `AmbiguousPathError` (distinct from
+  `PathConflictError`) surfaces on REST 409 with a `candidates`
+  array.
+- **Empty notes are valid.** Skeleton notes,
+  drafts-saved-before-content, organizing-only notes all create +
+  round-trip cleanly.
+- **Lean response shape.** `update-note include_content: false`
+  returns `NoteIndex` (drops `content`, keeps `byteSize`,
+  `preview`, `validation_status`). HTTP `validation_status`
+  symmetric with MCP on create/update.
+- **`init --no-autostart`.** Skip daemon registration. For CI, dev
+  sandboxes, Docker, alt supervisors.
+- **Per-vault admin SPA.** Vault detail, tokens, permissions at
+  `/vault/<name>/admin/` (reachable through hub's proxy with
+  hub-issued JWT).
+- **`vault-info` projection.** Comprehensive schema-bearing view
+  (own + effective fields, indexed-field catalog, query hints). MCP
+  `initialize` carries the markdown projection so agents see the
+  schema landscape at session start.
+- **Public `/auth/status` discovery endpoint.** Unauthenticated,
+  rate-limit-eligible. Boolean-only token presence response.
+
+### Where to learn more
+
+- [CHANGELOG.md](./CHANGELOG.md) — chronological per-release notes
+  with the npm-vs-published meta-note at the top.
+- [parachute-patterns cookbook](https://github.com/ParachuteComputer/parachute-patterns)
+  — recipes for portable export, schema inheritance, upsert sync,
+  tag-scoped tokens.
+- [parachute.computer/design](https://parachute.computer/design) —
+  architecture references: module protocol, OAuth shape, hub-as-AS.
+
+### Reporting issues
+
+If your upgrade surfaces something not covered here, please file at
+[ParachuteComputer/parachute-vault/issues](https://github.com/ParachuteComputer/parachute-vault/issues).


### PR DESCRIPTION
## Summary

Doc-only PR. Fourth iteration of the 0.2.4 → 0.4.5 upgrade guide,
reframed around two facts Aaron confirmed during the prior round:

1. **Direct upgrade is correctness-safe.** Schema migrations
   idempotent, filesystem migrations auto-run with target-wins,
   no incremental hops required. UPGRADING.md leads with this so
   operators understand "the work is short" before reading
   active-change details.

2. **The `0.3.6-rc.X` CHANGELOG entries don't reflect installable
   npm versions.** What actually published to npm between launch
   and 0.4.5 is `0.3.0-rc.1`, `0.3.0`, `0.3.1`, `0.3.3`, `0.4.0`,
   `0.4.3`, `0.4.4-rc.11/12/14`, `0.4.5`. The 0.3.6 series was a
   development-diary chain, not a release chain.

Prior PRs #333, #334, #335 were each closed when a deeper audit
revealed the framing was wrong; this iteration draws from the
third-pass primary-sourced synthesis with the corrected reality.

- **Commit 1** — `docs: add UPGRADING.md with 0.2.4 → 0.4.5
  migration guide`: new file at repo root, ~2334 words.
  - Opens with "Migration is automatic" section (schema + filesystem
    + one data-loss carve-out for v17 dropping note_schemas /
    schema_mappings — harmless for direct upgraders since those
    tables only existed in unpublished dev RCs).
  - TL;DR of five operator-visible actions.
  - Seven numbered active changes (CLI rename, URL prefix, token
    audience, priv-esc audit, scope enforcement, mcp-install
    defaults, catchall §7).
  - "What if I happen to be on" section with light notes for
    intermediate published versions.
  - One-paragraph shipped-then-changed-mid-arc note (was a section
    in prior draft).
  - 19-item ranked adoption list including the bonus `query-notes
    near` SQL fix mention.

- **Commit 2** — `docs(changelog): meta-note + 0.4.5 entry
  refinement for direct-upgrade framing`:
  - Adds a top-of-file meta-note (before `[Unreleased]`) with the
    CHANGELOG-vs-npm table.
  - Names the seven npm versions beta users actually ended up on.
  - Points at `parachute-patterns/patterns/governance.md` Rule 2 as
    the forward-looking remedy.
  - Refines the `[0.4.5]` entry with full-arc framing + "Coming
    from 0.2.4?" pointer to UPGRADING.md.

## Test plan

- [ ] Read UPGRADING.md end-to-end. The "Migration is automatic"
      section at the top should reassure a time-pressed operator
      before they read the active-change list.
- [ ] Verify the TL;DR action list is concrete enough to act on
      without scrolling.
- [ ] Verify the "What if I happen to be on" intermediate-version
      notes don't promise behaviors that aren't actually present
      at those versions.
- [ ] Verify the priv-esc audit step is action-first
      (`api_keys[].scope: read` in config.yaml).
- [ ] Verify the CHANGELOG meta-note table is accurate against
      `npm view @openparachute/vault versions` (Aaron's call to
      confirm against the registry).
- [ ] Verify the link from CHANGELOG 0.4.5 entry to UPGRADING.md
      renders correctly in GitHub's diff view.

## Patterns check

Doc-only. No code touched. Establishes the convention that
`UPGRADING.md` at repo root is the canonical migration-guide file
going forward; future upgrade paths append as new H2 sections.

The CHANGELOG meta-note is a one-off acknowledgement of past
versioning drift, paired with a forward-looking pointer at
governance.md Rule 2 which prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)