### PR TITLE
feat(deploy): Dockerfile + render.yaml + bearer-token auth gate for non-loopback (closes #339)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,68 @@
-node_modules
+# Keep the build context small — Docker uploads everything not listed here
+# to the daemon on every build.
+
+# VCS + editor noise
 .git
-*.test.ts
-*.test.js
-.env
+.gitignore
+.github
+.vscode
+.idea
+*.swp
+*.swo
+
+# Install artifacts (re-installed inside the builder stage)
+node_modules
+**/node_modules
+.bun
+
+# Build artifacts
+**/dist
+**/*.tsbuildinfo
+coverage
+
+# Local runtime state — never want this baked into an image
+.parachute
+parachute-home
+*.db
+*.db-journal
 *.log
 *.err
+
+# Docs / launch artifacts — not needed at runtime
+docs
+scratch
+UPGRADING.md
+CHANGELOG.md
+README.md
+LICENSE
+LAUNCH_SMOKE.md
+RELEASE-NOTES-*.md
+WAKE-UP-*.md
+BETA-EMAIL-*.md
+
+# Tests + fixtures — not needed in the runtime image
+**/*.test.ts
+**/*.test.js
+**/__tests__
+**/__snapshots__
+**/*.test.ts.snap
+
+# The web/ui React SPA is not served by vault's core HTTP loop (admin SPA
+# bundle is built into core/), so skip the source tree.
+web
+
+# Other deploy targets (we don't bake docker-compose or systemd unit files
+# into the image; they're host-side artifacts).
+deploy
+docker-compose.yml
+fly.toml
+railway.json
+Caddyfile
+
+# OS junk
 .DS_Store
+Thumbs.db
+
+# Don't ship the Dockerfile itself into the image
+Dockerfile
+.dockerignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,56 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.6-rc.1] — 2026-05-18
+
+Phase 1 of the v0.6 Render self-host arc (closes vault#339). Lands the
+container-shape primitives vault needs to run as a sibling Render
+service alongside hub:
+
+- **Dockerfile + .dockerignore** — two-stage build mirroring
+  parachute-hub's shape: `oven/bun:1.3-alpine` base, runtime stage with
+  `tini` for SIGTERM forwarding, runs as non-root `bun` (uid 1000) with
+  pre-chowned `/parachute` mount point. Build context pruned to
+  runtime essentials; tests, docs, and the web/ui SPA tree are
+  excluded.
+- **render.yaml Blueprint** — one `web` service on the `starter` plan
+  (persistent disks aren't available on Render's free tier), persistent
+  disk mounted at `/parachute` so vault state survives container
+  restarts. Health probe at `/health`. Env vars wired: `PARACHUTE_HOME`,
+  `PORT`, `VAULT_BIND=0.0.0.0`, `VAULT_AUTH_TOKEN` (sync: false),
+  `TRUST_PROXY=1`, optional `SCRIBE_URL`.
+- **`VAULT_AUTH_TOKEN` server-wide operator bearer** — when the env
+  var is set, a request with `Authorization: Bearer <value>` matching
+  the env var (constant-time compare) authenticates as full/admin
+  against any vault on the server. The minimum cross-container auth
+  shape: hub (sibling Render container) uses this stable bearer to
+  call vault's HTTP surface. When the env var is unset, vault's
+  existing token surface (per-vault DB tokens, hub-issued JWTs, legacy
+  YAML keys) is unchanged — full backwards compat for local
+  self-hosters and `bun link` dev. The end-state hub-issued-JWT-only
+  shape stays on the roadmap at vault#282.
+- **`/health` invariant pinned** — always returns 200 regardless of
+  `VAULT_AUTH_TOKEN` config so Render's health probe + Docker
+  `HEALTHCHECK` stay green even before the operator has wired a
+  bearer. The response shape (vault names leaked only to authed
+  callers) is unchanged.
+
+Deliberately deferred to follow-up PRs / issues:
+
+- Multi-token operator model (one shared bearer fits the v0.6
+  closed-beta; per-user operator tokens land alongside hub#258).
+- Full hub-issued JWT integration on every endpoint — already shipped
+  for the per-vault routes, but the operator-channel use case
+  intentionally keeps a simpler shared-bearer path until the JWT-only
+  endgame at vault#282.
+- Building the admin SPA (`web/ui/dist`) into the container image. The
+  503 fallback in `src/admin-spa.ts` covers the missing-bundle case
+  and the operator-facing UI lives on hub for v0.6.
+
+Gates on this PR:
+- `bun test ./src`: 957 pass, 0 fail (was 941 pre-change).
+- `bun run typecheck`: clean.
+
 ## [0.4.5] — 2026-05-15
 
 0.4.5 closes the substrate cycle that started with the launch &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.6-rc.2] — 2026-05-18
+
+Fold reviewer nits on PR #340:
+
+- **server.ts** — log `VAULT_AUTH_TOKEN` active state at startup
+  (`[auth] VAULT_AUTH_TOKEN set — server-wide operator bearer active`),
+  parallel to the existing `[transcribe]` boot signal. Operator gets a
+  bare-minimum visible confirmation the gate is armed.
+- **render.yaml** — comment that Render injects `$PORT` at runtime; the
+  hardcoded `1940` value is the fallback for local `docker run`
+  invocations.
+
 ## [0.4.6-rc.1] — 2026-05-18
 
 Phase 1 of the v0.6 Render self-host arc (closes vault#339). Lands the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,109 @@
-FROM oven/bun:1.2-alpine AS base
+# syntax=docker/dockerfile:1.7
+#
+# Parachute Vault container image.
+#
+# Two-stage shape mirroring parachute-hub's Dockerfile (hub#258/#261):
+#   Stage 1 (`builder`) — install dependencies against the lockfile so the
+#     install layer caches across source-only changes.
+#   Stage 2 (`runtime`) — slim runtime layer with deps + source, run as the
+#     non-root `bun` user under `tini` for proper SIGTERM forwarding.
+#
+# Bun reads `src/cli.ts` directly — no separate transpile step. The
+# entrypoint runs `parachute-vault serve`, which imports `src/server.ts`
+# and foregrounds the Bun.serve loop. Container hosts (Docker, Render,
+# Fly, Railway) own process lifecycle; this image stays out of pidfile
+# / launchd / systemd land.
+#
+# Operator-facing env vars:
+#   PORT                  — bind port (Render injects this; default 1940)
+#   PARACHUTE_HOME        — config root (mount the persistent disk here;
+#                           default /parachute → vault state at /parachute/vault)
+#   VAULT_BIND            — bind host (container default 0.0.0.0 so the
+#                           platform's HTTP forwarder can reach us)
+#   VAULT_AUTH_TOKEN      — optional server-wide bearer token. When set,
+#                           any `Authorization: Bearer <token>` matching
+#                           the env value authenticates as full/admin
+#                           against any vault. The "single shared operator
+#                           token" path for sibling services on Render.
+#                           When unset, vault falls back to its existing
+#                           per-vault tokens + hub JWT validation paths.
+#   SCRIBE_URL            — opt-in scribe endpoint for transcription worker.
+
+ARG BUN_VERSION=1.3
+FROM oven/bun:${BUN_VERSION}-alpine AS builder
+
 WORKDIR /app
 
-# Install deps
+# Copy manifests first so Docker layer-caches the install step across
+# source-only changes.
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production
 
-# Copy source
+# Install with the lockfile pinned. `--frozen-lockfile` matches CI; we
+# only need runtime deps in the image.
+RUN bun install --frozen-lockfile --production --ignore-scripts
+
+# Copy the runtime source. The `.dockerignore` already prunes test files,
+# node_modules, etc.
 COPY core core
 COPY src src
-COPY bunfig.toml ./
+COPY bunfig.toml tsconfig.json ./
 
-# Data directory — mount a volume here for persistence
-ENV PARACHUTE_HOME=/data
-RUN mkdir -p /data
+# ---- Runtime stage --------------------------------------------------------
+
+FROM oven/bun:${BUN_VERSION}-alpine AS runtime
+
+WORKDIR /app
+
+# tini reaps zombies + forwards signals so `docker stop` / Render redeploys
+# shut vault down cleanly via the SIGTERM drain path in server.ts instead
+# of getting SIGKILLed after the grace period. wget for HEALTHCHECK.
+RUN apk add --no-cache tini wget
+
+# Bring over installed deps + source from the builder stage.
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/core ./core
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/bunfig.toml ./bunfig.toml
+COPY --from=builder /app/tsconfig.json ./tsconfig.json
+COPY --from=builder /app/package.json ./package.json
+
+# Vault state root. The container's persistent disk mounts here — every
+# vault DB, config.yaml, .env, and attachment lives under
+# `$PARACHUTE_HOME/vault/`. Override at run time with
+# `-e PARACHUTE_HOME=/somewhere/else` if the host wants a different
+# mount point.
+ENV PARACHUTE_HOME=/parachute \
+    PORT=1940 \
+    VAULT_BIND=0.0.0.0 \
+    NODE_ENV=production
+
+# Pre-create the persistent-disk mount point and hand it to the non-root
+# `bun` user (uid 1000). Docker creates a VOLUME mount with root:root
+# permissions inheriting the image layer's owner; without this chown the
+# first `mkdirSync` from server boot fails with EACCES. Render's disks
+# come up pre-owned per Render's docs but anonymous-volume `docker run`
+# and bind-mount paths both need this seed directory.
+RUN mkdir -p /parachute && chown -R bun:bun /parachute
+
+# Render mounts the persistent disk at $PARACHUTE_HOME; declare the volume
+# so a `docker run` without a bind mount still gets an anonymous volume
+# rather than writing under the image layer.
+VOLUME ["/parachute"]
 
 EXPOSE 1940
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
-  CMD wget -qO- http://localhost:1940/health || exit 1
+# /health is unauthenticated and cheap — safe to poll. Use the same PORT
+# the server bound to; default 1940 matches the EXPOSE above.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s \
+  CMD wget -qO- "http://localhost:${PORT:-1940}/health" || exit 1
 
-CMD ["bun", "src/server.ts"]
+# Run as the non-root `bun` user that the base image already provides.
+USER bun
+
+ENTRYPOINT ["/sbin/tini", "--"]
+# `parachute-vault serve` is the container-shape entrypoint: foregrounded
+# Bun.serve loop, SIGTERM-drained shutdown, .env loaded from
+# $PARACHUTE_HOME/vault/.env. Equivalent to `bun src/server.ts` since
+# `cmdServe` just imports server.ts, but routing through cli.ts keeps the
+# image's entrypoint aligned with the CLI surface users already know.
+CMD ["bun", "src/cli.ts", "serve"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.6-rc.1",
+  "version": "0.4.6-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.5",
+  "version": "0.4.6-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,102 @@
+# Render Blueprint for self-hosting @openparachute/vault.
+#
+# Layout: one `web` service (the vault HTTP server) backed by a persistent
+# disk at /parachute. Vault state lands at /parachute/vault/ (per-vault
+# SQLite DBs, config.yaml, .env, attachments). The hub Blueprint
+# (parachute-hub/render.yaml) is a sibling — deploy both for a full
+# Parachute self-host on Render.
+#
+# To use: fork this repo, connect Render to the fork, click
+# "New Blueprint" → point at this file. Render provisions the service +
+# disk and runs the build. Set VAULT_AUTH_TOKEN in the Render dashboard
+# (marked `sync: false`) before exposing the service publicly — once
+# hub is on a different container, hub's outbound calls to vault need a
+# shared bearer to authenticate.
+#
+# Cross-service auth shape (issue #339):
+#   - Hub container → vault container: VAULT_AUTH_TOKEN bearer. Set the
+#     SAME value on both services (hub reads it from the matching env
+#     var name it expects; see parachute-hub/render.yaml).
+#   - The full hub-issued JWT integration with audience/scope claims
+#     stays the canonical path for end-user OAuth tokens; the shared
+#     bearer is the minimum-viable operator-channel auth for v0.6
+#     closed-beta. See vault#282 for the JWT-only endgame.
+
+services:
+  - type: web
+    name: parachute-vault
+    runtime: docker
+    # Starter plan ($7/mo) required: persistent disks are NOT available
+    # on Render's free tier, and vault state must survive container
+    # restarts (it's the system of record for notes, tags, links).
+    # Render resizes plans online if capacity needs to grow.
+    plan: starter
+    # /health is unauthenticated and always returns 200 — safe to use
+    # as Render's health probe even before VAULT_AUTH_TOKEN is set.
+    healthCheckPath: /health
+    autoDeploy: true
+    disk:
+      name: parachute-home
+      mountPath: /parachute
+      # 1 GiB covers a single-operator install with a few vaults +
+      # routine attachment volume. Bump in the Render dashboard for
+      # heavier use; Render resizes online (no redeploy).
+      sizeGB: 1
+    envVars:
+      # The persistent disk mount. Vault honors this for `~/.parachute/`,
+      # so per-vault SQLite DBs + config + attachments all land on the
+      # persistent volume rather than the ephemeral container filesystem.
+      - key: PARACHUTE_HOME
+        value: /parachute
+
+      # Container listens on whatever port Render injects via $PORT.
+      # Render's HTTP forwarder maps the public 443 → this port.
+      - key: PORT
+        value: 1940
+
+      # Bind to all interfaces inside the container so Render's HTTP
+      # forwarder can reach us — vault's on-box default of 127.0.0.1
+      # only works behind a same-host reverse proxy.
+      - key: VAULT_BIND
+        value: 0.0.0.0
+
+      # Server-wide operator bearer token. When set, any request with
+      # `Authorization: Bearer <this-value>` authenticates as full/admin
+      # against any vault. This is how the hub container (sibling
+      # service) authenticates its outbound calls to vault.
+      #
+      # `sync: false` because the value is a secret — each operator's
+      # Render deploy mints its own. Generate with:
+      #   openssl rand -hex 32
+      # …and set the SAME value on hub's render.yaml under the matching
+      # env var.
+      #
+      # Leave unset for a vault that only talks to local-loopback
+      # clients (the on-box CLI / hub-link case); the existing per-vault
+      # token surface (`parachute-vault tokens create`) still works.
+      - key: VAULT_AUTH_TOKEN
+        sync: false
+
+      # Trust proxy headers — Render terminates TLS upstream and passes
+      # the client IP via X-Forwarded-For. Without this, vault's
+      # per-IP OAuth-consent rate limiter sees Render's load balancer
+      # IP for every request.
+      - key: TRUST_PROXY
+        value: "1"
+
+      # Optional: scribe-service URL for the transcription worker. If
+      # set, vault polls scribe for attachments tagged
+      # `transcribe_status=pending`. Leave unset on a vault-only deploy.
+      #
+      # On Render, sibling services reach each other at the
+      # `<service-name>.onrender.com` public hostname OR via Render's
+      # internal mesh hostname (`<service-name>:<port>`) if both
+      # services live in the same region. Pin whichever shape your
+      # deploy uses; `sync: false` so the value doesn't land in source.
+      - key: SCRIBE_URL
+        sync: false
+
+      # Run with a sensible Node-style production hint. Bun honors this
+      # for any libraries that branch on NODE_ENV.
+      - key: NODE_ENV
+        value: production

--- a/render.yaml
+++ b/render.yaml
@@ -51,6 +51,8 @@ services:
 
       # Container listens on whatever port Render injects via $PORT.
       # Render's HTTP forwarder maps the public 443 → this port.
+      # Render injects $PORT at runtime to its platform-assigned value;
+      # this hardcoded value is the fallback for local `docker run` invocations.
       - key: PORT
         value: 1940
 

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -398,3 +398,238 @@ describe("auth — legacy global YAML keys honor declared scope", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// VAULT_AUTH_TOKEN — server-wide operator bearer (vault#339)
+//
+// The container-shape auth gate. When the env var is set, a request whose
+// `Authorization: Bearer <value>` matches authenticates as full/admin
+// against any vault on the server — the operator-channel path for sibling
+// services on Render where vault and hub run as separate containers and
+// hub needs a stable shared bearer to call vault.
+//
+// Semantic confirmed for the loopback/non-loopback split (auth gate is
+// orthogonal to socket-level loopback): when VAULT_AUTH_TOKEN is unset,
+// vault's existing token surface (per-vault DB tokens + hub JWTs + legacy
+// YAML keys) is the ONLY auth surface. The bind socket defaults to
+// 127.0.0.1 (`VAULT_BIND` in bind.ts), but no implicit loopback trust
+// exists at the auth layer — a request from 127.0.0.1 still has to
+// present a valid bearer. This matches docs/auth-model.md §1.
+// ---------------------------------------------------------------------------
+
+describe("auth — VAULT_AUTH_TOKEN server-wide operator bearer", () => {
+  const TOKEN = "test-operator-token-deadbeef0123456789abcdef";
+  let prevToken: string | undefined;
+
+  beforeEach(() => {
+    prevToken = process.env.VAULT_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    if (prevToken === undefined) delete process.env.VAULT_AUTH_TOKEN;
+    else process.env.VAULT_AUTH_TOKEN = prevToken;
+  });
+
+  test("env set + matching bearer → 200 on vault auth, full permission, admin scopes", async () => {
+    process.env.VAULT_AUTH_TOKEN = TOKEN;
+    seedVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(
+      bearer(TOKEN),
+      journalConfig,
+      journalStore.db,
+    );
+
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("full");
+      expect(result.scopes).toContain("vault:admin");
+      expect(result.legacyDerived).toBe(false);
+      expect(result.scoped_tags).toBeNull();
+    }
+  });
+
+  test("env set + matching bearer authenticates against ANY vault on the server", async () => {
+    // Server-wide → not tied to any one vault's DB. Same bearer works
+    // for journal and work without minting a per-vault token in either.
+    process.env.VAULT_AUTH_TOKEN = TOKEN;
+    seedVault("journal");
+    seedVault("work");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+    const workConfig = readVaultConfig("work")!;
+    const workStore = getVaultStore("work");
+
+    const j = await authenticateVaultRequest(bearer(TOKEN), journalConfig, journalStore.db);
+    const w = await authenticateVaultRequest(bearer(TOKEN), workConfig, workStore.db);
+
+    expect("error" in j).toBe(false);
+    expect("error" in w).toBe(false);
+  });
+
+  test("env set + missing bearer → 401 (no implicit auth)", async () => {
+    process.env.VAULT_AUTH_TOKEN = TOKEN;
+    seedVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    // No Authorization header at all.
+    const noBearer = new Request("https://vault.test/x");
+    const result = await authenticateVaultRequest(noBearer, journalConfig, journalStore.db);
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+    }
+  });
+
+  test("env set + wrong bearer → 401", async () => {
+    process.env.VAULT_AUTH_TOKEN = TOKEN;
+    seedVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(
+      bearer("wrong-token-doesnotmatch"),
+      journalConfig,
+      journalStore.db,
+    );
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+    }
+  });
+
+  test("env set + bearer that matches a vault token still resolves (server-wide first, but per-vault unchanged)", async () => {
+    // Per-vault tokens keep working even when the server-wide bearer is
+    // set. The server-wide check is a fast-path lookup before token DB
+    // resolution — a per-vault token doesn't match the env var so it
+    // falls through to the existing path.
+    process.env.VAULT_AUTH_TOKEN = TOKEN;
+    seedVault("journal");
+    const perVaultToken = mintTokenInVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(
+      bearer(perVaultToken),
+      journalConfig,
+      journalStore.db,
+    );
+
+    expect("error" in result).toBe(false);
+  });
+
+  test("env unset + valid per-vault bearer → 200 (existing behavior preserved)", async () => {
+    delete process.env.VAULT_AUTH_TOKEN;
+    seedVault("journal");
+    const token = mintTokenInVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    const result = await authenticateVaultRequest(bearer(token), journalConfig, journalStore.db);
+    expect("error" in result).toBe(false);
+  });
+
+  test("env unset + missing bearer → 401 (existing behavior preserved)", async () => {
+    delete process.env.VAULT_AUTH_TOKEN;
+    seedVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    const noBearer = new Request("https://vault.test/x");
+    const result = await authenticateVaultRequest(noBearer, journalConfig, journalStore.db);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+    }
+  });
+
+  test("env unset + non-loopback simulated via X-Forwarded-For → still 401 without bearer", async () => {
+    // Doc note: vault has NO implicit loopback trust at the auth layer.
+    // The X-Forwarded-For shape (set by hub / Cloudflare Tunnel / etc.)
+    // doesn't affect the auth gate; tokens are required regardless of
+    // socket origin. The `bind.ts` 127.0.0.1 default is a socket-level
+    // listen-restriction, not a trust-asymmetric auth bypass.
+    delete process.env.VAULT_AUTH_TOKEN;
+    seedVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    const remote = new Request("https://vault.test/x", {
+      headers: { "X-Forwarded-For": "203.0.113.7" },
+    });
+    const result = await authenticateVaultRequest(remote, journalConfig, journalStore.db);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+    }
+  });
+
+  test("env set with whitespace-only value → treated as unset", async () => {
+    process.env.VAULT_AUTH_TOKEN = "   ";
+    seedVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    // An empty/whitespace VAULT_AUTH_TOKEN must NOT allow any bearer to
+    // pass — the operator either commits to bearer auth or doesn't.
+    const result = await authenticateVaultRequest(
+      bearer(""),
+      journalConfig,
+      journalStore.db,
+    );
+    expect("error" in result).toBe(true);
+  });
+
+  test("env set + matching bearer also works on the global auth surface", async () => {
+    // /vaults metadata listing + /health vault names go through
+    // authenticateGlobalRequest. The server-wide bearer must work there
+    // too — otherwise hub couldn't enumerate vaults using the operator
+    // channel.
+    process.env.VAULT_AUTH_TOKEN = TOKEN;
+    seedVault("journal");
+
+    const result = await authenticateGlobalRequest(bearer(TOKEN));
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("full");
+    }
+  });
+
+  test("env set + wrong bearer on global auth surface → 401", async () => {
+    process.env.VAULT_AUTH_TOKEN = TOKEN;
+    seedVault("journal");
+
+    const result = await authenticateGlobalRequest(bearer("wrong-token"));
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(401);
+    }
+  });
+
+  test("near-miss bearer (one-char difference, same length) → 401 (constant-time compare)", async () => {
+    // Defensive: the server-wide compare uses crypto.timingSafeEqual so
+    // a one-char-off bearer that matches length-wise still rejects.
+    // We can't measure timing in a unit test, but we can pin the
+    // correctness side: a same-length near-miss must still reject.
+    process.env.VAULT_AUTH_TOKEN = TOKEN;
+    seedVault("journal");
+    const journalConfig = readVaultConfig("journal")!;
+    const journalStore = getVaultStore("journal");
+
+    const nearMiss = TOKEN.slice(0, -1) + "x";
+    expect(nearMiss).not.toBe(TOKEN);
+    expect(nearMiss.length).toBe(TOKEN.length);
+
+    const result = await authenticateVaultRequest(
+      bearer(nearMiss),
+      journalConfig,
+      journalStore.db,
+    );
+    expect("error" in result).toBe(true);
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -20,6 +20,7 @@ import type { VaultConfig, StoredKey } from "./config.ts";
 import { resolveToken } from "./token-store.ts";
 import type { TokenPermission } from "./token-store.ts";
 import type { Database } from "bun:sqlite";
+import crypto from "node:crypto";
 import { getVaultStore } from "./vault-store.ts";
 import {
   findBroadVaultScopes,
@@ -31,6 +32,66 @@ import {
   SCOPE_WRITE,
 } from "./scopes.ts";
 import { HubJwtError, looksLikeJwt, validateHubJwt } from "./hub-jwt.ts";
+
+/**
+ * Server-wide operator bearer token, sourced from the `VAULT_AUTH_TOKEN`
+ * environment variable.
+ *
+ * Read dynamically per request (not cached at import time) so test seams
+ * that mutate `process.env.VAULT_AUTH_TOKEN` work without re-importing.
+ * In production the env var is set at container start and doesn't change.
+ *
+ * Empty / whitespace-only values are treated as unset — the operator
+ * either commits to bearer auth or doesn't, no degraded "empty token
+ * always matches" failure mode.
+ */
+function getServerWideAuthToken(env: NodeJS.ProcessEnv = process.env): string | null {
+  const raw = env.VAULT_AUTH_TOKEN;
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+/**
+ * Constant-time string equality. Returns false when lengths differ
+ * (timingSafeEqual throws on length mismatch; we want a quiet false).
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) return false;
+  return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * If `VAULT_AUTH_TOKEN` is set and the provided bearer matches it
+ * (constant-time), return a full-admin AuthResult that's accepted by
+ * every vault on the server.
+ *
+ * The operator-channel auth shape for non-loopback deploys (Render,
+ * sibling-container setups, vault#339). Hub uses this to call vault
+ * across a container boundary; end-user OAuth tokens still take the
+ * per-vault hub-JWT / pvt_* paths below. See `docs/auth-model.md` §2.
+ *
+ * Scope set is broad (`vault:admin`) — the env-var bearer is an
+ * operator credential, not a user credential. Tag-scoping doesn't
+ * apply; we represent it as unscoped (`scoped_tags: null`).
+ */
+function tryServerWideAuth(
+  providedKey: string,
+  env: NodeJS.ProcessEnv = process.env,
+): AuthResult | null {
+  const configured = getServerWideAuthToken(env);
+  if (configured === null) return null;
+  if (!constantTimeEquals(providedKey, configured)) return null;
+  return {
+    permission: "full",
+    scopes: [SCOPE_ADMIN, SCOPE_WRITE, SCOPE_READ],
+    legacyDerived: false,
+    scoped_tags: null,
+    vault_name: null,
+  };
+}
 
 /** Result of a successful auth check. */
 export interface AuthResult {
@@ -167,6 +228,15 @@ export async function authenticateVaultRequest(
   if (!key) {
     return { error: Response.json({ error: "Unauthorized", message: "API key required" }, { status: 401 }) };
   }
+
+  // Server-wide operator token (vault#339). When VAULT_AUTH_TOKEN is set,
+  // a matching bearer authenticates as full/admin against any vault. This
+  // is the cross-container path for Render / sibling-service deployments
+  // where hub talks to vault over HTTP. Checked first so it short-circuits
+  // both JWT validation and per-vault DB lookups — the operator token is
+  // a credential the operator opts into, not one we'd ever fall through.
+  const serverWide = tryServerWideAuth(key);
+  if (serverWide !== null) return serverWide;
 
   // JWT path: hub-issued tokens. Trust pinned to the hub origin via `iss`
   // verification inside validateHubJwt; signature checked against hub's JWKS.
@@ -325,6 +395,14 @@ export async function authenticateGlobalRequest(
   if (!key) {
     return { error: Response.json({ error: "Unauthorized", message: "API key required" }, { status: 401 }) };
   }
+
+  // Server-wide operator token (vault#339). When VAULT_AUTH_TOKEN is set,
+  // a matching bearer authenticates as full/admin on cross-vault routes
+  // (/vaults metadata listing, /health detail). Checked first so a
+  // container-host operator-channel call doesn't depend on any per-vault
+  // DB lookup.
+  const serverWide = tryServerWideAuth(key);
+  if (serverWide !== null) return serverWide;
 
   // Hub-issued JWTs are always vault-bound (aud=vault.<name>). The unified
   // /vaults / /health surface spans every vault and has no single audience to

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -17,7 +17,7 @@
  * never touch ~/.parachute.
  */
 
-import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, afterAll } from "bun:test";
 import { rmSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -1639,5 +1639,89 @@ describe("scope enforcement on /api/*", () => {
       writePath,
     );
     expect(writeRes.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /health — smoke tests for the unauthenticated liveness probe (vault#339).
+//
+// /health must ALWAYS return 200 regardless of VAULT_AUTH_TOKEN config so
+// Render's health probe + Docker HEALTHCHECK can poll the container even
+// before the operator has configured a bearer. The response shape changes
+// (vault names are leaked only to authed callers) but the status code is
+// invariant.
+// ---------------------------------------------------------------------------
+
+describe("/health — always 200 (Render/Docker healthcheck contract)", () => {
+  let prevToken: string | undefined;
+
+  beforeEach(() => {
+    prevToken = process.env.VAULT_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    if (prevToken === undefined) delete process.env.VAULT_AUTH_TOKEN;
+    else process.env.VAULT_AUTH_TOKEN = prevToken;
+  });
+
+  test("env unset + no bearer → 200 (anonymous probe)", async () => {
+    delete process.env.VAULT_AUTH_TOKEN;
+    createVault("journal");
+
+    const res = await route(new Request("http://localhost:1940/health"), "/health");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    // No bearer → no vault names leaked.
+    expect(body.vaults).toBeUndefined();
+  });
+
+  test("env set + no bearer → 200 (Render's health probe doesn't have the secret)", async () => {
+    process.env.VAULT_AUTH_TOKEN = "operator-token-xyz";
+    createVault("journal");
+
+    const res = await route(new Request("http://localhost:1940/health"), "/health");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.vaults).toBeUndefined();
+  });
+
+  test("env set + matching bearer → 200 + vault names leaked", async () => {
+    process.env.VAULT_AUTH_TOKEN = "operator-token-xyz";
+    createVault("journal");
+    createVault("work");
+
+    const res = await route(
+      new Request("http://localhost:1940/health", {
+        headers: { Authorization: "Bearer operator-token-xyz" },
+      }),
+      "/health",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(Array.isArray(body.vaults)).toBe(true);
+    expect(body.vaults).toContain("journal");
+    expect(body.vaults).toContain("work");
+  });
+
+  test("env set + wrong bearer → 200 (still healthy, just no vault detail)", async () => {
+    // /health doesn't 401 on a wrong bearer — it just falls back to the
+    // anonymous response. The operator's probe stays green even if the
+    // bearer is mid-rotation.
+    process.env.VAULT_AUTH_TOKEN = "operator-token-xyz";
+    createVault("journal");
+
+    const res = await route(
+      new Request("http://localhost:1940/health", {
+        headers: { Authorization: "Bearer wrong-token" },
+      }),
+      "/health",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.vaults).toBeUndefined();
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -98,6 +98,10 @@ if (process.env.SCRIBE_URL) {
   console.log("[transcribe] worker disabled (set SCRIBE_URL to enable)");
 }
 
+if (process.env.VAULT_AUTH_TOKEN?.trim()) {
+  console.log("[auth] VAULT_AUTH_TOKEN set — server-wide operator bearer active");
+}
+
 // Auto-init: create a default vault if none exist (first run in Docker)
 if (listVaults().length === 0) {
   const globalConfig = readGlobalConfig();


### PR DESCRIPTION
## Summary

Phase 1 of the v0.6 Render self-host arc. Sibling to hub#258 / hub#261 — gives vault the container-shape primitives it needs to run as a separate Render service.

- **Container shape**: Two-stage Dockerfile on `oven/bun:1.3-alpine`, non-root `bun` user under `tini`, pre-chowned `/parachute` mount, `parachute-vault serve` as the foreground CMD. Plus a `render.yaml` Blueprint with one `web` service on the `starter` plan + 1 GiB persistent disk + the env wiring hub's blueprint also uses.
- **Auth gate for non-loopback**: New `VAULT_AUTH_TOKEN` env var. When set, a matching `Authorization: Bearer` (constant-time compared) authenticates as full/admin against any vault on the server. Checked first in both `authenticateVaultRequest` and `authenticateGlobalRequest`. When unset, vault's existing token surface (per-vault DB tokens, hub-issued JWTs, legacy YAML keys) is unchanged — full back-compat for local self-hosters and ``bun link`` dev.
- **Tests**: New ``VAULT_AUTH_TOKEN`` describe block in ``auth.test.ts`` (11 cases — env set + matching/missing/wrong/near-miss bearer; works on global surface; whitespace-only env treated as unset; both ``authenticateVaultRequest`` and ``authenticateGlobalRequest`` paths). New ``/health`` describe block in ``routing.test.ts`` (4 cases pinning the always-200 contract — anonymous probe, env-set + no-bearer, env-set + matching bearer, env-set + wrong bearer).

## Test results

- ``bun test ./src``: **957 pass, 0 fail, 2599 expect() calls** (was 941 pre-change; +16 new tests).
- ``bun run typecheck``: clean.
- ``docker build .``: succeeds (verified locally via orbstack).
- ``docker run`` smoke against the built image:
  - ``GET /health`` (no auth) → 200 ``{"status":"ok"}``.
  - ``GET /vaults`` (no auth) → 401.
  - ``GET /vaults`` (``Authorization: Bearer <VAULT_AUTH_TOKEN>``) → 200 with the vault list.
  - ``GET /vault/default/api/notes`` with the same bearer → 200.

## Notes on what was deliberately deferred

- **Multi-token operator model** — one shared bearer fits the v0.6 closed-beta. Per-user operator tokens land alongside hub's parallel work.
- **Full hub-issued JWT integration on the operator channel** — already shipped for the per-vault routes (audience/scope-narrowed JWTs from hub work today). The operator channel intentionally keeps the simpler shared-bearer path until the JWT-only endgame at vault#282.
- **Building the web/ui admin SPA into the container image** — ``src/admin-spa.ts`` already 503s gracefully when ``dist/`` is absent, and hub serves the operator-facing UI surface for v0.6. Adding the SPA build step to the Dockerfile is a clean follow-up if/when vault's per-vault admin pages become primary.
- **CHANGELOG** entry under ``[Unreleased]`` / new ``[0.4.6-rc.1]`` heading; ``package.json`` bumped ``0.4.5`` → ``0.4.6-rc.1`` per governance Rule 2 (rc.N until ready-for-release).

## Test plan

- [ ] CI runs ``bun test ./src`` clean
- [ ] CI typecheck clean
- [ ] Manual: ``docker build .`` reproduces locally
- [ ] Manual: ``docker run -e VAULT_AUTH_TOKEN=… -p 1940:1940 <image>`` boots, ``/health`` 200, bearer-authed ``/vaults`` returns the auto-created default vault
- [ ] Render preview: deploy the Blueprint to a fresh Render account, verify persistent disk wires through and ``VAULT_AUTH_TOKEN`` flows
- [ ] Cross-container: hub's blueprint reaches this vault using the shared ``VAULT_AUTH_TOKEN`` bearer (the actual cross-deploy validation lands alongside hub#261's merge)

Closes #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)