### PR TITLE
feat(vault): PARACHUTE_VAULT_NAME for first-boot + deprecate standalone render.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,28 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.6-rc.3] — 2026-05-20
+
+Two small items bundled as one cohesive PR:
+
+- **`PARACHUTE_VAULT_NAME` first-boot env var** — companion fix for the
+  hub first-boot wizard (hub#267). When the server starts with zero
+  vaults on disk and `PARACHUTE_VAULT_NAME` is set to a valid name, the
+  auto-created vault uses that name instead of `"default"`. Validation
+  reuses `validateVaultName` so the env var, the `--vault-name` flag,
+  and hub's wizard all share one rule (lowercase alphanumeric +
+  hyphens/underscores, `list` reserved). Invalid values trigger a
+  warning and fall back to `"default"` rather than aborting first boot.
+  First-boot log lines call out which path was taken:
+  `[vault first-boot] using PARACHUTE_VAULT_NAME=<name>` or
+  `[vault first-boot] using default name (no PARACHUTE_VAULT_NAME set)`.
+- **Standalone `render.yaml` deprecated as primary path** (closes
+  vault#341, Option A). The file stays in tree for the operators who
+  specifically want vault as its own Render service, but the
+  `render.yaml` header and the README's Deployment → Cloud platforms
+  section now point the typical v0.6 user at the hub-managed Render
+  deploy (`https://parachute.computer/deploy/render/`).
+
 ## [0.4.6-rc.2] — 2026-05-18
 
 Fold reviewer nits on PR #340:

--- a/README.md
+++ b/README.md
@@ -812,6 +812,29 @@ docker compose up -d
 
 ### Cloud platforms
 
+#### Render — recommended (hub-managed, v0.6)
+
+Most users deploy vault via parachute-hub's `/admin/modules` after the
+hub itself is on Render. See <https://parachute.computer/deploy/render/>
+for the primary v0.6 self-host story: one Render Blueprint provisions
+hub on a persistent disk, then you install vault (and the other
+Parachute modules) from the hub's admin UI. The hub container
+supervises vault's process, the shared persistent disk holds vault
+state, and module upgrades flow through the admin UI rather than
+separate Render redeploys.
+
+#### Render — standalone vault (advanced)
+
+The `render.yaml` Blueprint at the repo root deploys vault as its own
+Render web service, separate from hub. This is the **advanced path** —
+useful when you want vault on its own container (separate scaling,
+isolated logs, vault-only deploy without a hub) but not what the
+typical v0.6 self-host wants. If you're not sure, use the hub-managed
+path above. The standalone Blueprint stays in tree because some
+operators specifically want this shape (vault#341).
+
+#### Other platforms
+
 **Railway** ($5/mo) — Deploy from GitHub, persistent volume, public URL.
 **Fly.io** ($3-5/mo) — `fly launch --copy-config && fly volumes create vault_data --size 1 && fly deploy`
 

--- a/README.md
+++ b/README.md
@@ -810,6 +810,8 @@ cp .env.example .env   # edit with your config
 docker compose up -d
 ```
 
+Optionally set `PARACHUTE_VAULT_NAME` to choose a name for your first vault (defaults to `default`). Lowercase alphanumeric + hyphens or underscores, 2–32 chars.
+
 ### Cloud platforms
 
 #### Render — recommended (hub-managed, v0.6)
@@ -832,6 +834,10 @@ isolated logs, vault-only deploy without a hub) but not what the
 typical v0.6 self-host wants. If you're not sure, use the hub-managed
 path above. The standalone Blueprint stays in tree because some
 operators specifically want this shape (vault#341).
+
+Optionally set `PARACHUTE_VAULT_NAME` to choose a name for your first
+vault (defaults to `default`). Lowercase alphanumeric + hyphens or
+underscores, 2–32 chars.
 
 #### Other platforms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.6-rc.2",
+  "version": "0.4.6-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,20 @@
 # Render Blueprint for self-hosting @openparachute/vault.
 #
+# ADVANCED — STANDALONE VAULT DEPLOY (vault#341)
+# ----------------------------------------------
+# This Blueprint runs vault as its OWN Render service. Most v0.6 users
+# do not want this — they want parachute-hub's render.yaml, which boots
+# hub on Render and then installs vault (and the other modules) via the
+# admin UI at /admin/modules. That's the primary v0.6 self-host story
+# and is documented at:
+#
+#     https://parachute.computer/deploy/render/
+#
+# Keep using this file only if you specifically want vault as its own
+# Render container (separate scaling, separate logs, vault-only deploy
+# without a hub). For the typical case, follow the link above instead.
+# ----------------------------------------------
+#
 # Layout: one `web` service (the vault HTTP server) backed by a persistent
 # disk at /parachute. Vault state lands at /parachute/vault/ (per-vault
 # SQLite DBs, config.yaml, .env, attachments). The hub Blueprint

--- a/render.yaml
+++ b/render.yaml
@@ -117,3 +117,12 @@ services:
       # for any libraries that branch on NODE_ENV.
       - key: NODE_ENV
         value: production
+
+      # Optional: name your first-boot vault (default: "default"). When
+      # vault starts with zero vaults on disk, it auto-creates one named
+      # PARACHUTE_VAULT_NAME (if set + valid) or "default" (otherwise).
+      # Lowercase alphanumeric + hyphens or underscores, 2–32 chars; the
+      # name "list" is reserved. Uncomment and set in the Render dashboard
+      # to pick a name; leave commented to use "default".
+      # - key: PARACHUTE_VAULT_NAME
+      #   sync: false

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@
 import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile, generateApiKey, hashKey, stopSignalPath } from "./config.ts";
 import { existsSync, rmSync } from "fs";
 import { migrateVaultKeys } from "./token-store.ts";
+import { resolveFirstBootVaultName } from "./vault-name.ts";
 import { getVaultStore, getVaultNameForStore } from "./vault-store.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTriggers } from "./triggers.ts";
@@ -102,13 +103,27 @@ if (process.env.VAULT_AUTH_TOKEN?.trim()) {
   console.log("[auth] VAULT_AUTH_TOKEN set — server-wide operator bearer active");
 }
 
-// Auto-init: create a default vault if none exist (first run in Docker)
+// Auto-init: create a default vault if none exist (first run in Docker).
+// The vault name comes from PARACHUTE_VAULT_NAME when set + valid; otherwise
+// falls back to "default". Hub's first-boot wizard (hub#267) passes through
+// an operator-chosen name via this env var.
 if (listVaults().length === 0) {
   const globalConfig = readGlobalConfig();
   if (!globalConfig.default_vault) {
+    const firstBoot = resolveFirstBootVaultName(process.env.PARACHUTE_VAULT_NAME);
+    if (firstBoot.source === "env") {
+      console.log(`[vault first-boot] using PARACHUTE_VAULT_NAME=${firstBoot.name}`);
+    } else if (firstBoot.source === "env-invalid") {
+      console.warn(
+        `[vault first-boot] PARACHUTE_VAULT_NAME=${JSON.stringify(firstBoot.rawValue)} is invalid (${firstBoot.reason}); falling back to "default"`,
+      );
+    } else {
+      console.log("[vault first-boot] using default name (no PARACHUTE_VAULT_NAME set)");
+    }
+    const vaultName = firstBoot.name;
     const { fullKey, keyId } = generateApiKey();
     writeVaultConfig({
-      name: "default",
+      name: vaultName,
       api_keys: [{
         id: keyId,
         label: "default",
@@ -118,7 +133,7 @@ if (listVaults().length === 0) {
       }],
       created_at: new Date().toISOString(),
     });
-    globalConfig.default_vault = "default";
+    globalConfig.default_vault = vaultName;
     if (!globalConfig.api_keys?.length) {
       globalConfig.api_keys = [{
         id: keyId,
@@ -129,7 +144,7 @@ if (listVaults().length === 0) {
       }];
     }
     writeGlobalConfig(globalConfig);
-    console.log(`Auto-created default vault (API key: ${fullKey})`);
+    console.log(`Auto-created vault "${vaultName}" (API key: ${fullKey})`);
   }
 }
 

--- a/src/vault-name.test.ts
+++ b/src/vault-name.test.ts
@@ -1,7 +1,9 @@
 /**
  * Unit tests for `validateVaultName` — the rule enforced by the `init`
- * prompt and the `--vault-name` flag. Covers each rejection branch plus
- * the happy paths the prompt has to accept (default, hyphens, underscores).
+ * prompt, the `--vault-name` flag, and the `PARACHUTE_VAULT_NAME` env var
+ * at server first-boot. Covers each rejection branch (empty, length,
+ * regex, reserved) plus the happy paths the prompt has to accept (default,
+ * hyphens, underscores, length boundaries).
  */
 
 import { describe, test, expect } from "bun:test";
@@ -14,11 +16,12 @@ describe("validateVaultName", () => {
       "aaron",
       "personal",
       "work",
-      "a",
+      "ab", // 2-char boundary (min length)
       "vault-1",
       "my_vault",
       "a-b_c-1",
       "abc123",
+      "a".repeat(32), // 32-char boundary (max length)
     ])("%s", (name) => {
       const result = validateVaultName(name);
       expect(result.ok).toBe(true);
@@ -70,6 +73,24 @@ describe("validateVaultName", () => {
       const result = validateVaultName("list");
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error).toContain("reserved");
+    });
+
+    test("single character (below 2-char min)", () => {
+      const result = validateVaultName("a");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("2");
+    });
+
+    test("33 characters (above 32-char max)", () => {
+      const result = validateVaultName("a".repeat(33));
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("32");
+    });
+
+    test("200 characters (well above max)", () => {
+      const result = validateVaultName("a".repeat(200));
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("32");
     });
   });
 });
@@ -176,5 +197,23 @@ describe("resolveFirstBootVaultName", () => {
     const r = resolveFirstBootVaultName("team/work");
     expect(r.source).toBe("env-invalid");
     expect(r.name).toBe("default");
+  });
+
+  test("env var set to a 200-char name → fallback to default (over max-length)", () => {
+    const r = resolveFirstBootVaultName("a".repeat(200));
+    expect(r.source).toBe("env-invalid");
+    expect(r.name).toBe("default");
+    if (r.source === "env-invalid") {
+      expect(r.reason).toContain("32");
+    }
+  });
+
+  test("env var set to a single character → fallback to default (under min-length)", () => {
+    const r = resolveFirstBootVaultName("a");
+    expect(r.source).toBe("env-invalid");
+    expect(r.name).toBe("default");
+    if (r.source === "env-invalid") {
+      expect(r.reason).toContain("2");
+    }
   });
 });

--- a/src/vault-name.test.ts
+++ b/src/vault-name.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { validateVaultName, decideInitVaultName } from "./vault-name.ts";
+import { validateVaultName, decideInitVaultName, resolveFirstBootVaultName } from "./vault-name.ts";
 
 describe("validateVaultName", () => {
   describe("accepts", () => {
@@ -119,5 +119,62 @@ describe("decideInitVaultName", () => {
   test("--vault-name with leading whitespace is trimmed and accepted", () => {
     const d = decideInitVaultName(["--vault-name", "  aaron  "], { isTTY: true });
     expect(d).toEqual({ kind: "name", name: "aaron" });
+  });
+});
+
+describe("resolveFirstBootVaultName", () => {
+  test("env var unset → fallback to default", () => {
+    const r = resolveFirstBootVaultName(undefined);
+    expect(r).toEqual({ source: "default", name: "default" });
+  });
+
+  test("env var empty string → fallback to default", () => {
+    const r = resolveFirstBootVaultName("");
+    expect(r).toEqual({ source: "default", name: "default" });
+  });
+
+  test("env var whitespace-only → fallback to default", () => {
+    const r = resolveFirstBootVaultName("   ");
+    expect(r).toEqual({ source: "default", name: "default" });
+  });
+
+  test("env var set to a valid name → that name (positive path)", () => {
+    const r = resolveFirstBootVaultName("smoke-1939");
+    expect(r).toEqual({ source: "env", name: "smoke-1939" });
+  });
+
+  test("env var set to a valid name with underscores → that name", () => {
+    const r = resolveFirstBootVaultName("my_vault");
+    expect(r).toEqual({ source: "env", name: "my_vault" });
+  });
+
+  test("env var set with surrounding whitespace → trimmed + accepted", () => {
+    const r = resolveFirstBootVaultName("  aaron  ");
+    expect(r).toEqual({ source: "env", name: "aaron" });
+  });
+
+  test("env var set to invalid (uppercase + spaces + special) → fallback to default + record raw + reason", () => {
+    const r = resolveFirstBootVaultName("Bad Name!!");
+    expect(r.source).toBe("env-invalid");
+    expect(r.name).toBe("default");
+    if (r.source === "env-invalid") {
+      expect(r.rawValue).toBe("Bad Name!!");
+      expect(r.reason).toContain("lowercase alphanumeric");
+    }
+  });
+
+  test("env var set to reserved name 'list' → fallback to default", () => {
+    const r = resolveFirstBootVaultName("list");
+    expect(r.source).toBe("env-invalid");
+    expect(r.name).toBe("default");
+    if (r.source === "env-invalid") {
+      expect(r.reason).toContain("reserved");
+    }
+  });
+
+  test("env var set to slash-containing name → fallback to default", () => {
+    const r = resolveFirstBootVaultName("team/work");
+    expect(r.source).toBe("env-invalid");
+    expect(r.name).toBe("default");
   });
 });

--- a/src/vault-name.ts
+++ b/src/vault-name.ts
@@ -78,3 +78,43 @@ export function decideInitVaultName(
   }
   return { kind: "prompt" };
 }
+
+/**
+ * Pick the first-boot vault name based on `PARACHUTE_VAULT_NAME`. Used by
+ * `server.ts` when the server starts with zero vaults on disk (Docker
+ * first-boot, hub-driven self-host install).
+ *
+ *   - env var unset / empty / whitespace-only → `{ source: "default", name: "default" }`
+ *   - env var present + valid → `{ source: "env", name: <validated> }`
+ *   - env var present + invalid → `{ source: "env-invalid", name: "default",
+ *     rawValue: <original>, reason: <validator message> }` (caller logs a
+ *     warning and proceeds with the default name; we never abort first-boot
+ *     over a misconfigured env var)
+ *
+ * Validation uses the same `validateVaultName` rule as the `--vault-name`
+ * flag — lowercase alphanumeric + hyphens/underscores, with the `list`
+ * reserved-name carveout — so hub's wizard, the CLI flag, and the env var
+ * all share one truth.
+ */
+export type FirstBootVaultName =
+  | { source: "default"; name: "default" }
+  | { source: "env"; name: string }
+  | { source: "env-invalid"; name: "default"; rawValue: string; reason: string };
+
+export function resolveFirstBootVaultName(
+  rawEnvValue: string | undefined,
+): FirstBootVaultName {
+  if (rawEnvValue === undefined || rawEnvValue.trim() === "") {
+    return { source: "default", name: "default" };
+  }
+  const v = validateVaultName(rawEnvValue);
+  if (v.ok) {
+    return { source: "env", name: v.name };
+  }
+  return {
+    source: "env-invalid",
+    name: "default",
+    rawValue: rawEnvValue,
+    reason: v.error,
+  };
+}

--- a/src/vault-name.ts
+++ b/src/vault-name.ts
@@ -5,12 +5,17 @@
  * the SQLite filename, and the OAuth consent page — anything that breaks
  * URL routing or filesystem assumptions has to be rejected up front.
  *
- * Used by the `init` prompt and the `--vault-name` flag. `cmdCreate` keeps
- * its own (slightly more permissive, legacy) regex for backward compat —
- * tightening it would reject names existing users may already have minted.
+ * Rule: lowercase alphanumeric + hyphens or underscores, 2–32 chars, with
+ * `list` reserved. Used by the `init` prompt, the `--vault-name` flag, and
+ * the `PARACHUTE_VAULT_NAME` env var at server first-boot. `cmdCreate`
+ * keeps its own (slightly more permissive, legacy) regex for backward
+ * compat — tightening it would reject names existing users may already
+ * have minted.
  */
 
 const VAULT_NAME_RE = /^[a-z0-9_-]+$/;
+const VAULT_NAME_MIN_LEN = 2;
+const VAULT_NAME_MAX_LEN = 32;
 
 const RESERVED_NAMES = new Set([
   // Collides with the `/vaults/list` discovery endpoint historically; the
@@ -23,10 +28,23 @@ export type VaultNameValidation =
   | { ok: true; name: string }
   | { ok: false; error: string };
 
+/**
+ * Validate a vault name. Accepts lowercase alphanumeric + hyphens or
+ * underscores, 2–32 chars. Trims surrounding whitespace before checking.
+ * `cmdCreate` keeps its own (legacy-permissive) regex; this validator is
+ * the strict gate used by the env var, the `--vault-name` flag, and
+ * hub's first-boot wizard.
+ */
 export function validateVaultName(raw: string): VaultNameValidation {
   const name = raw.trim();
   if (!name) {
     return { ok: false, error: "vault name cannot be empty." };
+  }
+  if (name.length < VAULT_NAME_MIN_LEN || name.length > VAULT_NAME_MAX_LEN) {
+    return {
+      ok: false,
+      error: `vault names must be ${VAULT_NAME_MIN_LEN}–${VAULT_NAME_MAX_LEN} characters long.`,
+    };
   }
   if (!VAULT_NAME_RE.test(name)) {
     return {
@@ -92,9 +110,9 @@ export function decideInitVaultName(
  *     over a misconfigured env var)
  *
  * Validation uses the same `validateVaultName` rule as the `--vault-name`
- * flag — lowercase alphanumeric + hyphens/underscores, with the `list`
- * reserved-name carveout — so hub's wizard, the CLI flag, and the env var
- * all share one truth.
+ * flag — lowercase alphanumeric + hyphens or underscores, 2–32 chars, with
+ * the `list` reserved-name carveout — so hub's wizard, the CLI flag, and
+ * the env var all share one truth.
  */
 export type FirstBootVaultName =
   | { source: "default"; name: "default" }


### PR DESCRIPTION
## Summary

Two small items bundled as one cohesive PR (one steward, one session, both touch the same v0.6 Render-deploy / first-boot story):

1. **`PARACHUTE_VAULT_NAME` first-boot env var** — companion fix for the hub first-boot wizard at hub#267.
2. **Standalone `render.yaml` deprecated as primary path** — closes #341 with Option A (keep the file, mark it advanced, point typical users at hub-managed deploy).

## Item 1 — `PARACHUTE_VAULT_NAME` first-boot env var

**Why.** The hub first-boot wizard (hub#267) collects an operator-chosen vault name but had nowhere to thread it — vault's auto-init in `src/server.ts` was hardcoded to `name: "default"`. This PR opens the env-var seam so hub can pass through.

**How.**
- New `resolveFirstBootVaultName(rawEnvValue)` in `src/vault-name.ts` reuses the existing `validateVaultName` rule so the env var, the `--vault-name` CLI flag, and hub's wizard all share one truth (lowercase alphanumeric + hyphens/underscores, `list` reserved).
- `server.ts` auto-init block now reads `process.env.PARACHUTE_VAULT_NAME`. Three paths:
  - Unset / empty / whitespace-only → falls back to `"default"`, logs `[vault first-boot] using default name (no PARACHUTE_VAULT_NAME set)`.
  - Set + valid → uses the validated name, logs `[vault first-boot] using PARACHUTE_VAULT_NAME=<name>`.
  - Set + invalid → falls back to `"default"`, logs a warn line with the raw value + validator reason. Never aborts first-boot over a misconfigured env var.

## Item 2 — Standalone `render.yaml` deprecated (closes #341)

**Why.** Per the v0.6 deploy story locked in 2026-05-18 (single container, hub-as-supervisor, `$7/mo` flat, modules installed via admin SPA), the typical user does *not* want a standalone vault-on-Render container — they want hub on Render and vault installed via `/admin/modules`. The standalone Blueprint stays useful for operators who specifically want vault as its own Render service, but presenting it as the default is now wrong.

**How.** Option A from #341 — keep the file, add clarifying docs.
- `render.yaml` header: new comment block flags this as "ADVANCED — STANDALONE VAULT DEPLOY", links to `https://parachute.computer/deploy/render/` as the primary v0.6 path.
- `README.md` Deployment → Cloud platforms: splits Render into "Recommended (hub-managed, v0.6)" and "Standalone vault (advanced)". Railway + Fly.io fall under a new "Other platforms" subhead.

## Test plan

- [x] `bun test ./src/` — **966 pass / 0 fail** (was 957 pre-change; +9 new tests in `vault-name.test.ts` for `resolveFirstBootVaultName`).
- [x] `bun run typecheck` — clean.
- [x] Smoke (PARACHUTE_HOME=/tmp scratch, port 11939): `PARACHUTE_VAULT_NAME=smoke-1939` creates vault `smoke-1939`, writes `default_vault: smoke-1939` to `~/.parachute/vault/config.yaml`, logs `[vault first-boot] using PARACHUTE_VAULT_NAME=smoke-1939`.
- [x] Smoke invalid: `PARACHUTE_VAULT_NAME="Bad Name!!"` logs the warn line with raw value + reason, falls back to `"default"`, writes `default_vault: default`.
- [x] Smoke unset: no env var → logs `[vault first-boot] using default name (no PARACHUTE_VAULT_NAME set)`, creates vault `default`.

## Versioning

`0.4.6-rc.3` — continues the `0.4.6` rc chain (rc.2 landed on PR #340 with the Render Blueprint primitives; this rc.3 layers the first-boot env-var + the standalone-deprecate doc note on top).

Closes #341.