### PR TITLE
feat(auth): consume vault_scope claim from hub-issued JWT — Phase 1 PR 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,46 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.6-rc.4] — 2026-05-20
+
+Hub multi-user Phase 1 PR 5 — consumer-side adoption of the new
+`vault_scope` claim hub mints on every JWT (per
+[`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)).
+
+### Added
+
+- **`authenticateHubJwt` consumes the `vault_scope` claim** via
+  scope-guard's new `enforceVaultScope` helper and refuses cross-vault
+  access at the consumer with a **403 + `error_type:
+  "vault_scope_mismatch"`** response. A token whose `vault_scope`
+  claim names a different vault than the URL targets is rejected
+  before any vault data is read. Defense-in-depth: hub's mint path
+  (PR 4 / parachute-hub#283) already narrows scopes to the user's
+  `assigned_vault`, and the existing audience strict-check + broad-
+  scope rejection are the primary gates. The new claim adds a second
+  pin against the case where a token-mint bug, manual edit, or
+  third-party RS not enforcing the scope-string vocabulary correctly
+  produces scope strings naming the wrong vault. Five new tests in
+  `auth-hub-jwt.test.ts` cover the matching-pin happy path, the cross-
+  vault attempt (403), admin tokens (`vault_scope: []`), pre-PR-4
+  tokens (claim absent → unrestricted back-compat), and the ordering
+  invariant that broad-scope rejection takes precedence over
+  vault_scope_mismatch.
+
+### Changed
+
+- **`@openparachute/scope-guard` dep bumped from `^0.2.0` to
+  `^0.3.0-rc.1`.** The 0.3.0 minor adds `HubJwtClaims.vaultScope:
+  string[]` (parsed from the JWT's `vault_scope` claim; surfaces as
+  `[]` when absent / malformed / explicitly empty) and the
+  `enforceVaultScope(claims, requestVaultName)` helper. See
+  [parachute-hub#285](https://github.com/ParachuteComputer/parachute-hub/pull/285)
+  for the library release.
+
+  **Install order**: scope-guard `0.3.0-rc.1` must publish to npm
+  before `bun install` here will succeed. The lockfile auto-updates on
+  first post-publish install; CI install fails until then.
+
 ## [0.4.6-rc.3] — 2026-05-20
 
 Two small items bundled as one cohesive PR:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.6-rc.3",
+  "version": "0.4.6-rc.4",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@openparachute/scope-guard": "^0.2.0",
+    "@openparachute/scope-guard": "^0.3.0-rc.1",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode-terminal": "^0.12.0"

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -98,12 +98,24 @@ interface SignOpts {
   ttlSeconds?: number;
   /** Override the random jti — needed when a test wants to revoke this exact token. */
   jti?: string;
+  /**
+   * `vault_scope` claim (multi-user Phase 1 PR 4 / scope-guard 0.3+).
+   * Undefined → omit the claim entirely (pre-PR-4 token shape; surfaces
+   * at scope-guard as `[]` = unrestricted). Provide `[]` explicitly for
+   * a hub-minted admin token; provide `["<name>"]` for a non-admin user.
+   */
+  vaultScope?: string[];
 }
 
 async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
   const iat = Math.floor(Date.now() / 1000);
   const exp = iat + (opts.ttlSeconds ?? 60);
-  return await new SignJWT({ scope: opts.scope, client_id: "test-client" })
+  const payload: Record<string, unknown> = {
+    scope: opts.scope,
+    client_id: "test-client",
+  };
+  if (opts.vaultScope !== undefined) payload.vault_scope = opts.vaultScope;
+  return await new SignJWT(payload)
     .setProtectedHeader({ alg: "RS256", kid: kp.kid })
     .setIssuer(opts.iss)
     .setSubject(opts.sub ?? "user-1")
@@ -316,6 +328,145 @@ describe("authenticateVaultRequest — hub JWT integration", () => {
     if (!("error" in result)) {
       expect(result.permission).toBe("full");
       expect(result.scopes).toEqual(["vault:journal:write"]);
+    }
+  });
+
+  test("vault_scope=[aaron] reaching /vault/aaron → success (matching pin)", async () => {
+    // Non-admin user assigned to vault "aaron" presenting their token
+    // at their own vault. The vault_scope claim names "aaron"; the
+    // request targets "aaron"; the defense-in-depth check passes.
+    seedVault("aaron");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.aaron",
+      scope: "vault:aaron:write",
+      vaultScope: ["aaron"],
+    });
+    const config = readVaultConfig("aaron")!;
+    const store = getVaultStore("aaron");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("full");
+      expect(result.scopes).toEqual(["vault:aaron:write"]);
+    }
+  });
+
+  test("vault_scope=[aaron] reaching /vault/bob (cross-vault) → 403 vault_scope_mismatch", async () => {
+    // The exact threat model multi-user Phase 1 PR 5 protects against.
+    // A non-admin user pinned to "aaron" somehow gets a token naming
+    // "bob" in its scope string (mint bug, edited token, third-party RS
+    // bug, replay attack). The audience strict-check inside
+    // validateHubJwt would catch the obvious shape (aud=vault.bob
+    // reaching journal endpoint), but the case below pre-fabricates a
+    // token whose aud + scope DO name bob — only the vault_scope claim
+    // pins the user to aaron. Without the new enforcement, the request
+    // would coast through.
+    seedVault("aaron");
+    seedVault("bob");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.bob", // audience matches bob (so the aud check passes)
+      scope: "vault:bob:write", // scope strings name bob too
+      vaultScope: ["aaron"], // but the user is pinned to aaron
+    });
+    const bobConfig = readVaultConfig("bob")!;
+    const bobStore = getVaultStore("bob");
+
+    const result = await authenticateVaultRequest(bearer(token), bobConfig, bobStore.db);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(403);
+      const body = (await result.error.json()) as {
+        error: string;
+        error_type: string;
+        message: string;
+        required_vault: string;
+        granted_vault_scope: string[];
+      };
+      expect(body.error).toBe("Forbidden");
+      expect(body.error_type).toBe("vault_scope_mismatch");
+      expect(body.message).toContain("aaron");
+      expect(body.message).toContain("bob");
+      expect(body.required_vault).toBe("bob");
+      expect(body.granted_vault_scope).toEqual(["aaron"]);
+    }
+  });
+
+  test("vault_scope=[] (admin token) passes any-vault check", async () => {
+    // Admin tokens carry vault_scope: [] — the explicit "no per-user pin"
+    // sentinel. The defense-in-depth check skips, and the request is
+    // gated purely by audience + scope strings. Both name "work" here,
+    // so the request succeeds.
+    seedVault("work");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.work",
+      scope: "vault:work:admin",
+      vaultScope: [],
+    });
+    const config = readVaultConfig("work")!;
+    const store = getVaultStore("work");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("full");
+      expect(result.scopes).toEqual(["vault:work:admin"]);
+    }
+  });
+
+  test("pre-PR-4 token (vault_scope claim absent) → treated as admin (back-compat)", async () => {
+    // Every operator token + CLI-mint that existed before hub PR 4
+    // merged lacks the vault_scope claim entirely. scope-guard surfaces
+    // the absent claim as `[]`, which the helper treats as
+    // "unrestricted" — so the request goes through as long as audience
+    // + scope strings are correct. Without this back-compat, the entire
+    // pre-PR-4 fleet would 403 the moment this code shipped, which is
+    // the wrong tradeoff for a defense-in-depth check.
+    seedVault("legacy");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.legacy",
+      scope: "vault:legacy:write",
+      // vaultScope intentionally omitted — pre-PR-4 token shape
+    });
+    const config = readVaultConfig("legacy")!;
+    const store = getVaultStore("legacy");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.permission).toBe("full");
+      expect(result.scopes).toEqual(["vault:legacy:write"]);
+    }
+  });
+
+  test("vault_scope check runs AFTER broad-scope check — broad scope still wins the failure mode", async () => {
+    // A token with a broad vault scope AND a vault_scope pin gets
+    // rejected for the broad scope (more diagnostic). Pinning the
+    // ordering matters because the 401 message tells the operator
+    // "your token shape is wrong" whereas 403 vault_scope_mismatch
+    // tells them "your user can't reach this vault" — those have
+    // different remediation paths.
+    seedVault("aaron");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.aaron",
+      scope: "vault:write", // broad — should trigger 401 first
+      vaultScope: ["other-vault"], // would also fail vault_scope check
+    });
+    const config = readVaultConfig("aaron")!;
+    const store = getVaultStore("aaron");
+
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      // 401, not 403 — broad-scope rejection takes precedence.
+      expect(result.error.status).toBe(401);
+      const body = (await result.error.json()) as { error: string; message: string };
+      expect(body.message).toContain("broad vault scope");
     }
   });
 

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -383,14 +383,23 @@ describe("authenticateVaultRequest — hub JWT integration", () => {
         error_type: string;
         message: string;
         required_vault: string;
-        granted_vault_scope: string[];
+        granted_vault_scope?: unknown;
       };
       expect(body.error).toBe("Forbidden");
       expect(body.error_type).toBe("vault_scope_mismatch");
+      // Message names both the pinned vault (aaron) and the requested
+      // vault (bob) so operators reading 403 logs can correlate to
+      // user assignment without needing to decode the token.
       expect(body.message).toContain("aaron");
       expect(body.message).toContain("bob");
       expect(body.required_vault).toBe("bob");
-      expect(body.granted_vault_scope).toEqual(["aaron"]);
+      // Surface hygiene: the pinned vault is intentionally NOT echoed
+      // back in a dedicated body field. The message carries enough
+      // diagnostic for an operator reading logs; a dedicated field
+      // would only leak the pin to a passive observer (the attacker
+      // already has it via local decode, but pattern hygiene says
+      // don't volunteer it).
+      expect(body.granted_vault_scope).toBeUndefined();
     }
   });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -362,6 +362,24 @@ async function authenticateHubJwt(
     // call site), the check is skipped — the audience strict-check
     // inside validateHubJwt is the primary pin in that case.
     if (opts.vaultName !== undefined && !enforceVaultScope(claims, opts.vaultName)) {
+      // Invariant: by the contract of `enforceVaultScope`, the false
+      // branch requires `claims.vaultScope.length > 0` — an empty
+      // `vaultScope` always returns true. The defensive assertion
+      // pins that so a future refactor can't slip an empty-scope
+      // request into this branch (which would render an empty
+      // parenthesised list in the message and break the diagnostic).
+      // Body shape: client gets `required_vault` + a message naming
+      // the conflict. The token's pinned vault is intentionally NOT
+      // echoed back — the attacker holds the token (and can decode
+      // claims locally), so the message would only leak the pin to a
+      // legitimate operator looking at a 403 log line. They already
+      // know which user they assigned where; the required_vault is
+      // the actionable piece.
+      if (claims.vaultScope.length === 0) {
+        throw new Error(
+          "unreachable: enforceVaultScope returned false on an empty vaultScope",
+        );
+      }
       return {
         error: Response.json(
           {
@@ -369,7 +387,6 @@ async function authenticateHubJwt(
             error_type: "vault_scope_mismatch",
             message: `token's vault_scope (${claims.vaultScope.join(", ")}) does not include the requested vault '${opts.vaultName}'`,
             required_vault: opts.vaultName,
-            granted_vault_scope: claims.vaultScope,
           },
           { status: 403 },
         ),

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -31,6 +31,7 @@ import {
   SCOPE_READ,
   SCOPE_WRITE,
 } from "./scopes.ts";
+import { enforceVaultScope } from "@openparachute/scope-guard";
 import { HubJwtError, looksLikeJwt, validateHubJwt } from "./hub-jwt.ts";
 
 /**
@@ -241,9 +242,15 @@ export async function authenticateVaultRequest(
   // JWT path: hub-issued tokens. Trust pinned to the hub origin via `iss`
   // verification inside validateHubJwt; signature checked against hub's JWKS.
   // Audience strict-checked against `vault.<name>` so a token stamped for
-  // one vault can't reach another.
+  // one vault can't reach another. `vault_scope` claim additionally checked
+  // against `vaultConfig.name` so a per-user vault pin refuses cross-vault
+  // access even if a scope-string somehow named the wrong vault (multi-user
+  // Phase 1 defense-in-depth — see hub#283 + scope-guard 0.3.0).
   if (looksLikeJwt(key)) {
-    return await authenticateHubJwt(key, { expectedAudience: `vault.${vaultConfig.name}` });
+    return await authenticateHubJwt(key, {
+      expectedAudience: `vault.${vaultConfig.name}`,
+      vaultName: vaultConfig.name,
+    });
   }
 
   // Try vault's token DB first
@@ -319,10 +326,20 @@ export async function authenticateVaultRequest(
  * here — Phase B2 settled that hub tokens always name the resource. Per-
  * vault audience enforcement happens inside `validateHubJwt` via
  * `opts.expectedAudience`.
+ *
+ * Per-user vault-pin enforcement (multi-user Phase 1 PR 5): when
+ * `opts.vaultName` is set, the token's `vault_scope` claim is checked
+ * against it via scope-guard's `enforceVaultScope`. Non-admin tokens
+ * (`vault_scope: [<assigned_vault>]`) refuse cross-vault access with a
+ * 403 + `vault_scope_mismatch` error code. Admin tokens (`vault_scope:
+ * []`) and pre-PR-4 tokens (claim absent → surfaced as `[]`) pass
+ * unchanged. The 403 (not 401) signals "your credential is valid but
+ * doesn't grant access to this vault" — distinct from authentication
+ * failures upstream. See hub#283 + scope-guard 0.3.0 for the mint side.
  */
 async function authenticateHubJwt(
   token: string,
-  opts: { expectedAudience: string | null },
+  opts: { expectedAudience: string | null; vaultName?: string },
 ): Promise<{ error: Response } | AuthResult> {
   try {
     const claims = await validateHubJwt(token, { expectedAudience: opts.expectedAudience });
@@ -335,6 +352,26 @@ async function authenticateHubJwt(
             message: `hub JWT carries broad vault scope(s): ${broad.join(" ")}. Hub-issued tokens must use resource-narrowed scopes (vault:<name>:<verb>).`,
           },
           { status: 401 },
+        ),
+      };
+    }
+    // Defense-in-depth vault-pin check (multi-user Phase 1 PR 5). Runs
+    // AFTER the broad-scope check — a malformed token gets the more-
+    // descriptive scope-shape error rather than a generic pin-mismatch.
+    // When `vaultName` is unset (no per-vault binding known at this
+    // call site), the check is skipped — the audience strict-check
+    // inside validateHubJwt is the primary pin in that case.
+    if (opts.vaultName !== undefined && !enforceVaultScope(claims, opts.vaultName)) {
+      return {
+        error: Response.json(
+          {
+            error: "Forbidden",
+            error_type: "vault_scope_mismatch",
+            message: `token's vault_scope (${claims.vaultScope.join(", ")}) does not include the requested vault '${opts.vaultName}'`,
+            required_vault: opts.vaultName,
+            granted_vault_scope: claims.vaultScope,
+          },
+          { status: 403 },
         ),
       };
     }


### PR DESCRIPTION
## Summary

- Wires scope-guard's new `enforceVaultScope` helper into `authenticateHubJwt` so vault refuses cross-vault access at the consumer when a token's `vault_scope` claim names a different vault (multi-user Phase 1 defense-in-depth).
- New error shape: **403** with `error_type: "vault_scope_mismatch"` and `required_vault` in the body. Distinct from upstream 401 auth failures so operators can tell "valid token, wrong vault" from "invalid token."
- vault `0.4.6-rc.3` → `0.4.6-rc.4`. scope-guard dep `^0.2.0` → `^0.3.0-rc.1`.

**Draft until** [parachute-hub#285](https://github.com/ParachuteComputer/parachute-hub/pull/285) merges + Aaron publishes `@openparachute/scope-guard@0.3.0-rc.1` to npm. CI install fails until then — see the merge-day sequence below.

Closes the consumer-side of the hub multi-user Phase 1 PR 5 chain. Design: [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/). Companion: hub#283 (mint side) + parachute-hub#285 (scope-guard lib).

## What changed

`authenticateHubJwt` (in `src/auth.ts`) gains a `vaultName?: string` option. When set, the function calls `enforceVaultScope(claims, vaultName)` after the audience + broad-scope checks. On mismatch:

```json
{
  "error": "Forbidden",
  "error_type": "vault_scope_mismatch",
  "message": "token's vault_scope (aaron) does not include the requested vault 'bob'",
  "required_vault": "bob"
}
```

The 403 (not 401) signals "your credential is valid but doesn't grant access to this vault" — distinct from upstream 401 auth failures (bad signature, audience mismatch, expired).

## Why defense-in-depth, not primary gate

Hub PR 4's `narrowVaultScopes` already narrows scopes to the user's `assigned_vault` at mint time. Vault's existing `authenticateHubJwt` already rejects broad `vault:<verb>` scopes; the per-route check matches `vault:<name>:<verb>` against the URL. So the primary gate is intact.

The new `vault_scope` claim adds a second pin. If a token-mint bug, a manually-edited token, or a third-party RS not enforcing the scope-string vocabulary correctly somehow produces a `vault:bob:write` for a user assigned to `aaron`, this check refuses the cross-vault access *before any vault data is read*.

## Token-shape compatibility

Pre-PR-4 tokens lack the `vault_scope` claim entirely. scope-guard 0.3+ surfaces those as `[]` (unrestricted); `enforceVaultScope([], anything)` returns `true`. So the entire pre-PR-4 fleet keeps authenticating against any vault they have scope strings for — no operational disruption. Pinned by a regression test ("pre-PR-4 token (claim absent) → treated as admin").

## Ordering: broad-scope rejection wins

The new check runs AFTER the existing broad-vault-scope rejection. A token with a broad scope `vault:write` AND a vault_scope pin gets the 401 "broad vault scope" diagnostic, not the 403 vault_scope_mismatch — the 401 tells the operator "your token shape is wrong" (more fundamental) whereas 403 tells them "your user can't reach this vault." Pinned by a regression test.

## Tests

`bun test ./src/` → **977/977 pass** (972 baseline + 5 new vault_scope cases):

| case | shape | expected |
|---|---|---|
| matching pin | `vault_scope=[aaron]` reaching `/vault/aaron` | 200 |
| cross-vault attempt (threat model) | `vault_scope=[aaron]` reaching `/vault/bob` with `aud=vault.bob` + `scope=vault:bob:write` | 403 `vault_scope_mismatch` |
| admin token | `vault_scope=[]` | 200 any-vault |
| pre-PR-4 token | claim absent → surfaces as `[]` | 200 (back-compat) |
| ordering invariant | broad scope + bad pin | 401 broad-scope (not 403) |

`bun run typecheck` clean.

## Versioning

- vault: `0.4.6-rc.3` → `0.4.6-rc.4`. RC chain continues.
- `@openparachute/scope-guard`: `^0.2.0` → `^0.3.0-rc.1`. Gating dependency.

## Merge-day sequence (this is the load-bearing ordering)

The current `bun.lock` still pins `@openparachute/scope-guard@0.2.0`. A clean `bun install` (CI's first step on every push) will **fail** until `@openparachute/scope-guard@0.3.0-rc.1` is on npm. The order is:

1. **Land [parachute-hub#285](https://github.com/ParachuteComputer/parachute-hub/pull/285)** (the scope-guard 0.3.0-rc.1 release).
2. **Aaron runs `npm publish --tag rc` for `@openparachute/scope-guard@0.3.0-rc.1`** (per "npm publishes are Aaron's job"). Verify with `npm view @openparachute/scope-guard@0.3.0-rc.1` before moving on.
3. **Flip this PR from draft → ready-for-review.** The push triggers a new CI run; `bun install` now resolves the new version and updates `bun.lock` automatically.
4. **CI install + tests + typecheck pass.** Reviewer dispatched.
5. **Merge.**

If step 2 is skipped or delayed, every CI run on this branch will fail with `package not found` until the package lands on npm. That's the expected red-light state during draft.

## Patterns check

Adopts scope-guard 0.3+'s `enforceVaultScope` per the documented adoption pattern in scope-guard's CHANGELOG. The 403 + `error_type: "vault_scope_mismatch"` shape mirrors hub's PR-4 mint-side shape so failure-code vocabulary stays uniform across mint + consume. No new patterns; one new scope-guard adoption.

## Test plan

- [ ] hub#285 merged + `@openparachute/scope-guard@0.3.0-rc.1` on npm
- [ ] PR flipped from draft to ready
- [ ] CI install + tests + typecheck green on the new push
- [ ] Reviewer dispatched + verification summary
- [ ] Aaron merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)