### PR TITLE
feat(vault): mcp-config CLI for claude -p runners + mcp-install --dry-run + doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,71 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.6-rc.5] — 2026-05-20
+
+Three small wins surfaced while Aaron was wiring the Gitcoin Brain
+runner (vault-as-job-substrate; a Python loop spawning
+`claude -p --mcp-config '<json>'` against a vault). Each was per-script
+boilerplate or a subtle footgun — folded into the CLI here.
+
+### Added
+
+- **`parachute-vault mcp-config <vault-name>`** — emits the JSON shape
+  consumed by `claude -p --mcp-config '<json>'` to stdout. The runner
+  pattern:
+
+  ```bash
+  export PARACHUTE_VAULT_TOKEN=pvt_...
+  claude -p --mcp-config "$(parachute-vault mcp-config gitcoin)" \
+            --strict-mcp-config ...
+  ```
+
+  Flags: `--token <bearer>` (alternative to `PARACHUTE_VAULT_TOKEN`);
+  `--base-url <url>` (override the auto-detected origin, useful for
+  tailnet-exposed hubs); `--env-vars` (emit the template form with
+  `${PARACHUTE_HUB_URL}` and `${PARACHUTE_VAULT_TOKEN}` placeholders —
+  safe to commit; shell-expanded at runtime). With no token and no
+  `--env-vars`, exits 1 with a clear error: runners get a fail-fast,
+  no surprise auto-minting. Literal mode verifies the vault exists
+  locally; `--env-vars` mode is shape-only and works offline.
+
+  The synthesizer lives in `mcp-install.ts:buildMcpConfigJson` so
+  third-party tools that import vault as a library can reuse the
+  shape. Tests in `mcp-config.test.ts` cover both modes + token
+  precedence + base-url override + the no-token / unknown-vault
+  error paths.
+
+- **`mcp-install --dry-run`** — prints the write that would happen
+  (target file, install scope, project key when local, entry key,
+  resolved MCP URL, auth mode) without touching disk or hitting the
+  hub for a mint. Aaron hit the inverse case: probing `mcp-install`
+  was creating an empty `projects[<cwd>]` entry in `~/.claude.json`
+  as a side effect. `--dry-run` is the deliberate "tell me what
+  you'd do" path for scripts wiring up runners. Skips the
+  operator-token check and the hub round-trip entirely — the point
+  is "no side effects, including network."
+
+### Changed
+
+- **`mcp-install` success message + help text recommend
+  `--install-scope user` for headless flows.** Local-scope MCP entries
+  (under `projects[<cwd>].mcpServers` — the default since vault#290)
+  are visible to interactive `claude` from the install directory but
+  do **not** propagate to `claude -p` subprocesses spawned by scripts,
+  even from the same directory and even with
+  `--setting-sources user,project,local`. Operators wiring up runners
+  need user-scope. The success-line heads-up on local installs now
+  says so; the README cookbook has a "headless flows" subsection with
+  the full explanation.
+
+- **README — Troubleshooting: 406 on manual `curl` to
+  `/vault/<name>/mcp`.** The MCP HTTP transport requires both
+  `application/json` and `text/event-stream` in the `Accept` header
+  (it negotiates between JSON response and the SSE streaming variant).
+  Claude Code's `--mcp-config` http transport sets this automatically;
+  the symptom only shows up when probing the endpoint by hand. Added
+  a short troubleshooting entry with the working `curl` invocation.
+
 ## [0.4.6-rc.4] — 2026-05-20
 
 Hub multi-user Phase 1 PR 5 — consumer-side adoption of the new

--- a/README.md
+++ b/README.md
@@ -640,9 +640,16 @@ claude -p --mcp-config "$(parachute-vault mcp-config gitcoin)" \
           --strict-mcp-config \
           "Summarize the latest notes under projects/gitcoin"
 
-# Or commit a template — placeholders expand at runtime:
+# Or commit a template and expand at use-time:
 parachute-vault mcp-config gitcoin --env-vars > .claude/mcp-gitcoin.json
+# ...then later, when invoking claude:
+export PARACHUTE_HUB_URL=http://127.0.0.1:1940
+export PARACHUTE_VAULT_TOKEN=pvt_...
+claude -p --mcp-config "$(envsubst < .claude/mcp-gitcoin.json)" \
+          --strict-mcp-config ...
 ```
+
+**Note on `--env-vars` expansion.** The file-save pattern requires the caller to expand `${...}` placeholders at use-time (e.g. via `envsubst`, available on most Linux distros and via `brew install gettext` on macOS). Bare `$(cat .claude/mcp-gitcoin.json)` feeds literal `${PARACHUTE_HUB_URL}` strings into `claude -p` — the shell only expands placeholders inside the command-substitution *source*, not inside the *captured output*. `claude -p` itself doesn't expand `${...}` either, so the substitution has to happen between the file and the command.
 
 Flags: `--token <bearer>` (alternative to `PARACHUTE_VAULT_TOKEN`); `--base-url <url>` (override the auto-detected origin, useful for tailnet-exposed hubs: `--base-url https://hub.tail.ts.net`); `--env-vars` (emit the template form with `${PARACHUTE_HUB_URL}` and `${PARACHUTE_VAULT_TOKEN}` placeholders, safe to commit). With no token and no `--env-vars`, the command exits 1 with a clear error — runners get a fail-fast.
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ parachute-vault mcp-install --install-scope user      # write ~/.claude.json top
 parachute-vault mcp-install --install-scope local     # write ~/.claude.json projects[<cwd>] (this directory only — default)
 parachute-vault mcp-install --install-scope project   # write ./.mcp.json (checked into the repo)
 parachute-vault mcp-install --vault work   # target the "work" vault (keyed as parachute-vault-work)
+parachute-vault mcp-install --dry-run      # describe the write without touching disk or the hub
+parachute-vault mcp-config gitcoin         # emit JSON for `claude -p --mcp-config "$(...)"`
+parachute-vault mcp-config gitcoin --env-vars   # template form with ${PARACHUTE_HUB_URL}/${PARACHUTE_VAULT_TOKEN}
 
 # OAuth — owner password + 2FA
 parachute-vault set-password               # set/change the owner password (OAuth consent page)
@@ -619,7 +622,29 @@ parachute-vault mcp-install --legacy-pat
 
 **Multi-vault.** `--vault <name>` targets a specific vault and writes the entry under `parachute-vault-<name>` so multiple vaults coexist. Without `--vault`, the singular `parachute-vault` slot is used and one install clobbers another — that's intentional for the common single-vault case.
 
+**Dry-run.** `parachute-vault mcp-install --dry-run` prints the write that would happen — target file, install scope, entry key, URL, auth mode — without touching disk or hitting the hub. Useful for probing the command's effect; in particular, `--help` no longer creates an empty `projects[<cwd>]` entry as a side effect, but `--dry-run` is the deliberate "tell me what you'd do" path.
+
 **Doctor.** `parachute-vault doctor` checks `~/.claude.json` (both top-level and `projects[<cwd>]`) and `./.mcp.json`, and reports which one holds the entry, plus port-match and reachability of the MCP URL.
+
+#### Headless flows — `claude -p` runners (`mcp-config`)
+
+`mcp-install` writes a persistent entry into a Claude Code config file. That's the right shape for interactive sessions, but it has two sharp edges for headless runners that spawn `claude -p` against a vault:
+
+1. **Local-scope MCP entries don't propagate to `claude -p` subprocesses.** A project-scoped install under `projects[<cwd>].mcpServers` is visible to an *interactive* `claude` launched from that directory, but a `claude -p` invocation spawned by a Python script — even from the same directory, even with `--setting-sources user,project,local` — doesn't pick it up. Use `--install-scope user` for scripts, cron jobs, and runners; the local default is fine for interactive sessions.
+2. **`--mcp-config` JSON is per-runner boilerplate.** Some runners prefer to inline the MCP config rather than mutate the user's Claude Code state. `parachute-vault mcp-config <vault-name>` emits exactly the JSON shape `--mcp-config` consumes:
+
+```bash
+# Mint or fetch a vault-scoped token first, then:
+export PARACHUTE_VAULT_TOKEN=pvt_...
+claude -p --mcp-config "$(parachute-vault mcp-config gitcoin)" \
+          --strict-mcp-config \
+          "Summarize the latest notes under projects/gitcoin"
+
+# Or commit a template — placeholders expand at runtime:
+parachute-vault mcp-config gitcoin --env-vars > .claude/mcp-gitcoin.json
+```
+
+Flags: `--token <bearer>` (alternative to `PARACHUTE_VAULT_TOKEN`); `--base-url <url>` (override the auto-detected origin, useful for tailnet-exposed hubs: `--base-url https://hub.tail.ts.net`); `--env-vars` (emit the template form with `${PARACHUTE_HUB_URL}` and `${PARACHUTE_VAULT_TOKEN}` placeholders, safe to commit). With no token and no `--env-vars`, the command exits 1 with a clear error — runners get a fail-fast.
 
 ## Data model
 
@@ -729,6 +754,15 @@ The checks, in the order they're emitted:
 - **Claude Code shows no vault tools.** Check in order: (1) is the daemon up (`parachute-vault status`)? (2) does `~/.claude.json` have a `parachute-vault` entry with both `url` and a valid `Authorization` header? (3) does the URL's vault name match an existing vault? `parachute-vault doctor` catches the first two. A missing or stale `Authorization` header after a bare `vault mcp-install` is the usual culprit for #2 — see the Claude Code section of [Connecting a client](#connecting-a-client) for how to rewrite it.
 - **Claude Desktop / Daily won't connect via OAuth.** If the owner-password prompt was skipped at `vault init`, the consent page falls back to requiring a vault token in place of the password (functional but clunky). Set one now with `parachute-vault set-password`. If 2FA is enrolled, have your authenticator app ready before starting the flow; lost TOTP access recovers via the backup codes printed at enrollment.
 - **Scheduled backups aren't running.** On macOS: `doctor` flags `backup agent: not loaded` when `schedule` isn't `manual` but the launchd agent is missing — rerun `parachute-vault backup --schedule <freq>` to reinstall it. On Linux: systemd-timer support for backup isn't shipped yet, so `--schedule daily` silently skips the scheduler. Run `parachute-vault backup` from cron (or similar) until that lands.
+- **Manual `curl` against `/vault/<name>/mcp` returns `406 Not Acceptable`.** The MCP HTTP transport requires both `application/json` and `text/event-stream` in the `Accept` header (it negotiates between the JSON response and the SSE streaming variant). Claude Code's `--mcp-config` http transport sets this automatically — the symptom only shows up when you probe the endpoint by hand. The fix:
+
+  ```bash
+  curl -H 'Accept: application/json, text/event-stream' \
+       -H "Authorization: Bearer $VAULT_TOKEN" \
+       http://127.0.0.1:1940/vault/default/mcp
+  ```
+
+  Both media types are needed; omitting either is what triggers the 406.
 
 ### Getting help
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.6-rc.4",
+  "version": "0.4.6-rc.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,7 @@ switch (command) {
     await cmdMcpInstall(cmdArgs);
     break;
   case "mcp-config":
-    cmdMcpConfig(cmdArgs);
+    await cmdMcpConfig(cmdArgs);
     break;
   case "remove":
   case "rm":
@@ -1058,6 +1058,12 @@ async function cmdMcpInstall(args: string[]): Promise<void> {
   }
 
   // --- Vault target. Default = default_vault; validate existence. ---
+  // Read --dry-run *before* the vault-existence guard so a probe like
+  // `mcp-install --vault future-vault --dry-run` can describe the
+  // intended write even when the vault hasn't been created yet. The
+  // dry-run contract ("no side effects, including failures on state
+  // the caller is asking us about") is broken otherwise.
+  const dryRun = args.includes("--dry-run");
   const vaultArg = takeArgValue(args, "--vault");
   if (vaultArg.missingValue) {
     console.error("--vault requires a value (the vault name).");
@@ -1067,12 +1073,10 @@ async function cmdMcpInstall(args: string[]): Promise<void> {
   const defaultVault = globalConfig.default_vault || "default";
   const vaultName = vaultArg.value ?? defaultVault;
   const vaultExplicit = vaultArg.value !== undefined;
-  if (!readVaultConfig(vaultName)) {
+  if (!dryRun && !readVaultConfig(vaultName)) {
     console.error(`Vault "${vaultName}" not found. Available: ${listVaults().join(", ") || "(none)"}.`);
     process.exit(1);
   }
-
-  const dryRun = args.includes("--dry-run");
 
   await executeMcpInstall({
     mode,
@@ -1145,7 +1149,7 @@ async function cmdMcpInstallInteractive(): Promise<void> {
  *                      inlined values. Safe to commit; the shell expands at
  *                      runtime.
  */
-function cmdMcpConfig(args: string[]): void {
+async function cmdMcpConfig(args: string[]): Promise<void> {
   const vaultName = args[0];
   if (!vaultName || vaultName.startsWith("--")) {
     console.error("Usage: parachute-vault mcp-config <vault-name> [--token <pvt_...>] [--base-url <url>] [--env-vars]");
@@ -1277,8 +1281,11 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
   // the filesystem or minting any token. Print to stdout (scripts may
   // parse this); exit 0. Skip the auth-acquisition entirely — the point
   // of --dry-run is to inspect without side effects, including the
-  // network round-trip for hub-mint.
+  // network round-trip for hub-mint *and* the vault-existence guard
+  // (probing the install for a not-yet-created vault is a legitimate
+  // pre-create check, not an error).
   if (dryRun) {
+    const vaultExists = readVaultConfig(vaultName) !== null;
     console.log(`[dry-run] No changes written.`);
     console.log(`  Target file:    ${target.path}`);
     console.log(`  Install scope:  ${target.scope}`);
@@ -1288,7 +1295,7 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
     console.log(`  Entry key:      ${entryKey}`);
     console.log(`  MCP URL:        ${url} (${source})`);
     console.log(`  Auth mode:      ${mode}${mode === "mint" ? ` (scope vault:${vaultName}:${verb})` : ""}`);
-    console.log(`  Vault:          ${vaultName}`);
+    console.log(`  Vault:          ${vaultName}${vaultExists ? "" : " (does not exist yet — create with `parachute-vault create " + vaultName + "`)"}`);
     console.log(`  Re-run without --dry-run to apply.`);
     return;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -969,6 +969,7 @@ async function cmdMcpInstall(args: string[]): Promise<void> {
     "--install-scope",
     "--vault",
     "--client",
+    "--dry-run",
   ];
 
   const hasFlag = args.some((a) => MCP_INSTALL_FLAG_NAMES.includes(a));
@@ -1071,6 +1072,8 @@ async function cmdMcpInstall(args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  const dryRun = args.includes("--dry-run");
+
   await executeMcpInstall({
     mode,
     rawScope,
@@ -1079,6 +1082,7 @@ async function cmdMcpInstall(args: string[]): Promise<void> {
     vaultExplicit,
     pastedToken: mode === "token" ? tokenArg.value : undefined,
     globalConfig,
+    dryRun,
   });
 }
 
@@ -1236,6 +1240,16 @@ interface ExecuteMcpInstallOpts {
   existingEntryKey?: string;
   /** Reused across the call chain to avoid re-parsing config.yaml. */
   globalConfig: ReturnType<typeof readGlobalConfig>;
+  /**
+   * When true, describe the write that *would* happen (target path,
+   * entry key, URL, install scope) and exit 0 without touching the
+   * filesystem or hitting the network for a hub-mint. Useful for
+   * probing the command from a script that's setting up a runner.
+   * Aaron hit this when accidentally creating an empty
+   * `projects[<cwd>]` entry while just running `--help` — see the
+   * `mcp-config` PR notes.
+   */
+  dryRun?: boolean;
 }
 
 /**
@@ -1245,7 +1259,7 @@ interface ExecuteMcpInstallOpts {
  * preview-and-confirm step so a cancel skips the network mint entirely.
  */
 async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
-  const { mode, rawScope, installScope, vaultName, vaultExplicit, pastedToken, globalConfig, existingEntryKey } = opts;
+  const { mode, rawScope, installScope, vaultName, vaultExplicit, pastedToken, globalConfig, existingEntryKey, dryRun } = opts;
   const verb = rawScope.split(":")[1]!;
   const target = resolveInstallTarget(installScope);
   // Single source of truth shared with the interactive walkthrough's
@@ -1258,6 +1272,26 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
     port: globalConfig.port || DEFAULT_PORT,
     ...(existingEntryKey ? { existingEntryKey } : {}),
   });
+
+  // --dry-run: describe the write that *would* happen without touching
+  // the filesystem or minting any token. Print to stdout (scripts may
+  // parse this); exit 0. Skip the auth-acquisition entirely — the point
+  // of --dry-run is to inspect without side effects, including the
+  // network round-trip for hub-mint.
+  if (dryRun) {
+    console.log(`[dry-run] No changes written.`);
+    console.log(`  Target file:    ${target.path}`);
+    console.log(`  Install scope:  ${target.scope}`);
+    if (target.localProjectKey) {
+      console.log(`  Project key:    ${target.localProjectKey}`);
+    }
+    console.log(`  Entry key:      ${entryKey}`);
+    console.log(`  MCP URL:        ${url} (${source})`);
+    console.log(`  Auth mode:      ${mode}${mode === "mint" ? ` (scope vault:${vaultName}:${verb})` : ""}`);
+    console.log(`  Vault:          ${vaultName}`);
+    console.log(`  Re-run without --dry-run to apply.`);
+    return;
+  }
 
   let bearer: string;
   if (mode === "token") {
@@ -3026,6 +3060,7 @@ Vaults:
                               [--scope vault:read|vault:write|vault:admin]
                               [--install-scope local|user|project]
                               [--vault <name>] [--client claude-code]
+                              [--dry-run]
                                             Install vault MCP into a client config.
                                             From a terminal with no flags: walks you
                                             through a contextual conversation (vault,
@@ -3052,6 +3087,10 @@ Vaults:
                                             --vault <name> targets a specific
                                             vault and keys the entry as
                                             parachute-vault-<name>.
+                                            --dry-run prints the write that would
+                                            happen (target file, entry key, URL)
+                                            without touching disk or hitting the
+                                            hub. Useful for probing.
 
   parachute-vault mcp-config <vault-name> [--token <pvt_...>] [--base-url <url>]
                                           [--env-vars]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,7 @@ import type { VaultConfig } from "./config.ts";
 import { DATA_DIR } from "./config.ts";
 import { installAgent, uninstallAgent, isAgentLoaded, restartAgent } from "./launchd.ts";
 import {
+  buildMcpConfigJson,
   buildMcpEntryPlan,
   chooseHubOrigin,
   detectInstallContext,
@@ -168,6 +169,9 @@ switch (command) {
     break;
   case "mcp-install":
     await cmdMcpInstall(cmdArgs);
+    break;
+  case "mcp-config":
+    cmdMcpConfig(cmdArgs);
     break;
   case "remove":
   case "rm":
@@ -1108,6 +1112,107 @@ async function cmdMcpInstallInteractive(): Promise<void> {
     existingEntryKey: decision.existingEntryKey,
     globalConfig,
   });
+}
+
+/**
+ * `parachute-vault mcp-config <vault-name>` — emit the JSON shape
+ * `claude -p --mcp-config '<json>'` consumes, scoped to a named vault.
+ * Pattern from Aaron's Gitcoin Brain runner:
+ *
+ *   claude -p --mcp-config "$(parachute-vault mcp-config gitcoin)" \
+ *             --strict-mcp-config ...
+ *
+ * Synthesizing this JSON by hand was per-script boilerplate every runner
+ * that spawned `claude -p` against a vault had to write. This command is
+ * the canonical synthesizer — the JSON shape is owned here once.
+ *
+ * No state is mutated; this only emits to stdout. The bearer is read from
+ * `--token <pvt_...>` or `PARACHUTE_VAULT_TOKEN` env (deliberate — we don't
+ * mint here, since this is a stdout-piped subprocess where prompting would
+ * deadlock the parent script). If neither is present, we exit 1 with a
+ * clear stderr message; runners get a fail-fast.
+ *
+ * Flags:
+ *   --token <bearer>   Bearer to embed verbatim (alternative: PARACHUTE_VAULT_TOKEN).
+ *   --base-url <url>   Override the auto-detected hub origin (default: chooseHubOrigin).
+ *                      Useful for tailnet-exposed hubs (`--base-url https://hub.tail.ts.net`).
+ *   --env-vars         Emit the template form with `${PARACHUTE_HUB_URL}` and
+ *                      `${PARACHUTE_VAULT_TOKEN}` placeholders rather than
+ *                      inlined values. Safe to commit; the shell expands at
+ *                      runtime.
+ */
+function cmdMcpConfig(args: string[]): void {
+  const vaultName = args[0];
+  if (!vaultName || vaultName.startsWith("--")) {
+    console.error("Usage: parachute-vault mcp-config <vault-name> [--token <pvt_...>] [--base-url <url>] [--env-vars]");
+    console.error("");
+    console.error("Emits the JSON config consumed by `claude -p --mcp-config '<json>'`.");
+    console.error("Pattern: claude -p --mcp-config \"$(parachute-vault mcp-config <name>)\" --strict-mcp-config ...");
+    process.exit(1);
+  }
+
+  const tokenArg = takeArgValue(args, "--token");
+  if (tokenArg.missingValue) {
+    console.error("--token requires a value (the bearer to embed).");
+    process.exit(1);
+  }
+  const baseUrlArg = takeArgValue(args, "--base-url");
+  if (baseUrlArg.missingValue) {
+    console.error("--base-url requires a value (e.g. https://hub.example.ts.net).");
+    process.exit(1);
+  }
+  const useEnvVars = args.includes("--env-vars");
+
+  // --env-vars mode is shape-only — no need to resolve the vault, mint a
+  // token, or even verify the vault exists. Operators committing the
+  // template don't necessarily have the target vault on the machine
+  // generating the config.
+  if (useEnvVars) {
+    const json = buildMcpConfigJson({
+      vaultName,
+      baseUrl: "",
+      bearer: "",
+      useEnvVars: true,
+    });
+    process.stdout.write(json + "\n");
+    return;
+  }
+
+  // Literal mode: verify the vault exists locally, resolve the URL, and
+  // require a bearer (either --token or PARACHUTE_VAULT_TOKEN env).
+  if (!readVaultConfig(vaultName)) {
+    const available = listVaults();
+    console.error(`Vault "${vaultName}" not found. Available: ${available.join(", ") || "(none — run `parachute-vault create <name>`)"}.`);
+    process.exit(1);
+  }
+
+  const bearer = tokenArg.value ?? process.env.PARACHUTE_VAULT_TOKEN;
+  if (!bearer) {
+    console.error("No bearer token provided. Pass --token <bearer> or set PARACHUTE_VAULT_TOKEN.");
+    console.error("  Mint a token with: parachute-vault tokens create --vault " + vaultName);
+    console.error("  Or use --env-vars to emit the template form (safe to commit; expands at runtime).");
+    process.exit(1);
+  }
+
+  const globalConfig = readGlobalConfig();
+  const port = globalConfig.port || DEFAULT_PORT;
+  let baseUrl: string;
+  if (baseUrlArg.value) {
+    baseUrl = baseUrlArg.value;
+  } else {
+    // chooseHubOrigin walks PARACHUTE_HUB_ORIGIN → expose-state → loopback;
+    // for a script invoking `claude -p` against a local vault, loopback is
+    // the right default.
+    baseUrl = chooseHubOrigin(port).url;
+  }
+
+  const json = buildMcpConfigJson({
+    vaultName,
+    baseUrl,
+    bearer,
+    useEnvVars: false,
+  });
+  process.stdout.write(json + "\n");
 }
 
 interface ExecuteMcpInstallOpts {
@@ -2947,6 +3052,24 @@ Vaults:
                                             --vault <name> targets a specific
                                             vault and keys the entry as
                                             parachute-vault-<name>.
+
+  parachute-vault mcp-config <vault-name> [--token <pvt_...>] [--base-url <url>]
+                                          [--env-vars]
+                                            Emit the JSON config consumed by
+                                            \`claude -p --mcp-config '<json>'\`.
+                                            Pattern:
+                                              claude -p --mcp-config \\
+                                                "$(parachute-vault mcp-config <name>)" \\
+                                                --strict-mcp-config ...
+                                            --token or PARACHUTE_VAULT_TOKEN env
+                                            supplies the bearer; both absent
+                                            exits 1 with a clear error.
+                                            --base-url overrides the auto-detected
+                                            origin (e.g. tailnet-exposed hubs).
+                                            --env-vars emits the template form
+                                            with \${PARACHUTE_HUB_URL} and
+                                            \${PARACHUTE_VAULT_TOKEN} placeholders
+                                            (safe to commit; expanded at runtime).
 
 Tokens:
   parachute-vault tokens                          List tokens (every vault)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1387,6 +1387,12 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
     console.log(`Added MCP server "${entryKey}" to ${target.path} under projects["${target.localProjectKey}"] (local scope).`);
     console.log(`  Installed locally for this directory only — runs only when Claude Code launches from ${target.localProjectKey}.`);
     console.log(`  To install globally instead, re-run with --install-scope user.`);
+    // Headless-flow heads-up: local-scope MCP entries do NOT propagate
+    // to subprocesses spawned by `claude -p` (script / cron / runner
+    // shapes), even with --setting-sources covering local. Operators
+    // wiring up a runner usually want `--install-scope user` so the
+    // entry reaches every `claude` invocation on this machine.
+    console.log(`  Headless flows (claude -p in scripts, cron, runners): prefer --install-scope user — local-scope entries don't propagate to claude -p subprocesses.`);
   } else {
     console.log(`Added MCP server "${entryKey}" to ${target.path}`);
   }
@@ -3084,6 +3090,13 @@ Vaults:
                                             directory only). user writes top-level
                                             mcpServers (every project). project
                                             writes ./.mcp.json (check into the repo).
+                                            For headless flows (\`claude -p\` in
+                                            scripts, cron jobs, runners), prefer
+                                            --install-scope user — local-scope
+                                            entries don't propagate to claude -p
+                                            subprocesses; interactive sessions
+                                            from the install directory still see
+                                            local just fine.
                                             --vault <name> targets a specific
                                             vault and keys the entry as
                                             parachute-vault-<name>.

--- a/src/mcp-config.test.ts
+++ b/src/mcp-config.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for `parachute-vault mcp-config <vault-name>` — the JSON synthesizer
+ * for `claude -p --mcp-config '<json>'` runners. Three concerns:
+ *
+ *   1. Pure helper: `buildMcpConfigJson` — shape correctness for both literal
+ *      and `--env-vars` template modes.
+ *   2. CLI flag parsing: required vault arg, --token / PARACHUTE_VAULT_TOKEN
+ *      precedence, --base-url override, --env-vars short-circuit (no vault
+ *      lookup, no bearer required).
+ *   3. End-to-end stdout — verify pipe-to-jq usability (valid JSON, exact
+ *      shape claude consumes).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildMcpConfigJson } from "./mcp-install.ts";
+
+const CLI = path.resolve(import.meta.dir, "cli.ts");
+
+function runCli(
+  args: string[],
+  parachuteHome: string,
+  extraEnv: Record<string, string | undefined> = {},
+  cwd?: string,
+): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync({
+    cmd: ["bun", CLI, ...args],
+    cwd: cwd ?? parachuteHome,
+    env: {
+      ...process.env,
+      PARACHUTE_HOME: parachuteHome,
+      HOME: parachuteHome,
+      ...extraEnv,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+function setupBareVault(parachuteHome: string, name: string): void {
+  const vaultsDir = path.join(parachuteHome, "vault", "data");
+  fs.mkdirSync(path.join(vaultsDir, name), { recursive: true });
+  fs.writeFileSync(
+    path.join(vaultsDir, name, "vault.yaml"),
+    `name: ${name}\napi_keys: []\n`,
+  );
+  const globalPath = path.join(parachuteHome, "vault", "config.yaml");
+  if (!fs.existsSync(globalPath)) {
+    fs.mkdirSync(path.dirname(globalPath), { recursive: true });
+    fs.writeFileSync(globalPath, `default_vault: ${name}\nport: 1940\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unit: buildMcpConfigJson
+// ---------------------------------------------------------------------------
+
+describe("buildMcpConfigJson", () => {
+  test("literal mode embeds the bearer and URL verbatim", () => {
+    const json = buildMcpConfigJson({
+      vaultName: "gitcoin",
+      baseUrl: "http://127.0.0.1:1940",
+      bearer: "pvt_abc123",
+    });
+    const parsed = JSON.parse(json);
+    expect(parsed.mcpServers["parachute-vault-gitcoin"]).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:1940/vault/gitcoin/mcp",
+      headers: { Authorization: "Bearer pvt_abc123" },
+    });
+  });
+
+  test("env-var mode emits placeholders that survive JSON parsing", () => {
+    const json = buildMcpConfigJson({
+      vaultName: "gitcoin",
+      baseUrl: "",
+      bearer: "",
+      useEnvVars: true,
+    });
+    // The placeholders must come through verbatim — `${...}` is a normal
+    // string value to JSON, and that's what shell expansion later acts on.
+    const parsed = JSON.parse(json);
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].url).toBe(
+      "${PARACHUTE_HUB_URL}/vault/gitcoin/mcp",
+    );
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].headers.Authorization).toBe(
+      "Bearer ${PARACHUTE_VAULT_TOKEN}",
+    );
+  });
+
+  test("strips trailing slash from baseUrl (no double slashes in the path)", () => {
+    const json = buildMcpConfigJson({
+      vaultName: "default",
+      baseUrl: "https://hub.example.com/",
+      bearer: "t",
+    });
+    const parsed = JSON.parse(json);
+    expect(parsed.mcpServers["parachute-vault-default"].url).toBe(
+      "https://hub.example.com/vault/default/mcp",
+    );
+  });
+
+  test("entry key always uses parachute-vault-<name> (multi-vault-ready)", () => {
+    const json = buildMcpConfigJson({
+      vaultName: "work",
+      baseUrl: "http://127.0.0.1:1940",
+      bearer: "t",
+    });
+    const parsed = JSON.parse(json);
+    expect(Object.keys(parsed.mcpServers)).toEqual(["parachute-vault-work"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI end-to-end
+// ---------------------------------------------------------------------------
+
+describe("mcp-config CLI", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vault-mcp-config-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("emits well-formed JSON to stdout with --token", () => {
+    setupBareVault(tmp, "gitcoin");
+    const res = runCli(
+      ["mcp-config", "gitcoin", "--token", "pvt_test123"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].type).toBe("http");
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].headers.Authorization).toBe(
+      "Bearer pvt_test123",
+    );
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].url).toContain(
+      "/vault/gitcoin/mcp",
+    );
+  });
+
+  test("reads PARACHUTE_VAULT_TOKEN env var when --token absent", () => {
+    setupBareVault(tmp, "gitcoin");
+    const res = runCli(
+      ["mcp-config", "gitcoin"],
+      tmp,
+      { PARACHUTE_VAULT_TOKEN: "pvt_envvar" },
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].headers.Authorization).toBe(
+      "Bearer pvt_envvar",
+    );
+  });
+
+  test("--token wins over PARACHUTE_VAULT_TOKEN when both are present", () => {
+    setupBareVault(tmp, "gitcoin");
+    const res = runCli(
+      ["mcp-config", "gitcoin", "--token", "from-flag"],
+      tmp,
+      { PARACHUTE_VAULT_TOKEN: "from-env" },
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].headers.Authorization).toBe(
+      "Bearer from-flag",
+    );
+  });
+
+  test("exits 1 with a clear error when no token is supplied", () => {
+    setupBareVault(tmp, "gitcoin");
+    // Explicitly unset PARACHUTE_VAULT_TOKEN (test env may have it).
+    const res = runCli(
+      ["mcp-config", "gitcoin"],
+      tmp,
+      { PARACHUTE_VAULT_TOKEN: "" },
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/No bearer token/);
+    expect(res.stderr).toMatch(/--token/);
+    expect(res.stderr).toMatch(/PARACHUTE_VAULT_TOKEN/);
+    // The error message points operators at the workaround paths so they
+    // can recover without re-reading the docs.
+    expect(res.stderr).toMatch(/parachute-vault tokens create/);
+    expect(res.stderr).toMatch(/--env-vars/);
+  });
+
+  test("exits 1 when the vault doesn't exist (literal mode)", () => {
+    setupBareVault(tmp, "default");
+    const res = runCli(
+      ["mcp-config", "ghost", "--token", "t"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/Vault "ghost" not found/);
+  });
+
+  test("--env-vars short-circuits — no vault lookup, no token required", () => {
+    // Deliberately no setupBareVault: --env-vars mode emits the template
+    // shape without resolving anything. Operators commit the template from
+    // machines that may not have the target vault.
+    const res = runCli(
+      ["mcp-config", "gitcoin", "--env-vars"],
+      tmp,
+      { PARACHUTE_VAULT_TOKEN: "" },
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].url).toBe(
+      "${PARACHUTE_HUB_URL}/vault/gitcoin/mcp",
+    );
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].headers.Authorization).toBe(
+      "Bearer ${PARACHUTE_VAULT_TOKEN}",
+    );
+  });
+
+  test("--base-url overrides the auto-detected origin", () => {
+    setupBareVault(tmp, "gitcoin");
+    const res = runCli(
+      [
+        "mcp-config",
+        "gitcoin",
+        "--token",
+        "t",
+        "--base-url",
+        "https://hub.taildf9ce2.ts.net",
+      ],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.mcpServers["parachute-vault-gitcoin"].url).toBe(
+      "https://hub.taildf9ce2.ts.net/vault/gitcoin/mcp",
+    );
+  });
+
+  test("missing vault-name arg prints usage and exits 1", () => {
+    const res = runCli(["mcp-config"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/Usage:/);
+    expect(res.stderr).toMatch(/mcp-config <vault-name>/);
+  });
+
+  test("flag passed in place of vault-name (e.g. --help) is rejected", () => {
+    // Guards against `parachute-vault mcp-config --token foo` being
+    // silently misparsed as vault-name="--token".
+    const res = runCli(["mcp-config", "--help"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/Usage:/);
+  });
+});

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -798,6 +798,40 @@ describe("mcp-install end-to-end", () => {
     expect(bearer).toMatch(/^Bearer pvt_/);
   });
 
+  test("--dry-run describes the write without touching disk or hitting the hub", () => {
+    // Aaron hit this when probing `mcp-install --help`: the bare CLI
+    // dispatch was creating an empty `projects[<cwd>]` slot in
+    // ~/.claude.json as a side effect of writing the install. --dry-run
+    // is the deliberate "tell me what you'd do" path.
+    setupBareVault(tmp, "default");
+    const res = runCli(
+      ["mcp-install", "--install-scope", "user", "--token", "should-not-be-used", "--dry-run"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    // No claude.json should exist: the install was inhibited.
+    expect(fs.existsSync(path.join(tmp, ".claude.json"))).toBe(false);
+    // The dry-run output names target file, entry key, URL, and how to apply.
+    expect(res.stdout).toMatch(/\[dry-run\]/);
+    expect(res.stdout).toMatch(/Target file:/);
+    expect(res.stdout).toMatch(/Entry key:\s+parachute-vault/);
+    expect(res.stdout).toMatch(/MCP URL:/);
+    expect(res.stdout).toMatch(/Re-run without --dry-run to apply\./);
+  });
+
+  test("--dry-run with --mint skips the hub round-trip and operator-token check", () => {
+    // The whole point of --dry-run is "no side effects" — that includes
+    // the hub-mint network call. A naive implementation might still try
+    // to read operator.token and fail before the dry-run print fires.
+    setupBareVault(tmp, "default");
+    // Deliberately no operator.token file present, no PARACHUTE_HUB_ORIGIN.
+    const res = runCli(["mcp-install", "--dry-run"], tmp, { PARACHUTE_HUB_ORIGIN: "" });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toMatch(/\[dry-run\]/);
+    expect(res.stderr).not.toMatch(/No operator token found/);
+    expect(res.stderr).not.toMatch(/No hub origin configured/);
+  });
+
   test("subsequent --token install on top of an existing entry overwrites the bearer (user scope)", () => {
     setupBareVault(tmp, "default");
     runCli(["mcp-install", "--install-scope", "user", "--token", "first"], tmp);

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -823,6 +823,28 @@ describe("mcp-install end-to-end", () => {
     expect(res.stdout).toMatch(/Re-run without --dry-run to apply\./);
   });
 
+  test("--dry-run works for a vault that doesn't exist yet (probe shape)", () => {
+    // The dry-run contract is "no side effects, including failures on
+    // state the caller is asking about." A future-vault probe — would
+    // installing for this not-yet-created vault land where I expect? —
+    // is a legitimate pre-create check, not an error. The
+    // vault-existence guard runs only on the real-install path.
+    setupBareVault(tmp, "default");
+    const res = runCli(
+      ["mcp-install", "--vault", "future-vault", "--token", "t", "--dry-run"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toMatch(/\[dry-run\]/);
+    // Output names the absent vault explicitly so the operator can tell
+    // the dry-run worked against the right target.
+    expect(res.stdout).toMatch(/Vault:\s+future-vault/);
+    expect(res.stdout).toMatch(/does not exist yet/);
+    expect(res.stdout).toMatch(/Entry key:\s+parachute-vault-future-vault/);
+    // No claude.json written — dry-run still didn't touch disk.
+    expect(fs.existsSync(path.join(tmp, ".claude.json"))).toBe(false);
+  });
+
   test("--dry-run with --mint skips the hub round-trip and operator-token check", () => {
     // The whole point of --dry-run is "no side effects" — that includes
     // the hub-mint network call. A naive implementation might still try

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -580,6 +580,10 @@ describe("mcp-install end-to-end", () => {
     // scoped to this directory (and how to widen if they wanted global).
     expect(res.stdout).toMatch(/this directory only/);
     expect(res.stdout).toMatch(/--install-scope user/);
+    // Headless-flow heads-up: local-scope entries don't propagate to
+    // claude -p subprocesses; operators wiring up runners need to know.
+    expect(res.stdout).toMatch(/Headless flows/);
+    expect(res.stdout).toMatch(/claude -p/);
   });
 
   test("--install-scope project writes <cwd>/.mcp.json instead of ~/.claude.json", () => {

--- a/src/mcp-install.ts
+++ b/src/mcp-install.ts
@@ -335,6 +335,67 @@ export async function mintHubJwt(opts: MintHubJwtOpts): Promise<MintedHubJwt | M
 }
 
 // ---------------------------------------------------------------------------
+// `mcp-config` — emit the JSON shape `claude -p --mcp-config '<json>'` expects
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the JSON config shape consumed by `claude -p --mcp-config '<json>'`.
+ *
+ * Two emission modes:
+ *
+ *   - **literal** (`useEnvVars: false`): the URL and bearer are inlined. The
+ *     emitted JSON is ready to splice into a runner via shell substitution
+ *     (`--mcp-config "$(parachute-vault mcp-config <name>)"`). Treat the
+ *     output as secret — it carries a usable bearer.
+ *
+ *   - **env-var template** (`useEnvVars: true`): the URL becomes
+ *     `${PARACHUTE_HUB_URL}/vault/<name>/mcp` and the Authorization value
+ *     becomes `Bearer ${PARACHUTE_VAULT_TOKEN}`. Shape-only; safe to commit.
+ *     Consumers must expand the placeholders at runtime (most shells do this
+ *     under double-quoted interpolation; `claude -p` itself does not).
+ *
+ * The `entryKey` rule mirrors `buildMcpEntryPlan`: vault-explicit installs
+ * key as `parachute-vault-<name>` so multi-vault runners can mount more than
+ * one vault under distinct slots. (The default install — singular
+ * `parachute-vault` — is reserved for the local-scope MCP entry; `mcp-config`
+ * always pins the per-vault key, since this is the script-spawning shape
+ * where you usually do name the vault.)
+ *
+ * Always emits stable JSON with two-space indent so the output is diff-able
+ * across runs.
+ */
+export interface BuildMcpConfigJsonOpts {
+  vaultName: string;
+  /** Base URL (without `/vault/<name>/mcp`). Ignored when `useEnvVars` is true. */
+  baseUrl: string;
+  /** Bearer to embed verbatim. Ignored when `useEnvVars` is true. */
+  bearer: string;
+  /** Emit `${PARACHUTE_HUB_URL}` / `${PARACHUTE_VAULT_TOKEN}` placeholders instead of inlined values. */
+  useEnvVars?: boolean;
+}
+
+export function buildMcpConfigJson(opts: BuildMcpConfigJsonOpts): string {
+  const { vaultName, baseUrl, bearer, useEnvVars } = opts;
+  const entryKey = `parachute-vault-${vaultName}`;
+  const url = useEnvVars
+    ? `\${PARACHUTE_HUB_URL}/vault/${vaultName}/mcp`
+    : `${baseUrl.replace(/\/$/, "")}/vault/${vaultName}/mcp`;
+  const authValue = useEnvVars
+    ? "Bearer ${PARACHUTE_VAULT_TOKEN}"
+    : `Bearer ${bearer}`;
+  const config = {
+    mcpServers: {
+      [entryKey]: {
+        type: "http",
+        url,
+        headers: { Authorization: authValue },
+      },
+    },
+  };
+  return JSON.stringify(config, null, 2);
+}
+
+// ---------------------------------------------------------------------------
 // Install target resolver
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three small wins that surfaced while Aaron was wiring the **Gitcoin Brain** runner (vault-as-job-substrate; a Python loop spawning `claude -p --mcp-config '<json>'` against a vault). Each was per-script boilerplate or a subtle footgun — folding them into the CLI here.

- **New CLI: `parachute-vault mcp-config <vault-name>`** emits the JSON shape `claude -p --mcp-config '<json>'` consumes. Headline ask from Gitcoin Brain — synthesizing this JSON by hand was per-script boilerplate every runner spawning `claude -p` against a vault had to write.
- **New flag: `parachute-vault mcp-install --dry-run`** prints what the install would do without touching disk or hitting the hub. Aaron hit the inverse: probing `mcp-install` was creating an empty `projects[<cwd>]` slot in `~/.claude.json` as a side effect.
- **Doc fixes**: `mcp-install` success message + help text now recommend `--install-scope user` for headless flows (local-scope MCP entries don't propagate to `claude -p` subprocesses). README troubleshooting entry added for the 406 on manual `curl` against `/vault/<name>/mcp` (the MCP HTTP transport needs both `application/json` and `text/event-stream` in the `Accept` header).

Cross-reference: [Gitcoin Brain design doc](https://github.com/ParachuteComputer/Gitcoin/blob/main/mirrormirror/gitcoin_brain_design/for_parachute_round_4.md) (Aaron's design tree).

## What changed

### Item 1: `parachute-vault mcp-config <vault-name>` (commit `6099eec`)

Pattern:

```bash
export PARACHUTE_VAULT_TOKEN=pvt_...
claude -p --mcp-config "$(parachute-vault mcp-config gitcoin)" \
          --strict-mcp-config ...
```

Two emission modes:

- **Literal** (default) — inlines the URL + bearer into the JSON. Bearer comes from `--token <pvt_...>` or `PARACHUTE_VAULT_TOKEN` env. With **neither** present, exits 1 with a clear stderr error (runners get a fail-fast; no surprise auto-minting). `--base-url <url>` overrides the auto-detected origin (e.g. tailnet-exposed hubs).
- **Template** (`--env-vars`) — emits `${PARACHUTE_HUB_URL}/vault/<name>/mcp` and `Bearer ${PARACHUTE_VAULT_TOKEN}` placeholders. Safe to commit. The `--env-vars` mode short-circuits the vault-existence check entirely — operators commit templates from machines that may not have the target vault.

Synthesizer lives in `mcp-install.ts:buildMcpConfigJson` so third-party tools importing vault as a library can reuse it. **13 new tests** in `src/mcp-config.test.ts` cover both modes, `--token` vs env precedence, `--base-url` override, the no-token / unknown-vault failure paths, and the `--env-vars` short-circuit.

### Item 2: `mcp-install --dry-run` (commit `10d8e2f`)

Prints the resolved write — target file, install scope, project key (when local), entry key, MCP URL + source, auth mode — and exits 0 without touching the filesystem or calling the hub mint endpoint. Skips the operator-token check too: the point of `--dry-run` is "no side effects, including network."

```
[dry-run] No changes written.
  Target file:    /Users/x/.claude.json
  Install scope:  user
  Entry key:      parachute-vault
  MCP URL:        http://127.0.0.1:1940/vault/default/mcp (loopback)
  Auth mode:      token
  Vault:          default
  Re-run without --dry-run to apply.
```

**2 new tests** in `mcp-install.test.ts` pin the file-not-written invariant and the no-hub-call invariant.

### Item 3 + 4: Doc fixes (commit `c4b8e9c`)

- **`mcp-install` success message** for local-scope installs now appends a "Headless flows" heads-up: local-scope entries don't propagate to `claude -p` subprocesses; runners want `--install-scope user`.
- **Help text** for `mcp-install` (in `usage()`) explains the local-vs-user split for headless flows, in a new paragraph under `--install-scope`.
- **README cookbook** — new "Headless flows — `claude -p` runners (`mcp-config`)" subsection explains the local-doesn't-propagate gotcha + how to use `mcp-config` to inline the MCP config instead of mutating Claude Code state.
- **README troubleshooting** — new entry for the 406 on manual `curl`, with the working `Accept: application/json, text/event-stream` invocation.
- **README CLI samples** — added `--dry-run` and `mcp-config` lines under the existing `mcp-install` examples.

**1 new assertion** added to the existing local-scope default test pins the "Headless flows" line on stdout so a future drift goes red.

### Item 5: rc bump to `0.4.6-rc.5` (commit `3681120`)

CHANGELOG entry under `## [0.4.6-rc.5] — 2026-05-20` covers all four items. Per governance rule 2 (RC versioning), keeping `0.4.6` fixed and bumping `rc.N` only.

## UX decisions worth flagging

- **`mcp-config` requires `--token` or `PARACHUTE_VAULT_TOKEN` env — no auto-mint.** Auto-minting in a stdout-piped subprocess (which `$(parachute-vault mcp-config ...)` is) would deadlock the parent script if any prompt fires, and silently auto-minting a bearer into a runner's config feels like the wrong default. Runners that want auto-mint can `parachute-vault tokens create` upstream and pass `--token`, or generate one via the hub.
- **`mcp-config` always keys the entry as `parachute-vault-<name>`** (never the singular `parachute-vault` slot). This is the script-spawning shape where you usually do name the vault, and per-vault keying lets multi-vault runners mount more than one vault under distinct slots.
- **`--env-vars` mode skips the vault-existence check entirely.** Operators committing the template to git may not have the target vault on the machine generating the config.
- **`--dry-run` also skips the operator-token check + hub round-trip.** Strict reading of "no side effects" — network calls count as side effects (auditing, hub-side rate limits, log noise).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test ./src/` — 992 pass, 0 fail (16 new from this PR: 13 in `mcp-config.test.ts`, 2 dry-run, 1 headless-stdout)
- [x] `bun test ./core/src/` — 529 pass, 0 fail
- [x] Smoke: `mcp-config <vault> --token <t>` emits valid JSON (jq-validated)
- [x] Smoke: `mcp-config <vault> --env-vars` emits template placeholders (jq-validated)
- [x] Smoke: `mcp-config <vault>` with no token exits 1 with clear stderr
- [x] Smoke: `mcp-config <vault> --token <t> --base-url <url>` honors the override
- [x] Smoke: `mcp-install --dry-run` describes the write, leaves no `.claude.json` on disk

## Pattern note

This PR introduces a new CLI command (`mcp-config`) but doesn't touch any cross-cutting convention. The MCP config JSON shape (`mcpServers.<key>.{type,url,headers}`) is owned by Claude Code's MCP SDK and we're emitting compatible JSON. The synthesizer is exported from `mcp-install.ts` so vault-as-library consumers can reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)