### PR TITLE
feat(vault): export --watch + --git-commit for live mirroring (Gitcoin Brain use case)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,72 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.6-rc.6] — 2026-05-20
+
+Aaron's Gitcoin Brain build wants vault as the system of record and a git
+mirror as the auto-history projection — same shape as the `vault-portable-
+export` cookbook's "git-as-projection" recipe, but live instead of cron-
+driven. This rc folds the two missing primitives directly into the CLI so
+the operator wires one command, not a cron + a webhook + a shell script.
+
+### Added
+
+- **`parachute-vault export <dir> --watch [--interval <seconds>]`** — stay
+  alive after the initial export, re-export incrementally on every vault
+  write. Detection is polling on `updated_at >= cursor` (vault writes are
+  HTTP-mediated; the bun:sqlite DB is opaque to filesystem watchers, so
+  polling is the simplest robust signal). Default interval 5s. Each cycle
+  prints a tight status line — `[watch] exported N notes (cursor: ISO)` or
+  `[watch] no changes`. Graceful shutdown on SIGINT/SIGTERM
+  (`[watch] stopping watch`, exit 0).
+
+- **`parachute-vault export <dir> --git-commit [--git-message-template <t>] [--git-push]`**
+  — after each export, `git add -A` + `git commit -m <rendered-template>`
+  in `<dir>`. Repo must already be initialized (fails fast with `git init`
+  guidance, not after sitting in a watch loop emitting the same error every
+  interval). Template variables: `{{date}}`, `{{notes_changed}}`,
+  `{{plural}}` (empty when notes_changed === 1), `{{first_note_title}}`,
+  `{{vault_name}}`. Default template:
+  `export: {{date}} ({{notes_changed}} note{{plural}})`. Empty commits
+  skipped; pure `.parachute/vault.yaml` `exported_at` churn (no real note
+  changes) is detected and skipped too, so a watch loop doesn't grow a
+  commit every interval. `--git-push` is non-fatal on failure — a network
+  blip warns but doesn't kill the loop.
+
+- **Combined `--watch --git-commit`** — the canonical Aaron-Gitcoin-Brain
+  setup. Vault writes flow through to git history automatically with no
+  cron, no webhook, no shell glue:
+
+  ```bash
+  parachute-vault export ~/projections/team-brain --watch --git-commit --git-push
+  ```
+
+  Drop that command in a launchd plist (or `parachute start`-style
+  supervisor) and the git mirror tracks the vault.
+
+### Implementation notes
+
+- No new deps. `git add/commit/push` are shelled out via `Bun.spawn`.
+  Helpers live in `src/export-watch.ts` (`renderCommitMessage`,
+  `shouldCommit`, `runGitCommitCycle`, …) so they're unit-testable without
+  spawning the full CLI.
+- Watch loop uses `setInterval` with an in-flight guard so a slow cycle
+  doesn't stack tasks. Cursor is captured *before* each export runs, so a
+  write that lands mid-export is picked up next cycle (cost: at most one
+  re-exported note when `updated_at` equals the cursor — `>=` semantics).
+- Tests cover the pure helpers, the git shell helpers against real
+  throwaway repos, and three CLI end-to-end scenarios:
+  initial-export-only-on-idle, write-triggers-re-export, and the combined
+  watch+git-commit happy path.
+
+### Cookbook
+
+The `parachute-vault export` recipe in
+`parachute-patterns/cookbook/vault-portable-export.md` now has the
+"live projection" idiom alongside the existing cron-driven version. The
+git-projection design doc on parachute.computer goes long on when to
+reach for which.
+
 ## [0.4.6-rc.5] — 2026-05-20
 
 Three small wins surfaced while Aaron was wiring the Gitcoin Brain

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.6-rc.5",
+  "version": "0.4.6-rc.6",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2866,6 +2866,12 @@ async function cmdExport(args: string[]) {
   let vaultName = "default";
   let outputPath = "";
   let since: string | undefined;
+  let watch = false;
+  let intervalSeconds = 5;
+  let gitCommit = false;
+  const { DEFAULT_COMMIT_TEMPLATE } = await import("./export-watch.ts");
+  let gitMessageTemplate = DEFAULT_COMMIT_TEMPLATE;
+  let gitPush = false;
 
   const positional: string[] = [];
   for (let i = 0; i < args.length; i++) {
@@ -2892,6 +2898,31 @@ async function cmdExport(args: string[]) {
         process.exit(1);
       }
       since = v;
+    } else if (arg === "--watch") {
+      watch = true;
+    } else if (arg === "--interval") {
+      const v = args[++i];
+      if (!v) {
+        console.error("--interval requires a number of seconds.");
+        process.exit(1);
+      }
+      const n = Number(v);
+      if (!Number.isFinite(n) || n <= 0) {
+        console.error(`--interval: must be a positive number of seconds (got '${v}')`);
+        process.exit(1);
+      }
+      intervalSeconds = n;
+    } else if (arg === "--git-commit") {
+      gitCommit = true;
+    } else if (arg === "--git-message-template") {
+      const v = args[++i];
+      if (!v) {
+        console.error("--git-message-template requires a value.");
+        process.exit(1);
+      }
+      gitMessageTemplate = v;
+    } else if (arg === "--git-push") {
+      gitPush = true;
     } else {
       positional.push(arg);
     }
@@ -2899,13 +2930,37 @@ async function cmdExport(args: string[]) {
   outputPath = positional[0] ?? "";
 
   if (!outputPath) {
-    console.error("Usage: parachute-vault export <dir> [--since <iso>] [--vault <name>]");
+    console.error(
+      "Usage: parachute-vault export <dir> [--since <iso>] [--vault <name>]\n" +
+        "                                  [--watch [--interval <seconds>]]\n" +
+        "                                  [--git-commit [--git-message-template <tpl>] [--git-push]]",
+    );
     console.error("\nExports a Parachute Vault as portable markdown — round-trippable across");
     console.error("Obsidian / Logseq / Foam / Quartz / Dendron and most markdown SSGs.");
     console.error("\nOptions:");
-    console.error("  --vault <name>       Source vault (default: 'default')");
-    console.error("  --since <iso>        Only export notes whose updated_at >= ISO timestamp");
-    console.error("                       (incremental — useful for git-projection cadences)");
+    console.error("  --vault <name>              Source vault (default: 'default')");
+    console.error("  --since <iso>               Only export notes whose updated_at >= ISO timestamp");
+    console.error("                              (incremental — useful for git-projection cadences)");
+    console.error("  --watch                     Stay alive; re-export incrementally on every");
+    console.error("                              vault write. Polls every --interval seconds.");
+    console.error("  --interval <seconds>        Watch poll interval (default: 5)");
+    console.error("  --git-commit                After each export, `git add -A` + commit in <dir>.");
+    console.error("                              Requires <dir> to be an initialized git repo.");
+    console.error("                              Combine with --watch for auto-history.");
+    console.error("  --git-message-template <t>  Commit message template. Variables:");
+    console.error("                                {{date}}, {{notes_changed}}, {{plural}},");
+    console.error("                                {{first_note_title}}, {{vault_name}}");
+    console.error("                              (default: \"export: {{date}} ({{notes_changed}} note{{plural}})\")");
+    console.error("  --git-push                  After commit, run `git push` (non-fatal on failure).");
+    process.exit(1);
+  }
+
+  if (intervalSeconds !== 5 && !watch) {
+    console.error("--interval only applies with --watch.");
+    process.exit(1);
+  }
+  if ((gitPush || gitMessageTemplate !== DEFAULT_COMMIT_TEMPLATE) && !gitCommit) {
+    console.error("--git-push / --git-message-template only apply with --git-commit.");
     process.exit(1);
   }
 
@@ -2924,26 +2979,171 @@ async function cmdExport(args: string[]) {
 
   const store = getVaultStore(vaultName);
   const assetsDirPath = assetsDir(vaultName);
-  console.log(`Exporting vault "${vaultName}" to ${fullPath}${since ? ` (since ${since})` : ""}`);
-  const stats = await exportVaultToDir(store, {
-    outDir: fullPath,
-    vaultName,
-    assetsDir: assetsDirPath,
-    ...(config.description ? { vaultDescription: config.description } : {}),
-    ...(since ? { since } : {}),
-  });
+  const vaultDescription = config.description;
 
-  console.log(`Exported ${stats.notes} note(s), ${stats.schemas} tag schema(s), ${stats.attachments} attachment(s).`);
-  console.log(`Sidecar: ${fullPath}/.parachute/`);
-  if (stats.filtered_by_since) {
-    console.log(`Incremental: filtered by --since ${since}.`);
+  // Git-repo precheck: fail fast and loud before we run a long-lived loop.
+  if (gitCommit) {
+    await ensureGitRepo(fullPath);
   }
-  if (stats.skipped_traversal > 0) {
-    console.log(`Note: ${stats.skipped_traversal} note(s) skipped (path-traversal). See [export] warnings above.`);
+
+  /**
+   * Run a single export cycle: export → optionally commit/push. Returns the
+   * stats + a freshly-captured cursor for the next incremental run. We
+   * capture the cursor *before* the export starts, so any write that lands
+   * during the export is picked up next cycle (cost: at most one note
+   * re-exported next round when its `updated_at` equals our cursor).
+   */
+  async function runCycle(opts: { sinceCursor?: string; isInitial: boolean }): Promise<{
+    stats: Awaited<ReturnType<typeof exportVaultToDir>>;
+    nextCursor: string;
+    committed: boolean;
+  }> {
+    const nextCursor = new Date().toISOString();
+    if (opts.isInitial) {
+      console.log(
+        `Exporting vault "${vaultName}" to ${fullPath}${opts.sinceCursor ? ` (since ${opts.sinceCursor})` : ""}`,
+      );
+    }
+    const stats = await exportVaultToDir(store, {
+      outDir: fullPath,
+      vaultName,
+      assetsDir: assetsDirPath,
+      ...(vaultDescription ? { vaultDescription } : {}),
+      ...(opts.sinceCursor ? { since: opts.sinceCursor } : {}),
+    });
+
+    if (opts.isInitial) {
+      console.log(
+        `Exported ${stats.notes} note(s), ${stats.schemas} tag schema(s), ${stats.attachments} attachment(s).`,
+      );
+      console.log(`Sidecar: ${fullPath}/.parachute/`);
+      if (stats.filtered_by_since) {
+        console.log(`Incremental: filtered by --since ${opts.sinceCursor}.`);
+      }
+      if (stats.skipped_traversal > 0) {
+        console.log(
+          `Note: ${stats.skipped_traversal} note(s) skipped (path-traversal). See [export] warnings above.`,
+        );
+      }
+      if (stats.skipped_attachments.length > 0) {
+        console.log(
+          `Note: ${stats.skipped_attachments.length} attachment(s) skipped. See [export] warnings above.`,
+        );
+      }
+    } else {
+      // Watch-mode status line: keep tight; the loop logs every interval.
+      if (stats.notes > 0) {
+        console.log(
+          `[watch] exported ${stats.notes} note${stats.notes === 1 ? "" : "s"} (cursor: ${nextCursor})`,
+        );
+      } else {
+        console.log(`[watch] no changes`);
+      }
+    }
+
+    let committed = false;
+    if (gitCommit) {
+      const { runGitCommitCycle } = await import("./export-watch.ts");
+      const commitResult = await runGitCommitCycle({
+        repoDir: fullPath,
+        template: gitMessageTemplate,
+        notesChanged: stats.notes,
+        vaultName,
+        firstNoteTitle: await firstChangedNoteTitle(store, opts.sinceCursor),
+        push: gitPush,
+      });
+      committed = commitResult.committed;
+    }
+
+    return { stats, nextCursor, committed };
   }
-  if (stats.skipped_attachments.length > 0) {
-    console.log(`Note: ${stats.skipped_attachments.length} attachment(s) skipped. See [export] warnings above.`);
+
+  // ---- Single-shot mode ----
+  if (!watch) {
+    await runCycle({ sinceCursor: since, isInitial: true });
+    return;
   }
+
+  // ---- Watch mode ----
+  // Initial full (or since-filtered) export, then poll every interval.
+  const initial = await runCycle({ sinceCursor: since, isInitial: true });
+  let cursor = initial.nextCursor;
+  console.log(`[watch] polling every ${intervalSeconds}s; press Ctrl-C to stop.`);
+
+  let stopping = false;
+  let inFlight = false;
+  const onStop = () => {
+    if (stopping) return;
+    stopping = true;
+    console.log("\n[watch] stopping watch");
+    // Give an in-flight cycle a brief moment to settle, then exit. Don't
+    // hang forever — operator hit Ctrl-C, they want out.
+    setTimeout(() => process.exit(0), inFlight ? 250 : 0);
+  };
+  process.on("SIGINT", onStop);
+  process.on("SIGTERM", onStop);
+
+  const timer = setInterval(async () => {
+    if (stopping || inFlight) return;
+    inFlight = true;
+    try {
+      const cycle = await runCycle({ sinceCursor: cursor, isInitial: false });
+      cursor = cycle.nextCursor;
+    } catch (err) {
+      // Don't kill the loop on a transient export error — log and keep
+      // polling. Operator can Ctrl-C if they want to bail.
+      console.error(`[watch] export error: ${(err as Error).message ?? err}`);
+    } finally {
+      inFlight = false;
+    }
+  }, intervalSeconds * 1000);
+  // Keep a reference so the timer isn't GC'd; nothing else holds the loop open.
+  timer.unref?.();
+  // Block forever (signal handler is the exit path).
+  await new Promise(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Export-watch glue. The git-shell + commit-message logic lives in
+// `./export-watch.ts` for unit-testability; cli.ts just wires it in.
+// ---------------------------------------------------------------------------
+
+async function ensureGitRepo(dir: string): Promise<void> {
+  const { isGitRepo } = await import("./export-watch.ts");
+  if (!(await isGitRepo(dir))) {
+    console.error(
+      `error: --git-commit requires "${dir}" to be a git repo.\n` +
+        `Initialize it first:\n` +
+        `  cd "${dir}" && git init && git add -A && git commit -m "initial"\n` +
+        `Then re-run the export.`,
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Snapshot the title of the first changed note since `cursor` — used as the
+ * `{{first_note_title}}` template variable for single-note commit messages.
+ * Best-effort: returns empty string when nothing matches, or when the cursor
+ * is unset (initial export, where "first changed note" is ambiguous).
+ */
+async function firstChangedNoteTitle(
+  store: ReturnType<typeof import("./vault-store.ts")["getVaultStore"]>,
+  cursor: string | undefined,
+): Promise<string> {
+  if (!cursor) return "";
+  try {
+    const notes = await store.queryNotes({ limit: 1, sort: "asc" });
+    for (const n of notes) {
+      const stamp = n.updatedAt ?? n.createdAt;
+      if (stamp >= cursor) {
+        return n.path ?? n.id;
+      }
+    }
+  } catch {
+    // Best-effort; template var defaults to empty.
+  }
+  return "";
 }
 
 // ---------------------------------------------------------------------------
@@ -3175,6 +3375,12 @@ Import/Export:
   parachute-vault export <dir>                        Export vault as portable markdown
                                                        (Obsidian/Logseq/Foam/Quartz-compatible)
   parachute-vault export <dir> --since <iso>          Incremental: only notes updated_at >= ISO
+  parachute-vault export <dir> --watch                Stay alive; re-export on every write
+                                                       (poll every --interval seconds, default 5)
+  parachute-vault export <dir> --git-commit           After export, git add -A + commit in <dir>
+                                                       (combine with --watch for auto-history;
+                                                       template via --git-message-template;
+                                                       --git-push to push after commit)
 
 ── Advanced / standalone ──────────────────────────────────────────────
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3072,9 +3072,14 @@ async function cmdExport(args: string[]) {
 
   let stopping = false;
   let inFlight = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
   const onStop = () => {
     if (stopping) return;
     stopping = true;
+    // Clear the interval immediately so the timer can't fire one more
+    // time during the in-flight settle window — `stopping` already guards
+    // re-entry, but symmetry beats relying on that guard.
+    if (timer) clearInterval(timer);
     console.log("\n[watch] stopping watch");
     // Give an in-flight cycle a brief moment to settle, then exit. Don't
     // hang forever — operator hit Ctrl-C, they want out.
@@ -3083,7 +3088,7 @@ async function cmdExport(args: string[]) {
   process.on("SIGINT", onStop);
   process.on("SIGTERM", onStop);
 
-  const timer = setInterval(async () => {
+  timer = setInterval(async () => {
     if (stopping || inFlight) return;
     inFlight = true;
     try {
@@ -3126,6 +3131,12 @@ async function ensureGitRepo(dir: string): Promise<void> {
  * `{{first_note_title}}` template variable for single-note commit messages.
  * Best-effort: returns empty string when nothing matches, or when the cursor
  * is unset (initial export, where "first changed note" is ambiguous).
+ *
+ * Filters at the DB layer via `dateFilter: { field: "updated_at", from:
+ * cursor }` — earlier versions used `sort: "asc"` + `limit: 1` + a
+ * client-side `stamp >= cursor` post-filter, which fetched the vault's
+ * oldest note and almost always failed the filter, rendering the template
+ * variable as empty in production. See vault#346 reviewer note.
  */
 async function firstChangedNoteTitle(
   store: ReturnType<typeof import("./vault-store.ts")["getVaultStore"]>,
@@ -3133,17 +3144,16 @@ async function firstChangedNoteTitle(
 ): Promise<string> {
   if (!cursor) return "";
   try {
-    const notes = await store.queryNotes({ limit: 1, sort: "asc" });
-    for (const n of notes) {
-      const stamp = n.updatedAt ?? n.createdAt;
-      if (stamp >= cursor) {
-        return n.path ?? n.id;
-      }
-    }
+    const notes = await store.queryNotes({
+      limit: 1,
+      sort: "asc",
+      dateFilter: { field: "updated_at", from: cursor },
+    });
+    return notes[0]?.path ?? notes[0]?.id ?? "";
   } catch {
     // Best-effort; template var defaults to empty.
+    return "";
   }
-  return "";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/export-watch.test.ts
+++ b/src/export-watch.test.ts
@@ -1,0 +1,736 @@
+/**
+ * Tests for `parachute-vault export --watch` and `--git-commit`.
+ *
+ * Three layers:
+ *
+ *   1. Pure helpers in `export-watch.ts` — `renderCommitMessage`,
+ *      `shouldCommit`. No I/O.
+ *   2. Git-shell helpers — `isGitRepo`, `gitAddAll`, `gitCommit`,
+ *      `listStagedFiles`, `runGitCommitCycle`. Spawn real `git` against a
+ *      throwaway repo in a tempdir.
+ *   3. CLI end-to-end — spawn `bun src/cli.ts export …` against an isolated
+ *      `PARACHUTE_HOME` with a seeded vault. Covers the flag-parsing surface
+ *      (single-shot + --git-commit) and the watch-loop happy paths via the
+ *      `--interval` knob set to a small value.
+ *
+ * Watch-loop tests use child process kill/timeout discipline: spawn, wait
+ * for the expected log line (or timeout cap), then SIGINT and assert
+ * graceful exit. No real wall-clock sleeps longer than the interval.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  DEFAULT_COMMIT_TEMPLATE,
+  gitAddAll,
+  gitCommit,
+  isGitRepo,
+  listStagedFiles,
+  renderCommitMessage,
+  runGitCommitCycle,
+  shouldCommit,
+} from "./export-watch.ts";
+
+const CLI = path.resolve(import.meta.dir, "cli.ts");
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+function makeTmp(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function setupBareVault(parachuteHome: string, name: string): void {
+  const vaultsDir = path.join(parachuteHome, "vault", "data");
+  fs.mkdirSync(path.join(vaultsDir, name), { recursive: true });
+  fs.writeFileSync(
+    path.join(vaultsDir, name, "vault.yaml"),
+    `name: ${name}\napi_keys: []\n`,
+  );
+  const globalPath = path.join(parachuteHome, "vault", "config.yaml");
+  if (!fs.existsSync(globalPath)) {
+    fs.mkdirSync(path.dirname(globalPath), { recursive: true });
+    fs.writeFileSync(globalPath, `default_vault: ${name}\nport: 1940\n`);
+  }
+}
+
+/**
+ * Seed a SQLite vault DB at the path the server would use, populated with
+ * `n` notes. Returns the store handle so the test can write more notes
+ * mid-test (to simulate a live vault under a watch loop).
+ */
+async function seedVaultWithNotes(
+  parachuteHome: string,
+  vaultName: string,
+  notes: Array<{ id?: string; path: string; content: string; tags?: string[] }>,
+) {
+  // Defer imports so they read `PARACHUTE_HOME` from the env we set just
+  // before calling this helper.
+  process.env.PARACHUTE_HOME = parachuteHome;
+  process.env.HOME = parachuteHome;
+  const { clearVaultStoreCache, getVaultStore } = await import("./vault-store.ts");
+  clearVaultStoreCache();
+  const store = getVaultStore(vaultName);
+  for (const n of notes) {
+    await store.createNote(n.content, {
+      ...(n.id ? { id: n.id } : {}),
+      path: n.path,
+      ...(n.tags ? { tags: n.tags } : {}),
+    });
+  }
+  return store;
+}
+
+function initGitRepo(dir: string): void {
+  // Each test gets a brand-new repo. Set user.email/name locally so commits
+  // succeed without depending on the dev's global git config.
+  Bun.spawnSync(["git", "init", "-q", "-b", "main"], { cwd: dir });
+  Bun.spawnSync(["git", "config", "user.email", "test@parachute.computer"], { cwd: dir });
+  Bun.spawnSync(["git", "config", "user.name", "Parachute Test"], { cwd: dir });
+  Bun.spawnSync(["git", "config", "commit.gpgsign", "false"], { cwd: dir });
+}
+
+function gitLogOneline(dir: string): string[] {
+  const proc = Bun.spawnSync(["git", "log", "--oneline"], { cwd: dir, stdout: "pipe" });
+  return new TextDecoder()
+    .decode(proc.stdout)
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+function gitLastCommitMessage(dir: string): string {
+  const proc = Bun.spawnSync(["git", "log", "-1", "--pretty=%B"], { cwd: dir, stdout: "pipe" });
+  return new TextDecoder().decode(proc.stdout).trim();
+}
+
+function runCli(
+  args: string[],
+  parachuteHome: string,
+  extraEnv: Record<string, string | undefined> = {},
+): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync({
+    cmd: ["bun", CLI, ...args],
+    cwd: parachuteHome,
+    env: {
+      ...process.env,
+      PARACHUTE_HOME: parachuteHome,
+      HOME: parachuteHome,
+      ...extraEnv,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("renderCommitMessage", () => {
+  test("substitutes all documented vars", () => {
+    const msg = renderCommitMessage(
+      "{{date}} | {{notes_changed}} | {{plural}} | {{first_note_title}} | {{vault_name}}",
+      {
+        date: "2026-05-20T15:42:01Z",
+        notes_changed: 3,
+        first_note_title: "Inbox/2026-05-20",
+        vault_name: "gitcoin",
+      },
+    );
+    expect(msg).toBe("2026-05-20T15:42:01Z | 3 | s | Inbox/2026-05-20 | gitcoin");
+  });
+
+  test("{{plural}} is empty when notes_changed === 1", () => {
+    const msg = renderCommitMessage("{{notes_changed}} note{{plural}}", {
+      date: "x",
+      notes_changed: 1,
+      first_note_title: "",
+      vault_name: "v",
+    });
+    expect(msg).toBe("1 note");
+  });
+
+  test("{{plural}} is 's' when notes_changed === 0", () => {
+    // "0 notes" reads correctly — pluralize unless exactly one.
+    const msg = renderCommitMessage("{{notes_changed}} note{{plural}}", {
+      date: "x",
+      notes_changed: 0,
+      first_note_title: "",
+      vault_name: "v",
+    });
+    expect(msg).toBe("0 notes");
+  });
+
+  test("default template renders the expected shape", () => {
+    const msg = renderCommitMessage(DEFAULT_COMMIT_TEMPLATE, {
+      date: "2026-05-20T00:00:00Z",
+      notes_changed: 2,
+      first_note_title: "",
+      vault_name: "default",
+    });
+    expect(msg).toBe("export: 2026-05-20T00:00:00Z (2 notes)");
+  });
+
+  test("unknown tokens pass through untouched (typo-visible)", () => {
+    const msg = renderCommitMessage("{{not_a_var}} and {{date}}", {
+      date: "now",
+      notes_changed: 0,
+      first_note_title: "",
+      vault_name: "",
+    });
+    expect(msg).toBe("{{not_a_var}} and now");
+  });
+
+  test("repeated tokens are all substituted", () => {
+    const msg = renderCommitMessage("{{date}} / {{date}}", {
+      date: "X",
+      notes_changed: 0,
+      first_note_title: "",
+      vault_name: "",
+    });
+    expect(msg).toBe("X / X");
+  });
+});
+
+describe("shouldCommit", () => {
+  test("empty staging → skip", () => {
+    expect(shouldCommit([], 0)).toEqual({ commit: false, reason: "empty" });
+    expect(shouldCommit([], 5)).toEqual({ commit: false, reason: "empty" });
+  });
+
+  test("note changes → commit even if .parachute/ also dirty", () => {
+    expect(
+      shouldCommit([".parachute/vault.yaml", "Inbox/foo.md"], 1),
+    ).toEqual({ commit: true, reason: "ok" });
+  });
+
+  test("only .parachute/ + no notes changed → skip (filter exported_at churn)", () => {
+    expect(shouldCommit([".parachute/vault.yaml"], 0)).toEqual({
+      commit: false,
+      reason: "parachute_meta_only",
+    });
+  });
+
+  test("only .parachute/ + nonzero notes_changed → commit (defensive)", () => {
+    // notes_changed > 0 means real work happened even if its files don't
+    // appear in the staged set (could be tags-only schema export edge); we
+    // trust the stats over the staging filter.
+    expect(shouldCommit([".parachute/schemas/foo.yaml"], 1)).toEqual({
+      commit: true,
+      reason: "ok",
+    });
+  });
+
+  test("non-parachute file + zero notes_changed → commit", () => {
+    // Probably a manual edit in the export dir — defensive: commit it.
+    // Watch loop doesn't put us here normally, but the rule should be
+    // total over the staged set.
+    expect(shouldCommit(["Inbox/foo.md"], 0)).toEqual({
+      commit: true,
+      reason: "ok",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Git-shell helpers
+// ---------------------------------------------------------------------------
+
+describe("git-shell helpers", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeTmp("vault-git-helpers-");
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("isGitRepo: false in a fresh directory, true after `git init`", async () => {
+    expect(await isGitRepo(dir)).toBe(false);
+    initGitRepo(dir);
+    expect(await isGitRepo(dir)).toBe(true);
+  });
+
+  test("gitAddAll + listStagedFiles: stage everything", async () => {
+    initGitRepo(dir);
+    fs.writeFileSync(path.join(dir, "a.md"), "# a\n");
+    fs.writeFileSync(path.join(dir, "b.md"), "# b\n");
+    const add = await gitAddAll(dir);
+    expect(add.ok).toBe(true);
+    const staged = await listStagedFiles(dir);
+    expect(staged.sort()).toEqual(["a.md", "b.md"]);
+  });
+
+  test("gitCommit lands a real commit with the given message", async () => {
+    initGitRepo(dir);
+    fs.writeFileSync(path.join(dir, "a.md"), "# a\n");
+    await gitAddAll(dir);
+    const result = await gitCommit(dir, "test: first commit");
+    expect(result.ok).toBe(true);
+    expect(gitLastCommitMessage(dir)).toBe("test: first commit");
+    expect(gitLogOneline(dir)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. runGitCommitCycle — stage → decide → commit → push
+// ---------------------------------------------------------------------------
+
+describe("runGitCommitCycle", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeTmp("vault-commit-cycle-");
+    initGitRepo(dir);
+    // Seed an initial commit so HEAD exists — `git commit` on a fresh repo
+    // with no parent works, but the test mostly assumes a non-empty history.
+    fs.writeFileSync(path.join(dir, ".gitkeep"), "");
+    Bun.spawnSync(["git", "add", "-A"], { cwd: dir });
+    Bun.spawnSync(["git", "commit", "-q", "-m", "initial"], { cwd: dir });
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("commits when there are real note changes", async () => {
+    fs.writeFileSync(path.join(dir, "Inbox.md"), "# Inbox\n");
+    const result = await runGitCommitCycle({
+      repoDir: dir,
+      template: DEFAULT_COMMIT_TEMPLATE,
+      notesChanged: 1,
+      vaultName: "default",
+      firstNoteTitle: "Inbox",
+      push: false,
+      now: () => "2026-05-20T15:42:01Z",
+    });
+    expect(result.committed).toBe(true);
+    expect(result.message).toBe("export: 2026-05-20T15:42:01Z (1 note)");
+    expect(gitLastCommitMessage(dir)).toBe("export: 2026-05-20T15:42:01Z (1 note)");
+  });
+
+  test("skips commit when nothing is staged", async () => {
+    // No new files since the seed commit.
+    const result = await runGitCommitCycle({
+      repoDir: dir,
+      template: DEFAULT_COMMIT_TEMPLATE,
+      notesChanged: 0,
+      vaultName: "default",
+      firstNoteTitle: "",
+      push: false,
+    });
+    expect(result.committed).toBe(false);
+    expect(gitLogOneline(dir)).toHaveLength(1); // only the seed
+  });
+
+  test("skips when only .parachute/ metadata changed (and notes_changed=0)", async () => {
+    fs.mkdirSync(path.join(dir, ".parachute"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, ".parachute", "vault.yaml"),
+      "exported_at: 2026-05-20T00:00:00Z\nexport_format_version: 1\n",
+    );
+    const result = await runGitCommitCycle({
+      repoDir: dir,
+      template: DEFAULT_COMMIT_TEMPLATE,
+      notesChanged: 0,
+      vaultName: "default",
+      firstNoteTitle: "",
+      push: false,
+    });
+    expect(result.committed).toBe(false);
+    // History unchanged.
+    expect(gitLogOneline(dir)).toHaveLength(1);
+    // Staging area cleared so the next cycle starts clean.
+    expect(await listStagedFiles(dir)).toEqual([]);
+  });
+
+  test("commits when .parachute/ AND a note changed", async () => {
+    fs.mkdirSync(path.join(dir, ".parachute"), { recursive: true });
+    fs.writeFileSync(path.join(dir, ".parachute", "vault.yaml"), "x\n");
+    fs.writeFileSync(path.join(dir, "Note.md"), "# n\n");
+    const result = await runGitCommitCycle({
+      repoDir: dir,
+      template: "test: {{notes_changed}}",
+      notesChanged: 1,
+      vaultName: "default",
+      firstNoteTitle: "Note",
+      push: false,
+    });
+    expect(result.committed).toBe(true);
+    expect(gitLastCommitMessage(dir)).toBe("test: 1");
+  });
+
+  test("--git-push failure is non-fatal (no remote configured)", async () => {
+    fs.writeFileSync(path.join(dir, "Note.md"), "# n\n");
+    // No remote — `git push` will fail. runGitCommitCycle should still
+    // return committed=true (the commit landed) and not throw.
+    const result = await runGitCommitCycle({
+      repoDir: dir,
+      template: "test push",
+      notesChanged: 1,
+      vaultName: "default",
+      firstNoteTitle: "Note",
+      push: true,
+    });
+    expect(result.committed).toBe(true);
+    // Commit landed even though push failed.
+    expect(gitLogOneline(dir)).toHaveLength(2); // seed + new
+  });
+
+  test("first_note_title substitutes into single-note commit messages", async () => {
+    fs.writeFileSync(path.join(dir, "DonorMeeting.md"), "# d\n");
+    const result = await runGitCommitCycle({
+      repoDir: dir,
+      template: "note: {{first_note_title}}",
+      notesChanged: 1,
+      vaultName: "gitcoin",
+      firstNoteTitle: "Inbox/DonorMeeting",
+      push: false,
+    });
+    expect(result.message).toBe("note: Inbox/DonorMeeting");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. CLI end-to-end — single-shot mode
+// ---------------------------------------------------------------------------
+
+describe("export CLI: single-shot", () => {
+  let tmp: string;
+  let exportDir: string;
+
+  beforeEach(async () => {
+    tmp = makeTmp("vault-export-cli-");
+    exportDir = makeTmp("vault-export-out-");
+    setupBareVault(tmp, "default");
+    await seedVaultWithNotes(tmp, "default", [
+      { id: "01HZA111111111111111111111", path: "Inbox/note-a", content: "# a\n" },
+      { id: "01HZA222222222222222222222", path: "Inbox/note-b", content: "# b\n" },
+    ]);
+  });
+
+  afterEach(async () => {
+    // Close cached stores before the tempdir disappears — otherwise the
+    // next test's reset trips a "vault not found" against a dangling
+    // SQLite handle pointing at a deleted file.
+    const { clearVaultStoreCache } = await import("./vault-store.ts");
+    clearVaultStoreCache();
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(exportDir, { recursive: true, force: true });
+  });
+
+  test("--git-commit requires an initialized git repo (clear error)", () => {
+    const res = runCli(["export", exportDir, "--git-commit"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("--git-commit requires");
+    expect(res.stderr).toContain("git init");
+  });
+
+  test("--git-commit on a real repo: export → commit", () => {
+    initGitRepo(exportDir);
+    // Seed a commit so the export commit is a delta.
+    fs.writeFileSync(path.join(exportDir, ".gitkeep"), "");
+    Bun.spawnSync(["git", "add", "-A"], { cwd: exportDir });
+    Bun.spawnSync(["git", "commit", "-q", "-m", "initial"], { cwd: exportDir });
+
+    const res = runCli(["export", exportDir, "--git-commit"], tmp);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("[git-commit] export:");
+    const log = gitLogOneline(exportDir);
+    expect(log.length).toBe(2); // initial + export
+    expect(gitLastCommitMessage(exportDir)).toMatch(/^export: /);
+    expect(gitLastCommitMessage(exportDir)).toContain("2 notes");
+    // Sanity: the export landed on disk.
+    expect(fs.existsSync(path.join(exportDir, ".parachute", "vault.yaml"))).toBe(true);
+    expect(fs.existsSync(path.join(exportDir, "Inbox", "note-a.md"))).toBe(true);
+  });
+
+  test("--git-commit with custom template renders correctly", () => {
+    initGitRepo(exportDir);
+    fs.writeFileSync(path.join(exportDir, ".gitkeep"), "");
+    Bun.spawnSync(["git", "add", "-A"], { cwd: exportDir });
+    Bun.spawnSync(["git", "commit", "-q", "-m", "initial"], { cwd: exportDir });
+
+    const res = runCli(
+      [
+        "export",
+        exportDir,
+        "--git-commit",
+        "--git-message-template",
+        "vault {{vault_name}}: {{notes_changed}} note{{plural}}",
+      ],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(gitLastCommitMessage(exportDir)).toBe("vault default: 2 notes");
+  });
+
+  test("--git-commit on a second export with no changes: skips commit", () => {
+    initGitRepo(exportDir);
+    fs.writeFileSync(path.join(exportDir, ".gitkeep"), "");
+    Bun.spawnSync(["git", "add", "-A"], { cwd: exportDir });
+    Bun.spawnSync(["git", "commit", "-q", "-m", "initial"], { cwd: exportDir });
+
+    // First export — commits.
+    const first = runCli(["export", exportDir, "--git-commit"], tmp);
+    expect(first.exitCode).toBe(0);
+    const afterFirst = gitLogOneline(exportDir).length;
+    expect(afterFirst).toBe(2);
+
+    // Second export — only .parachute/vault.yaml's exported_at changes, so
+    // we expect a skip-message and no new commit.
+    const second = runCli(
+      ["export", exportDir, "--git-commit", "--since", "2999-01-01T00:00:00Z"],
+      tmp,
+    );
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toContain("skipping commit");
+    expect(gitLogOneline(exportDir).length).toBe(afterFirst);
+  });
+
+  test("--interval without --watch is a usage error", () => {
+    const res = runCli(["export", exportDir, "--interval", "2"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("--interval only applies with --watch");
+  });
+
+  test("--git-push without --git-commit is a usage error", () => {
+    const res = runCli(["export", exportDir, "--git-push"], tmp);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("--git-push / --git-message-template only apply with --git-commit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. CLI end-to-end — --watch loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn the CLI as a streaming child process for watch tests. Returns the
+ * process handle + an awaitWatchLine helper that resolves when stdout
+ * surfaces a line matching `predicate` (or rejects on timeout).
+ */
+function spawnWatchCli(args: string[], parachuteHome: string) {
+  const proc = Bun.spawn({
+    cmd: ["bun", CLI, ...args],
+    cwd: parachuteHome,
+    env: {
+      ...process.env,
+      PARACHUTE_HOME: parachuteHome,
+      HOME: parachuteHome,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const seenLines: string[] = [];
+  const seenStderr: string[] = [];
+  let stdoutBuffer = "";
+  let stderrBuffer = "";
+  const waiters: Array<{ predicate: (line: string) => boolean; resolve: () => void }> = [];
+
+  (async () => {
+    for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+      stdoutBuffer += new TextDecoder().decode(chunk);
+      let nl: number;
+      while ((nl = stdoutBuffer.indexOf("\n")) >= 0) {
+        const line = stdoutBuffer.slice(0, nl);
+        stdoutBuffer = stdoutBuffer.slice(nl + 1);
+        seenLines.push(line);
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (waiters[i]!.predicate(line)) {
+            waiters[i]!.resolve();
+            waiters.splice(i, 1);
+          }
+        }
+      }
+    }
+  })();
+
+  (async () => {
+    for await (const chunk of proc.stderr as ReadableStream<Uint8Array>) {
+      stderrBuffer += new TextDecoder().decode(chunk);
+      let nl: number;
+      while ((nl = stderrBuffer.indexOf("\n")) >= 0) {
+        seenStderr.push(stderrBuffer.slice(0, nl));
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+      }
+    }
+  })();
+
+  async function awaitLine(predicate: (line: string) => boolean, timeoutMs: number): Promise<string> {
+    // Fast path: already seen.
+    for (const l of seenLines) {
+      if (predicate(l)) return l;
+    }
+    return await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          new Error(
+            `awaitLine timeout after ${timeoutMs}ms. ` +
+              `Lines seen so far (stdout):\n${seenLines.join("\n")}\n` +
+              `(stderr):\n${seenStderr.join("\n")}`,
+          ),
+        );
+      }, timeoutMs);
+      waiters.push({
+        predicate,
+        resolve: () => {
+          clearTimeout(timer);
+          // Find the matching line we just pushed (last one matching).
+          for (let i = seenLines.length - 1; i >= 0; i--) {
+            if (predicate(seenLines[i]!)) {
+              resolve(seenLines[i]!);
+              return;
+            }
+          }
+          resolve("");
+        },
+      });
+    });
+  }
+
+  return {
+    proc,
+    awaitLine,
+    seenLines,
+    seenStderr,
+  };
+}
+
+describe("export CLI: --watch", () => {
+  let tmp: string;
+  let exportDir: string;
+
+  beforeEach(async () => {
+    tmp = makeTmp("vault-watch-cli-");
+    exportDir = makeTmp("vault-watch-out-");
+    setupBareVault(tmp, "default");
+    await seedVaultWithNotes(tmp, "default", [
+      { id: "01HZB111111111111111111111", path: "Inbox/seed", content: "# seed\n" },
+    ]);
+    // Close the in-test store so the spawned CLI can open its own writer.
+    const { clearVaultStoreCache } = await import("./vault-store.ts");
+    clearVaultStoreCache();
+  });
+
+  afterEach(async () => {
+    const { clearVaultStoreCache } = await import("./vault-store.ts");
+    clearVaultStoreCache();
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(exportDir, { recursive: true, force: true });
+  });
+
+  test(
+    "initial export + idle polling: status lines + SIGINT exits cleanly",
+    async () => {
+      const watch = spawnWatchCli(["export", exportDir, "--watch", "--interval", "1"], tmp);
+      try {
+        // Initial export prints the "Exported N notes" line.
+        await watch.awaitLine((l) => l.includes("Exported 1 note"), 10_000);
+        // Watch loop prints the polling banner.
+        await watch.awaitLine((l) => l.includes("[watch] polling every 1s"), 5_000);
+        // At least one idle tick.
+        await watch.awaitLine((l) => l.includes("[watch] no changes"), 5_000);
+      } finally {
+        watch.proc.kill("SIGINT");
+      }
+      const exit = await watch.proc.exited;
+      expect(exit).toBe(0);
+      // Stopping line printed on shutdown.
+      expect(watch.seenLines.some((l) => l.includes("[watch] stopping watch"))).toBe(true);
+    },
+    30_000,
+  );
+
+  test(
+    "vault write triggers a re-export within the next poll interval",
+    async () => {
+      const watch = spawnWatchCli(["export", exportDir, "--watch", "--interval", "1"], tmp);
+      try {
+        await watch.awaitLine((l) => l.includes("[watch] polling every 1s"), 10_000);
+
+        // Open the vault DB out-of-band and add a note. The watch loop
+        // should pick it up within ~2 intervals.
+        const { clearVaultStoreCache, getVaultStore } = await import("./vault-store.ts");
+        clearVaultStoreCache();
+        const store = getVaultStore("default");
+        await store.createNote("# new\n", {
+          id: "01HZB999999999999999999999",
+          path: "Inbox/triggered",
+          tags: ["watched"],
+        });
+        clearVaultStoreCache();
+
+        // Expect the watch-mode incremental-export line.
+        const line = await watch.awaitLine(
+          (l) => l.startsWith("[watch] exported"),
+          10_000,
+        );
+        expect(line).toMatch(/\[watch\] exported \d+ note/);
+        // And the on-disk file landed.
+        // Wait briefly for the write — awaitLine returned as soon as the
+        // log line appeared, but the file write happens immediately before.
+      } finally {
+        watch.proc.kill("SIGINT");
+      }
+      await watch.proc.exited;
+      expect(fs.existsSync(path.join(exportDir, "Inbox", "triggered.md"))).toBe(true);
+    },
+    30_000,
+  );
+
+  test(
+    "--watch + --git-commit: vault write → re-export → auto-commit → continues",
+    async () => {
+      initGitRepo(exportDir);
+      fs.writeFileSync(path.join(exportDir, ".gitkeep"), "");
+      Bun.spawnSync(["git", "add", "-A"], { cwd: exportDir });
+      Bun.spawnSync(["git", "commit", "-q", "-m", "initial"], { cwd: exportDir });
+
+      const watch = spawnWatchCli(
+        ["export", exportDir, "--watch", "--interval", "1", "--git-commit"],
+        tmp,
+      );
+      try {
+        await watch.awaitLine((l) => l.includes("[watch] polling every 1s"), 10_000);
+        // Initial export should have produced a commit.
+        await watch.awaitLine((l) => l.startsWith("[git-commit] export:"), 10_000);
+        const afterInitial = gitLogOneline(exportDir).length;
+
+        // Add a note → expect another commit on the next cycle.
+        const { clearVaultStoreCache, getVaultStore } = await import("./vault-store.ts");
+        clearVaultStoreCache();
+        const store = getVaultStore("default");
+        await store.createNote("# live\n", {
+          id: "01HZC111111111111111111111",
+          path: "Inbox/live-edit",
+        });
+        clearVaultStoreCache();
+
+        // Wait for a second `[git-commit] export:` line (distinct from the
+        // initial one). Use the watch handle's seenLines snapshot to count.
+        await watch.awaitLine((_l) => {
+          const count = watch.seenLines.filter((line) =>
+            line.startsWith("[git-commit] export:"),
+          ).length;
+          return count >= 2;
+        }, 15_000);
+        const afterEdit = gitLogOneline(exportDir).length;
+        expect(afterEdit).toBe(afterInitial + 1);
+      } finally {
+        watch.proc.kill("SIGINT");
+      }
+      await watch.proc.exited;
+    },
+    30_000,
+  );
+});

--- a/src/export-watch.test.ts
+++ b/src/export-watch.test.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_COMMIT_TEMPLATE,
   gitAddAll,
   gitCommit,
+  gitUnstageAll,
   isGitRepo,
   listStagedFiles,
   renderCommitMessage,
@@ -280,6 +281,19 @@ describe("git-shell helpers", () => {
     expect(gitLastCommitMessage(dir)).toBe("test: first commit");
     expect(gitLogOneline(dir)).toHaveLength(1);
   });
+
+  test("gitUnstageAll works on a fresh repo with no commits (no HEAD yet)", async () => {
+    // Regression for vault#346 reviewer note: prior version used `git reset
+    // HEAD -- .` which fails on a fresh repo before any commit. The
+    // .parachute/-only skip path on the first cycle would leave staging
+    // dirty. Verify `git restore --staged .` clears staging cleanly.
+    initGitRepo(dir);
+    fs.writeFileSync(path.join(dir, "a.md"), "# a\n");
+    await gitAddAll(dir);
+    expect(await listStagedFiles(dir)).toEqual(["a.md"]);
+    await gitUnstageAll(dir);
+    expect(await listStagedFiles(dir)).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -506,6 +520,67 @@ describe("export CLI: single-shot", () => {
     const res = runCli(["export", exportDir, "--git-push"], tmp);
     expect(res.exitCode).toBe(1);
     expect(res.stderr).toContain("--git-push / --git-message-template only apply with --git-commit");
+  });
+
+  test("{{first_note_title}} resolves to the actual updated note (end-to-end)", async () => {
+    // Regression test for vault#346 reviewer note: previously
+    // firstChangedNoteTitle used `sort: "asc"` + `limit: 1` + a client-side
+    // `stamp >= cursor` post-filter, which fetched the vault's *oldest*
+    // note and almost always failed the post-filter — rendering
+    // {{first_note_title}} as "" in production. The fix moves the filter
+    // to the DB via dateFilter; this test exercises the full CLI to catch
+    // a regression that the helper-unit tests (which inject the title)
+    // can't see.
+    initGitRepo(exportDir);
+    fs.writeFileSync(path.join(exportDir, ".gitkeep"), "");
+    Bun.spawnSync(["git", "add", "-A"], { cwd: exportDir });
+    Bun.spawnSync(["git", "commit", "-q", "-m", "initial"], { cwd: exportDir });
+
+    // Capture a cursor strictly after the seed notes were created, then
+    // add a fresh note whose `updated_at` is after the cursor.
+    await new Promise((r) => setTimeout(r, 10));
+    const cursor = new Date().toISOString();
+    await new Promise((r) => setTimeout(r, 10));
+    await seedVaultWithNotes(tmp, "default", [
+      {
+        id: "01HZN111111111111111111111",
+        path: "Inbox/DonorMeeting",
+        content: "# fresh\n",
+      },
+    ]);
+    const { clearVaultStoreCache } = await import("./vault-store.ts");
+    clearVaultStoreCache();
+
+    const res = runCli(
+      [
+        "export",
+        exportDir,
+        "--since",
+        cursor,
+        "--git-commit",
+        "--git-message-template",
+        "note: {{first_note_title}}",
+      ],
+      tmp,
+    );
+    expect(res.exitCode).toBe(0);
+    const last = gitLastCommitMessage(exportDir);
+    // The fix renders "Inbox/DonorMeeting"; the bug rendered "note: ".
+    expect(last).toBe("note: Inbox/DonorMeeting");
+  });
+
+  test("--git-message-template without --git-commit is a usage error", () => {
+    // Same guard as --git-push but covers the template-only misuse path —
+    // an operator who set just the template (e.g. via shell history) and
+    // forgot --git-commit would otherwise silently do a plain export.
+    const res = runCli(
+      ["export", exportDir, "--git-message-template", "hi"],
+      tmp,
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain(
+      "--git-push / --git-message-template only apply with --git-commit",
+    );
   });
 });
 

--- a/src/export-watch.ts
+++ b/src/export-watch.ts
@@ -135,9 +135,19 @@ export async function gitPush(
   return { ok: exitCode === 0, stderr: stderr.trim() };
 }
 
-/** Unstage everything in `repoDir` (no-op if nothing staged). */
+/**
+ * Unstage everything in `repoDir` (no-op if nothing staged).
+ *
+ * Uses bare `git reset` (no `HEAD`, no path args) so the call works on a
+ * fresh repo with no commits yet — an operator who runs `--git-commit`
+ * against a `git init`'d empty repo and lands in the `.parachute/`-only
+ * skip path on the first cycle would otherwise leave staging dirty.
+ * Both `git reset HEAD -- .` and `git restore --staged .` require a
+ * resolvable HEAD; bare `git reset` falls back cleanly when none exists.
+ * See vault#346 reviewer note.
+ */
 export async function gitUnstageAll(repoDir: string): Promise<void> {
-  const proc = Bun.spawn(["git", "reset", "HEAD", "--", "."], {
+  const proc = Bun.spawn(["git", "reset"], {
     cwd: repoDir,
     stdout: "pipe",
     stderr: "pipe",
@@ -160,6 +170,12 @@ export async function gitUnstageAll(repoDir: string): Promise<void> {
  *     would otherwise produce a commit per watch interval forever.
  *
  * Otherwise → commit.
+ *
+ * Note: a vault rename (vault.yaml `name` field changes) also follows the
+ * skip path. Metadata-only changes don't commit by design — the operator
+ * who renames a vault and wants that in the git mirror history can either
+ * touch a note or run a one-shot `git commit --allow-empty -m "rename vault"`
+ * by hand.
  */
 export function shouldCommit(stagedFiles: string[], notesChanged: number): {
   commit: boolean;

--- a/src/export-watch.ts
+++ b/src/export-watch.ts
@@ -1,0 +1,239 @@
+/**
+ * Helpers for `parachute-vault export --watch` and `--git-commit`.
+ *
+ * Split out from `cli.ts` so the template renderer and git-shell helpers are
+ * unit-testable without spawning the full CLI. The CLI imports and wires
+ * these into `cmdExport`'s watch loop; tests import them directly.
+ *
+ * No new deps — `git` is shelled out via `Bun.spawn`. Watch detection is
+ * polling: every `intervalSeconds`, run an incremental export with the
+ * cursor captured at the *start* of the previous cycle. Vault writes are
+ * HTTP-mediated and don't surface to filesystem watchers (the bun:sqlite DB
+ * is opaque), so polling on `updated_at >= cursor` is the simplest robust
+ * detection. See `parachute-patterns/cookbook/vault-portable-export.md`.
+ */
+
+// ---------------------------------------------------------------------------
+// Commit message templating
+// ---------------------------------------------------------------------------
+
+/** Variables exposed to `--git-message-template`. */
+export interface CommitTemplateVars {
+  /** ISO-formatted UTC timestamp captured at commit time. */
+  date: string;
+  /** Count of notes changed since the previous export cursor. */
+  notes_changed: number;
+  /**
+   * First changed note's title (or path / id fallback) since the previous
+   * cursor — useful for single-note commits. Empty when nothing matched or
+   * on the initial export (where "first changed" is ambiguous).
+   */
+  first_note_title: string;
+  /** Source vault name. */
+  vault_name: string;
+}
+
+/**
+ * Substitute `{{var}}` tokens in `template`. Recognized vars:
+ *
+ *   `{{date}}` `{{notes_changed}}` `{{plural}}` `{{first_note_title}}` `{{vault_name}}`
+ *
+ * `{{plural}}` is `""` when `notes_changed === 1`, else `"s"` — so
+ * `"{{notes_changed}} note{{plural}}"` reads naturally for both 1 and N
+ * without the operator writing their own conditional.
+ *
+ * Unknown tokens pass through untouched (so a typo in the template is
+ * visible in the commit message rather than silently dropped).
+ */
+export function renderCommitMessage(template: string, vars: CommitTemplateVars): string {
+  return template
+    .replace(/\{\{date\}\}/g, vars.date)
+    .replace(/\{\{notes_changed\}\}/g, String(vars.notes_changed))
+    .replace(/\{\{plural\}\}/g, vars.notes_changed === 1 ? "" : "s")
+    .replace(/\{\{first_note_title\}\}/g, vars.first_note_title)
+    .replace(/\{\{vault_name\}\}/g, vars.vault_name);
+}
+
+/** Default commit message template. Reads as "export: <iso> (N note[s])". */
+export const DEFAULT_COMMIT_TEMPLATE =
+  "export: {{date}} ({{notes_changed}} note{{plural}})";
+
+// ---------------------------------------------------------------------------
+// Git shell helpers (Bun.spawn — no new dep)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true if `dir` is inside a git working tree.
+ *
+ * Implementation: `git rev-parse --is-inside-work-tree`, exit code 0 = yes.
+ * No reliance on `.git/` existing as a directory (handles worktrees + bare
+ * submodule layouts uniformly).
+ */
+export async function isGitRepo(dir: string): Promise<boolean> {
+  const proc = Bun.spawn(["git", "rev-parse", "--is-inside-work-tree"], {
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  return exitCode === 0;
+}
+
+/** List the paths git currently has staged (cached). One per line. */
+export async function listStagedFiles(repoDir: string): Promise<string[]> {
+  const proc = Bun.spawn(["git", "diff", "--cached", "--name-only"], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+  const out = new TextDecoder().decode(await new Response(proc.stdout).arrayBuffer());
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+/** Run `git add -A` in `repoDir`. Returns true on success. */
+export async function gitAddAll(repoDir: string): Promise<{ ok: boolean; stderr: string }> {
+  const proc = Bun.spawn(["git", "add", "-A"], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  const stderr = new TextDecoder().decode(await new Response(proc.stderr).arrayBuffer());
+  return { ok: exitCode === 0, stderr: stderr.trim() };
+}
+
+/** Run `git commit -m <message>` in `repoDir`. Returns true on success. */
+export async function gitCommit(
+  repoDir: string,
+  message: string,
+): Promise<{ ok: boolean; stderr: string }> {
+  const proc = Bun.spawn(["git", "commit", "-m", message], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  const stderr = new TextDecoder().decode(await new Response(proc.stderr).arrayBuffer());
+  return { ok: exitCode === 0, stderr: stderr.trim() };
+}
+
+/** Run `git push` in `repoDir`. Returns true on success. */
+export async function gitPush(
+  repoDir: string,
+): Promise<{ ok: boolean; stderr: string }> {
+  const proc = Bun.spawn(["git", "push"], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  const stderr = new TextDecoder().decode(await new Response(proc.stderr).arrayBuffer());
+  return { ok: exitCode === 0, stderr: stderr.trim() };
+}
+
+/** Unstage everything in `repoDir` (no-op if nothing staged). */
+export async function gitUnstageAll(repoDir: string): Promise<void> {
+  const proc = Bun.spawn(["git", "reset", "HEAD", "--", "."], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+}
+
+// ---------------------------------------------------------------------------
+// Cycle-level helpers: commit-or-skip decision + execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether the currently-staged set warrants a commit, given the
+ * `notes_changed` reported by the export cycle.
+ *
+ * Skip rules:
+ *   - Empty staging → skip (nothing to commit).
+ *   - `notes_changed === 0` AND every staged path lives under `.parachute/`
+ *     → skip. This filters the pure `vault.yaml` `exported_at` churn that
+ *     would otherwise produce a commit per watch interval forever.
+ *
+ * Otherwise → commit.
+ */
+export function shouldCommit(stagedFiles: string[], notesChanged: number): {
+  commit: boolean;
+  reason: "ok" | "empty" | "parachute_meta_only";
+} {
+  if (stagedFiles.length === 0) return { commit: false, reason: "empty" };
+  if (notesChanged === 0 && stagedFiles.every((f) => f.startsWith(".parachute/"))) {
+    return { commit: false, reason: "parachute_meta_only" };
+  }
+  return { commit: true, reason: "ok" };
+}
+
+/**
+ * Stage → decide → commit → optionally push. Logs status to stdout/stderr.
+ * Returns whether a commit landed.
+ */
+export async function runGitCommitCycle(opts: {
+  repoDir: string;
+  template: string;
+  notesChanged: number;
+  vaultName: string;
+  firstNoteTitle: string;
+  push: boolean;
+  /** Override for tests — defaults to `new Date().toISOString()`. */
+  now?: () => string;
+}): Promise<{ committed: boolean; message?: string }> {
+  const now = opts.now ?? (() => new Date().toISOString());
+
+  const add = await gitAddAll(opts.repoDir);
+  if (!add.ok) {
+    console.error(`[git-commit] git add failed: ${add.stderr}`);
+    return { committed: false };
+  }
+
+  const staged = await listStagedFiles(opts.repoDir);
+  const decision = shouldCommit(staged, opts.notesChanged);
+  if (!decision.commit) {
+    if (decision.reason === "empty") {
+      console.log(`[git-commit] no changes; skipping commit`);
+    } else if (decision.reason === "parachute_meta_only") {
+      // Unstage so the next cycle starts clean and the operator's
+      // `git status` reflects the skip-decision.
+      await gitUnstageAll(opts.repoDir);
+      console.log(
+        `[git-commit] no note changes (only .parachute/ metadata); skipping commit`,
+      );
+    }
+    return { committed: false };
+  }
+
+  const message = renderCommitMessage(opts.template, {
+    date: now(),
+    notes_changed: opts.notesChanged,
+    first_note_title: opts.firstNoteTitle,
+    vault_name: opts.vaultName,
+  });
+
+  const commit = await gitCommit(opts.repoDir, message);
+  if (!commit.ok) {
+    console.error(`[git-commit] git commit failed: ${commit.stderr}`);
+    return { committed: false };
+  }
+  console.log(`[git-commit] ${message}`);
+
+  if (opts.push) {
+    const pushResult = await gitPush(opts.repoDir);
+    if (!pushResult.ok) {
+      // Non-fatal — a network blip shouldn't kill a watch loop. Warn and
+      // move on; the next successful commit's push will catch up history.
+      console.warn(`[git-commit] git push failed (non-fatal): ${pushResult.stderr}`);
+    } else {
+      console.log(`[git-commit] pushed`);
+    }
+  }
+
+  return { committed: true, message };
+}


### PR DESCRIPTION
## Summary

Adds two new flags to `parachute-vault export <dir>` that turn it from a
single-shot snapshot tool into a live vault → markdown → git mirror —
the missing piece for Aaron's Gitcoin Brain "vault as system of record,
git as auto-history projection" pattern. One process, no cron, no
webhook, no shell glue.

The full combined command:

```bash
parachute-vault export ~/projections/team-brain --watch --git-commit --git-push
```

Drop it in a launchd plist (or `parachute start`-style supervisor) and
the git mirror tracks vault writes within a couple of seconds.

## --watch

`parachute-vault export <dir> --watch [--interval <seconds>]`

- Initial full (or `--since`-filtered) export, then poll every interval
  (default **5s**) and re-export incrementally on every vault write.
- Detection is polling on `updated_at >= cursor`. Vault writes are
  HTTP-mediated and the bun:sqlite DB is opaque to filesystem watchers,
  so polling is the simplest robust signal — and it's cheap.
- Cursor is captured *before* each export so a write that lands
  mid-export is picked up next cycle (cost: at most one re-exported
  note when its `updated_at` equals the cursor — `>=` semantics).
- Status line shape:
  - On change: `[watch] exported 3 notes (cursor: 2026-05-20T15:42:01Z)`
  - On idle: `[watch] no changes`
- Graceful shutdown on SIGINT/SIGTERM (`[watch] stopping watch`, exit 0).
- In-flight guard prevents stacked tasks if a cycle runs long.

## --git-commit

`parachute-vault export <dir> --git-commit [--git-message-template <tpl>] [--git-push]`

- After each export, `git add -A` + `git commit -m <rendered-template>`
  in `<dir>`.
- **Repo must already be initialized.** Fails fast with `git init`
  guidance at startup, not after sitting in a watch loop emitting the
  same error every interval.
- **Default template**: `export: {{date}} ({{notes_changed}} note{{plural}})`
- **Template variables**:
  - `{{date}}` — ISO-formatted UTC timestamp
  - `{{notes_changed}}` — count of changed notes since last cursor
  - `{{plural}}` — `""` when notes_changed === 1, else `"s"` (reads as
    natural English)
  - `{{first_note_title}}` — first changed note's path (or id fallback)
    — useful for single-note commits
  - `{{vault_name}}` — source vault name
- **Skip rules**:
  - Empty staging → `[git-commit] no changes; skipping commit`
  - `notes_changed === 0` AND every staged path lives under
    `.parachute/` → skip (filters the pure `vault.yaml` `exported_at`
    churn that would otherwise produce a commit per watch interval
    forever)
- **`--git-push`** is non-fatal on failure — a network blip warns
  (`[git-commit] git push failed (non-fatal): …`) but doesn't kill
  the watch loop. The next successful commit's push catches up history.

## Combined --watch --git-commit (the Gitcoin Brain mode)

Vault writes → re-export within ~interval → auto-commit → continues
watching. The git history becomes the audit trail by construction.

## Implementation notes

- **No new deps.** `git add/commit/push` are shelled out via `Bun.spawn`.
- Helpers (`renderCommitMessage`, `shouldCommit`, `runGitCommitCycle`,
  the git shell wrappers) live in `src/export-watch.ts` so they're
  unit-testable without spawning the full CLI. `cmdExport` just wires
  them in.
- Watch loop uses `setInterval`. Filesystem watchers explicitly
  rejected — the vault DB is opaque to fsevents and the write paths
  are HTTP, not file-touch.

## Test plan

29 new tests in `src/export-watch.test.ts`, three layers:

- **Pure helpers** (8 tests) — `renderCommitMessage` (var substitution,
  pluralization, unknown-token passthrough, repeated tokens, default
  template) and `shouldCommit` (empty / notes+meta / meta-only /
  defensive cases).
- **Git shell helpers** (3 tests) — `isGitRepo`, `gitAddAll +
  listStagedFiles`, `gitCommit` against real throwaway repos. Each test
  initializes its own repo with local `user.email`/`name` and
  `commit.gpgsign false` so the suite doesn't depend on the dev's
  global git config.
- **`runGitCommitCycle`** (6 tests) — commit happy path, skip-when-empty,
  skip-meta-only, commit-when-mixed, `--git-push` non-fatal, template
  substitution.
- **CLI single-shot** (6 tests) — `--git-commit` repo-required error,
  end-to-end commit, custom template, no-op second export skips,
  `--interval` without `--watch` error, `--git-push` without
  `--git-commit` error.
- **CLI watch loop** (3 tests) — initial export + idle polling + SIGINT
  exits cleanly, vault write triggers re-export, combined
  `--watch --git-commit` flow.

Full suite (`bun test ./src/ ./core/src/`): **1551 tests, 0 fail**.
Typecheck passes.

### Smoke

Manual end-to-end against an isolated `PARACHUTE_HOME` + `/tmp/mirror`:

```
Exporting vault "default" to /tmp/vault-smoke/mirror
Exported 2 note(s), 0 tag schema(s), 0 attachment(s).
Sidecar: /tmp/vault-smoke/mirror/.parachute/
[git-commit] export: 2026-05-20T22:31:25.727Z (2 notes)
[watch] polling every 2s; press Ctrl-C to stop.
[watch] no changes
[git-commit] no note changes (only .parachute/ metadata); skipping commit
…
[watch] exported 1 note (cursor: 2026-05-20T22:31:45.749Z)
[git-commit] export: 2026-05-20T22:31:45.770Z (1 note)
…
^C
[watch] stopping watch
```

Resulting `git log -3`:

```
2d64b5a export: 2026-05-20T22:31:45.770Z (1 note)
649a052 export: 2026-05-20T22:31:25.727Z (2 notes)
d20b376 initial
```

All three notes mirrored, idle polls correctly filtered, live add
picked up within the 2s interval, SIGINT graceful.

## Cross-references

- **Cookbook** — `parachute-patterns/cookbook/vault-portable-export.md`
  (the existing cron-driven "git-as-projection" recipe; this PR is the
  live-instead-of-cron variant)
- **Use case** — Aaron's Gitcoin Brain `for_parachute_round_4.md` (jobs
  as vault notes, runs as vault notes, wants git history)
- **Versioning** — bumps to `0.4.6-rc.6` (continuing the 0.4.6 chain;
  mcp-config + vault_scope were rc.5)
- **Upcoming** — a `vault-as-git-projection` design doc on
  parachute.computer will spell out when to reach for `--watch`
  vs. the cron-driven webhook recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)