### PR TITLE
fix(vault): mcp-install rejects --mint --scope vault:admin pre-flight (hub policy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,67 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.7-rc.3] — 2026-05-21
+
+fix(vault): `mcp-install` admin-scope path no longer round-trips to hub
+mint-token (which rejects it by policy).
+
+### Symptom
+
+Running `parachute vault mcp-install`, picking the `admin` option in the
+interactive auth prompt, surfaced:
+
+```
+Hub mint-token rejected (HTTP 400, invalid_scope): scope vault:default:admin
+is not requestable via mint-token; use OAuth flow or operator rotation
+```
+
+The mint-token endpoint has always rejected `vault:<name>:admin` — per-vault
+admin is non-requestable by hub policy (see
+[`parachute-hub/src/scope-explanations.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/scope-explanations.ts)'s
+`VAULT_ADMIN_RE` + `api-mint-token.ts`'s non-requestable guard). It's mintable
+only through the session-cookie-gated `/admin/vault-admin-token/<name>` SPA
+endpoint. Vault's `mcp-install` flow shipped this latent bug since vault#291
+introduced the `--mint` mode; it stayed latent until an operator exercised
+the admin branch.
+
+### Fixed
+
+- **Interactive flow auto-routes `admin` → `legacy-pat`.** Picking "admin"
+  at the auth prompt now mints a vault-DB `pvt_*` with full admin
+  permissions (the right shape for a local MCP entry needing schema
+  management) and prints a one-line explanation of the auto-route so the
+  switch isn't silent. Prompt help text updated to telegraph the routing
+  upfront.
+
+- **Flag-driven `--mint --scope vault:admin` rejected pre-flight.** The
+  combination errors out with an actionable remediation before any
+  operator-token / hub-origin check, pointing at
+  `--legacy-pat --scope vault:admin` (the working path) and naming the
+  admin SPA at `<hub>/admin/vaults/<name>` for operators who'd rather use
+  the browser path. The rejection happens locally — no hub round-trip.
+
+- **Docs + help text.** The `mcp-install` function docstring, the inline
+  `--legacy-pat` description in `parachute-vault --help`, and the
+  interactive prompt's help block all now say "admin requires
+  --legacy-pat" explicitly. Removes the trap where the help text listed
+  `vault:admin` as a `--scope` choice with no caveat.
+
+### Tests
+
+- `src/mcp-install-interactive.test.ts` — the existing
+  `"typing 'admin' produces vault:admin mint"` test was inverted: it
+  pinned the buggy behavior. Replaced with a regression test that
+  asserts (a) `mode === "legacy-pat"`, (b) `scope === "vault:admin"`,
+  and (c) the user-facing explanation appears in the captured log.
+- `src/mcp-install.test.ts` — new
+  `"rejects --mint --scope vault:admin pre-flight"` test exercising
+  Aaron's exact CLI invocation. Pins the remediation message wording
+  (`--legacy-pat --scope vault:admin`) and verifies the reject fires
+  *before* the operator-token / hub-origin checks (no "Hub unreachable"
+  / "No hub origin configured" leak when the operator wasn't going to
+  reach the hub anyway).
+
 ## [0.4.7-rc.2] — 2026-05-21
 
 fix(vault): export detects case-collision on case-insensitive filesystems

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.7-rc.2",
+  "version": "0.4.7-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -943,6 +943,11 @@ function takeArgValue(args: string[], name: string): { value?: string; missingVa
  * Targeting:
  *   --scope <verb>        vault:read | vault:write | vault:admin (default: vault:read).
  *                         For --mint, expands to vault:<vault-name>:<verb>.
+ *                         vault:admin requires --legacy-pat — hub policy makes
+ *                         per-vault admin non-requestable via mint-token (it's
+ *                         operator-only, minted only through the session-
+ *                         cookie-gated admin SPA endpoint), so --mint + admin
+ *                         is rejected pre-flight.
  *   --install-scope <s>   local (default) | user | project. local writes to
  *                         ~/.claude.json under projects[<cwd>].mcpServers
  *                         (private, this directory only — matches Claude
@@ -1331,6 +1336,28 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
     bearer = fullToken;
   } else {
     // mode === "mint"
+    // Pre-flight: hub policy rejects `vault:<name>:admin` via the public
+    // mint-token endpoint. Per-vault admin is operator-only, mintable
+    // only through the session-cookie-gated `/admin/vault-admin-token/:name`
+    // SPA path. Calling hub with admin would surface a 400:
+    //   "Hub mint-token rejected (HTTP 400, invalid_scope):
+    //    scope vault:default:admin is not requestable via mint-token;
+    //    use OAuth flow or operator rotation"
+    // Fail early with the actionable remediation rather than letting
+    // the operator chase the hub's wire-level error. See
+    // `parachute-hub/src/scope-explanations.ts` (VAULT_ADMIN_RE) and
+    // `parachute-hub/src/api-mint-token.ts` (non-requestable guard).
+    if (verb === "admin") {
+      console.error(
+        "Hub policy: vault:<name>:admin is not requestable via mint-token " +
+          "(per-vault admin is operator-only, minted only by the session-cookie-gated " +
+          "admin SPA at <hub>/admin/vaults/" + vaultName + ").\n" +
+          "  Fix: use `--legacy-pat --scope vault:admin` to mint a vault-DB pvt_* with admin scope " +
+          "(the right shape for an MCP entry needing schema management).\n" +
+          "  Or:  drop --scope to default to vault:read (least privilege), or use --scope vault:write.",
+      );
+      process.exit(1);
+    }
     const operatorToken = readOperatorToken();
     if (!operatorToken) {
       console.error(
@@ -3392,7 +3419,13 @@ Vaults:
                                             (any shape) instead of minting.
                                             --legacy-pat: mint a vault-DB pvt_*
                                             token (deprecated; for self-hosted-
-                                            without-hub setups).
+                                            without-hub setups). Also the only
+                                            path for --scope vault:admin — hub
+                                            policy reserves per-vault admin for
+                                            operator-only minting (the admin SPA
+                                            session-cookie path), so --mint
+                                            --scope vault:admin is rejected
+                                            pre-flight.
                                             --install-scope local (default) writes
                                             ~/.claude.json under
                                             projects[<cwd>].mcpServers (this

--- a/src/mcp-install-interactive.test.ts
+++ b/src/mcp-install-interactive.test.ts
@@ -287,8 +287,23 @@ describe("runInteractiveInstall — decision tree", () => {
     expect(result.scope).toBe("vault:write");
   });
 
-  test("scope widening: typing 'admin' produces vault:admin mint", async () => {
-    const { io } = mockIO([
+  test("typing 'admin' auto-routes to legacy-pat with vault:admin scope (hub mint-token rejects admin)", async () => {
+    // Regression for the symptom Aaron hit on hub 0.5.12-rc.2 / vault
+    // 0.4.7-rc.1: picking "admin" in the mint prompt sent
+    // `vault:default:admin` to `POST /api/auth/mint-token`, which hub
+    // rejects by policy (per-vault admin is non-requestable; see
+    // `parachute-hub/src/scope-explanations.ts:VAULT_ADMIN_RE` and
+    // `api-mint-token.ts`'s non-requestable guard):
+    //
+    //   Hub mint-token rejected (HTTP 400, invalid_scope):
+    //   scope vault:default:admin is not requestable via mint-token;
+    //   use OAuth flow or operator rotation
+    //
+    // Fix: auto-route "admin" in the interactive prompt to legacy-pat
+    // mode (which mints a vault-DB pvt_* — the right shape for an MCP
+    // entry needing admin permissions), with a printed explanation so
+    // the switch isn't silent.
+    const { io, state } = mockIO([
       null,    // accept install-scope default
       "admin",
       true,
@@ -296,7 +311,13 @@ describe("runInteractiveInstall — decision tree", () => {
     const result = await runInteractiveInstall(baseCtx(), io);
     expect(result).not.toBe("abort");
     if (result === "abort") return;
+    expect(result.mode).toBe("legacy-pat");
     expect(result.scope).toBe("vault:admin");
+    // The auto-route must surface the reason — silent re-routing would
+    // mislead operators who specifically want a hub JWT.
+    const logged = state.logs.join("\n");
+    expect(logged).toMatch(/admin requires a vault-DB pvt_\*/);
+    expect(logged).toMatch(/hub policy/);
   });
 
   test("typing 'paste' at the auth prompt switches to token mode + asks for token", async () => {

--- a/src/mcp-install-interactive.ts
+++ b/src/mcp-install-interactive.ts
@@ -190,7 +190,9 @@ export async function runInteractiveInstall(
         "Choices:",
         "  Enter       → mint a hub JWT with vault:read scope (recommended).",
         "  write       → mint with vault:write (mutations).",
-        "  admin       → mint with vault:admin (schema management).",
+        "  admin       → mint a vault-DB pvt_* with vault:admin (schema management;",
+        "                hub policy reserves per-vault admin for operator-only paths,",
+        "                so this auto-routes to legacy-pat).",
         "  paste       → use an existing token instead of minting.",
         "  legacy      → mint a vault-DB pvt_* (self-hosted-without-hub).",
       ].join("\n"),
@@ -209,10 +211,27 @@ export async function runInteractiveInstall(
       // operator gets the same control they get when widening a hub
       // JWT's scope. (vault#292 review F2.)
       scope = await askScope(io);
+    } else if (answer === "admin") {
+      // `vault:<name>:admin` is non-requestable via hub mint-token by
+      // policy — only the session-cookie-gated `/admin/vault-admin-token/:name`
+      // endpoint can mint per-vault admin scopes (see
+      // `parachute-hub/src/scope-explanations.ts:VAULT_ADMIN_RE` and
+      // `api-mint-token.ts`'s non-requestable guard). Hub returns
+      // HTTP 400 invalid_scope: "scope vault:<name>:admin is not
+      // requestable via mint-token; use OAuth flow or operator rotation".
+      //
+      // Auto-route to legacy-pat which mints a vault-DB pvt_* with full
+      // permissions — that's the right shape for an operator who wants
+      // admin scope on a local MCP entry. Print a one-line explanation
+      // so the switch isn't silent.
+      io.log("  → admin requires a vault-DB pvt_* (hub policy: per-vault admin");
+      io.log("    is operator-only, not mintable via the public mint-token API).");
+      io.log("    Switching to legacy-pat mode with vault:admin scope.");
+      mode = "legacy-pat";
+      scope = "vault:admin";
     } else {
       mode = "mint";
       if (answer === "write") scope = "vault:write";
-      else if (answer === "admin") scope = "vault:admin";
     }
   } else {
     // No hub-mint path available — explain why and offer the alternatives.

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -522,6 +522,46 @@ describe("mcp-install flag parsing", () => {
     expect(res.exitCode).toBe(1);
     expect(res.stderr).toMatch(/No hub origin configured/);
   });
+
+  test("rejects --mint --scope vault:admin pre-flight (hub policy: per-vault admin is non-requestable)", () => {
+    // Regression for the symptom Aaron hit on hub 0.5.12-rc.2 / vault
+    // 0.4.7-rc.1: `parachute vault mcp-install` with the "admin" mint
+    // option sent `vault:default:admin` to `POST /api/auth/mint-token`,
+    // and hub responded:
+    //
+    //   Hub mint-token rejected (HTTP 400, invalid_scope):
+    //   scope vault:default:admin is not requestable via mint-token;
+    //   use OAuth flow or operator rotation
+    //
+    // The combination is invalid by hub policy (see
+    // `parachute-hub/src/scope-explanations.ts:VAULT_ADMIN_RE` and
+    // `api-mint-token.ts`'s non-requestable guard) — per-vault admin
+    // is operator-only, mintable only through the session-cookie-gated
+    // `/admin/vault-admin-token/:name` SPA path.
+    //
+    // The fix rejects the combination pre-flight in vault's mcp-install
+    // with a clear remediation pointing at `--legacy-pat --scope vault:admin`
+    // (which mints a vault-DB pvt_* with admin scope — the right shape
+    // for a local MCP entry needing schema management).
+    setupBareVault(tmp, "default");
+    fs.writeFileSync(path.join(tmp, "operator.token"), "operator-bearer-stub");
+    const res = runCli(
+      ["mcp-install", "--mint", "--scope", "vault:admin"],
+      tmp,
+      { PARACHUTE_HUB_ORIGIN: "https://hub.example.org" },
+    );
+    expect(res.exitCode).toBe(1);
+    // Surface the policy reason so the operator knows why this combo is
+    // rejected (not a transient bug).
+    expect(res.stderr).toMatch(/not requestable via mint-token/);
+    // Point at the working remediation.
+    expect(res.stderr).toMatch(/--legacy-pat --scope vault:admin/);
+    // Pre-flight must fire BEFORE the operator-token / hub-origin checks
+    // pass the request to the network — no "Hub unreachable" / "No hub
+    // origin configured" leak.
+    expect(res.stderr).not.toMatch(/No hub origin configured/);
+    expect(res.stderr).not.toMatch(/Hub unreachable/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix the regression Aaron hit running `parachute vault mcp-install` and picking the "admin" option in the interactive auth prompt:

```
Hub mint-token rejected (HTTP 400, invalid_scope): scope vault:default:admin
is not requestable via mint-token; use OAuth flow or operator rotation
```

## Root cause

`vault:<name>:admin` has never been mintable via the public mint-token endpoint — per-vault admin is operator-only by hub policy ([`scope-explanations.ts:VAULT_ADMIN_RE`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/scope-explanations.ts) + `api-mint-token.ts`'s non-requestable guard), mintable only through the session-cookie-gated `/admin/vault-admin-token/<name>` SPA path. vault#291 introduced `--mint` mode but let the admin path through unchecked; it stayed latent until an operator hit it.

This is **vault-side**, not a hub regression. Hub's policy is correct: cross-vault admin blast radius doesn't justify mint-token requestability.

## Fix shape

- **Interactive flow**: picking "admin" now auto-routes to legacy-pat with `vault:admin` scope (a vault-DB `pvt_*` — the right shape for an MCP entry needing schema management) and prints a one-line explanation of the switch.
- **Flag path**: `--mint --scope vault:admin` errors pre-flight with an actionable remediation pointing at `--legacy-pat`. No hub round-trip, no operator-token check leak.
- **Help text + docstrings**: updated to telegraph the routing upfront so the `--scope vault:admin` choice no longer reads as a no-caveat option alongside read / write.

## Test plan

- [x] `bun test ./src/` — 1088/1088 pass (locally)
- [x] `bun run typecheck` — clean
- [x] New regression test in `mcp-install.test.ts` (`"rejects --mint --scope vault:admin pre-flight"`) exercises Aaron's exact CLI invocation
- [x] Existing `mcp-install-interactive.test.ts` test that pinned the buggy behavior was inverted to pin the new auto-route + explanation
- [ ] Reviewer dispatch
- [ ] Smoke: `parachute vault mcp-install` interactive → pick "admin" → confirms auto-routes to legacy-pat without a hub round-trip
- [ ] Smoke: `parachute vault mcp-install --mint --scope vault:admin` → errors pre-flight with remediation message

## Version

`0.4.7-rc.2` → `0.4.7-rc.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)