### PR TITLE
feat(vault): auto-transcribe voice uploads via scribe (vault#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,99 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.8-rc.1] — 2026-05-21
+
+feat(vault): auto-transcribe voice uploads via scribe (vault#353).
+
+Part 2 of the [vault↔scribe connection design](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-scribe-config-and-vault-scribe-connect.md)
+(site#52). When an audio attachment lands in a vault — via Notes capture,
+the REST API, or any other write path — and the operator has enabled
+auto-transcribe, vault forwards the audio to scribe asynchronously and
+materializes the result as a sibling `<attachment-path>.transcript.md`
+note. Failures (no provider configured, scribe down, timeout) surface as
+the same transcript note with `transcript_status: failed` plus the cause
+in `transcript_error`. The original audio attachment is never deleted by
+this path — it's preserved for retry.
+
+### What ships
+
+- **Inline audio-detect on attachment write.** `POST /vault/<name>/api/notes/<id>/attachments`
+  inspects the incoming `mime_type`; when it starts with `audio/` AND
+  `auto_transcribe.enabled === true` AND scribe is discoverable, the
+  attachment is stamped with `transcribe_status: pending` +
+  `transcribe_origin: "auto"`. The existing transcription worker picks it
+  up via the `attachment:created` hook (single-digit-ms event-driven path)
+  or the 30s sweep (safety net).
+- **Service discovery via `~/.parachute/services.json`** (`scribe-discovery.ts`).
+  Vault locates scribe by reading the canonical hub-maintained registry
+  on first call; the `SCRIBE_URL` env var still wins when set. Cached
+  for process lifetime; restart vault to pick up a re-registered scribe.
+- **Bearer generation at first boot** (`scribe-env.ts:ensureScribeBearer`).
+  When neither `SCRIBE_AUTH_TOKEN` nor the legacy `SCRIBE_TOKEN` is set,
+  vault generates a 32-byte base64url bearer and persists it to
+  `~/.parachute/vault/.env`. Idempotent — subsequent boots see the
+  existing value and don't rotate. Operators are expected to mirror the
+  generated bearer into scribe's `SCRIBE_AUTH_TOKEN`; without that
+  mirror, transcription fails gracefully with a 401 captured on the
+  transcript note.
+- **Transcript-note materialization** (`transcript-note.ts`). The
+  worker's auto-origin path writes a note at `<attachment-path>.transcript`
+  with frontmatter linking back to the original audio:
+
+  ```yaml
+  title: Transcript of <filename>
+  transcript_of: <attachment-path>
+  transcript_attachment_id: <attachment id>
+  transcript_status: complete | failed
+  transcript_duration_ms: <ms>
+  transcript_error: <cause — failed only>
+  ```
+
+  Body is the transcript text on success, empty on failure. Tags are
+  `[transcript, capture]`. A typed link `transcript_of` is also
+  materialized so vault graph queries surface the relation without
+  walking frontmatter.
+- **Retry endpoint.** `POST /vault/<name>/api/notes/<note-id>/retry-transcription`
+  re-enqueues the original audio attachment by flipping its
+  `transcribe_status` back to `pending` and kicking the worker.
+  Validates the target is a failed transcript note, surfaces clear
+  error branches (`invalid_target`, `not_failed`,
+  `missing_attachment_id`, `attachment_missing`, `audio_missing`).
+  202 on success. The same transcript note is overwritten in place;
+  the note id is preserved across retries.
+- **Config schema grows `autoTranscribe.*`** (`module-config.ts`). Three
+  fields per the design's Q4:
+  - `autoTranscribe.enabled` — boolean toggle, default false. Persisted
+    in `~/.parachute/vault/config.yaml` under the new `auto_transcribe`
+    block.
+  - `autoTranscribe.scribeUrl` — readOnly. Effective value resolved
+    per-process via `scribe-discovery.ts` (services.json or env override).
+  - `autoTranscribe.scribeBearer` — writeOnly. Never returned by GET.
+    Sourced from `SCRIBE_AUTH_TOKEN`.
+
+  Legacy `scribe_url` / `scribe_token` are kept as deprecated aliases
+  for one release so existing hub admin SPA renders don't regress.
+
+### What's deferred to v0.7
+
+- **Hub-issued JWT replaces the shared bearer.** The loopback shared
+  secret is the v0.6 stepping stone per design Q2. Vault swaps the
+  bearer for a hub-minted JWT with scope `scribe:transcribe` when
+  hub-as-issuer lands; scribe's existing `hub-jwt.ts` validation seam
+  is already in place. No wire-shape change — only the token contents.
+- **Live-tail of transcription progress** (websocket / SSE from scribe).
+  Today's flow is fire-and-write-when-done.
+- **Audio retention `until_transcribed` polish.** Today's worker already
+  honors the retention enum; no change needed for v0.6.
+- **Auto-retry on transient 5xx with backoff cap.** Already implemented
+  for the legacy worker path — extends naturally to auto-origin in a
+  future PR.
+
+### Versioning
+
+`0.4.8-rc.1`. New rc chain for a feature PR (per governance Rule 2 —
+RC versioning at the target stable, not as separate patches).
+
 ## [0.4.7-rc.3] — 2026-05-21
 
 fix(vault): `mcp-install` admin-scope path no longer round-trips to hub

--- a/README.md
+++ b/README.md
@@ -339,16 +339,45 @@ Webhook servers (scribe, narrate) are stateless — they don't need vault's API 
 
 ### On-upload transcription
 
-The trigger system above handles the "tag a note and let a webhook fill in content later" shape. Clients that already know at upload time that an audio file should be transcribed can take a shorter path: `POST /api/notes/{id}/attachments` with `{transcribe: true}` in the body. The vault stamps the attachment with `transcribe_status: "pending"` and the note with `transcribe_stub: true`, then a background worker drains the queue FIFO.
+Two paths feed the same transcription worker; they differ in how the
+result surfaces.
 
-Enable the worker by pointing the server at a Whisper-compatible endpoint:
+**Auto-transcribe (vault#353).** When the operator flips
+`auto_transcribe.enabled: true` in vault's config AND scribe is
+reachable (registered in `~/.parachute/services.json`, or pointed at
+via `SCRIBE_URL`), any audio attachment uploaded to the vault is
+automatically queued for transcription. The worker writes a sibling
+`<attachment-path>.transcript.md` note with the transcript text +
+frontmatter linking back to the audio (`transcript_of`,
+`transcript_status`, `transcript_duration_ms`, etc.). Failures land as
+the same note with `transcript_status: failed` and the cause in
+`transcript_error`; the original audio is preserved. Operators can
+retry a failed transcript via `POST /vault/<name>/api/notes/<note-id>/retry-transcription`.
 
-```
-SCRIBE_URL=http://localhost:3200
-SCRIBE_TOKEN=optional-bearer-token
-```
+**Explicit `transcribe: true` (legacy, Lens flow).** Callers that already
+know at upload time that an audio file should be transcribed pass
+`transcribe: true` to `POST /api/notes/{id}/attachments`. The vault
+stamps the attachment with `transcribe_status: "pending"` and the note
+with `transcribe_stub: true`. The worker replaces the literal
+`_Transcript pending._` placeholder in the note body with the transcript
+on success (or the whole body if no placeholder is present).
 
-The worker POSTs audio as multipart to `${SCRIBE_URL}/v1/audio/transcriptions` and expects `{ text: string }` back. On success it replaces the `_Transcript pending._` placeholder in the note body (or the whole body if the placeholder is absent), clears `transcribe_stub`, and records `transcript` + `transcribe_done_at` on the attachment. If the user edited the note and cleared `transcribe_stub` before the transcript landed, the note is left alone — but the transcript is still stored on the attachment. Failures retry with exponential backoff up to three attempts before flipping `transcribe_status` to `"failed"`.
+Service discovery is automatic — when scribe lands in
+`~/.parachute/services.json` (the canonical hub-maintained registry),
+vault picks up its URL on next restart. The `SCRIBE_URL` env var still
+wins when set. The shared bearer for vault→scribe auth is generated
+once at first boot and persisted to `~/.parachute/vault/.env` as
+`SCRIBE_AUTH_TOKEN`; mirror that value into scribe's
+`SCRIBE_AUTH_TOKEN` env so scribe accepts the Authorization header.
+
+The worker POSTs audio as multipart to
+`${SCRIBE_URL}/v1/audio/transcriptions` and expects `{ text: string }`
+back. On success it records `transcript` + `transcribe_done_at` +
+`transcribe_duration_ms` on the attachment row regardless of the
+result-surface path. Failures retry with exponential backoff up to three
+attempts before flipping `transcribe_status` to `"failed"`; 4xx
+responses carrying `error_code` (e.g. `missing_provider`) are treated as
+terminal on the first failure.
 
 Per-vault `audio_retention` controls what happens to the audio file on disk once the worker reaches a terminal state. It's readable and mutable at runtime via `GET` / `PATCH /api/vault` (under `config.audio_retention`), or by hand-editing `vault.yaml`.
 

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -206,30 +206,77 @@ Body: `{"tags": ["a", "b"]}`.
 #### `POST /notes/{id}/attachments`
 Body: `{"path": "files/a.png", "mimeType": "image/png", "transcribe"?: boolean}`.
 
-When `transcribe: true` and the file is audio, the server queues a
-transcription job: `attachment.metadata.transcribe_status = "pending"` is
-set, and `note.metadata.transcribe_stub = true` is written as the opt-in to
-overwrite content when the transcript lands. A background worker (enabled
-by setting `SCRIBE_URL` on the server) drains the queue FIFO, one at a
-time, calling `${SCRIBE_URL}/v1/audio/transcriptions` with the audio as
-multipart `file` and expecting `{ text: string }` back.
+There are **two transcription paths**; both feed the same worker but
+differ in how the transcript surface is materialized.
 
-On success:
-- If `note.metadata.transcribe_stub === true`, the worker replaces the
-  literal `_Transcript pending._` placeholder in the note body with the
-  transcript, or the whole body if the placeholder is absent. The stub
-  marker is cleared. A user edit clearing `transcribe_stub` before the
-  transcript arrives opts out of the overwrite.
-- `attachment.metadata.transcribe_status` becomes `"done"` and
-  `transcript` + `transcribe_done_at` are recorded on the attachment even
-  when the note opted out, so the transcript is always addressable.
+**Path A — explicit caller opt-in (`transcribe: true`).** Legacy flow,
+used by Lens's voice memo client. Server queues a transcription job:
+`attachment.metadata.transcribe_status = "pending"` is set, and
+`note.metadata.transcribe_stub = true` is written as the opt-in to
+overwrite content when the transcript lands. On success the worker
+replaces the literal `_Transcript pending._` placeholder in the note
+body with the transcript (or the whole body if the placeholder is
+absent). A user edit clearing `transcribe_stub` before the transcript
+arrives opts out of the overwrite.
 
-On failure, the worker retries with exponential backoff up to three
-attempts before setting `transcribe_status = "failed"` and capturing
-`transcribe_error`.
+**Path B — auto-transcribe (vault#353).** When `mimeType` starts with
+`audio/` AND `auto_transcribe.enabled === true` AND scribe is
+discoverable, the attachment is queued automatically — no caller flag
+needed. Instead of patching the source note, the worker materializes a
+sibling `<attachment-path>.transcript.md` note with frontmatter:
+
+```yaml
+title: Transcript of <filename>
+tags: [transcript, capture]
+transcript_of: <attachment-path>
+transcript_attachment_id: <id>
+transcript_status: complete | failed
+transcript_duration_ms: <ms>
+transcript_error: <cause — failed only>
+```
+
+On success the transcript text is the note body. On failure (no
+provider configured, scribe down, timeout) the same note is written
+with `transcript_status: failed`, empty body, and the cause in
+`transcript_error`. The original audio attachment is never deleted by
+this path — operators can retry via the dedicated endpoint below.
+
+Across both paths, `attachment.metadata.transcribe_status` becomes
+`"done"` and `transcript` + `transcribe_done_at` + `transcribe_duration_ms`
+are recorded on the attachment row, so the transcript is always
+addressable from the attachment side too. On failure the worker retries
+5xx / network errors with exponential backoff (up to three attempts);
+4xx errors with structured `error_code` (e.g. `missing_provider`) are
+treated as terminal on the first failure since re-POSTing the same audio
+at a broken scribe just fails the same way.
 
 The queue lives in the DB (`attachments` table), so a server restart
 resumes pending work without replay.
+
+#### `POST /notes/{id}/retry-transcription`
+
+Re-enqueues the original audio attachment for a transcript note whose
+`transcript_status` is `failed`. Returns 202 on success:
+
+```json
+{
+  "status": "queued",
+  "attachment_id": "<id>",
+  "attachment_path": "<path>",
+  "transcript_note_id": "<id>",
+  "worker": "kicked" | "sweep-only"
+}
+```
+
+Error branches:
+- `400 invalid_target` — target note has no `transcript_status` frontmatter (not a transcript note).
+- `400 not_failed` — transcript already succeeded; nothing to retry.
+- `400 missing_attachment_id` — transcript note lacks `transcript_attachment_id` (likely written by an older vault version).
+- `404 attachment_missing` — original audio attachment row has been deleted.
+- `404 audio_missing` — original audio file no longer exists on disk (e.g. `audio_retention: never` already unlinked it).
+
+The same transcript note is overwritten in place; the note id is
+preserved across retries.
 
 #### `GET /notes/{id}/attachments`
 Returns `Attachment[]`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.7-rc.3",
+  "version": "0.4.8-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/auto-transcribe.test.ts
+++ b/src/auto-transcribe.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Auto-transcribe gating decisions (vault#353).
+ *
+ * Three independent guards: mime-type prefix, enabled toggle, scribe URL
+ * present. Pure function — exercise the truth table.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { shouldAutoTranscribe } from "./auto-transcribe.ts";
+
+function readGlobalConfig(enabled: boolean | undefined) {
+  return () => ({
+    port: 1940,
+    ...(enabled !== undefined ? { auto_transcribe: { enabled } } : {}),
+  }) as any;
+}
+
+describe("shouldAutoTranscribe", () => {
+  const scribePresent = () => "http://127.0.0.1:1943";
+  const scribeAbsent = () => undefined;
+
+  test("triggers on audio/* mime-type when enabled + scribe reachable", () => {
+    expect(shouldAutoTranscribe("audio/wav", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(true);
+  });
+
+  test("triggers on audio/mp4 (m4a)", () => {
+    expect(shouldAutoTranscribe("audio/mp4", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(true);
+  });
+
+  test("triggers on audio/webm", () => {
+    expect(shouldAutoTranscribe("audio/webm", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(true);
+  });
+
+  test("triggers case-insensitively (AUDIO/WAV)", () => {
+    expect(shouldAutoTranscribe("AUDIO/WAV", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(true);
+  });
+
+  test("skips non-audio mime-types (image/png, application/pdf, video/mp4)", () => {
+    expect(shouldAutoTranscribe("image/png", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(false);
+    expect(shouldAutoTranscribe("application/pdf", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(false);
+    expect(shouldAutoTranscribe("video/mp4", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(false);
+  });
+
+  test("skips when enabled is false (default off)", () => {
+    expect(shouldAutoTranscribe("audio/wav", {
+      readGlobalConfigImpl: readGlobalConfig(false),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(false);
+  });
+
+  test("skips when enabled is unset (no auto_transcribe block in config)", () => {
+    expect(shouldAutoTranscribe("audio/wav", {
+      readGlobalConfigImpl: readGlobalConfig(undefined),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(false);
+  });
+
+  test("skips when scribe URL is undefined (no services.json entry, no env)", () => {
+    expect(shouldAutoTranscribe("audio/wav", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribeAbsent,
+    })).toBe(false);
+  });
+
+  test("skips when scribe URL is empty string", () => {
+    expect(shouldAutoTranscribe("audio/wav", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: () => "",
+    })).toBe(false);
+  });
+
+  test("skips on garbage mime-type input", () => {
+    expect(shouldAutoTranscribe("", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(false);
+    expect(shouldAutoTranscribe("not-a-mime", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+    })).toBe(false);
+  });
+
+  test("respects enabledOverride when present", () => {
+    expect(shouldAutoTranscribe("audio/wav", {
+      readGlobalConfigImpl: readGlobalConfig(false),
+      getCachedScribeUrlImpl: scribePresent,
+      enabledOverride: true,
+    })).toBe(true);
+    expect(shouldAutoTranscribe("audio/wav", {
+      readGlobalConfigImpl: readGlobalConfig(true),
+      getCachedScribeUrlImpl: scribePresent,
+      enabledOverride: false,
+    })).toBe(false);
+  });
+});

--- a/src/auto-transcribe.ts
+++ b/src/auto-transcribe.ts
@@ -1,0 +1,48 @@
+/**
+ * Auto-transcribe trigger decision (vault#353, design 2026-05-21 Part 2).
+ *
+ * One pure function: given an attachment's mime-type + the operator's
+ * settings + whether scribe is reachable, decide whether to enqueue the
+ * attachment for the transcription worker. Lives in its own module so the
+ * attachment-write code path (`routes.ts`) and the retry endpoint share the
+ * same gate without duplicating logic.
+ */
+
+import { readGlobalConfig } from "./config.ts";
+import { getCachedScribeUrl } from "./scribe-discovery.ts";
+
+/**
+ * Pre-vault#353 callers passed `transcribe: true` explicitly on the
+ * attachment POST. The auto-transcribe path inlines the decision: if the
+ * upload is an audio mime-type AND the toggle is on AND scribe is reachable,
+ * the worker is enqueued. This function is the single decision site.
+ *
+ * Returns `true` only when ALL three conditions hold:
+ *   1. mime-type starts with `audio/` (case-insensitive).
+ *   2. `globalConfig.auto_transcribe?.enabled === true`.
+ *   3. Scribe is discoverable (services.json entry OR SCRIBE_URL env).
+ *
+ * The three conditions are independent guards: a single `false` is sufficient
+ * to skip enqueuing. The audio stays as a regular attachment in that case.
+ */
+export function shouldAutoTranscribe(
+  mimeType: string,
+  opts: {
+    /** Injection seam for tests — defaults to live globals. */
+    readGlobalConfigImpl?: typeof readGlobalConfig;
+    getCachedScribeUrlImpl?: () => string | undefined;
+    /** Allow per-call enabled override — used by the explicit-opt-in path. */
+    enabledOverride?: boolean;
+  } = {},
+): boolean {
+  if (typeof mimeType !== "string" || !mimeType.toLowerCase().startsWith("audio/")) {
+    return false;
+  }
+  const enabled = opts.enabledOverride
+    ?? (opts.readGlobalConfigImpl ?? readGlobalConfig)().auto_transcribe?.enabled
+    ?? false;
+  if (!enabled) return false;
+  const url = (opts.getCachedScribeUrlImpl ?? getCachedScribeUrl)();
+  if (!url || !url.trim()) return false;
+  return true;
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,9 +1,12 @@
 import { describe, test, expect } from "bun:test";
+import { statSync } from "fs";
+import { join } from "path";
 import {
   writeVaultConfig,
   readVaultConfig,
   writeGlobalConfig,
   readGlobalConfig,
+  writeEnvFile,
   generateApiKey,
   hashKey,
   verifyKey,
@@ -208,6 +211,29 @@ describe("config", () => {
     );
     const reloaded = readGlobalConfig();
     expect(reloaded.api_keys?.find((k) => k.id === "k_legacy")?.scope).toBe("write");
+  });
+
+  test("writeEnvFile writes .env at 0600 (SCRIBE_AUTH_TOKEN secrecy)", () => {
+    // Regression for vault#354 reviewer finding: the .env holds
+    // SCRIBE_AUTH_TOKEN (the vault↔scribe loopback bearer). On a
+    // shared-user machine or a Docker image with a loose umask, a
+    // world-readable .env would leak the bearer to any local process.
+    //
+    // Resolve the path dynamically from PARACHUTE_HOME (not the
+    // module-load-time `ENV_PATH` constant) so this test is robust to
+    // earlier tests in the suite that mutate PARACHUTE_HOME — writeEnvFile
+    // itself resolves the path dynamically via `envFilePath()`.
+    const envPath = join(process.env.PARACHUTE_HOME!, "vault", ".env");
+    writeEnvFile({ SCRIBE_AUTH_TOKEN: "test-bearer-do-not-leak", PORT: "1940" });
+    const mode = statSync(envPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+
+    // Existing-file branch: writeFileSync's `mode` only applies on
+    // create, so the defensive chmodSync must downgrade an existing
+    // (e.g. 0644-from-an-older-version) .env to 0600 on the next write.
+    writeEnvFile({ SCRIBE_AUTH_TOKEN: "rotated", PORT: "1940" });
+    const mode2 = statSync(envPath).mode & 0o777;
+    expect(mode2).toBe(0o600);
   });
 
   test("round-trips autostart: true|false (#113)", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1439,7 +1439,15 @@ export function writeEnvFile(env: Record<string, string>): void {
       lines.push(`${key}=${val}`);
     }
   }
-  writeFileSync(envFilePath(), lines.join("\n") + "\n");
+  // 0600 — owner read/write only. This file holds SCRIBE_AUTH_TOKEN (the
+  // vault↔scribe loopback bearer) and any other secrets the operator drops
+  // in via `parachute-vault config set`. It must not be world- or
+  // group-readable on shared-user machines or Docker images with a loose
+  // umask. Mirrors the writeGlobalConfig pattern above.
+  writeFileSync(envFilePath(), lines.join("\n") + "\n", { mode: 0o600 });
+  // writeFileSync's `mode` only applies on file creation, so chmod an existing
+  // file explicitly in case it was written by an older version at 0644.
+  try { chmodSync(envFilePath(), 0o600); } catch {}
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -277,6 +277,24 @@ export interface GlobalConfig {
    * resolved path. See `./mirror-config.ts`.
    */
   mirror?: MirrorConfigType;
+  /**
+   * Auto-transcribe configuration for the vault↔scribe handoff (vault#353,
+   * design 2026-05-21 Part 2). When `enabled: true` AND scribe is discoverable
+   * (`services.json` or `SCRIBE_URL` env), audio attachments uploaded to any
+   * vault are automatically sent to scribe and the resulting transcript lands
+   * as a sibling `<attachment-path>.transcript.md` note.
+   *
+   * URL + bearer are not stored here — URL is resolved per-process from
+   * `services.json` via `scribe-discovery.ts`, and bearer comes from the
+   * `SCRIBE_AUTH_TOKEN` env var (persisted in `~/.parachute/vault/.env`).
+   * The schema's `autoTranscribe.scribeUrl` / `autoTranscribe.scribeBearer`
+   * fields are projection of those resolved values (readOnly / writeOnly),
+   * not separate storage.
+   */
+  auto_transcribe?: {
+    /** Master toggle. Default false; the worker is a no-op when unset. */
+    enabled?: boolean;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1141,6 +1159,22 @@ export function readGlobalConfig(): GlobalConfig {
       const totpSecretMatch = yaml.match(/^totp_secret:\s*"([^"]+)"/m);
       const discoveryMatch = yaml.match(/^discovery:\s*(enabled|disabled)/m);
       const autostartMatch = yaml.match(/^autostart:\s*(true|false)/m);
+      // auto_transcribe block — currently single boolean `enabled` (vault#353).
+      // Parsed as a nested 2-space-indent block so future fields can grow under
+      // it without breaking the regex; only `enabled` is read for v0.6.
+      const autoTranscribeStart = yaml.match(/^auto_transcribe:\s*$/m);
+      let autoTranscribeEnabled: boolean | undefined;
+      if (autoTranscribeStart) {
+        const after = yaml.slice((autoTranscribeStart.index ?? 0) + autoTranscribeStart[0].length);
+        for (const line of after.split("\n")) {
+          if (line.match(/^\S/) && line.trim().length > 0) break; // next top-level key
+          const m = line.match(/^\s+enabled:\s*(true|false)/);
+          if (m) {
+            autoTranscribeEnabled = m[1]! === "true";
+            break;
+          }
+        }
+      }
       const config: GlobalConfig = {
         port: portMatch ? parseInt(portMatch[1]!, 10) : DEFAULT_PORT,
         default_vault: defaultVaultMatch?.[1],
@@ -1152,6 +1186,9 @@ export function readGlobalConfig(): GlobalConfig {
       }
       if (autostartMatch) {
         config.autostart = autostartMatch[1]! === "true";
+      }
+      if (autoTranscribeEnabled !== undefined) {
+        config.auto_transcribe = { enabled: autoTranscribeEnabled };
       }
 
       // Parse backup_codes: a YAML list of quoted bcrypt hashes under
@@ -1295,6 +1332,13 @@ export function writeGlobalConfig(config: GlobalConfig): void {
 
   if (config.mirror) {
     lines.push(...serializeMirrorSection(config.mirror));
+  }
+
+  if (config.auto_transcribe) {
+    lines.push("auto_transcribe:");
+    if (config.auto_transcribe.enabled !== undefined) {
+      lines.push(`  enabled: ${config.auto_transcribe.enabled}`);
+    }
   }
 
   // 0600 — owner read/write only. This file may contain the bcrypt password

--- a/src/module-config.ts
+++ b/src/module-config.ts
@@ -72,7 +72,7 @@ export function buildConfigSchema(): ModuleConfigSchema {
             default: false,
             title: "Enable auto-transcription",
             description:
-              "Master toggle. When false, audio uploads land normally without any scribe interaction.",
+              "Master toggle. When false, audio uploads land normally without any scribe interaction. Global — persisted in `GlobalConfig.auto_transcribe.enabled` and applies to every vault on this server. Per-vault control is a future enhancement when multi-vault deployments need it.",
           },
           scribeUrl: {
             type: "string",

--- a/src/module-config.ts
+++ b/src/module-config.ts
@@ -15,15 +15,27 @@
  * PUT /.parachute/config is Phase 3 — not implemented here.
  *
  * Fields currently described:
- *   - audio_retention: per-vault enum, backed by VaultConfig.audio_retention.
- *   - scribe_url:      env var SCRIBE_URL (read-only for now — there is no
- *                      yaml slot yet, so PUT won't come online until Phase 3).
- *   - scribe_token:    env var SCRIBE_TOKEN, writeOnly (never returned).
- *   - port:            GlobalConfig.port, exposed read-only so the hub can
- *                      display it without round-tripping through /health.
+ *   - audio_retention:      per-vault enum, backed by VaultConfig.audio_retention.
+ *   - port:                 GlobalConfig.port, exposed read-only.
+ *   - autoTranscribe.*:     vault↔scribe handoff (vault#353, design 2026-05-21
+ *                           Part 2). Three nested fields per design Q4:
+ *       - enabled:          boolean toggle, default false (persisted in
+ *                           GlobalConfig.auto_transcribe.enabled).
+ *       - scribeUrl:        readOnly — resolved per-process from
+ *                           `~/.parachute/services.json` via
+ *                           `scribe-discovery.ts`. Operators can't point at an
+ *                           arbitrary scribe; the discovery layer is the gate.
+ *       - scribeBearer:     writeOnly — sourced from SCRIBE_AUTH_TOKEN env var.
+ *                           Hub install generates one at first boot
+ *                           (see scribe-env.ts:ensureScribeBearer); manual
+ *                           rotation is via `parachute-vault config set`.
+ *   - scribe_url / scribe_token (deprecated): kept under their legacy names
+ *                           through one release for the hub admin SPA's prior
+ *                           render path; new code should read autoTranscribe.*.
  */
 
 import type { VaultConfig, GlobalConfig } from "./config.ts";
+import { resolveScribeUrl } from "./scribe-discovery.ts";
 
 export interface ModuleConfigSchema {
   $schema: string;
@@ -49,20 +61,54 @@ export function buildConfigSchema(): ModuleConfigSchema {
         description:
           "What to do with audio attachments after transcription. `keep` leaves the file on disk; `until_transcribed` unlinks on successful transcribe (keeps on failure for retry); `never` unlinks on any terminal state (including failure — no retries).",
       },
+      autoTranscribe: {
+        type: "object",
+        title: "Auto-transcribe voice uploads",
+        description:
+          "When enabled, audio attachments (mime-type prefix `audio/`) are automatically sent to scribe and the resulting transcript lands as a sibling `<attachment-path>.transcript.md` note. Scribe must be reachable for transcription to succeed; failures are recorded as a transcript note with `transcript_status: failed`.",
+        properties: {
+          enabled: {
+            type: "boolean",
+            default: false,
+            title: "Enable auto-transcription",
+            description:
+              "Master toggle. When false, audio uploads land normally without any scribe interaction.",
+          },
+          scribeUrl: {
+            type: "string",
+            format: "uri",
+            readOnly: true,
+            title: "Scribe URL",
+            description:
+              "URL of the scribe service. Auto-populated from `~/.parachute/services.json` at vault startup (or from the SCRIBE_URL env var when set). Read-only — operators can't point at an arbitrary scribe.",
+          },
+          scribeBearer: {
+            type: "string",
+            writeOnly: true,
+            title: "Scribe auth bearer",
+            description:
+              "Shared bearer for the vault→scribe loopback contract. Hub install generates one at first boot. Write-only — never returned by GET.",
+          },
+        },
+      },
+      // Legacy aliases kept for back-compat with callers that read the
+      // pre-vault#353 shape. New consumers should read `autoTranscribe.*`.
       scribe_url: {
         type: "string",
         format: "uri",
-        title: "Scribe URL",
+        title: "Scribe URL (deprecated alias)",
         description:
-          "URL of the Scribe service for transcription. Empty disables the background worker. Currently sourced from the SCRIBE_URL env var; a PUT slot lands in Phase 3.",
+          "Legacy alias for `autoTranscribe.scribeUrl`. Will be removed in a future release.",
         readOnly: true,
+        deprecated: true,
       },
       scribe_token: {
         type: "string",
-        title: "Scribe auth token",
+        title: "Scribe auth token (deprecated alias)",
         description:
-          "Optional bearer token for Scribe. Stored in the SCRIBE_TOKEN env var today. Write-only — never returned by GET.",
+          "Legacy alias for `autoTranscribe.scribeBearer`. Will be removed in a future release.",
         writeOnly: true,
+        deprecated: true,
       },
       port: {
         type: "integer",
@@ -77,18 +123,28 @@ export function buildConfigSchema(): ModuleConfigSchema {
 }
 
 /**
- * Effective config values, with `writeOnly` fields stripped. `scribe_token` is
- * declared `writeOnly` and is never returned here, even when SCRIBE_TOKEN is
- * set in the environment.
+ * Effective config values, with `writeOnly` fields stripped. `scribeBearer`
+ * (and its legacy alias `scribe_token`) are declared `writeOnly` and never
+ * returned, even when set in the environment.
  */
 export function buildConfigValues(
   vaultConfig: VaultConfig,
   globalConfig: GlobalConfig,
   env: { SCRIBE_URL?: string | undefined } = process.env as { SCRIBE_URL?: string },
 ): Record<string, unknown> {
+  // Resolve scribe URL through the discovery layer so the GET shape reflects
+  // what the worker will actually use (services.json > SCRIBE_URL > unset).
+  // Pass env through so the test harness's override is honored.
+  const scribeUrl = resolveScribeUrl(env as NodeJS.ProcessEnv) ?? "";
   return {
     audio_retention: vaultConfig.audio_retention ?? "keep",
-    scribe_url: env.SCRIBE_URL ?? "",
+    autoTranscribe: {
+      enabled: globalConfig.auto_transcribe?.enabled ?? false,
+      scribeUrl,
+    },
+    // Legacy alias mirrors `autoTranscribe.scribeUrl` so hubs reading the
+    // pre-vault#353 shape don't regress.
+    scribe_url: scribeUrl,
     port: globalConfig.port,
   };
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -45,6 +45,7 @@ import {
 import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { vaultDir } from "./config.ts";
+import { shouldAutoTranscribe } from "./auto-transcribe.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -813,19 +814,33 @@ async function handleNotesInner(
       const body = await req.json() as { path: string; mimeType: string; transcribe?: boolean };
       if (!body.path || !body.mimeType) return json({ error: "path and mimeType are required" }, 400);
 
-      // `transcribe: true` asks the transcription worker to read this audio
-      // file and replace the note's content with the transcript. The caller
-      // is declaring "overwrite my current content when the transcript lands"
-      // — we persist that as `transcribe_stub: true` on the note so a later
-      // user edit (which clears the marker) can opt out before the worker
-      // runs.
-      const attMeta = body.transcribe
-        ? { transcribe_status: "pending" as const, transcribe_requested_at: new Date().toISOString() }
+      // Decide whether to enqueue this attachment for transcription. Two paths:
+      //
+      // - **Explicit caller opt-in (legacy path, Lens flow):** `transcribe: true`
+      //   on the POST. The note already has a `_Transcript pending._` stub the
+      //   worker replaces on success — `transcribe_origin: "legacy"` preserves
+      //   the stub-patching behavior.
+      // - **Auto-transcribe (vault#353):** mime-type is `audio/*` AND the
+      //   operator has flipped `auto_transcribe.enabled = true` AND scribe is
+      //   reachable. The caller didn't opt in explicitly; we infer from the
+      //   audio mime-type. `transcribe_origin: "auto"` tells the worker to
+      //   materialize a `<attachment-path>.transcript.md` note on completion.
+      //
+      // Explicit `transcribe: true` wins — if the caller asked, we honor that
+      // regardless of the auto-transcribe toggle (back-compat).
+      const explicitOptIn = body.transcribe === true;
+      const autoOptIn = !explicitOptIn && shouldAutoTranscribe(body.mimeType);
+      const attMeta = (explicitOptIn || autoOptIn)
+        ? {
+            transcribe_status: "pending" as const,
+            transcribe_requested_at: new Date().toISOString(),
+            transcribe_origin: (explicitOptIn ? "legacy" : "auto") as "legacy" | "auto",
+          }
         : undefined;
 
       const attachment = await store.addAttachment(note.id, body.path, body.mimeType, attMeta);
 
-      if (body.transcribe) {
+      if (explicitOptIn) {
         const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
         if (noteMeta.transcribe_stub !== true) {
           await store.updateNote(note.id, {
@@ -872,6 +887,33 @@ async function handleNotesInner(
       return new Response(null, { status: 204 });
     }
     return json({ error: "Method not allowed" }, 405);
+  }
+
+  // POST /notes/:idOrPath/retry-transcription — vault#353 design Q5.
+  //
+  // Re-runs the auto-transcribe pipeline against the original audio
+  // attachment recorded in the transcript note's `transcript_attachment_id`
+  // frontmatter. Only valid on transcript notes (the target idOrPath must
+  // be a transcript note with `transcript_status: "failed"`); calling on
+  // anything else returns 400 with a clear reason.
+  //
+  // Wire shape:
+  //   POST .../notes/<idOrPath>/retry-transcription
+  //   →  202 { attachment_id, transcript_path } when re-enqueued
+  //      400 invalid_target          (not a transcript note)
+  //      400 not_failed              (transcript already succeeded; nothing to retry)
+  //      404 attachment_missing      (transcript_attachment_id row deleted)
+  //      404 audio_missing           (audio file unlinked from disk)
+  //      503 scribe_unavailable      (no worker configured this boot)
+  if (sub === "/retry-transcription") {
+    if (method !== "POST") return json({ error: "Method not allowed" }, 405);
+    if (!vault) return json({ error: "Vault context required" }, 400);
+    const note = await resolveNote(store, idOrPath);
+    if (!note) return json({ error: "Not found" }, 404);
+    if (!noteWithinTagScope(note, tagScope.allowed, tagScope.raw)) {
+      return json({ error: "Not found" }, 404);
+    }
+    return handleRetryTranscription(store, note, vault);
   }
 
   if (sub !== "") return json({ error: "Not found" }, 404);
@@ -1821,6 +1863,128 @@ ${rendered}
       "Content-Security-Policy": "default-src 'self'; script-src 'none'; style-src 'unsafe-inline'",
     },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Retry transcription (vault#353 design Q5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-enqueue the original audio attachment for a `transcript_status: failed`
+ * transcript note. Steps:
+ *
+ *   1. Validate target is a transcript note (`transcript_status` set in
+ *      metadata) AND that status is `failed`.
+ *   2. Find the original audio attachment by id from
+ *      `transcript_attachment_id` frontmatter. 404 if the row's gone.
+ *   3. Validate the audio file still exists on disk (retention=keep is
+ *      assumed by the retry contract; retention=until_transcribed unlinks
+ *      only on success, retention=never unlinks on failure — that last one
+ *      explicitly breaks retry, by design).
+ *   4. Reset `transcribe_status = "pending"`, clear backoff + error fields.
+ *      The auto-origin marker is preserved so the worker writes a transcript
+ *      note (overwriting this one in place).
+ *   5. Kick the worker if registered; otherwise the sweep picks it up.
+ */
+async function handleRetryTranscription(
+  store: Store,
+  note: Note,
+  vault: string,
+): Promise<Response> {
+  const meta = (note.metadata as Record<string, unknown> | undefined) ?? {};
+  if (typeof meta.transcript_status !== "string") {
+    return json(
+      {
+        error: "invalid_target",
+        message: "Target note is not a transcript note (no transcript_status frontmatter).",
+      },
+      400,
+    );
+  }
+  if (meta.transcript_status !== "failed") {
+    return json(
+      {
+        error: "not_failed",
+        message: `Transcript note status is "${meta.transcript_status}" — only failed transcripts can be retried.`,
+        transcript_status: meta.transcript_status,
+      },
+      400,
+    );
+  }
+  const attachmentId = typeof meta.transcript_attachment_id === "string"
+    ? meta.transcript_attachment_id
+    : undefined;
+  if (!attachmentId) {
+    return json(
+      {
+        error: "missing_attachment_id",
+        message: "Transcript note has no `transcript_attachment_id` — can't locate the original audio.",
+      },
+      400,
+    );
+  }
+  const attachment = await store.getAttachment(attachmentId);
+  if (!attachment) {
+    return json(
+      {
+        error: "attachment_missing",
+        message: `Original audio attachment ${attachmentId} no longer exists in the vault.`,
+      },
+      404,
+    );
+  }
+  // Audio file existence + safety: defense-in-depth against a bad attachment
+  // row pointing outside the vault assets dir. Same guard as the worker.
+  const assetsRoot = assetsDir(vault);
+  const audioFilePath = normalize(join(assetsRoot, attachment.path));
+  if (!audioFilePath.startsWith(normalize(assetsRoot)) || !existsSync(audioFilePath)) {
+    return json(
+      {
+        error: "audio_missing",
+        message: `Original audio file at "${attachment.path}" no longer exists on disk.`,
+      },
+      404,
+    );
+  }
+
+  // Reset transcribe_status. Worker reads this row, sees "pending", processes
+  // it. Preserve `transcribe_origin: "auto"` so the worker materializes the
+  // transcript note (overwriting this failed note in place).
+  const attMeta = { ...(attachment.metadata ?? {}) } as Record<string, unknown>;
+  attMeta.transcribe_status = "pending";
+  attMeta.transcribe_requested_at = new Date().toISOString();
+  attMeta.transcribe_origin = "auto";
+  delete attMeta.transcribe_backoff_until;
+  delete attMeta.transcribe_error;
+  delete attMeta.transcribe_error_code;
+  delete attMeta.transcribe_attempts;
+  await store.setAttachmentMetadata(attachment.id, attMeta);
+
+  // Kick the worker for an event-driven re-run (no 30s sweep wait). The
+  // worker re-reads the row + processes immediately. If the worker isn't
+  // registered (scribe not configured this boot), we still reset the row;
+  // the next boot's sweep will pick it up. The 503 path is for callers that
+  // want certainty — but for v0.6 the sweep guarantee is enough.
+  const { getTranscriptionWorker } = await import("./transcription-registry.ts");
+  const worker = getTranscriptionWorker();
+  if (worker) {
+    // Refresh the attachment after the metadata write so the worker's
+    // in-process dedupe check sees pending.
+    const fresh = await store.getAttachment(attachment.id) ?? attachment;
+    // Fire-and-forget — the response shouldn't wait on transcription.
+    void worker.kick(vault, fresh);
+  }
+
+  return json(
+    {
+      status: "queued",
+      attachment_id: attachment.id,
+      attachment_path: attachment.path,
+      transcript_note_id: note.id,
+      worker: worker ? "kicked" : "sweep-only",
+    },
+    202,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/scribe-discovery.test.ts
+++ b/src/scribe-discovery.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for vault's scribe service-discovery (vault#353).
+ *
+ * Single decision site for "where does scribe live": env override, then
+ * `~/.parachute/services.json`. The cache layer is exercised separately
+ * so the resolution rule stays unit-testable without filesystem state.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { resolveScribeUrl, clearScribeUrlCache } from "./scribe-discovery.ts";
+
+function mkManifest(services: Array<{ name: string; port: number; origin?: string }>): typeof import("./services-manifest.ts").readManifest {
+  return () => ({
+    services: services.map((s) => ({
+      name: s.name,
+      port: s.port,
+      paths: [`/${s.name}`],
+      health: "/health",
+      version: "0.0.0-test",
+      ...(s.origin ? { origin: s.origin } : {}),
+    })) as any,
+  });
+}
+
+beforeEach(() => {
+  clearScribeUrlCache();
+});
+
+describe("resolveScribeUrl", () => {
+  test("returns SCRIBE_URL env var (overrides services.json)", () => {
+    const env = { SCRIBE_URL: "http://example.test:9999" } as NodeJS.ProcessEnv;
+    const manifest = mkManifest([{ name: "parachute-scribe", port: 1943 }]);
+    expect(resolveScribeUrl(env, manifest)).toBe("http://example.test:9999");
+  });
+
+  test("strips trailing slash from SCRIBE_URL env var", () => {
+    const env = { SCRIBE_URL: "http://example.test:9999/" } as NodeJS.ProcessEnv;
+    const manifest = mkManifest([]);
+    expect(resolveScribeUrl(env, manifest)).toBe("http://example.test:9999");
+  });
+
+  test("falls back to services.json parachute-scribe entry", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const manifest = mkManifest([{ name: "parachute-scribe", port: 1943 }]);
+    expect(resolveScribeUrl(env, manifest)).toBe("http://127.0.0.1:1943");
+  });
+
+  test("honors explicit `origin` on the service entry (v0.7 shape)", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const manifest = mkManifest([
+      { name: "parachute-scribe", port: 1943, origin: "https://scribe.cloud.example.com" },
+    ]);
+    expect(resolveScribeUrl(env, manifest)).toBe("https://scribe.cloud.example.com");
+  });
+
+  test("returns undefined when no env override AND no scribe entry", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const manifest = mkManifest([{ name: "parachute-vault", port: 1940 }]);
+    expect(resolveScribeUrl(env, manifest)).toBeUndefined();
+  });
+
+  test("returns undefined when manifest read throws", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const calls: unknown[][] = [];
+    const logger = { warn: (...args: unknown[]) => calls.push(args) };
+    const manifest = (() => { throw new Error("boom"); }) as unknown as Parameters<typeof resolveScribeUrl>[1];
+    expect(resolveScribeUrl(env, manifest, logger)).toBeUndefined();
+    expect(calls.length).toBe(1);
+  });
+
+  test("trims whitespace-only SCRIBE_URL as unset", () => {
+    const env = { SCRIBE_URL: "   " } as NodeJS.ProcessEnv;
+    const manifest = mkManifest([{ name: "parachute-scribe", port: 1943 }]);
+    // Whitespace-only env falls through to services.json.
+    expect(resolveScribeUrl(env, manifest)).toBe("http://127.0.0.1:1943");
+  });
+});

--- a/src/scribe-discovery.ts
+++ b/src/scribe-discovery.ts
@@ -1,0 +1,91 @@
+/**
+ * Service discovery for the scribe transcription module.
+ *
+ * Per the 2026-05-21 vault↔scribe design (Part 2, design question 2), vault
+ * locates scribe via `~/.parachute/services.json` — the canonical hub-
+ * maintained registry. This module is the single read site so the
+ * resolution rule lives in one place.
+ *
+ * Resolution order (first hit wins):
+ *
+ *   1. `SCRIBE_URL` env var (operator override; useful for tests, Docker
+ *      compose, and any deploy where scribe runs at a non-loopback host).
+ *   2. Entry `name === "parachute-scribe"` in `~/.parachute/services.json`
+ *      → construct `http://127.0.0.1:<port>`.
+ *   3. `undefined` (auto-transcribe stays a no-op).
+ *
+ * The bearer token resolution stays in `./scribe-env.ts:resolveScribeAuthToken`.
+ * Service discovery is just about WHERE scribe lives; AUTH is a separate
+ * concern with its own env-var precedence (SCRIBE_AUTH_TOKEN over the legacy
+ * SCRIBE_TOKEN). When the v0.7 hub-issued-JWT path lands, the bearer source
+ * changes but the URL source stays the same — one file, one concern.
+ *
+ * v0.6 deploy is single-container (hub-as-supervisor) so loopback is fine.
+ * v0.7 cloud-multi-container will grow an `origin` field on the services.json
+ * entry; this resolver will honor it without API changes — `port` becomes
+ * a fallback when `origin` isn't set, no breaking change for v0.6 callers.
+ */
+
+import { readManifest, ServicesManifestError } from "./services-manifest.ts";
+
+/**
+ * Resolve the scribe base URL (no trailing slash) by consulting the env-var
+ * override first, then services.json. Returns `undefined` when scribe isn't
+ * configured — callers MUST treat that as "auto-transcribe disabled."
+ *
+ * The `env` + `readManifestImpl` parameters are injection seams for tests;
+ * production callers omit them and pick up `process.env` + the real
+ * `~/.parachute/services.json`.
+ */
+export function resolveScribeUrl(
+  env: NodeJS.ProcessEnv = process.env,
+  readManifestImpl: typeof readManifest = readManifest,
+  logger: { warn?: (...args: unknown[]) => void } = console,
+): string | undefined {
+  const override = env.SCRIBE_URL?.trim();
+  if (override) return override.replace(/\/$/, "");
+
+  let manifest;
+  try {
+    manifest = readManifestImpl();
+  } catch (err) {
+    if (err instanceof ServicesManifestError) {
+      logger.warn?.(`[scribe-discovery] services.json unreadable: ${err.message}`);
+    } else {
+      logger.warn?.(`[scribe-discovery] services.json read failed: ${err}`);
+    }
+    return undefined;
+  }
+  const entry = manifest.services.find((s) => s.name === "parachute-scribe");
+  if (!entry) return undefined;
+  // v0.6 loopback shape; v0.7 will add an explicit `origin` field on the
+  // service entry which wins over loopback when present.
+  const origin = (entry as { origin?: string }).origin;
+  if (typeof origin === "string" && origin.trim()) {
+    return origin.trim().replace(/\/$/, "");
+  }
+  return `http://127.0.0.1:${entry.port}`;
+}
+
+/**
+ * Process-lifetime cache. Computed at first call (typically during server
+ * boot), reused for every subsequent transcription request. Operators who
+ * change the scribe URL via `services.json` (re-install of scribe with a
+ * different port) need to restart vault; we deliberately don't watch the
+ * file because the v0.6 deploy model has a single restart-on-change story.
+ *
+ * Tests should pass an explicit `env` + `readManifestImpl` to `resolveScribeUrl`
+ * directly to bypass the cache.
+ */
+let cachedScribeUrl: string | undefined | null = null;
+
+export function getCachedScribeUrl(): string | undefined {
+  if (cachedScribeUrl === null) {
+    cachedScribeUrl = resolveScribeUrl();
+  }
+  return cachedScribeUrl;
+}
+
+export function clearScribeUrlCache(): void {
+  cachedScribeUrl = null;
+}

--- a/src/scribe-env.test.ts
+++ b/src/scribe-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { resolveScribeAuthToken } from "./scribe-env.ts";
+import { resolveScribeAuthToken, generateScribeBearer, ensureScribeBearer } from "./scribe-env.ts";
 
 function captureWarn() {
   const calls: unknown[][] = [];
@@ -45,5 +45,70 @@ describe("resolveScribeAuthToken", () => {
     const token = resolveScribeAuthToken({} as NodeJS.ProcessEnv, logger);
     expect(token).toBeUndefined();
     expect(calls.length).toBe(0);
+  });
+});
+
+describe("generateScribeBearer (vault#353)", () => {
+  test("returns 32-byte base64url string (~43 chars, no padding)", () => {
+    const bearer = generateScribeBearer();
+    // 32 bytes base64url-encoded = 43 chars (no `=` padding in base64url).
+    expect(bearer.length).toBe(43);
+    expect(bearer).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("each call yields a unique value", () => {
+    const a = generateScribeBearer();
+    const b = generateScribeBearer();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("ensureScribeBearer (vault#353)", () => {
+  test("generates + persists a bearer when neither env var is set", () => {
+    const env: Record<string, string> = {};
+    const writes: Array<[string, string]> = [];
+    const { created, token } = ensureScribeBearer(
+      () => ({ ...env }),
+      (k, v) => writes.push([k, v]),
+    );
+    expect(created).toBe(true);
+    expect(token.length).toBe(43);
+    expect(writes).toEqual([["SCRIBE_AUTH_TOKEN", token]]);
+  });
+
+  test("preserves existing SCRIBE_AUTH_TOKEN (idempotent)", () => {
+    const env: Record<string, string> = { SCRIBE_AUTH_TOKEN: "already-set" };
+    const writes: Array<[string, string]> = [];
+    const { created, token } = ensureScribeBearer(
+      () => ({ ...env }),
+      (k, v) => writes.push([k, v]),
+    );
+    expect(created).toBe(false);
+    expect(token).toBe("already-set");
+    expect(writes.length).toBe(0);
+  });
+
+  test("preserves legacy SCRIBE_TOKEN without rewriting it", () => {
+    const env: Record<string, string> = { SCRIBE_TOKEN: "legacy" };
+    const writes: Array<[string, string]> = [];
+    const { created, token } = ensureScribeBearer(
+      () => ({ ...env }),
+      (k, v) => writes.push([k, v]),
+    );
+    expect(created).toBe(false);
+    expect(token).toBe("legacy");
+    expect(writes.length).toBe(0);
+  });
+
+  test("treats whitespace-only env value as unset (generates fresh)", () => {
+    const env: Record<string, string> = { SCRIBE_AUTH_TOKEN: "   " };
+    const writes: Array<[string, string]> = [];
+    const { created, token } = ensureScribeBearer(
+      () => ({ ...env }),
+      (k, v) => writes.push([k, v]),
+    );
+    expect(created).toBe(true);
+    expect(token.length).toBe(43);
+    expect(writes[0]?.[0]).toBe("SCRIBE_AUTH_TOKEN");
   });
 });

--- a/src/scribe-env.ts
+++ b/src/scribe-env.ts
@@ -3,8 +3,11 @@
  *
  * Lives in its own module so the boot-time token resolution in server.ts is
  * testable without running the rest of server.ts (which has side effects:
- * triggers, auto-init, Bun.serve). Keep this module pure and dependency-free.
+ * triggers, auto-init, Bun.serve). Keep this module pure and dependency-free
+ * (except for the `node:crypto` import used by bearer generation).
  */
+
+import { randomBytes } from "node:crypto";
 
 /**
  * Resolve the scribe auth token. `SCRIBE_AUTH_TOKEN` is the canonical name
@@ -30,4 +33,42 @@ export function resolveScribeAuthToken(
     return legacy;
   }
   return undefined;
+}
+
+/**
+ * Generate a fresh shared bearer for the vault↔scribe loopback contract
+ * (design 2026-05-21 Part 2, design question 2). 32 random bytes → base64url
+ * encoded. The operator (or hub install) writes the result into vault's
+ * `~/.parachute/vault/.env` as `SCRIBE_AUTH_TOKEN` AND into scribe's config
+ * (via env propagation or the scribe admin endpoint).
+ *
+ * Generation is callable as a pure function so install code, tests, and any
+ * future "rotate scribe bearer" admin endpoint share the same length +
+ * encoding without copy-paste.
+ */
+export function generateScribeBearer(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * Ensure a scribe bearer exists in the vault .env. Idempotent: if a value
+ * (canonical or legacy) is already set, returns `{ created: false, token: ... }`
+ * without touching the file. Otherwise generates a fresh bearer, persists it
+ * to the .env via the provided writer, and returns `{ created: true, token }`.
+ *
+ * The `envReader` + `envWriter` parameters are injection seams for tests; the
+ * production caller (`cli.ts` init flow) passes `readEnvFile` + `setEnvVar`.
+ */
+export function ensureScribeBearer(
+  envReader: () => Record<string, string>,
+  envWriter: (key: string, value: string) => void,
+): { created: boolean; token: string } {
+  const env = envReader();
+  const existing = env.SCRIBE_AUTH_TOKEN ?? env.SCRIBE_TOKEN;
+  if (existing && existing.trim()) {
+    return { created: false, token: existing };
+  }
+  const token = generateScribeBearer();
+  envWriter("SCRIBE_AUTH_TOKEN", token);
+  return { created: true, token };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,8 +24,11 @@ import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTriggers } from "./triggers.ts";
 import { route } from "./routing.ts";
 import { startTranscriptionWorker, registerTranscriptionHook, type TranscriptionWorker } from "./transcription-worker.ts";
+import { setTranscriptionWorker } from "./transcription-registry.ts";
 import { assetsDir } from "./routes.ts";
-import { resolveScribeAuthToken } from "./scribe-env.ts";
+import { resolveScribeAuthToken, ensureScribeBearer } from "./scribe-env.ts";
+import { getCachedScribeUrl } from "./scribe-discovery.ts";
+import { readEnvFile, setEnvVar } from "./config.ts";
 import { resolveBindHostname } from "./bind.ts";
 import { MirrorManager } from "./mirror-manager.ts";
 import { setMirrorManager } from "./mirror-registry.ts";
@@ -47,8 +50,9 @@ function registerConfiguredTriggers(): void {
   // both will process the same attachments. The trigger's `missing_metadata`
   // guard keeps it idempotent once the worker marks `transcript` on the
   // attachment, but the noise is worth flagging.
-  if (process.env.SCRIBE_URL) {
-    const scribeHost = safeHost(process.env.SCRIBE_URL);
+  const probedScribeUrl = getCachedScribeUrl();
+  if (probedScribeUrl) {
+    const scribeHost = safeHost(probedScribeUrl);
     for (const t of config.triggers) {
       if (t.action.send !== "attachment") continue;
       if (scribeHost && safeHost(t.action.webhook) === scribeHost) {
@@ -74,17 +78,35 @@ loadEnvFile();
 registerConfiguredTriggers();
 
 /**
- * Start the transcription worker if SCRIBE_URL is configured. The worker
- * polls every vault for attachments with `metadata.transcribe_status = "pending"`
- * and sends the audio to scribe. Absent SCRIBE_URL, the worker stays off
- * — `{transcribe: true}` uploads still enqueue, they just wait.
+ * Start the transcription worker if scribe is discoverable. Scribe URL
+ * resolution order (per `scribe-discovery.ts`): `SCRIBE_URL` env var, then
+ * `~/.parachute/services.json` `parachute-scribe` entry, then nothing.
+ *
+ * Bearer generation (vault#353): if neither `SCRIBE_AUTH_TOKEN` nor the
+ * legacy `SCRIBE_TOKEN` is set, generate a fresh 32-byte base64url bearer
+ * and persist it to vault's `.env` so subsequent restarts use the same
+ * value. Idempotent — calls after the first see the existing token. The
+ * operator (or hub install) is expected to mirror this bearer to scribe's
+ * `SCRIBE_AUTH_TOKEN`; without that mirror, scribe will reject the
+ * Authorization header on a 401 and transcription fails with a friendly
+ * error captured on the transcript note.
  */
+const scribeUrl = getCachedScribeUrl();
 let transcriptionWorker: TranscriptionWorker | null = null;
-if (process.env.SCRIBE_URL) {
+if (scribeUrl) {
+  // Generate + persist the shared bearer on first boot. Subsequent boots
+  // pick up the existing value and don't rotate. Loading the .env back
+  // into process.env happens above (`loadEnvFile()`); we re-load here to
+  // pick up the just-written value without restart.
+  const { created, token } = ensureScribeBearer(readEnvFile, setEnvVar);
+  if (created) {
+    process.env.SCRIBE_AUTH_TOKEN = token;
+    console.log("[transcribe] generated SCRIBE_AUTH_TOKEN (32 bytes, base64url) — mirror this value into scribe's config");
+  }
   transcriptionWorker = startTranscriptionWorker({
     vaultList: () => listVaults(),
     getStore: (name) => getVaultStore(name),
-    scribeUrl: process.env.SCRIBE_URL,
+    scribeUrl,
     scribeToken: resolveScribeAuthToken(),
     resolveAssetsDir: (vault) => assetsDir(vault),
     getAudioRetention: (vault) => readVaultConfig(vault)?.audio_retention ?? "keep",
@@ -97,9 +119,12 @@ if (process.env.SCRIBE_URL) {
     transcriptionWorker,
     (store) => getVaultNameForStore(store as never),
   );
-  console.log(`[transcribe] worker started → ${process.env.SCRIBE_URL}`);
+  // Expose the worker to the REST retry endpoint so retries kick immediately
+  // instead of waiting for the sweep. Idempotent on second boot.
+  setTranscriptionWorker(transcriptionWorker);
+  console.log(`[transcribe] worker started → ${scribeUrl}`);
 } else {
-  console.log("[transcribe] worker disabled (set SCRIBE_URL to enable)");
+  console.log("[transcribe] worker disabled (no scribe in services.json and SCRIBE_URL unset)");
 }
 
 if (process.env.VAULT_AUTH_TOKEN?.trim()) {

--- a/src/transcript-note.test.ts
+++ b/src/transcript-note.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for vault transcript-note materialization (vault#353).
+ *
+ * Covers two surfaces:
+ *   - `buildTranscriptNote` — pure, frontmatter shape per design Q3.
+ *   - `upsertTranscriptNote` — DB-backed, create + retry-update flow.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { BunStore } from "./vault-store.ts";
+import { buildTranscriptNote, transcriptPathFor, upsertTranscriptNote } from "./transcript-note.ts";
+
+let db: Database;
+let store: BunStore;
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `transcript-note-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tmpDir, { recursive: true });
+  db = new Database(join(tmpDir, "test.db"));
+  store = new BunStore(db);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("transcriptPathFor", () => {
+  test("appends `.transcript` to the audio path", () => {
+    expect(transcriptPathFor("inbox/2026-05-21.m4a")).toBe("inbox/2026-05-21.m4a.transcript");
+  });
+
+  test("handles nested paths", () => {
+    expect(transcriptPathFor("a/b/c/voice.webm")).toBe("a/b/c/voice.webm.transcript");
+  });
+});
+
+describe("buildTranscriptNote — success shape", () => {
+  test("frontmatter includes transcript_of, status, attachment id, duration, and provider", () => {
+    const result = buildTranscriptNote({
+      attachmentPath: "inbox/voice.webm",
+      attachmentId: "att-1",
+      attachmentNoteId: "note-1",
+      status: "complete",
+      text: "hello world",
+      provider: "groq",
+      durationMs: 1234,
+      createdAt: new Date("2026-05-21T09:13:42Z"),
+    });
+    expect(result.path).toBe("inbox/voice.webm.transcript");
+    expect(result.content).toBe("hello world");
+    expect(result.tags).toEqual(["transcript", "capture"]);
+    expect(result.metadata.transcript_of).toBe("inbox/voice.webm");
+    expect(result.metadata.transcript_attachment_id).toBe("att-1");
+    expect(result.metadata.transcript_status).toBe("complete");
+    expect(result.metadata.transcript_provider).toBe("groq");
+    expect(result.metadata.transcript_duration_ms).toBe(1234);
+    expect(result.metadata.title).toBe("Transcript of voice.webm");
+    expect(result.createdAt).toBe("2026-05-21T09:13:42.000Z");
+    expect(result.metadata.transcript_error).toBeUndefined();
+  });
+
+  test("provider/duration omitted when not supplied", () => {
+    const result = buildTranscriptNote({
+      attachmentPath: "voice.m4a",
+      attachmentId: "att-x",
+      attachmentNoteId: "note-x",
+      status: "complete",
+      text: "no provider info",
+    });
+    expect(result.metadata.transcript_provider).toBeUndefined();
+    expect(result.metadata.transcript_duration_ms).toBeUndefined();
+  });
+});
+
+describe("buildTranscriptNote — failure shape", () => {
+  test("body is empty + transcript_error captured", () => {
+    const result = buildTranscriptNote({
+      attachmentPath: "inbox/voice.webm",
+      attachmentId: "att-1",
+      attachmentNoteId: "note-1",
+      status: "failed",
+      error: "no transcription provider configured",
+    });
+    expect(result.content).toBe("");
+    expect(result.metadata.transcript_status).toBe("failed");
+    expect(result.metadata.transcript_error).toBe("no transcription provider configured");
+  });
+
+  test("falls back to 'unknown error' when no error string is supplied", () => {
+    const result = buildTranscriptNote({
+      attachmentPath: "voice.m4a",
+      attachmentId: "att-1",
+      attachmentNoteId: "note-1",
+      status: "failed",
+    });
+    expect(result.metadata.transcript_error).toBe("unknown error");
+  });
+});
+
+describe("upsertTranscriptNote", () => {
+  test("creates a new note + link on first call", async () => {
+    const audioOwner = await store.createNote("# Voice memo\n", { id: "owner" });
+    await store.addAttachment(audioOwner.id, "memos/a.webm", "audio/webm");
+
+    const note = await upsertTranscriptNote(store, {
+      attachmentPath: "memos/a.webm",
+      attachmentId: "att-1",
+      attachmentNoteId: audioOwner.id,
+      status: "complete",
+      text: "spoken words",
+      provider: "groq",
+      durationMs: 999,
+    });
+    expect(note.content).toBe("spoken words");
+    expect(note.path).toBe("memos/a.webm.transcript");
+
+    const fetched = await store.getNoteByPath("memos/a.webm.transcript");
+    expect(fetched?.id).toBe(note.id);
+    expect((fetched?.metadata as any)?.transcript_status).toBe("complete");
+    expect(fetched?.tags).toContain("transcript");
+    expect(fetched?.tags).toContain("capture");
+  });
+
+  test("overwrites existing transcript note in place on retry (id preserved)", async () => {
+    const owner = await store.createNote("# Voice memo\n", { id: "owner-2" });
+    await store.addAttachment(owner.id, "memos/b.webm", "audio/webm");
+
+    const first = await upsertTranscriptNote(store, {
+      attachmentPath: "memos/b.webm",
+      attachmentId: "att-2",
+      attachmentNoteId: owner.id,
+      status: "failed",
+      error: "no transcription provider configured",
+    });
+    expect(first.content).toBe("");
+
+    const retried = await upsertTranscriptNote(store, {
+      attachmentPath: "memos/b.webm",
+      attachmentId: "att-2",
+      attachmentNoteId: owner.id,
+      status: "complete",
+      text: "transcript that finally landed",
+      durationMs: 500,
+    });
+    expect(retried.id).toBe(first.id);
+    expect(retried.content).toBe("transcript that finally landed");
+    expect((retried.metadata as any)?.transcript_status).toBe("complete");
+    expect((retried.metadata as any)?.transcript_error).toBeUndefined();
+  });
+
+  test("attempting to upsert when the attachmentNoteId is missing still creates the note (link skipped)", async () => {
+    // No owner note created — the link create will throw or silently skip;
+    // either way the transcript note must still land so the failure has
+    // a visible record. (Defensive: a deleted-attachment race.)
+    const note = await upsertTranscriptNote(store, {
+      attachmentPath: "missing/a.webm",
+      attachmentId: "att-x",
+      attachmentNoteId: "nonexistent-note",
+      status: "failed",
+      error: "audio file not found",
+    });
+    expect(note.path).toBe("missing/a.webm.transcript");
+    expect((note.metadata as any)?.transcript_status).toBe("failed");
+  });
+});

--- a/src/transcript-note.ts
+++ b/src/transcript-note.ts
@@ -1,0 +1,189 @@
+/**
+ * Transcript-note materialization for the vault↔scribe auto-transcribe path
+ * (vault#353, design 2026-05-21 Part 2, design question 3).
+ *
+ * When the transcription worker resolves an audio attachment, it asks this
+ * module to create (or update) a sibling `<attachment-path>.transcript.md`
+ * note. The note's frontmatter links back to the original audio attachment
+ * via `transcript_of`, lets vault graph queries surface the relation, and
+ * captures success / failure state in a single uniform shape.
+ *
+ * Design Q3's exact shape:
+ *
+ *   ---
+ *   title: Transcript of <attachment-name>
+ *   tags: [transcript, capture]
+ *   created_at: <iso>
+ *   transcript_of: <attachment-path>
+ *   transcript_status: complete | failed
+ *   transcript_provider: <name or unset>
+ *   transcript_duration_ms: <wall-clock ms>
+ *   transcript_error: <error-message — failed only>
+ *   ---
+ *
+ *   <transcript text — empty body when failed>
+ *
+ * The `transcript_status` values are uniform: `complete` for success and
+ * `failed` for any terminal failure (provider missing, scribe 5xx, timeout,
+ * etc.). The cause is in `transcript_error`. This matches the design's
+ * "same failure substrate" stance — no first-boot-specific branch, just
+ * different error strings.
+ *
+ * ## Retry semantics
+ *
+ * When the retry endpoint re-runs transcription on an already-failed
+ * transcript note, the same note is updated in place — `transcript_of`,
+ * `path`, and `id` all stay constant. Callers identify the transcript by
+ * note path (`<attachment-path>.transcript.md`) and call `upsertTranscriptNote`
+ * to overwrite. The transcript-of relation is materialized as both a
+ * frontmatter scalar AND a vault link (via `links.add` on create) so graph
+ * queries can find it without parsing frontmatter.
+ */
+
+import type { Store, Note } from "../core/src/types.ts";
+
+export type TranscriptStatus = "complete" | "failed";
+
+export interface TranscriptNoteInput {
+  /**
+   * Path of the source audio attachment (relative to the vault assets dir).
+   * Used to derive the transcript note's path and the `transcript_of`
+   * frontmatter scalar.
+   */
+  attachmentPath: string;
+  /**
+   * Attachment row id of the source audio. Stamped onto the transcript note
+   * frontmatter (`transcript_attachment_id`) so the retry endpoint can find
+   * the original audio in one DB lookup without walking links or paths.
+   */
+  attachmentId: string;
+  /**
+   * The note that owns the audio attachment. The transcript-of relation
+   * (vault link) is established to this note so graph queries can find the
+   * transcript from either side.
+   */
+  attachmentNoteId: string;
+  /** Outcome — `complete` (transcript text available) or `failed`. */
+  status: TranscriptStatus;
+  /**
+   * Transcript body. Required when `status === "complete"`; ignored otherwise.
+   * Failure transcript notes have an empty body — the error string is in
+   * frontmatter, not in the note body, so failures don't read like content.
+   */
+  text?: string;
+  /** Error cause for `status === "failed"`. Required for failed status. */
+  error?: string;
+  /** Scribe-reported provider (e.g. "groq", "whisper"). Optional. */
+  provider?: string;
+  /** Wall-clock duration of the scribe call. Optional; 0 if unknown. */
+  durationMs?: number;
+  /** Created-at override (defaults to `new Date()`). */
+  createdAt?: Date;
+}
+
+/**
+ * Compute the canonical transcript-note path for an audio attachment.
+ *
+ * Example: `inbox/Voice 2026-05-21 09-13.m4a` → `inbox/Voice 2026-05-21 09-13.m4a.transcript`
+ *
+ * The `.md` extension is implicit in the vault path normalization (paths are
+ * stored without `.md` per vault convention; on export to portable markdown,
+ * `.md` is appended).
+ */
+export function transcriptPathFor(attachmentPath: string): string {
+  return `${attachmentPath}.transcript`;
+}
+
+/**
+ * Build the body+metadata for a transcript note from the worker's input.
+ * Pure — no Store calls — so unit tests can assert shape without a DB.
+ * Exposed for tests and for any future caller that wants to materialize a
+ * transcript note independently of the worker.
+ */
+export function buildTranscriptNote(input: TranscriptNoteInput): {
+  path: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  tags: string[];
+  createdAt: string;
+} {
+  const created = (input.createdAt ?? new Date()).toISOString();
+  const filename = input.attachmentPath.split("/").pop() ?? input.attachmentPath;
+  const metadata: Record<string, unknown> = {
+    title: `Transcript of ${filename}`,
+    transcript_of: input.attachmentPath,
+    transcript_attachment_id: input.attachmentId,
+    transcript_status: input.status,
+  };
+  if (input.provider) metadata.transcript_provider = input.provider;
+  if (typeof input.durationMs === "number") {
+    metadata.transcript_duration_ms = input.durationMs;
+  }
+  if (input.status === "failed") {
+    metadata.transcript_error = input.error ?? "unknown error";
+  }
+  const body = input.status === "complete" ? (input.text ?? "") : "";
+  return {
+    path: transcriptPathFor(input.attachmentPath),
+    content: body,
+    metadata,
+    tags: ["transcript", "capture"],
+    createdAt: created,
+  };
+}
+
+/**
+ * Create or update the transcript note at `<attachmentPath>.transcript.md`.
+ *
+ * - If no note exists at that path, creates one with the standard shape,
+ *   establishes a `transcript_of` link to the attachment-owning note, and
+ *   returns the new note.
+ * - If a transcript note already exists (retry path), overwrites its content
+ *   + metadata in place, preserves the existing note id, and returns the
+ *   updated note. Links are NOT re-created — the existing relation survives.
+ *
+ * Errors from the Store (path collision with a non-transcript note, etc.)
+ * bubble up; the worker catches them and logs.
+ */
+export async function upsertTranscriptNote(
+  store: Store,
+  input: TranscriptNoteInput,
+): Promise<Note> {
+  const built = buildTranscriptNote(input);
+  const existing = await store.getNoteByPath(built.path);
+  if (existing) {
+    await store.updateNote(existing.id, {
+      content: built.content,
+      metadata: built.metadata,
+      // Preserve the original created_at; the retry doesn't reset it.
+      skipUpdatedAt: false,
+    });
+    // Re-apply tags via tagNote — updateNote() doesn't accept a tags field
+    // (the engine treats tag mutation as a separate op). tagNote upserts
+    // existing tags (no duplicates), so it's safe to call even when tags
+    // are unchanged from the prior write.
+    await store.tagNote(existing.id, built.tags);
+    const updated = await store.getNote(existing.id);
+    return updated ?? existing;
+  }
+  const created = await store.createNote(built.content, {
+    path: built.path,
+    tags: built.tags,
+    metadata: built.metadata,
+    created_at: built.createdAt,
+  });
+  // Materialize the transcript-of relation as a typed link too, so graph
+  // queries (find-path, neighborhood) surface the transcript without
+  // walking frontmatter. The relation is named "transcript_of" so it
+  // matches the frontmatter scalar; if the target note has been deleted
+  // by the time we get here (race during retry), skip silently — the
+  // frontmatter scalar still carries the relation for query-by-path.
+  try {
+    await store.createLink(created.id, input.attachmentNoteId, "transcript_of");
+  } catch {
+    // Target may be missing or the link constraint may reject — failure
+    // here doesn't invalidate the transcript itself, which is still
+    // queryable via the `transcript_of` frontmatter scalar + path.
+  }
+  return created;
+}

--- a/src/transcription-registry.ts
+++ b/src/transcription-registry.ts
@@ -1,0 +1,22 @@
+/**
+ * Process-singleton holder for the active TranscriptionWorker (vault#353).
+ *
+ * Mirrors `mirror-registry.ts`: `server.ts` constructs the worker on boot
+ * (when scribe is discoverable), and the REST retry endpoint
+ * (`/api/notes/:id/retry-transcription`) picks it up here to call `kick()`
+ * for an event-driven re-run. Absent the worker (no scribe), the retry
+ * endpoint still flips the attachment back to `pending` so the sweep would
+ * pick it up — but it'll just sit there until scribe shows up.
+ */
+
+import type { TranscriptionWorker } from "./transcription-worker.ts";
+
+let activeWorker: TranscriptionWorker | null = null;
+
+export function setTranscriptionWorker(worker: TranscriptionWorker | null): void {
+  activeWorker = worker;
+}
+
+export function getTranscriptionWorker(): TranscriptionWorker | null {
+  return activeWorker;
+}

--- a/src/transcription-worker.test.ts
+++ b/src/transcription-worker.test.ts
@@ -867,3 +867,253 @@ describe("transcription worker — hook-driven", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// vault#353 — auto-origin path: materialize <attachment-path>.transcript.md
+// notes on success AND on terminal failure (so the retry endpoint has a
+// surface to act on). The legacy `transcribe_stub`-patching path remains
+// unchanged; these tests pin the new behavior for attachments stamped with
+// `transcribe_origin: "auto"`.
+// ---------------------------------------------------------------------------
+
+describe("transcription worker — auto-origin (vault#353)", () => {
+  test("success: materializes <path>.transcript with frontmatter + body", async () => {
+    const owner = await store.createNote("# Voice memo\n", { id: "auto-1" });
+    seedAudio("memos/auto-1.webm");
+    await store.addAttachment(owner.id, "memos/auto-1.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_origin: "auto",
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ text: "this is the spoken text" }]),
+    });
+    try {
+      const processed = await worker.tick();
+      expect(processed).toBe(1);
+    } finally {
+      await worker.stop();
+    }
+
+    // The transcript note exists, with the expected shape.
+    const transcript = await store.getNoteByPath("memos/auto-1.webm.transcript");
+    expect(transcript).not.toBeNull();
+    expect(transcript!.content).toBe("this is the spoken text");
+    expect(transcript!.tags).toContain("transcript");
+    expect((transcript!.metadata as any)?.transcript_status).toBe("complete");
+    expect((transcript!.metadata as any)?.transcript_of).toBe("memos/auto-1.webm");
+    expect(typeof (transcript!.metadata as any)?.transcript_duration_ms).toBe("number");
+
+    // Source note is NOT touched (no stub patching on auto-origin).
+    const sourceNote = await store.getNote("auto-1");
+    expect(sourceNote!.content).toBe("# Voice memo\n");
+
+    // Attachment row also reflects success — sweep + retry hit the same row.
+    const [att] = await store.getAttachments(owner.id);
+    expect(att.metadata?.transcribe_status).toBe("done");
+  });
+
+  test("missing_provider 400: terminal failure on first try → failed transcript note", async () => {
+    const owner = await store.createNote("# Voice memo\n", { id: "auto-mp" });
+    seedAudio("memos/auto-mp.webm");
+    await store.addAttachment(owner.id, "memos/auto-mp.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_origin: "auto",
+    });
+
+    // Custom fetchImpl that returns the structured 400 missing_provider
+    // payload (scribe#47 shape).
+    const fetchImpl: typeof fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          error: "no transcription provider configured",
+          error_code: "missing_provider",
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const worker = makeWorker({ fetchImpl, maxAttempts: 5 });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const transcript = await store.getNoteByPath("memos/auto-mp.webm.transcript");
+    expect(transcript).not.toBeNull();
+    expect(transcript!.content).toBe("");
+    expect((transcript!.metadata as any)?.transcript_status).toBe("failed");
+    expect((transcript!.metadata as any)?.transcript_error).toContain("missing_provider");
+
+    // 4xx is terminal — attempts tracked but status went straight to failed,
+    // not parked in pending with backoff.
+    const [att] = await store.getAttachments(owner.id);
+    expect(att.metadata?.transcribe_status).toBe("failed");
+    expect((att.metadata as any)?.transcribe_error_code).toBe("missing_provider");
+  });
+
+  test("5xx timeout: retries with backoff (NOT terminal on first failure)", async () => {
+    const owner = await store.createNote("# Voice memo\n", { id: "auto-503" });
+    seedAudio("memos/auto-503.webm");
+    await store.addAttachment(owner.id, "memos/auto-503.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_origin: "auto",
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ error: "upstream timeout", status: 503 }]),
+      maxAttempts: 3,
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    // 5xx is retriable — attachment goes back to pending with backoff.
+    // The transcript note is NOT materialized yet (the failure isn't terminal
+    // and we don't want to surface intermediate failures to the user).
+    const [att] = await store.getAttachments(owner.id);
+    expect(att.metadata?.transcribe_status).toBe("pending");
+    expect(att.metadata?.transcribe_backoff_until).toBeTruthy();
+
+    const transcript = await store.getNoteByPath("memos/auto-503.webm.transcript");
+    expect(transcript).toBeNull();
+  });
+
+  test("audio gone: terminal failure → failed transcript note materialized", async () => {
+    const owner = await store.createNote("# Voice memo\n", { id: "auto-gone" });
+    // No seedAudio call — the file is missing.
+    await store.addAttachment(owner.id, "memos/auto-gone.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_origin: "auto",
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ text: "should never run" }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const transcript = await store.getNoteByPath("memos/auto-gone.webm.transcript");
+    expect(transcript).not.toBeNull();
+    expect((transcript!.metadata as any)?.transcript_status).toBe("failed");
+    expect((transcript!.metadata as any)?.transcript_error).toBe("audio file not found");
+  });
+
+  test("legacy stub flow unchanged: no transcript note materialized for transcribe_stub-only", async () => {
+    await store.createNote(
+      "# Voice\n\n_Transcript pending._\n",
+      { id: "legacy-1", metadata: { transcribe_stub: true } },
+    );
+    seedAudio("memos/legacy-1.webm");
+    await store.addAttachment("legacy-1", "memos/legacy-1.webm", "audio/webm", {
+      transcribe_status: "pending",
+      // Legacy path: NO transcribe_origin: "auto".
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ text: "stub-patched" }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    // The note body was patched in place (legacy behavior).
+    const note = await store.getNote("legacy-1");
+    expect(note!.content).toBe("# Voice\n\nstub-patched\n");
+
+    // No transcript note was created.
+    const transcript = await store.getNoteByPath("memos/legacy-1.webm.transcript");
+    expect(transcript).toBeNull();
+  });
+
+  test("retry path: failed transcript is overwritten in place on success", async () => {
+    const owner = await store.createNote("# Voice memo\n", { id: "auto-retry" });
+    seedAudio("memos/auto-retry.webm");
+    await store.addAttachment(owner.id, "memos/auto-retry.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_origin: "auto",
+    });
+
+    // Pass 1: missing_provider failure → failed transcript note materialized.
+    const fetch400: typeof fetch = (async () => {
+      return new Response(
+        JSON.stringify({ error: "missing", error_code: "missing_provider" }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+    const worker1 = makeWorker({ fetchImpl: fetch400 });
+    try { await worker1.tick(); } finally { await worker1.stop(); }
+
+    const failed = await store.getNoteByPath("memos/auto-retry.webm.transcript");
+    expect(failed).not.toBeNull();
+    const failedId = failed!.id;
+    expect((failed!.metadata as any)?.transcript_status).toBe("failed");
+
+    // Pass 2: re-enqueue by flipping the attachment back to pending (this is
+    // what the retry endpoint does) + give scribe a successful response.
+    const [att] = await store.getAttachments(owner.id);
+    await store.setAttachmentMetadata(att.id, {
+      ...(att.metadata ?? {}),
+      transcribe_status: "pending",
+      transcribe_origin: "auto",
+    });
+    const worker2 = makeWorker({
+      fetchImpl: mkFetchMock([{ text: "second time's the charm" }]),
+    });
+    try { await worker2.tick(); } finally { await worker2.stop(); }
+
+    const success = await store.getNoteByPath("memos/auto-retry.webm.transcript");
+    expect(success).not.toBeNull();
+    // Same note id — updated in place, not a fresh row.
+    expect(success!.id).toBe(failedId);
+    expect(success!.content).toBe("second time's the charm");
+    expect((success!.metadata as any)?.transcript_status).toBe("complete");
+    expect((success!.metadata as any)?.transcript_error).toBeUndefined();
+  });
+
+  test("concurrent uploads: 5 audio files yield 5 transcript notes (no path collision)", async () => {
+    const owners: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const note = await store.createNote(`# Voice ${i}\n`, { id: `concurrent-${i}` });
+      owners.push(note.id);
+      seedAudio(`memos/concurrent-${i}.webm`);
+      await store.addAttachment(note.id, `memos/concurrent-${i}.webm`, "audio/webm", {
+        transcribe_status: "pending",
+        transcribe_origin: "auto",
+      });
+    }
+
+    // Same transcript body to each. The worker drains FIFO.
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([
+        { text: "transcript-0" },
+        { text: "transcript-1" },
+        { text: "transcript-2" },
+        { text: "transcript-3" },
+        { text: "transcript-4" },
+      ]),
+    });
+    try {
+      const processed = await worker.tick();
+      expect(processed).toBe(5);
+    } finally {
+      await worker.stop();
+    }
+
+    // 5 transcript notes — one per audio file. The bodies map to FIFO order;
+    // we just assert each note exists with `complete` status.
+    for (let i = 0; i < 5; i++) {
+      const t = await store.getNoteByPath(`memos/concurrent-${i}.webm.transcript`);
+      expect(t).not.toBeNull();
+      expect((t!.metadata as any)?.transcript_status).toBe("complete");
+    }
+  });
+});

--- a/src/transcription-worker.ts
+++ b/src/transcription-worker.ts
@@ -54,6 +54,7 @@ import type { Store, Attachment } from "../core/src/types.ts";
 import type { HookRegistry } from "../core/src/hooks.ts";
 import { appendContextPart, fetchContextEntries, type ContextPayload } from "./context.ts";
 import type { TriggerIncludeContext } from "./config.ts";
+import { upsertTranscriptNote } from "./transcript-note.ts";
 
 /** Placeholder pattern written by Lens's voice-memo stub. */
 const TRANSCRIPT_PLACEHOLDER = /_Transcript pending\._/;
@@ -139,7 +140,36 @@ interface PendingMeta {
   transcribe_error?: string;
   transcript?: string;
   transcribe_done_at?: string;
+  /**
+   * Marker stamped by the attachment-write code path (vault#353) when the
+   * audio attachment was queued via the auto-transcribe pipeline (mime-type
+   * matched `audio/*` AND `autoTranscribe.enabled === true`). When set to
+   * `"auto"`, the worker materializes a `<attachment-path>.transcript.md`
+   * note on terminal states (success OR failure) so the transcript surface
+   * is uniform regardless of outcome. Absent or set to `"legacy"`, the
+   * worker preserves the original stub-patching behavior (Lens flow).
+   */
+  transcribe_origin?: "auto" | "legacy";
   [k: string]: unknown;
+}
+
+/**
+ * Structured error thrown when scribe returns a 4xx with a recognized
+ * `error_code` — we surface the code on the transcript note's frontmatter
+ * so callers can branch on stable strings instead of regex-matching message
+ * text. Today the canonical code is `missing_provider` (scribe#47).
+ */
+class ScribeApiError extends Error {
+  readonly errorCode?: string;
+  readonly httpStatus: number;
+  readonly retriable: boolean;
+  constructor(message: string, opts: { errorCode?: string; httpStatus: number; retriable: boolean }) {
+    super(message);
+    this.name = "ScribeApiError";
+    this.errorCode = opts.errorCode;
+    this.httpStatus = opts.httpStatus;
+    this.retriable = opts.retriable;
+  }
 }
 
 /**
@@ -216,6 +246,38 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
     }
   }
 
+  /**
+   * On a terminal failure for an attachment with `transcribe_origin: "auto"`,
+   * write (or update) a `<attachment-path>.transcript.md` note with
+   * `transcript_status: failed` so the user has a queryable record of the
+   * failure and a target for the retry endpoint. Best-effort: any error
+   * materializing the transcript note is logged, never propagated — the
+   * attachment metadata write is the durable record of failure.
+   */
+  async function writeFailureTranscriptNote(
+    store: Store,
+    attachment: Attachment,
+    errMsg: string,
+    errorCode: string | undefined,
+    durationMs: number | undefined,
+  ): Promise<void> {
+    try {
+      await upsertTranscriptNote(store, {
+        attachmentPath: attachment.path,
+        attachmentId: attachment.id,
+        attachmentNoteId: attachment.noteId,
+        status: "failed",
+        error: errorCode ? `${errorCode}: ${errMsg}` : errMsg,
+        durationMs,
+      });
+    } catch (err) {
+      logger.error(
+        `[transcribe] failed to write failure transcript note for attachment ${attachment.id}:`,
+        err,
+      );
+    }
+  }
+
   async function processOneLocked(vault: string, attachment: Attachment): Promise<void> {
     const store = opts.getStore(vault);
     // Re-read metadata — the in-memory `attachment` may be stale (the hook
@@ -226,6 +288,10 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
     if (meta.transcribe_status !== "pending") return;
 
     const attempts = (meta.transcribe_attempts as number | undefined) ?? 0;
+    // Whether to materialize a transcript note (vault#353 auto-transcribe path)
+    // vs. the legacy stub-patching path (Lens flow). Auto-write notes also
+    // surface failures so the user can retry from the transcript note.
+    const isAutoOrigin = meta.transcribe_origin === "auto";
 
     // Honor backoff — we re-check here in case another tick queued this
     // attachment between the listing and now.
@@ -243,7 +309,11 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
         transcribe_status: "failed",
         transcribe_error: "audio file not found",
       });
-      await applyFailureMarker(store, attachment.noteId);
+      if (isAutoOrigin) {
+        await writeFailureTranscriptNote(store, attachment, "audio file not found", undefined, undefined);
+      } else {
+        await applyFailureMarker(store, attachment.noteId);
+      }
       return;
     }
 
@@ -256,9 +326,9 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
       context = await fetchContextEntries(store, predicates, logger);
     }
 
-    let transcript: string;
+    let scribeResult: { text: string; durationMs: number };
     try {
-      transcript = await callScribe({
+      scribeResult = await callScribe({
         url: opts.scribeUrl,
         token: opts.scribeToken,
         filePath,
@@ -269,17 +339,34 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
         fetchImpl,
       });
     } catch (err) {
-      const nextAttempts = attempts + 1;
       const errMsg = err instanceof Error ? err.message : String(err);
-      if (nextAttempts >= maxAttempts) {
-        logger.error(`[transcribe] giving up on attachment ${attachment.id} after ${nextAttempts} attempts:`, errMsg);
+      const apiErr = err instanceof ScribeApiError ? err : null;
+      // 4xx with structured error code → terminal immediately. Re-POSTing the
+      // same audio at a scribe with no provider configured (or that rejects
+      // our bearer) will keep failing — the operator has to act, retries don't
+      // help. This is the "graceful first-boot path" from design Q5.
+      const nonRetriable = apiErr !== null && !apiErr.retriable;
+      const nextAttempts = attempts + 1;
+      const terminal = nonRetriable || nextAttempts >= maxAttempts;
+
+      if (terminal) {
+        if (nonRetriable) {
+          logger.error(`[transcribe] non-retriable scribe error on attachment ${attachment.id} (status ${apiErr!.httpStatus}${apiErr!.errorCode ? `, ${apiErr!.errorCode}` : ""}):`, errMsg);
+        } else {
+          logger.error(`[transcribe] giving up on attachment ${attachment.id} after ${nextAttempts} attempts:`, errMsg);
+        }
         await store.setAttachmentMetadata(attachment.id, {
           ...meta,
           transcribe_status: "failed",
           transcribe_attempts: nextAttempts,
           transcribe_error: errMsg,
+          ...(apiErr?.errorCode ? { transcribe_error_code: apiErr.errorCode } : {}),
         });
-        await applyFailureMarker(store, attachment.noteId);
+        if (isAutoOrigin) {
+          await writeFailureTranscriptNote(store, attachment, errMsg, apiErr?.errorCode, undefined);
+        } else {
+          await applyFailureMarker(store, attachment.noteId);
+        }
         // retention=never drops the audio on any terminal state, including
         // failure. The user opted in to "I don't want the audio kept around
         // regardless of outcome" — honor it.
@@ -302,23 +389,46 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
       return;
     }
 
-    // Success. Apply to note if the caller still wants us to.
-    const note = await store.getNote(attachment.noteId);
-    if (note) {
-      const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
-      if (noteMeta.transcribe_stub === true) {
-        const body = TRANSCRIPT_PLACEHOLDER.test(note.content)
-          ? note.content.replace(TRANSCRIPT_PLACEHOLDER, transcript)
-          : transcript;
-        const { transcribe_stub: _drop, ...restMeta } = noteMeta;
-        try {
-          await store.updateNote(note.id, {
-            content: body,
-            metadata: restMeta,
-            skipUpdatedAt: true,
-          });
-        } catch (err) {
-          logger.error(`[transcribe] failed to apply transcript to note ${note.id}:`, err);
+    const { text: transcript, durationMs } = scribeResult;
+
+    // Auto-origin success: materialize the transcript note (vault#353). The
+    // note's path is `<attachment-path>.transcript.md`, its frontmatter links
+    // back to the audio attachment via `transcript_of`.
+    if (isAutoOrigin) {
+      try {
+        await upsertTranscriptNote(store, {
+          attachmentPath: attachment.path,
+          attachmentId: attachment.id,
+          attachmentNoteId: attachment.noteId,
+          status: "complete",
+          text: transcript,
+          durationMs,
+        });
+      } catch (err) {
+        // Note write failure doesn't invalidate the transcript — it's still
+        // stored on the attachment row below. Log + continue so retention
+        // still applies and the attachment row reflects success.
+        logger.error(`[transcribe] failed to write transcript note for attachment ${attachment.id}:`, err);
+      }
+    } else {
+      // Legacy stub-patching path (Lens voice memo flow).
+      const note = await store.getNote(attachment.noteId);
+      if (note) {
+        const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
+        if (noteMeta.transcribe_stub === true) {
+          const body = TRANSCRIPT_PLACEHOLDER.test(note.content)
+            ? note.content.replace(TRANSCRIPT_PLACEHOLDER, transcript)
+            : transcript;
+          const { transcribe_stub: _drop, ...restMeta } = noteMeta;
+          try {
+            await store.updateNote(note.id, {
+              content: body,
+              metadata: restMeta,
+              skipUpdatedAt: true,
+            });
+          } catch (err) {
+            logger.error(`[transcribe] failed to apply transcript to note ${note.id}:`, err);
+          }
         }
       }
     }
@@ -330,10 +440,12 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
       transcribe_status: "done",
       transcribe_attempts: attempts + 1,
       transcribe_done_at: new Date().toISOString(),
+      transcribe_duration_ms: durationMs,
       transcript,
     };
     delete doneMeta.transcribe_backoff_until;
     delete doneMeta.transcribe_error;
+    delete doneMeta.transcribe_error_code;
     await store.setAttachmentMetadata(attachment.id, doneMeta);
 
     // Retention: drop the file but keep the row so the transcript stays
@@ -458,6 +570,24 @@ export function registerTranscriptionHook(
   });
 }
 
+/**
+ * Call scribe's `POST /v1/audio/transcriptions` with the audio file + optional
+ * context part. Returns the transcript text plus the wall-clock duration of
+ * the request, so the worker can surface `transcript_duration_ms` on the
+ * transcript note.
+ *
+ * Failure modes (encoded as throws):
+ *   - 4xx with a JSON body carrying `error_code`: throws `ScribeApiError`
+ *     with the code (`missing_provider` etc.). Treated as a non-retriable
+ *     terminal failure — re-POSTing the same audio at the same broken scribe
+ *     would just fail the same way; the operator has to act.
+ *   - 4xx without `error_code` (auth, malformed multipart): throws
+ *     `ScribeApiError` with the body text. Non-retriable.
+ *   - 5xx, network error, or timeout: throws a plain `Error`. Retriable —
+ *     the worker's backoff path picks it up.
+ *   - 200 with missing/invalid `text` field: throws a plain `Error`.
+ *     Retriable (could be a transient provider-output glitch).
+ */
 async function callScribe(args: {
   url: string;
   token?: string;
@@ -467,9 +597,10 @@ async function callScribe(args: {
   context: ContextPayload | null;
   timeoutMs: number;
   fetchImpl: typeof fetch;
-}): Promise<string> {
+}): Promise<{ text: string; durationMs: number }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), args.timeoutMs);
+  const startedAt = Date.now();
   try {
     const fileBuffer = readFileSync(args.filePath);
     const file = new File([fileBuffer], args.filename, { type: args.mimeType });
@@ -488,14 +619,42 @@ async function callScribe(args: {
       signal: controller.signal,
     });
     if (!resp.ok) {
-      throw new Error(`scribe returned ${resp.status}: ${await resp.text().catch(() => "")}`);
+      const body = await resp.text().catch(() => "");
+      // Try to extract structured error_code from JSON body (scribe#47).
+      let errorCode: string | undefined;
+      let errorMessage: string | undefined;
+      try {
+        const parsed = JSON.parse(body) as { error?: string; error_code?: string; message?: string };
+        if (typeof parsed.error_code === "string") errorCode = parsed.error_code;
+        if (typeof parsed.error === "string") errorMessage = parsed.error;
+        else if (typeof parsed.message === "string") errorMessage = parsed.message;
+      } catch {
+        // Not JSON — leave errorCode undefined; the raw body becomes the message.
+      }
+      // 4xx is terminal (re-POSTing the same audio at the same broken scribe
+      // will just fail again). 5xx is retriable — provider hiccup, will likely
+      // succeed on backoff.
+      const retriable = resp.status >= 500;
+      const message = errorMessage
+        ?? (errorCode ? `scribe ${errorCode}` : `scribe returned ${resp.status}: ${body}`);
+      throw new ScribeApiError(message, {
+        errorCode,
+        httpStatus: resp.status,
+        retriable,
+      });
     }
     const result = await resp.json() as { text?: string };
     if (typeof result.text !== "string") {
       throw new Error("scribe response missing text field");
     }
-    return result.text;
+    return { text: result.text, durationMs: Date.now() - startedAt };
   } finally {
     clearTimeout(timer);
   }
 }
+
+/**
+ * Re-export the structured error type so tests + callers can `instanceof`-check
+ * for terminal-failure semantics.
+ */
+export { ScribeApiError };

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2543,6 +2543,182 @@ describe("HTTP /notes", async () => {
       expect(body.map((n) => n.content)).toEqual(["new"]);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // POST /notes/:id/retry-transcription — vault#353 design Q5.
+  //
+  // The endpoint re-enqueues a failed transcript by flipping the matching
+  // attachment back to `transcribe_status: pending`. The worker (or sweep)
+  // picks it up. These tests exercise the request shape + error branches;
+  // the actual re-transcription is covered in transcription-worker.test.ts's
+  // auto-origin section.
+  // -------------------------------------------------------------------------
+  describe("POST /notes/:id/retry-transcription", async () => {
+    async function seedFailedTranscript(opts: {
+      audioPath?: string;
+      noteId?: string;
+      transcriptId?: string;
+      omitAttachmentId?: boolean;
+    } = {}): Promise<{ owner: { id: string }; attachmentId: string; transcriptId: string; audioPath: string }> {
+      const audioPath = opts.audioPath ?? `${opts.noteId ?? "src"}/voice.webm`;
+      const ownerId = opts.noteId ?? "src-note";
+      const owner = await store.createNote("# Voice\n", { id: ownerId });
+      const att = await store.addAttachment(owner.id, audioPath, "audio/webm", {
+        transcribe_status: "failed",
+        transcribe_origin: "auto",
+        transcribe_error: "no transcription provider configured",
+      });
+      // Seed the failed transcript note exactly as the worker would have.
+      const transcriptMeta: Record<string, unknown> = {
+        transcript_of: audioPath,
+        transcript_status: "failed",
+        transcript_error: "missing_provider: no transcription provider configured",
+      };
+      if (!opts.omitAttachmentId) transcriptMeta.transcript_attachment_id = att.id;
+      await store.createNote("", {
+        id: opts.transcriptId ?? "transcript-1",
+        path: `${audioPath}.transcript`,
+        tags: ["transcript", "capture"],
+        metadata: transcriptMeta,
+      });
+      // Audio file present on disk so the retry doesn't 404 on audio_missing.
+      const assetsRoot = join(tmpDir, "assets");
+      mkdirSync(join(assetsRoot, audioPath.split("/").slice(0, -1).join("/")), { recursive: true });
+      writeFileSync(join(assetsRoot, audioPath), Buffer.from([1, 2, 3]));
+      process.env.ASSETS_DIR = assetsRoot;
+      return { owner: { id: ownerId }, attachmentId: att.id, transcriptId: opts.transcriptId ?? "transcript-1", audioPath };
+    }
+
+    test("happy path: flips attachment to pending and returns 202", async () => {
+      const { attachmentId, transcriptId } = await seedFailedTranscript();
+      const res = await handleNotes(
+        mkReq("POST", `/notes/${transcriptId}/retry-transcription`),
+        store,
+        `/${transcriptId}/retry-transcription`,
+        "default",
+      );
+      expect(res.status).toBe(202);
+      const body = await res.json() as any;
+      expect(body.status).toBe("queued");
+      expect(body.attachment_id).toBe(attachmentId);
+      expect(body.transcript_note_id).toBe(transcriptId);
+
+      // Attachment metadata reset.
+      const att = await store.getAttachment(attachmentId);
+      expect(att?.metadata?.transcribe_status).toBe("pending");
+      expect(att?.metadata?.transcribe_origin).toBe("auto");
+      // Stale failure state cleared.
+      expect(att?.metadata?.transcribe_error).toBeUndefined();
+      expect(att?.metadata?.transcribe_attempts).toBeUndefined();
+
+      delete process.env.ASSETS_DIR;
+    });
+
+    test("404 when transcript note doesn't exist", async () => {
+      const res = await handleNotes(
+        mkReq("POST", "/notes/no-such-id/retry-transcription"),
+        store,
+        "/no-such-id/retry-transcription",
+        "default",
+      );
+      expect(res.status).toBe(404);
+    });
+
+    test("400 invalid_target when target is not a transcript note", async () => {
+      await store.createNote("regular note", { id: "regular" });
+      const res = await handleNotes(
+        mkReq("POST", "/notes/regular/retry-transcription"),
+        store,
+        "/regular/retry-transcription",
+        "default",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.error).toBe("invalid_target");
+    });
+
+    test("400 not_failed when transcript already succeeded", async () => {
+      const audioPath = "memo/done.webm";
+      const owner = await store.createNote("voice", { id: "src-done" });
+      const att = await store.addAttachment(owner.id, audioPath, "audio/webm");
+      await store.createNote("the spoken words", {
+        id: "transcript-done",
+        path: `${audioPath}.transcript`,
+        metadata: {
+          transcript_of: audioPath,
+          transcript_attachment_id: att.id,
+          transcript_status: "complete",
+        },
+      });
+      const res = await handleNotes(
+        mkReq("POST", "/notes/transcript-done/retry-transcription"),
+        store,
+        "/transcript-done/retry-transcription",
+        "default",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.error).toBe("not_failed");
+      expect(body.transcript_status).toBe("complete");
+    });
+
+    test("400 missing_attachment_id when frontmatter lacks the id", async () => {
+      await seedFailedTranscript({
+        transcriptId: "transcript-no-id",
+        noteId: "src-no-id",
+        omitAttachmentId: true,
+      });
+      const res = await handleNotes(
+        mkReq("POST", "/notes/transcript-no-id/retry-transcription"),
+        store,
+        "/transcript-no-id/retry-transcription",
+        "default",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.error).toBe("missing_attachment_id");
+      delete process.env.ASSETS_DIR;
+    });
+
+    test("404 attachment_missing when the attachment row no longer exists", async () => {
+      const owner = await store.createNote("voice", { id: "src-stale" });
+      await store.createNote("", {
+        id: "transcript-stale",
+        path: "memo/stale.webm.transcript",
+        metadata: {
+          transcript_of: "memo/stale.webm",
+          transcript_attachment_id: "deleted-attachment-id",
+          transcript_status: "failed",
+          transcript_error: "missing_provider",
+        },
+      });
+      const res = await handleNotes(
+        mkReq("POST", "/notes/transcript-stale/retry-transcription"),
+        store,
+        "/transcript-stale/retry-transcription",
+        "default",
+      );
+      expect(res.status).toBe(404);
+      const body = await res.json() as any;
+      expect(body.error).toBe("attachment_missing");
+    });
+
+    test("405 on GET (must POST)", async () => {
+      await seedFailedTranscript({
+        transcriptId: "transcript-405",
+        noteId: "src-405",
+        audioPath: "memo/405.webm",
+      });
+      const res = await handleNotes(
+        mkReq("GET", "/notes/transcript-405/retry-transcription"),
+        store,
+        "/transcript-405/retry-transcription",
+        "default",
+      );
+      expect(res.status).toBe(405);
+      delete process.env.ASSETS_DIR;
+    });
+  });
 });
 
 describe("HTTP GET /notes?format=graph", async () => {


### PR DESCRIPTION
## Summary

Part 2 of the [vault↔scribe connection design](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-scribe-config-and-vault-scribe-connect.md) (site#52). Vault now auto-transcribes audio attachments through scribe and materializes the result as a sibling `<attachment-path>.transcript.md` note with frontmatter linking back to the source audio. Failures (no provider configured, scribe down, timeout) land as the same note with `transcript_status: failed`, preserving the original audio for retry.

- **Inline audio-detect on attachment write.** When `mimeType` starts with `audio/` AND `auto_transcribe.enabled === true` AND scribe is discoverable, the attachment is queued automatically — no caller flag needed. Explicit `transcribe: true` (Lens flow) still works unchanged.
- **Service discovery via `~/.parachute/services.json`.** Vault locates scribe by reading the canonical hub-maintained registry; the `SCRIBE_URL` env var still wins when set. Cached for process lifetime.
- **Bearer generation at first boot.** When neither `SCRIBE_AUTH_TOKEN` nor the legacy `SCRIBE_TOKEN` is set, vault generates a 32-byte base64url bearer and persists it to `~/.parachute/vault/.env`. Idempotent.
- **Transcript notes + retry endpoint.** `POST /vault/<name>/api/notes/<note-id>/retry-transcription` re-enqueues the original audio attachment in place, overwrites the failed transcript note with the new result.
- **Config schema additions.** `autoTranscribe.{enabled,scribeUrl,scribeBearer}` per design Q4. Legacy `scribe_url` / `scribe_token` kept as deprecated aliases for one release.

## What's deferred to v0.7

- Hub-issued JWT replaces the shared bearer (design Q2 — shared bearer is the v0.6 stepping stone).
- Live-tail of transcription progress (websocket / SSE from scribe).
- Auto-retry on transient 5xx with cap.

## Test plan

Server tests: **1088 → 1135** (47 new across `scribe-discovery.test.ts`, `auto-transcribe.test.ts`, `transcript-note.test.ts`, plus 8 new tests in `transcription-worker.test.ts` auto-origin block and 6 in `vault.test.ts` retry endpoint block). Core: **536 unchanged**.

- [x] `bun run typecheck` clean
- [x] `bun test ./src/` — 1135 pass, 0 fail
- [x] `bun test ./core/src/` — 536 pass, 0 fail
- [x] `bunx biome check src/ core/` clean

### Unit-tested

- Mime-type detection: `audio/wav` → triggers, `image/png` → doesn't, case-insensitive
- `enabled=false` no-op; `scribeUrl` unset no-op
- Successful transcription: transcript note created with correct frontmatter + body
- 4xx with `error_code: missing_provider`: transcript note with `failed` + error string; treated as terminal (no retry)
- 5xx / network error: transcript note NOT yet materialized (retry path with backoff)
- Audio file deleted: terminal failure transcript note materialized
- Retry endpoint: 6 branches (happy, 404 not-found, 400 invalid_target, 400 not_failed, 400 missing_attachment_id, 404 attachment_missing, 405 on GET)
- Bearer generation idempotence (canonical, legacy, whitespace-only)
- Concurrent uploads: 5 audio files → 5 transcript notes, no race / path collision
- Legacy `transcribe_stub` flow unchanged

### Live smoke

Not run in this session — needs Aaron to start scribe + vault with the auto-transcribe toggle on and upload an m4a. The pipeline is mock-tested end-to-end (`mkFetchMock` + structured 400 response object) but no real scribe binary exercised. Expected smoke: `POST /storage/upload` (audio file) → `POST /notes/<id>/attachments` (with `mimeType: audio/m4a`) → wait 1-5s → query `/notes?path=<audio-path>.transcript` → see the transcript note with `transcript_status: complete`.

## Notes for review

- The transcription worker already shipped with retry/backoff/context — the new code is additive (auto-origin branch, ScribeApiError, transcript-note module). The legacy Lens stub-patching path is preserved untouched.
- The retry endpoint uses `transcript_attachment_id` as the foreign key (stable, stamped at materialization time). Falls back to clear 400/404 errors if the frontmatter is corrupt or the attachment row was deleted.
- `auto_transcribe.enabled` persists in `~/.parachute/vault/config.yaml` under the new `auto_transcribe:` block. YAML parser handles missing block as `enabled: false` (default-off).
- Scribe response format pinned: `{ text: string }` on 200; structured `{ error_code: "missing_provider" }` on 400 per scribe#47. We surface `error_code` on the transcript note's `transcribe_error_code` attachment metadata for callers that branch on stable strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)