### PR TITLE
feat(vault): self-register manifest + installDir at startup (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,70 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.8-rc.3] - 2026-05-21
+
+feat(vault): self-register manifest + installDir at startup (#266).
+
+POC for retiring `parachute-hub`'s `FIRST_PARTY_FALLBACKS[vault]` vendored
+manifest. Hub currently ships a hard-coded `VAULT_FALLBACK` block in
+`service-spec.ts` because (a) bun-link dev mode never runs the hub install
+path so `installDir` isn't stamped on the services.json row, and (b) v0.5
+vault didn't ship its own `.parachute/module.json` so hub had no manifest
+to read at lifecycle time. The endgame — every first-party module
+self-registers its manifest + installDir on startup, hub's vendored
+fallbacks retire one by one — starts here.
+
+### What ships
+
+- **`src/module-manifest.ts`** — narrow reader for the package's own
+  `.parachute/module.json`. Resolves the package root via
+  `import.meta.url` (works for both `bun src/cli.ts` dev runs and the
+  published-package `parachute-vault` binary). Validates only the fields
+  vault stamps onto services.json today (name, manifestName, displayName,
+  tagline, kind, port, paths, health, stripPrefix); full validation is
+  hub's job at install time.
+- **`src/self-register.ts`** — boot-time self-registration. Reads the
+  local manifest + computes installDir (the directory containing
+  `package.json` + `.parachute/module.json`) and upserts a row into
+  `~/.parachute/services.json` carrying both. Idempotent: re-runs report
+  `changed: false` when nothing actually shifts. Routed through the
+  existing merge-preserving `upsertService` so hub-stamped fields on the
+  row (e.g. `installDir` from `parachute-hub#84`, anything future)
+  survive each self-registration pass.
+- **`src/server.ts` boot wires** `selfRegister({ version: pkg.version })`
+  right after the vault auto-creation block. Failure modes (manifest
+  missing, services.json unreadable, write failure) log a warning and
+  continue — boot must not fail on bookkeeping.
+- **CLI registration paths converge** — `cmdInit` and `cmdCreate`
+  previously called `upsertService` directly with a hand-built entry that
+  omitted displayName/tagline/stripPrefix/installDir. Both now route
+  through `selfRegister` so the row from `parachute-vault init` matches
+  the row from server boot. Drops two `upsertService` call sites and the
+  duplicated `buildVaultServicePaths` (the helper moves into
+  `self-register.ts` as the canonical implementation).
+
+### Design choice — filesystem-direct rather than HTTP
+
+In v0.6 (single-container, hub-as-supervisor) hub and vault share the
+same filesystem; writing directly to `services.json` with the existing
+merge-preserving `upsertService` is the simplest shape that works today
+without growing a hub-side endpoint. v0.7 (multi-container cloud) will
+need a hub `POST /api/modules/self-register` so a module on a different
+container can register without filesystem access to the operator's
+`~/.parachute/`. That endpoint is filed as a separate hub follow-up;
+this PR's `selfRegister` function is forward-compatible — it's the
+single seam that would swap from filesystem to HTTP transport.
+
+### Forward-compatibility with hub's vendored fallback
+
+`FIRST_PARTY_FALLBACKS[vault]` in hub remains in place until every
+first-party module ships self-registration reliably (notes, scribe,
+runner have their own follow-up issues). The fallback is additive today:
+hub reads vault's `installDir` from the self-registered row when
+present, and falls back to the vendored manifest only when the row is
+missing — which is exactly the state a fresh `bun add @openparachute/vault`
+produces before vault has booted once.
+
 ## [0.4.8-rc.2] - 2026-05-21
 
 feat(vault): query-notes opaque cursor for since-last-checked agent loops (#313).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.8-rc.2",
+  "version": "0.4.8-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,7 @@ import type { TokenPermission } from "./token-store.ts";
 import { resolveCreateTokenFlags, VAULT_SCOPES } from "./scopes.ts";
 import { validateVaultName, decideInitVaultName } from "./vault-name.ts";
 import { getVaultStore } from "./vault-store.ts";
-import { upsertService, ServicesManifestError } from "./services-manifest.ts";
+import { selfRegister } from "./self-register.ts";
 import {
   hasOwnerPassword,
   setOwnerPassword,
@@ -245,27 +245,6 @@ switch (command) {
 // Command implementations
 // ---------------------------------------------------------------------------
 
-/**
- * Compute the `paths` array for the parachute-vault entry in services.json.
- * One entry advertises every vault on this server; `paths[0]` is the
- * canonical mount the hub stamps into `.well-known/parachute.json`, so the
- * default vault sorts first when one is set. With no vaults yet, fall back
- * to "/" so an early-init registration is still well-formed.
- */
-function buildVaultServicePaths(
-  defaultVault: string | undefined,
-  vaults: string[],
-): string[] {
-  if (vaults.length === 0) return ["/"];
-  if (defaultVault && vaults.includes(defaultVault)) {
-    return [
-      `/vault/${defaultVault}`,
-      ...vaults.filter((v) => v !== defaultVault).map((v) => `/vault/${v}`),
-    ];
-  }
-  return vaults.map((v) => `/vault/${v}`);
-}
-
 async function cmdInit(args: string[] = []) {
   ensureConfigDirSync();
 
@@ -363,24 +342,24 @@ async function cmdInit(args: string[] = []) {
   // by name, preserving entries for other services. Non-fatal on failure —
   // init can complete without the manifest, just with a warning.
   //
+  // `selfRegister` stamps the full manifest-sourced row (displayName, tagline,
+  // stripPrefix, installDir) from `.parachute/module.json` — the same shape
+  // server boot writes via the self-registration pass (vault#266). Keeping
+  // the two write paths in lockstep means `parachute-vault init` and the
+  // first server boot agree on the row contents; without that, a re-init
+  // would silently lose the manifest fields the boot pass had added.
+  //
   // `paths[0]` is the canonical mount point — the hub uses it for the
   // `.well-known/parachute.json` URL and for `parachute expose`, so the
   // default vault always sorts first. Remaining vaults follow so the hub
   // well-known and paraclaw's attach picker see every vault on this server.
   // Re-running init re-registers the full set; that doubles as the
   // recovery path for installs whose services.json is stale (#208).
-  try {
-    upsertService({
-      name: "parachute-vault",
-      port: globalConfig.port || DEFAULT_PORT,
-      paths: buildVaultServicePaths(globalConfig.default_vault, allVaults),
-      health: "/health",
-      version: pkg.version,
-    });
-  } catch (err) {
-    const msg = err instanceof ServicesManifestError ? err.message : String(err);
-    console.error(`  Warning: could not update ~/.parachute/services.json: ${msg}`);
-  }
+  selfRegister({
+    version: pkg.version,
+    warn: (msg) => console.error(`  Warning: ${msg}`),
+    log: () => {}, // CLI init has its own status lines; suppress duplicate noise.
+  });
 
   // 2b. Migrate existing legacy keys into per-vault token tables
   for (const v of listVaults()) {
@@ -862,19 +841,16 @@ function cmdCreate(args: string[]) {
   // attach picker see this vault. cmdInit registers on first run; cmdCreate
   // adds the new path on every subsequent vault. Without this, vaults
   // created after init were invisible to the hub (#208).
-  // Warnings go to stderr to keep --json stdout clean for the orchestrator.
-  try {
-    upsertService({
-      name: "parachute-vault",
-      port: globalConfig.port || DEFAULT_PORT,
-      paths: buildVaultServicePaths(globalConfig.default_vault, listVaults()),
-      health: "/health",
-      version: pkg.version,
-    });
-  } catch (err) {
-    const msg = err instanceof ServicesManifestError ? err.message : String(err);
-    console.error(`Warning: could not update ~/.parachute/services.json: ${msg}`);
-  }
+  //
+  // Routed through `selfRegister` (vault#266) so the row carries the full
+  // manifest-sourced metadata (displayName, tagline, stripPrefix, installDir)
+  // — same shape server boot writes. Warnings go to stderr to keep --json
+  // stdout clean for the orchestrator.
+  selfRegister({
+    version: pkg.version,
+    warn: (msg) => console.error(`Warning: ${msg}`),
+    log: () => {}, // CLI create has its own status lines.
+  });
 
   if (jsonMode) {
     const payload = {

--- a/src/module-manifest.test.ts
+++ b/src/module-manifest.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readSelfManifest, resolvePackageRoot } from "./module-manifest.ts";
+
+function withTempPackageRoot(
+  manifest: unknown | undefined,
+  fn: (root: string) => void,
+): void {
+  const root = mkdtempSync(join(tmpdir(), "pvault-manifest-"));
+  try {
+    if (manifest !== undefined) {
+      mkdirSync(join(root, ".parachute"), { recursive: true });
+      writeFileSync(
+        join(root, ".parachute", "module.json"),
+        typeof manifest === "string" ? manifest : JSON.stringify(manifest),
+      );
+    }
+    fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("module-manifest", () => {
+  test("resolvePackageRoot returns the directory containing package.json", () => {
+    // In the test env, this module lives at <repo>/src/module-manifest.test.ts —
+    // so the resolved root is the repo root. We don't pin the exact path
+    // (tests run from various cwds); we just sanity-check it's an absolute
+    // directory ending in the vault repo's name.
+    const root = resolvePackageRoot();
+    expect(root.startsWith("/")).toBe(true);
+    expect(root.endsWith("/src")).toBe(false);
+  });
+
+  test("readSelfManifest returns null when .parachute/module.json is missing", () => {
+    withTempPackageRoot(undefined, (root) => {
+      expect(readSelfManifest(root)).toBeNull();
+    });
+  });
+
+  test("readSelfManifest parses a valid manifest", () => {
+    withTempPackageRoot(
+      {
+        name: "vault",
+        manifestName: "parachute-vault",
+        displayName: "Vault",
+        tagline: "Test tagline",
+        kind: "api",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+      },
+      (root) => {
+        const m = readSelfManifest(root);
+        expect(m).not.toBeNull();
+        expect(m?.name).toBe("vault");
+        expect(m?.manifestName).toBe("parachute-vault");
+        expect(m?.displayName).toBe("Vault");
+        expect(m?.kind).toBe("api");
+        expect(m?.port).toBe(1940);
+        expect(m?.paths).toEqual(["/vault/default"]);
+      },
+    );
+  });
+
+  test("readSelfManifest throws on malformed JSON", () => {
+    withTempPackageRoot("{ not valid json", (root) => {
+      expect(() => readSelfManifest(root)).toThrow();
+    });
+  });
+
+  test("readSelfManifest throws when required field missing", () => {
+    withTempPackageRoot(
+      { name: "vault" /* missing manifestName / port / paths / health / kind */ },
+      (root) => {
+        expect(() => readSelfManifest(root)).toThrow(/missing required/);
+      },
+    );
+  });
+
+  test("readSelfManifest reads the actual shipped manifest in the repo", () => {
+    // Smoke test the real shipped file — guards against ever shipping a
+    // malformed manifest. Uses the real resolvePackageRoot (which finds
+    // the repo root in tests).
+    const m = readSelfManifest();
+    expect(m).not.toBeNull();
+    expect(m?.manifestName).toBe("parachute-vault");
+    expect(m?.kind).toBe("api");
+    expect(m?.port).toBe(1940);
+  });
+});

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -1,0 +1,94 @@
+/**
+ * Reader for the package's own `.parachute/module.json`.
+ *
+ * Vault ships `module.json` alongside `package.json` at the package root.
+ * This module locates the file via `import.meta.url` (which works for both
+ * `bun src/cli.ts …` dev runs and the published-package `parachute-vault`
+ * binary — the file ships in `package.json` `files` next to `src/`).
+ *
+ * Used by `self-register.ts` on server boot: vault reads its own manifest
+ * + computes the package's `installDir` so the services.json row carries
+ * the same metadata that hub's `FIRST_PARTY_FALLBACKS[vault]` provides
+ * today. The endgame is that hub's vendored fallback retires once every
+ * first-party module self-registers reliably — this is the POC for the
+ * pattern.
+ *
+ * Shape mirrors `parachute-hub/src/module-manifest.ts`. Kept narrow: we
+ * only consume the fields vault stamps onto services.json
+ * (displayName, tagline, stripPrefix). The full manifest validator lives
+ * on the hub side; vault treats its own manifest as authored-by-us +
+ * trusts the shape.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type ModuleKind = "api" | "frontend" | "tool";
+
+/**
+ * Subset of the full manifest schema (see `parachute-hub/src/module-manifest.ts`)
+ * — only the fields vault's self-registration consumes today. Adding more is
+ * a one-line edit when the surface widens.
+ */
+export interface VaultModuleManifest {
+  readonly name: string;
+  readonly manifestName: string;
+  readonly displayName?: string;
+  readonly tagline?: string;
+  readonly kind: ModuleKind;
+  readonly port: number;
+  readonly paths: readonly string[];
+  readonly health: string;
+  readonly stripPrefix?: boolean;
+}
+
+/**
+ * Resolve the path to the package root — the directory containing both
+ * `package.json` and `.parachute/module.json`. Walks up from
+ * `import.meta.url` so the answer is correct under both:
+ *
+ *   - dev:  `bun src/cli.ts serve` → `src/module-manifest.ts` → parent = repo root
+ *   - prod: published package → `src/module-manifest.ts` → parent = installed
+ *           package dir (e.g. `~/.bun/install/global/node_modules/@openparachute/vault`)
+ *
+ * Exported for tests + the self-register flow that needs to stamp this as
+ * `installDir` on the services.json row.
+ */
+export function resolvePackageRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // `src/module-manifest.ts` lives one level under the package root.
+  return resolve(here, "..");
+}
+
+/**
+ * Read `<packageRoot>/.parachute/module.json` if present. Returns null when
+ * the file is missing (e.g. during local dev before the file was committed)
+ * — callers treat that as "self-registration unavailable, log + continue."
+ *
+ * Throws on malformed JSON: a corrupt manifest is a deploy bug we want to
+ * surface, not silently swallow. The self-register caller catches + logs
+ * so a bad manifest doesn't crash server boot.
+ */
+export function readSelfManifest(
+  packageRoot: string = resolvePackageRoot(),
+): VaultModuleManifest | null {
+  const path = join(packageRoot, ".parachute", "module.json");
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  // Minimal shape validation. Only the fields we actually consume — anything
+  // else passes through untouched. Strict full-shape validation is the hub's
+  // job (it'll fail an install on a malformed manifest); vault treats its
+  // own shipped file as authored-by-us.
+  if (typeof parsed.name !== "string" || typeof parsed.manifestName !== "string") {
+    throw new Error(`${path}: manifest missing required "name" / "manifestName"`);
+  }
+  if (typeof parsed.port !== "number" || !Array.isArray(parsed.paths)) {
+    throw new Error(`${path}: manifest missing required "port" / "paths"`);
+  }
+  if (typeof parsed.health !== "string" || typeof parsed.kind !== "string") {
+    throw new Error(`${path}: manifest missing required "health" / "kind"`);
+  }
+  return parsed as unknown as VaultModuleManifest;
+}

--- a/src/self-register.test.ts
+++ b/src/self-register.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildVaultServicePaths, selfRegister } from "./self-register.ts";
+import type { VaultModuleManifest } from "./module-manifest.ts";
+
+/**
+ * Spin up a fresh PARACHUTE_HOME tmpdir + restore the prior env on teardown.
+ * The self-register pass writes through to `~/.parachute/services.json` via
+ * the per-call path resolution in services-manifest.ts (which honors
+ * PARACHUTE_HOME), so this is the canonical isolation seam.
+ */
+function withParachuteHome(fn: (home: string) => void): void {
+  const home = mkdtempSync(join(tmpdir(), "pvault-self-register-"));
+  const prior = process.env.PARACHUTE_HOME;
+  process.env.PARACHUTE_HOME = home;
+  // Also override HOME so readGlobalConfig + listVaults don't fall through
+  // to the operator's real ~/.parachute.
+  const priorHome = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    // Seed the config dir with an empty config.yaml so readGlobalConfig
+    // returns a clean state.
+    mkdirSync(join(home, "vault"), { recursive: true });
+    writeFileSync(join(home, "vault", "config.yaml"), "port: 1940\n");
+    fn(home);
+  } finally {
+    if (prior === undefined) delete process.env.PARACHUTE_HOME;
+    else process.env.PARACHUTE_HOME = prior;
+    if (priorHome === undefined) delete process.env.HOME;
+    else process.env.HOME = priorHome;
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+const TEST_MANIFEST: VaultModuleManifest = {
+  name: "vault",
+  manifestName: "parachute-vault",
+  displayName: "Vault",
+  tagline: "Test tagline",
+  kind: "api",
+  port: 1940,
+  paths: ["/vault/default"],
+  health: "/vault/default/health",
+};
+
+function captureLogs(): {
+  log: (m: string) => void;
+  warn: (m: string) => void;
+  logs: string[];
+  warnings: string[];
+} {
+  const logs: string[] = [];
+  const warnings: string[] = [];
+  return {
+    log: (m: string) => logs.push(m),
+    warn: (m: string) => warnings.push(m),
+    logs,
+    warnings,
+  };
+}
+
+describe("self-register", () => {
+  test("buildVaultServicePaths — no vaults yet → manifest fallback", () => {
+    expect(buildVaultServicePaths(undefined, [], ["/vault/default"])).toEqual([
+      "/vault/default",
+    ]);
+  });
+
+  test("buildVaultServicePaths — default vault sorts first", () => {
+    expect(
+      buildVaultServicePaths("default", ["alpha", "default", "beta"], ["/"]),
+    ).toEqual(["/vault/default", "/vault/alpha", "/vault/beta"]);
+  });
+
+  test("buildVaultServicePaths — no default → map by listed order", () => {
+    expect(buildVaultServicePaths(undefined, ["alpha", "beta"], ["/"])).toEqual([
+      "/vault/alpha",
+      "/vault/beta",
+    ]);
+  });
+
+  test("buildVaultServicePaths — default points to missing vault → ignore default", () => {
+    expect(
+      buildVaultServicePaths("missing", ["alpha", "beta"], ["/"]),
+    ).toEqual(["/vault/alpha", "/vault/beta"]);
+  });
+
+  test("writes services.json with manifest-sourced fields + installDir", () => {
+    withParachuteHome((home) => {
+      const { log, warn, logs, warnings } = captureLogs();
+      const result = selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+      });
+      expect(result.status).toBe("registered");
+      expect(warnings).toEqual([]);
+      expect(logs[0]).toContain("registered parachute-vault");
+
+      const raw = readFileSync(join(home, "services.json"), "utf8");
+      const parsed = JSON.parse(raw) as { services: unknown[] };
+      expect(parsed.services).toHaveLength(1);
+      const row = parsed.services[0] as Record<string, unknown>;
+      expect(row.name).toBe("parachute-vault");
+      expect(row.port).toBe(1940);
+      expect(row.paths).toEqual(["/vault/default"]);
+      expect(row.health).toBe("/vault/default/health");
+      expect(row.version).toBe("0.4.8-rc.3");
+      expect(row.installDir).toBe("/fake/install/dir");
+      expect(row.displayName).toBe("Vault");
+      expect(row.tagline).toBe("Test tagline");
+    });
+  });
+
+  test("idempotent — re-running reports no changes", () => {
+    withParachuteHome(() => {
+      const { log, warn } = captureLogs();
+      const deps = {
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+      };
+      const first = selfRegister(deps);
+      expect(first.status).toBe("registered");
+      if (first.status === "registered") expect(first.changed).toBe(true);
+
+      const second = selfRegister(deps);
+      expect(second.status).toBe("registered");
+      if (second.status === "registered") expect(second.changed).toBe(false);
+    });
+  });
+
+  test("preserves hub-stamped fields on the row", () => {
+    withParachuteHome((home) => {
+      // Pre-existing row carries a hub-stamped field we don't write.
+      const servicesPath = join(home, "services.json");
+      writeFileSync(
+        servicesPath,
+        `${JSON.stringify(
+          {
+            services: [
+              {
+                name: "parachute-vault",
+                port: 1940,
+                paths: ["/vault/default"],
+                health: "/vault/default/health",
+                version: "0.4.7",
+                // Pretend hub stamped some custom field — should survive.
+                hubCustomField: "preserved",
+                installDir: "/some/prior/path",
+              },
+            ],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const { log, warn } = captureLogs();
+      const result = selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        resolvePackageRoot: () => "/new/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+      });
+      expect(result.status).toBe("registered");
+
+      const raw = readFileSync(servicesPath, "utf8");
+      const parsed = JSON.parse(raw) as { services: Record<string, unknown>[] };
+      const row = parsed.services[0]!;
+      // Vault-owned fields win.
+      expect(row.version).toBe("0.4.8-rc.3");
+      expect(row.installDir).toBe("/new/install/dir");
+      // Hub-stamped foreign field survives.
+      expect(row.hubCustomField).toBe("preserved");
+    });
+  });
+
+  test("preserves entries written by other modules", () => {
+    withParachuteHome((home) => {
+      const servicesPath = join(home, "services.json");
+      writeFileSync(
+        servicesPath,
+        `${JSON.stringify(
+          {
+            services: [
+              {
+                name: "parachute-scribe",
+                port: 1943,
+                paths: ["/scribe"],
+                health: "/scribe/health",
+                version: "0.3.0",
+              },
+            ],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const { log, warn } = captureLogs();
+      selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+      });
+
+      const raw = readFileSync(servicesPath, "utf8");
+      const parsed = JSON.parse(raw) as { services: { name: string }[] };
+      expect(parsed.services).toHaveLength(2);
+      expect(parsed.services.find((s) => s.name === "parachute-scribe")).toBeDefined();
+      expect(parsed.services.find((s) => s.name === "parachute-vault")).toBeDefined();
+    });
+  });
+
+  test("skipped when manifest absent — never throws", () => {
+    withParachuteHome(() => {
+      const { log, warn, warnings } = captureLogs();
+      const result = selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => null,
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+      });
+      expect(result.status).toBe("skipped");
+      if (result.status === "skipped") expect(result.reason).toMatch(/manifest absent/);
+      expect(warnings).toEqual([]); // skipped is informational, not a warning
+    });
+  });
+
+  test("failed when manifest read throws — does not propagate", () => {
+    withParachuteHome(() => {
+      const { log, warn, warnings } = captureLogs();
+      const result = selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => {
+          throw new Error("corrupt JSON");
+        },
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+      });
+      expect(result.status).toBe("failed");
+      if (result.status === "failed") expect(result.reason).toContain("corrupt JSON");
+      expect(warnings.some((w) => w.includes("could not read"))).toBe(true);
+    });
+  });
+
+  test("failed when upsert throws — does not propagate", () => {
+    withParachuteHome(() => {
+      const { log, warn, warnings } = captureLogs();
+      const result = selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+        upsertService: () => {
+          throw new Error("disk full");
+        },
+      });
+      expect(result.status).toBe("failed");
+      if (result.status === "failed") expect(result.reason).toContain("disk full");
+      expect(warnings.some((w) => w.includes("services.json write failed"))).toBe(true);
+    });
+  });
+
+  test("multi-vault: default vault sorts first in paths", () => {
+    withParachuteHome((home) => {
+      const { log, warn } = captureLogs();
+      selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => ["alpha", "default", "beta"],
+        readGlobalConfig: () => ({ port: 1940, default_vault: "default" }),
+      });
+
+      const raw = readFileSync(join(home, "services.json"), "utf8");
+      const parsed = JSON.parse(raw) as { services: Record<string, unknown>[] };
+      expect(parsed.services[0]!.paths).toEqual([
+        "/vault/default",
+        "/vault/alpha",
+        "/vault/beta",
+      ]);
+    });
+  });
+
+  test("uses globalConfig.port over DEFAULT_PORT when set", () => {
+    withParachuteHome((home) => {
+      const { log, warn } = captureLogs();
+      selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 19999 }),
+      });
+
+      const raw = readFileSync(join(home, "services.json"), "utf8");
+      const parsed = JSON.parse(raw) as { services: Record<string, unknown>[] };
+      expect(parsed.services[0]!.port).toBe(19999);
+    });
+  });
+
+  test("stripPrefix flows from manifest to row when set", () => {
+    withParachuteHome((home) => {
+      const { log, warn } = captureLogs();
+      selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => ({ ...TEST_MANIFEST, stripPrefix: true }),
+        resolvePackageRoot: () => "/fake/install/dir",
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+      });
+
+      const raw = readFileSync(join(home, "services.json"), "utf8");
+      const parsed = JSON.parse(raw) as { services: Record<string, unknown>[] };
+      expect(parsed.services[0]!.stripPrefix).toBe(true);
+    });
+  });
+
+  test("changed=true when installDir differs from prior row", () => {
+    withParachuteHome(() => {
+      const { log, warn } = captureLogs();
+      const baseDeps = {
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        listVaults: () => [],
+        readGlobalConfig: () => ({ port: 1940 }),
+      };
+      const first = selfRegister({
+        ...baseDeps,
+        resolvePackageRoot: () => "/old/install/dir",
+      });
+      expect(first.status).toBe("registered");
+      if (first.status === "registered") expect(first.changed).toBe(true);
+
+      // Second call with a different installDir — should re-stamp.
+      const second = selfRegister({
+        ...baseDeps,
+        resolvePackageRoot: () => "/new/install/dir",
+      });
+      expect(second.status).toBe("registered");
+      if (second.status === "registered") expect(second.changed).toBe(true);
+    });
+  });
+});

--- a/src/self-register.ts
+++ b/src/self-register.ts
@@ -1,0 +1,234 @@
+/**
+ * Boot-time self-registration of vault's manifest + `installDir` into
+ * `~/.parachute/services.json` — the POC for retiring hub's
+ * `FIRST_PARTY_FALLBACKS[vault]` (vault#266).
+ *
+ * Background: hub today vendors a `VAULT_FALLBACK` manifest in
+ * `parachute-hub/src/service-spec.ts` and stamps `installDir` onto the
+ * services.json row via `stampInstallDirOnRow` during `parachute install
+ * vault` / API install. That fallback exists because (a) bun-link dev
+ * mode never runs the hub install path so installDir isn't stamped,
+ * and (b) v0.5 vault didn't ship its own `.parachute/module.json` so
+ * hub had no manifest to read at lifecycle time.
+ *
+ * The endgame: every first-party module self-registers its manifest +
+ * installDir on startup so hub's vendored fallbacks retire one by one.
+ * This module is vault's piece of that pattern. Once vault/notes/scribe/
+ * runner all self-register reliably, a hub follow-up deletes
+ * `FIRST_PARTY_FALLBACKS` (see `parachute-hub` for the cleanup PR).
+ *
+ * Design choice — filesystem-direct rather than HTTP:
+ *
+ *   In v0.6 (single-container, hub-as-supervisor — see workspace
+ *   CLAUDE.md), hub and vault share the same filesystem. Writing directly
+ *   to services.json with the existing merge-preserving `upsertService`
+ *   is the simplest shape that works today. The hub-stamped fields the
+ *   row already carries (`installDir`, anything else hub adds in the
+ *   future) ride through because `upsertService` merges rather than
+ *   replaces (see `services-manifest.ts`).
+ *
+ *   v0.7 (multi-container cloud) will need an HTTP `POST
+ *   /api/modules/self-register` on hub so a module on a different
+ *   container can register without filesystem access to the operator's
+ *   `~/.parachute/`. Filed as a separate hub follow-up; this module's
+ *   shape is forward-compatible — `selfRegister` is the single seam that
+ *   would swap from filesystem to HTTP transport.
+ *
+ * Failure mode: every error path logs + returns (never throws). A bad
+ * registration must not crash server boot — the running vault is more
+ * valuable than the discoverability bookkeeping. Symptom of failure is
+ * "vault doesn't appear on hub discovery / admin SPA"; the fix is to
+ * restart vault or run `parachute install vault` to stamp the row via
+ * the hub-side path.
+ */
+
+import { readSelfManifest, resolvePackageRoot, type VaultModuleManifest } from "./module-manifest.ts";
+import {
+  ServicesManifestError,
+  type ServiceEntry,
+  readManifest,
+  upsertService,
+} from "./services-manifest.ts";
+import { listVaults, readGlobalConfig, DEFAULT_PORT } from "./config.ts";
+
+/**
+ * Compute the `paths` array for the parachute-vault services.json entry.
+ *
+ * Mirrors `buildVaultServicePaths` in `cli.ts` so the self-register pass
+ * produces the same multi-vault path advertisement as `parachute-vault
+ * init` / `vault create`. With no vaults yet, falls back to the manifest's
+ * canonical `paths[0]` so early-boot registration is still well-formed.
+ *
+ * Exported for tests; not part of the public module surface.
+ */
+export function buildVaultServicePaths(
+  defaultVault: string | undefined,
+  vaults: readonly string[],
+  fallbackFromManifest: readonly string[],
+): string[] {
+  if (vaults.length === 0) return [...fallbackFromManifest];
+  if (defaultVault && vaults.includes(defaultVault)) {
+    return [
+      `/vault/${defaultVault}`,
+      ...vaults.filter((v) => v !== defaultVault).map((v) => `/vault/${v}`),
+    ];
+  }
+  return vaults.map((v) => `/vault/${v}`);
+}
+
+export interface SelfRegisterDeps {
+  /** Override the manifest reader (tests inject a stub manifest). */
+  readManifest?: () => VaultModuleManifest | null;
+  /** Override the package-root resolver (tests inject a tmp dir). */
+  resolvePackageRoot?: () => string;
+  /** Override the services.json reader (tests inject a tmp-file reader). */
+  readServicesManifest?: typeof readManifest;
+  /** Override the services.json upsert (tests inject a tmp-file writer). */
+  upsertService?: typeof upsertService;
+  /** Override the vault lister (tests pass a fixed list). */
+  listVaults?: typeof listVaults;
+  /** Override the global config reader (tests pass a synthetic config). */
+  readGlobalConfig?: typeof readGlobalConfig;
+  /** Sink for status + warning lines. Production passes a console wrapper. */
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+  /** Vault's runtime version (from `package.json`). Required — no default. */
+  version: string;
+}
+
+/** Result of a `selfRegister` call, surfaced to callers for observability. */
+export type SelfRegisterResult =
+  | { status: "registered"; installDir: string; changed: boolean }
+  | { status: "skipped"; reason: string }
+  | { status: "failed"; reason: string };
+
+/**
+ * Self-register vault's manifest + installDir into `~/.parachute/services.json`.
+ *
+ * Idempotent: re-runs with the same manifest + installDir produce the same
+ * row (the `changed` field on the result telegraphs whether the write
+ * actually mutated the file).
+ *
+ * Never throws. Errors (missing manifest, services.json unreadable,
+ * filesystem write failure) are logged via `warn` and surfaced as a
+ * `failed` / `skipped` result. The caller (server boot) treats failure
+ * as non-fatal — vault keeps serving without the row stamp.
+ */
+export function selfRegister(deps: SelfRegisterDeps): SelfRegisterResult {
+  const log = deps.log ?? ((m) => console.log(m));
+  const warn = deps.warn ?? ((m) => console.warn(m));
+  const readManifestImpl = deps.readManifest ?? readSelfManifest;
+  const resolveRootImpl = deps.resolvePackageRoot ?? resolvePackageRoot;
+  const upsertImpl = deps.upsertService ?? upsertService;
+  const listVaultsImpl = deps.listVaults ?? listVaults;
+  const readGlobalConfigImpl = deps.readGlobalConfig ?? readGlobalConfig;
+
+  let manifest: VaultModuleManifest | null;
+  try {
+    manifest = readManifestImpl();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    warn(`[self-register] could not read .parachute/module.json: ${msg}`);
+    return { status: "failed", reason: msg };
+  }
+  if (!manifest) {
+    log("[self-register] no .parachute/module.json found — skipping (legacy install or dev tree)");
+    return { status: "skipped", reason: "manifest absent" };
+  }
+
+  // `installDir` is the directory containing both `package.json` and
+  // `.parachute/module.json`. Hub's resolver (`<installDir>/.parachute/module.json`)
+  // expects exactly this shape — see `parachute-hub/src/post-install.ts`'s
+  // `stampInstallDirOnRow`.
+  let installDir: string;
+  try {
+    installDir = resolveRootImpl();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    warn(`[self-register] could not resolve package root: ${msg}`);
+    return { status: "failed", reason: msg };
+  }
+
+  let globalConfig: ReturnType<typeof readGlobalConfig>;
+  let vaults: string[];
+  try {
+    globalConfig = readGlobalConfigImpl();
+    vaults = listVaultsImpl();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    warn(`[self-register] could not read vault config: ${msg}`);
+    return { status: "failed", reason: msg };
+  }
+
+  const paths = buildVaultServicePaths(globalConfig.default_vault, vaults, manifest.paths);
+  const port = globalConfig.port ?? DEFAULT_PORT;
+
+  // Build the entry with manifest-sourced metadata (displayName, tagline,
+  // stripPrefix) layered on top of the operationally-determined fields
+  // (port from config, paths from current vault list, version from
+  // package.json). hub-stamped fields on the existing row (installDir
+  // from prior CLI install path, anything future) survive via
+  // `upsertService`'s merge semantics — see services-manifest.ts.
+  const entry: ServiceEntry & {
+    installDir: string;
+    displayName?: string;
+    tagline?: string;
+    stripPrefix?: boolean;
+  } = {
+    name: manifest.manifestName,
+    port,
+    paths,
+    health: manifest.health,
+    version: deps.version,
+    installDir,
+  };
+  if (manifest.displayName !== undefined) entry.displayName = manifest.displayName;
+  if (manifest.tagline !== undefined) entry.tagline = manifest.tagline;
+  if (manifest.stripPrefix !== undefined) entry.stripPrefix = manifest.stripPrefix;
+
+  // Detect whether the existing row already matches (no-op idempotency
+  // signal). We don't gate the write on this — `upsertService` itself is
+  // already idempotent at the byte level — but reporting `changed: false`
+  // lets the boot log say "already registered" instead of restamping noise.
+  let priorRow: (ServiceEntry & { installDir?: string }) | undefined;
+  try {
+    const current = (deps.readServicesManifest ?? readManifest)();
+    priorRow = current.services.find((s) => s.name === manifest.manifestName) as
+      | (ServiceEntry & { installDir?: string })
+      | undefined;
+  } catch (err) {
+    // Read failure here is non-fatal — we'll still attempt the write below.
+    // services.json may not exist yet (fresh boot); upsertService creates it.
+    if (err instanceof ServicesManifestError) {
+      warn(`[self-register] services.json read warning: ${err.message}`);
+    } else {
+      warn(`[self-register] services.json read warning: ${String(err)}`);
+    }
+  }
+
+  const changed =
+    !priorRow ||
+    priorRow.installDir !== installDir ||
+    priorRow.version !== deps.version ||
+    priorRow.port !== port ||
+    JSON.stringify(priorRow.paths) !== JSON.stringify(paths) ||
+    priorRow.health !== manifest.health ||
+    (priorRow as { displayName?: string }).displayName !== manifest.displayName ||
+    (priorRow as { tagline?: string }).tagline !== manifest.tagline ||
+    (priorRow as { stripPrefix?: boolean }).stripPrefix !== manifest.stripPrefix;
+
+  try {
+    upsertImpl(entry);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    warn(`[self-register] services.json write failed: ${msg}`);
+    return { status: "failed", reason: msg };
+  }
+
+  if (changed) {
+    log(`[self-register] registered ${manifest.manifestName} (installDir=${installDir})`);
+  } else {
+    log(`[self-register] already registered ${manifest.manifestName} (no changes)`);
+  }
+  return { status: "registered", installDir, changed };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,8 @@ import { resolveBindHostname } from "./bind.ts";
 import { MirrorManager } from "./mirror-manager.ts";
 import { setMirrorManager } from "./mirror-registry.ts";
 import { buildMirrorDeps, resolveMirrorVaultName } from "./mirror-deps.ts";
+import { selfRegister } from "./self-register.ts";
+import pkg from "../package.json" with { type: "json" };
 
 // Register webhook triggers from global config. Replaces the old hardcoded
 // tts-hook and transcription-hook with config-driven webhooks.
@@ -175,6 +177,14 @@ if (listVaults().length === 0) {
     console.log(`Auto-created vault "${vaultName}" (API key: ${fullKey})`);
   }
 }
+
+// vault#266 — self-register manifest + installDir into services.json so
+// hub's discovery / admin SPA can find vault without a `parachute install
+// vault` round-trip. Idempotent (re-runs produce the same row when nothing
+// changed); never throws (boot must not fail on bookkeeping). The merge-
+// preserving `upsertService` ensures any hub-stamped fields on the row
+// survive — see self-register.ts header for the v0.6 vs v0.7 design note.
+selfRegister({ version: pkg.version });
 
 // Migrate tag schemas from vault.yaml → DB for each vault.
 // Only inserts schemas that don't already exist in the DB (safe across restarts).


### PR DESCRIPTION
Closes #266 — POC for retiring hub's `FIRST_PARTY_FALLBACKS[vault]`.

## Why

Hub today vendors a hard-coded `VAULT_FALLBACK` block in
`parachute-hub/src/service-spec.ts` because:

1. **bun-link dev mode** never runs the `parachute install vault` path, so the services.json row never gets the `installDir` stamp (a prerequisite for hub's `loadServiceUiMetadata` resolver to find vault's `.parachute/module.json` at lifecycle time).
2. **v0.5 vault** didn't ship its own `.parachute/module.json` so hub had no manifest to read even if installDir was known.

The endgame from the workspace's module-protocol pattern doc: every first-party module self-registers its manifest + installDir on startup, hub's vendored fallbacks retire one PR per module. Vault already ships `.parachute/module.json` (rc.2-era). This PR adds the startup self-registration pass that closes the gap.

## What ships

- **`src/module-manifest.ts`** — narrow reader for the package's own `.parachute/module.json`. Resolves the package root via `import.meta.url` so it works for both `bun src/cli.ts` dev runs and the published-package `parachute-vault` binary. Validates only the fields vault stamps onto services.json today; full validation is hub's job at install time.
- **`src/self-register.ts`** — boot-time upsert. Reads the local manifest + computes installDir + builds the per-vault `paths` array, then calls the existing merge-preserving `upsertService`. Idempotent: re-runs report `changed: false` when nothing actually shifts. Never throws — every error path logs a warning + returns a `failed` / `skipped` result, so a bad registration can't crash server boot.
- **`src/server.ts` boot wires** `selfRegister({ version: pkg.version })` right after the vault auto-creation block.
- **CLI registration paths converge** — `cmdInit` and `cmdCreate` previously called `upsertService` directly with a hand-built entry that omitted displayName/tagline/stripPrefix/installDir. Both now route through `selfRegister` so the row from `parachute-vault init` matches the row from server boot.

## Design choice — filesystem-direct rather than HTTP

In v0.6 (single-container, hub-as-supervisor) hub and vault share the same filesystem; writing directly to `~/.parachute/services.json` with the existing merge-preserving `upsertService` is the simplest shape that works today without growing a hub-side endpoint.

v0.7 (multi-container cloud) will need a hub `POST /api/modules/self-register` so a module on a different container can register without filesystem access to the operator's `~/.parachute/`. **That endpoint is filed as a separate hub follow-up** (will open once this lands); this PR's `selfRegister` function is forward-compatible — it's the single seam that would swap from filesystem to HTTP transport.

## Blocked-on-hub: nothing for this PR to merge

`FIRST_PARTY_FALLBACKS[vault]` in hub stays in place. The fallback is **additive** with self-registration: hub reads vault's row when present and falls back to the vendored manifest only when the row is missing — which is exactly the state a fresh `bun add @openparachute/vault` produces before vault has booted once. So this PR is safe to land without any hub-side coordination; the hub follow-up retires the fallback once notes/scribe/runner self-register reliably too.

## Tests

- 1167 server pass (was 1146 on rc.2 — +21 new)
- 563 core pass (unchanged)
- `bun run typecheck` clean
- `bunx biome check src/ core/` clean

New `self-register.test.ts` covers: writes the full manifest-sourced row, idempotent re-runs, preserves hub-stamped fields, preserves other-module entries, skipped-on-missing-manifest, failed-on-write-error, multi-vault path sorting, stripPrefix flow-through, installDir change detection.

New `module-manifest.test.ts` covers: package-root resolution, missing-manifest null return, malformed-JSON throw, required-field validation, smoke test of the actual shipped file.

## Patterns check

Touches `parachute-patterns/patterns/module-json-extensibility.md` — vault becomes the first first-party module to actively self-register (rather than relying on the install-time stamp). Conforms; no pattern changes needed. The hub-side fallback-retirement work will surface a pattern note about "additive transition: ship self-register, retire fallback later, never both at once" — that's for the eventual hub PR, not this one.