### PR TITLE
feat(vault): enable WAL mode for multi-process SQLite (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,49 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.8-rc.4] - 2026-05-21
+
+feat(vault): enable WAL mode for multi-process SQLite concurrency (#326).
+
+The vault SQLite database now runs in **WAL** (write-ahead logging) journal
+mode by default. Before this change `journal_mode` defaulted to the SQLite
+classic `DELETE` rollback journal — fine for a single-process daemon, but
+incompatible with concurrent multi-process access patterns. `parachute-runner`
+polling `tag:job` while the user writes notes through the running daemon is
+exactly that pattern, and `vault#323`'s `daemon-busy` guard on `import` was
+the symptom: a second connection couldn't get past the writer's lock.
+
+Under WAL: a single writer plus an arbitrary number of concurrent readers
+all see consistent snapshots. The new `applyConnectionPragmas` helper in
+`core/src/schema.ts` is invoked on every Database open via the existing
+`initSchema` entry point and the refactored `openVaultDb` — it sets:
+
+  - `PRAGMA journal_mode = WAL`
+  - `PRAGMA synchronous = NORMAL` (safe + recommended pairing per SQLite docs)
+  - `PRAGMA wal_autocheckpoint = 1000` (explicit default — 1000 pages ≈ 4MB)
+  - `PRAGMA foreign_keys = ON`
+
+It also verifies WAL actually took effect (capturing the return value of
+the `PRAGMA journal_mode = WAL` statement) and logs a one-time `[vault]
+WAL mode could not be enabled` warning when an underlying filesystem (NFS,
+some FUSE / Docker volume drivers) silently refuses the WAL flip. Operators
+on those filesystems retain single-writer semantics and now know it.
+
+**Backwards compatibility**: existing vaults created in DELETE journal mode
+are migrated to WAL on next open by SQLite itself — no data migration, no
+schema bump. **Backup compatibility**: `parachute-vault backup` already
+uses `VACUUM INTO` (WAL-safe by design), so the snapshot/restore path is
+unchanged. Manual hand-copies of `vault.db` should now also copy the
+`vault.db-wal` and `vault.db-shm` sidecars if the database is open and
+in-flight — documented in `README.md`.
+
+Long-term followup tracked at vault#326 is the **single-writer** rail
+(option 2 in the original issue): route the CLI's write-side commands
+through the daemon's HTTP/MCP surface when the daemon is running, so two
+processes never compete for the writer slot. This PR delivers option 1
+(the read-side win) so multi-reader patterns like `parachute-runner` work
+today; the writer-routing piece stays on the roadmap.
+
 ## [0.4.8-rc.3] - 2026-05-21
 
 feat(vault): self-register manifest + installDir at startup (#266).

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ A mental model for "where is my data?" and "what can I poke at?" after the one-c
       default/
         vault.db            # the SQLite database — notes, tags, links, attachments,
                             # per-vault tokens, OAuth clients + codes, tag schemas
+        vault.db-wal        # WAL journal (write-ahead log) — transient, recreated
+                            # on demand. Carries pending writes between checkpoints.
+        vault.db-shm        # WAL shared-memory index — transient, recreated on demand.
         vault.yaml          # per-vault config — description (sent as MCP session
                             # instruction), published_tag override, legacy api_keys
         assets/             # per-vault uploaded attachments (audio, images)
@@ -75,6 +78,8 @@ A mental model for "where is my data?" and "what can I poke at?" after the one-c
 `~/.parachute/` itself is the ecosystem root shared across sibling services — `services.json` and `well-known/` live at the root and are managed by the top-level CLI. Everything vault owns is scoped under `~/.parachute/vault/`. Pre-0.3 installs kept vault state directly at the root; any legacy paths still there are auto-migrated into `vault/` on first post-upgrade run (see CHANGELOG).
 
 `config.yaml` is the one file written at 0600 because it holds the bcrypt owner-password hash and the plaintext TOTP secret. `.env` is written with your umask default (typically 0644); if you add webhook API keys there, tighten the mode yourself. SQLite DBs follow your umask.
+
+The vault SQLite database runs in **WAL** (write-ahead logging) journal mode for multi-process concurrent access — the daemon, CLI tools, and out-of-process consumers (e.g. `parachute-runner` polling `tag:job`) can read concurrently while the daemon writes, without lock contention. WAL adds two sidecar files alongside `vault.db`: `vault.db-wal` (the journal) and `vault.db-shm` (shared-memory index). Both are recreated on demand; **don't back them up separately** — `parachute-vault backup` snapshots only `vault.db` via `VACUUM INTO`, which produces a consistent full-DB copy without needing the sidecars. If you copy a vault by hand, `vault.db` alone is sufficient on a checkpointed database; if you must capture an in-flight write, copy all three files. If WAL can't be enabled (NFS, some FUSE / Docker volume drivers don't support the `-shm` region), vault logs `[vault] WAL mode could not be enabled` on startup and falls back to the legacy single-writer mode.
 
 ### Registered externally
 

--- a/core/src/connection-pragmas.test.ts
+++ b/core/src/connection-pragmas.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for connection-level pragmas — WAL mode + synchronous=NORMAL +
+ * foreign_keys=ON. See applyConnectionPragmas in schema.ts and vault#326.
+ *
+ * `:memory:` databases land in journal_mode=memory and DO NOT support WAL
+ * (the WAL/shm sidecars need a real file). On-disk DBs are the realistic
+ * path; we exercise both so the readonly + filesystem-unsupported branches
+ * are covered.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { applyConnectionPragmas, initSchema } from "./schema.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "vault-pragma-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function pragma(db: Database, name: string): string | number {
+  const row = db.prepare(`PRAGMA ${name}`).get() as Record<string, string | number> | null;
+  if (!row) return "";
+  // PRAGMA xxx returns a one-key object whose key matches the pragma name.
+  const v = Object.values(row)[0];
+  return typeof v === "string" ? v.toLowerCase() : (v as number);
+}
+
+describe("applyConnectionPragmas — on-disk DB", () => {
+  it("enables WAL mode on a fresh on-disk database", () => {
+    const db = new Database(join(dir, "fresh.db"));
+    const result = applyConnectionPragmas(db);
+    expect(result.wal).toBe(true);
+    expect(result.journalMode).toBe("wal");
+    expect(pragma(db, "journal_mode")).toBe("wal");
+    db.close();
+  });
+
+  it("sets synchronous=NORMAL when WAL succeeds", () => {
+    const db = new Database(join(dir, "sync.db"));
+    applyConnectionPragmas(db);
+    // synchronous values: 0=off, 1=normal, 2=full, 3=extra. NORMAL is 1.
+    expect(pragma(db, "synchronous")).toBe(1);
+    db.close();
+  });
+
+  it("sets wal_autocheckpoint=1000 when WAL succeeds", () => {
+    const db = new Database(join(dir, "checkpoint.db"));
+    applyConnectionPragmas(db);
+    expect(pragma(db, "wal_autocheckpoint")).toBe(1000);
+    db.close();
+  });
+
+  it("enables foreign_keys", () => {
+    const db = new Database(join(dir, "fk.db"));
+    applyConnectionPragmas(db);
+    expect(pragma(db, "foreign_keys")).toBe(1);
+    db.close();
+  });
+
+  it("is idempotent — applying twice yields the same result", () => {
+    const dbPath = join(dir, "idem.db");
+    const db = new Database(dbPath);
+    const a = applyConnectionPragmas(db);
+    const b = applyConnectionPragmas(db);
+    expect(a).toEqual(b);
+    expect(b.wal).toBe(true);
+    db.close();
+  });
+
+  it("a DB created in DELETE mode is migrated to WAL on next open", () => {
+    const dbPath = join(dir, "migrate.db");
+
+    // First connection — manually force DELETE journal mode (the legacy
+    // shape that pre-WAL vaults shipped with). Write some data so we can
+    // verify it survives the WAL flip.
+    {
+      const db = new Database(dbPath);
+      db.exec("PRAGMA journal_mode = DELETE");
+      db.exec("CREATE TABLE legacy (k TEXT PRIMARY KEY, v TEXT)");
+      db.prepare("INSERT INTO legacy (k, v) VALUES (?, ?)").run("hello", "world");
+      expect(pragma(db, "journal_mode")).toBe("delete");
+      db.close();
+    }
+
+    // Second connection — apply pragmas. WAL takes effect, existing data
+    // intact.
+    {
+      const db = new Database(dbPath);
+      const result = applyConnectionPragmas(db);
+      expect(result.wal).toBe(true);
+      const row = db.prepare("SELECT v FROM legacy WHERE k = ?").get("hello") as { v: string };
+      expect(row.v).toBe("world");
+      db.close();
+    }
+  });
+});
+
+describe("applyConnectionPragmas — :memory: DB", () => {
+  it("returns wal:false, journalMode='memory' WITHOUT warning", () => {
+    // :memory: is bun:sqlite's ephemeral mode — journal_mode comes back as
+    // "memory" and WAL can't be enabled. This is an explicit caller choice
+    // (test fixtures, throwaway probes), not an operator-visible filesystem
+    // limitation, so applyConnectionPragmas suppresses the warning for it
+    // to keep test output clean.
+    const db = new Database(":memory:");
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: string) => warnings.push(msg);
+
+    try {
+      const result = applyConnectionPragmas(db);
+      expect(result.wal).toBe(false);
+      expect(result.journalMode).toBe("memory");
+      expect(warnings.length).toBe(0);
+    } finally {
+      console.warn = origWarn;
+      db.close();
+    }
+  });
+
+  it("still enables foreign_keys on the :memory: branch", () => {
+    const db = new Database(":memory:");
+    applyConnectionPragmas(db);
+    expect(pragma(db, "foreign_keys")).toBe(1);
+    db.close();
+  });
+});
+
+describe("applyConnectionPragmas — WAL-unsupported on-disk filesystem (simulated)", () => {
+  it("warns once when an on-disk DB lands in a non-WAL, non-memory mode", () => {
+    // We can't easily mount an NFS volume in CI, so simulate the
+    // unsupported-FS branch: open an on-disk DB and immediately force
+    // journal_mode to a non-WAL mode that sticks. PRAGMA journal_mode=WAL
+    // will then return that mode (because WAL silently fell back), which
+    // is the exact shape the unsupported-FS detection triggers on.
+    //
+    // We do this by stubbing prepare("PRAGMA journal_mode = WAL") to
+    // return { journal_mode: "delete" } — what bun:sqlite returns when
+    // SQLite refuses the WAL flip.
+    const db = new Database(join(dir, "stub.db"));
+
+    const origPrepare = db.prepare.bind(db);
+    // @ts-expect-error — narrow override for the one PRAGMA we care about
+    db.prepare = (sql: string) => {
+      if (sql === "PRAGMA journal_mode = WAL") {
+        return {
+          get: () => ({ journal_mode: "delete" }),
+          all: () => [{ journal_mode: "delete" }],
+          run: () => ({ changes: 0, lastInsertRowid: 0 }),
+        };
+      }
+      return origPrepare(sql);
+    };
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: string) => warnings.push(msg);
+
+    try {
+      const result = applyConnectionPragmas(db);
+      expect(result.wal).toBe(false);
+      expect(result.journalMode).toBe("delete");
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]).toContain("WAL mode could not be enabled");
+      expect(warnings[0]).toContain("journal_mode=delete");
+
+      // Second call on the same handle: dedupe by WeakSet, no second warn.
+      applyConnectionPragmas(db);
+      expect(warnings.length).toBe(1);
+    } finally {
+      console.warn = origWarn;
+      db.close();
+    }
+  });
+});
+
+describe("initSchema integration", () => {
+  it("leaves a fresh vault DB in WAL mode after full initialization", () => {
+    const db = new Database(join(dir, "vault.db"));
+    initSchema(db);
+    expect(pragma(db, "journal_mode")).toBe("wal");
+    expect(pragma(db, "foreign_keys")).toBe(1);
+    expect(pragma(db, "synchronous")).toBe(1);
+    db.close();
+  });
+});
+
+describe("multi-connection concurrency under WAL", () => {
+  it("allows a second connection to read while a first holds an open write txn", () => {
+    // The whole point of WAL: a reader running concurrently with a writer
+    // does NOT block. Under the legacy DELETE journal mode an open write
+    // txn locks out readers and a `BEGIN IMMEDIATE` from a sibling
+    // connection on the same file errors with SQLITE_BUSY.
+    //
+    // Setup: writer opens, applies pragmas (flips DB to WAL), inserts a
+    // row, BEGINS another txn (uncommitted). Reader opens a second
+    // connection to the same file and SELECTs — should succeed instantly
+    // with the pre-txn committed state.
+    const dbPath = join(dir, "concurrent.db");
+    const writer = new Database(dbPath);
+    initSchema(writer);
+
+    writer.exec(`CREATE TABLE k (id INTEGER PRIMARY KEY, v TEXT)`);
+    writer.prepare(`INSERT INTO k (id, v) VALUES (?, ?)`).run(1, "committed");
+
+    // Open a long-running write txn that doesn't commit.
+    writer.exec("BEGIN IMMEDIATE");
+    writer.prepare(`INSERT INTO k (id, v) VALUES (?, ?)`).run(2, "uncommitted");
+
+    // Reader: a separate connection (simulating a separate process).
+    // Under WAL this read should succeed and see only the committed row.
+    const reader = new Database(dbPath, { readonly: true });
+    try {
+      const rows = reader.prepare("SELECT id, v FROM k ORDER BY id").all() as { id: number; v: string }[];
+      expect(rows).toEqual([{ id: 1, v: "committed" }]);
+    } finally {
+      reader.close();
+    }
+
+    writer.exec("ROLLBACK");
+    writer.close();
+  });
+});

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -201,11 +201,107 @@ CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_id);
 `;
 
 /**
+ * Connection-level pragmas applied on every Database open, in the order they
+ * appear here.
+ *
+ * `journal_mode = WAL` is a persistent, DB-level setting (lives in the SQLite
+ * header). Once any writer flips a DB into WAL it stays in WAL across opens
+ * and processes — so daemon + CLI + parachute-runner + any read-side tool
+ * see the same mode. Re-applying on every open is cheap and idempotent;
+ * SQLite returns the current mode either way.
+ *
+ * `synchronous = NORMAL` is the safe, recommended pairing with WAL per the
+ * SQLite docs: fsync only at checkpoint rather than on every commit. Crash
+ * safety is preserved (WAL frames are still ordered + checksummed); the only
+ * cost vs FULL is that an OS-level crash *between* checkpoints might lose
+ * the last transaction. Acceptable for a knowledge graph that's snapshotted
+ * by `VACUUM INTO` for backups.
+ *
+ * `wal_autocheckpoint = 1000` is SQLite's default; we set it explicitly so
+ * the contract is visible in code rather than implicit. 1000 pages ≈ 4MB
+ * before a passive checkpoint is triggered on the next write.
+ *
+ * `foreign_keys = ON` is per-connection (not persistent) — must be re-applied
+ * on every open. Migrations occasionally disable it transiently (see
+ * migrateToV14's BEGIN IMMEDIATE block); the boot path re-enables.
+ *
+ * WAL requires a filesystem that supports memory-mapped shared-memory
+ * (the `-shm` sidecar). NFS, some FUSE mounts, and a few Docker volume
+ * drivers don't qualify and silently fall back to the prior journal mode
+ * (typically `delete`). `applyConnectionPragmas` detects this and returns
+ * `wal: false` so the caller can log a warning — operators on those
+ * filesystems should know they've lost multi-process concurrency.
+ */
+const APPLY_PRAGMAS_LOGGED = new WeakSet<Database>();
+
+export interface ConnectionPragmaResult {
+  /** True when the connection ended up in WAL mode. False means the FS doesn't support WAL. */
+  wal: boolean;
+  /** The actual journal_mode SQLite reports — "wal", "delete", "memory", etc. */
+  journalMode: string;
+}
+
+/**
+ * Apply connection-level pragmas (journal mode, synchronous, FK enforcement)
+ * and verify WAL took effect. Idempotent — safe to call multiple times on
+ * the same connection. Logs a one-time warning per connection when WAL
+ * couldn't be applied.
+ *
+ * Exported for read-side callers (auth-status, mirror-manager, etc.) that
+ * open a Database directly without going through initSchema. Setting
+ * `journal_mode` on a read-only handle is a no-op but harmless; the
+ * useful state is set by whichever writer opens first.
+ */
+export function applyConnectionPragmas(db: Database): ConnectionPragmaResult {
+  // PRAGMA journal_mode returns a row { journal_mode: "wal" } on success.
+  // Use `.get()` (not `.exec()`) so we capture the result. Some bun:sqlite
+  // versions throw on readonly handles attempting to set journal_mode; treat
+  // that as "we couldn't set it, just read the current value" and recover.
+  let journalMode: string;
+  try {
+    const row = db.prepare("PRAGMA journal_mode = WAL").get() as { journal_mode?: string } | null;
+    journalMode = (row?.journal_mode ?? "").toLowerCase();
+  } catch {
+    // Most likely: readonly handle. Read-only opens never write the DB
+    // header, so they can't change journal_mode — but they can still query
+    // the current mode, which is set by the most recent writer.
+    const row = db.prepare("PRAGMA journal_mode").get() as { journal_mode?: string } | null;
+    journalMode = (row?.journal_mode ?? "").toLowerCase();
+  }
+  const wal = journalMode === "wal";
+
+  // synchronous + wal_autocheckpoint only matter when WAL is active. They're
+  // harmless under DELETE mode but the rationale is WAL-specific, so gate
+  // them on the success path. Both are best-effort — wrap in try to keep
+  // readonly handles (which reject writes) from failing the whole open.
+  if (wal) {
+    try { db.exec("PRAGMA synchronous = NORMAL"); } catch {}
+    try { db.exec("PRAGMA wal_autocheckpoint = 1000"); } catch {}
+  } else if (journalMode !== "memory" && !APPLY_PRAGMAS_LOGGED.has(db)) {
+    // `journalMode === "memory"` ⇒ this is a `:memory:` database, an
+    // explicit choice (tests, ephemeral probes) rather than a filesystem
+    // limitation. Suppress the warning so the test suite stays quiet;
+    // real on-disk vaults that can't host WAL (NFS, some FUSE/Docker
+    // volume drivers) still surface the diagnostic.
+    APPLY_PRAGMAS_LOGGED.add(db);
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[vault] WAL mode could not be enabled (journal_mode=${journalMode || "unknown"}). ` +
+      `The underlying filesystem may not support WAL (NFS, some FUSE/Docker volume drivers). ` +
+      `Multi-process concurrent access will be limited to a single writer at a time.`,
+    );
+  }
+
+  try { db.exec("PRAGMA foreign_keys = ON"); } catch {}
+
+  return { wal, journalMode };
+}
+
+/**
  * Initialize database schema. Idempotent — safe to call on every startup.
  */
 export function initSchema(db: Database): void {
-  db.exec("PRAGMA journal_mode = WAL");
-  db.exec("PRAGMA foreign_keys = ON");
+  applyConnectionPragmas(db);
 
   // Check if we need to migrate from v2
   const hasOldTables = hasTable(db, "things");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.8-rc.3",
+  "version": "0.4.8-rc.4",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/auth-status.ts
+++ b/src/auth-status.ts
@@ -40,6 +40,10 @@ export interface AuthStatusResponse {
  * caller's signal to degrade `hasTokens` to `null`.
  */
 function vaultHasTokens(dbPath: string): boolean {
+  // Readonly handle — no pragma application here. Journal mode is a
+  // persistent DB-header setting written by the first writer (the daemon's
+  // BunSqliteStore via openVaultDb), so this probe sees WAL automatically
+  // and is safe under concurrent writes.
   const db = new Database(dbPath, { readonly: true });
   try {
     const row = db.prepare("SELECT 1 FROM tokens LIMIT 1").get();

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,11 +4,24 @@
 
 import { Database } from "bun:sqlite";
 import { vaultDbPath, vaultDir } from "./config.ts";
+import { applyConnectionPragmas } from "../core/src/schema.ts";
 import { mkdirSync } from "fs";
 
-/** Open (or create) a vault's SQLite database. */
+/**
+ * Open (or create) a vault's SQLite database with vault's standard
+ * connection pragmas (WAL + synchronous=NORMAL + foreign_keys=ON). Safe
+ * for both the in-process store and out-of-process consumers (CLI,
+ * parachute-runner, mirror tools) — pragmas are idempotent.
+ *
+ * The full schema migration runs separately when a `BunSqliteStore` is
+ * instantiated around the returned handle; callers that just want raw
+ * read access (auth probes, backup tooling) skip that and pay only the
+ * pragma cost.
+ */
 export function openVaultDb(name: string): Database {
   const dir = vaultDir(name);
   mkdirSync(dir, { recursive: true });
-  return new Database(vaultDbPath(name));
+  const db = new Database(vaultDbPath(name));
+  applyConnectionPragmas(db);
+  return db;
 }


### PR DESCRIPTION
## Summary

- Closes #326 (option 1 — the read-side concurrency win).
- Vault's SQLite database now runs in **WAL** (write-ahead logging) journal mode by default: a single writer + arbitrary concurrent readers, no lock contention timeouts. The motivating consumer is `parachute-runner` polling `tag:job` while the daemon writes notes, but every read-side consumer benefits (auth-status probes, mirror watchers, backup tooling, future external integrations).
- Pragma application centralized in a new `applyConnectionPragmas` helper in `core/src/schema.ts`, invoked by both `initSchema` (writer entry) and `openVaultDb` (raw-handle entry). Sets WAL + `synchronous = NORMAL` + `wal_autocheckpoint = 1000` + `foreign_keys = ON`.
- WAL verification + one-time warning when the underlying filesystem refuses WAL (NFS / some FUSE + Docker volume drivers). Operators on those filesystems retain single-writer semantics and now know it.

## Rationale + tradeoffs

`PRAGMA synchronous = NORMAL` is the safe, recommended pairing with WAL per the SQLite docs — fsync only at checkpoint instead of every commit. Crash safety preserved (WAL frames are ordered + checksummed); the only cost vs FULL is that an OS-level crash *between* checkpoints might lose the last transaction. Acceptable for a knowledge graph that's snapshotted by `VACUUM INTO` for backups.

`wal_autocheckpoint = 1000` is SQLite's documented default (1000 pages ≈ 4MB) — set explicitly so the contract is visible in code.

## Backwards compatibility

- Existing DELETE-mode vaults migrate to WAL automatically on next open. SQLite handles it in the DB header. No schema bump, no data migration.
- `parachute-vault backup` already uses `VACUUM INTO` (WAL-safe by design); snapshot/restore unchanged.
- Manual hand-copies of `vault.db` should copy the new `vault.db-wal` and `vault.db-shm` sidecars too when the DB is in-flight. Documented in `README.md`.
- `BEGIN EXCLUSIVE` / `BEGIN IMMEDIATE` usage: searched the tree, only `migrateToV14`'s `BEGIN IMMEDIATE` block uses it. Still works under WAL exactly as before — IMMEDIATE acquires the writer lock immediately, doesn't block readers under WAL.

## Long-term followup (still tracked at #326)

This PR ships **option 1** (WAL — read-side concurrency). **Option 2** — routing CLI write commands through the daemon's HTTP/MCP surface when the daemon is running so two writers never compete — stays on the roadmap. Today's `parachute-vault import` daemon-busy guard (vault#323) remains the writer-side rail.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./core/src/` — 573 pass
- [x] `bun test ./src/` — 1167 pass
- [x] New tests in `core/src/connection-pragmas.test.ts` (11) cover:
  - fresh on-disk DB lands in WAL with synchronous=NORMAL + autocheckpoint=1000
  - DELETE-mode DB migrates to WAL on reopen with data preserved
  - idempotency (re-apply yields same result)
  - `:memory:` returns `wal: false` without warning
  - simulated FS-unsupported branch (stubbed PRAGMA return) warns once + dedupes
  - multi-connection concurrency: reader sees committed state while writer holds an open `BEGIN IMMEDIATE`
- [ ] Manual smoke under bun-link before merge (orchestrator will exercise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)