### PR TITLE
chore(vault): drop kind from module.json (hub#301 Phase B)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -3,7 +3,6 @@
   "manifestName": "parachute-vault",
   "displayName": "Vault",
   "tagline": "Your owner-authenticated MCP knowledge store.",
-  "kind": "api",
   "port": 1940,
   "paths": ["/vault/default"],
   "health": "/vault/default/health",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.8-rc.5] - 2026-05-23
+
+### Removed
+
+- Dropped `kind` field from `.parachute/module.json`. Hub's validator made the field optional in hub#327; this PR completes the cleanup per hub#301 Phase B (kind retirement). No behavior change — vault was never branched-on by kind.
+
 ## [0.4.8-rc.4] - 2026-05-21
 
 feat(vault): enable WAL mode for multi-process SQLite concurrency (#326).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,12 @@ to `@latest`.
 
 ### Removed
 
-- Dropped `kind` field from `.parachute/module.json`. Hub's validator made the field optional in hub#327; this PR completes the cleanup per hub#301 Phase B (kind retirement). No behavior change — vault was never branched-on by kind.
+- Dropped `kind` field from `.parachute/module.json`. Hub's validator made the field optional in hub#327; this PR completes the cleanup per hub#330 Phase B (kind retirement). No behavior change — vault was never branched-on by kind.
+
+### Changed
+
+- `VaultModuleManifest.kind` is now optional (mirrors hub#327's posture). The required-field check on `health` was split out of the prior combined `health`/`kind` validation. Legacy manifests still ship-and-parse fine; new manifests omit the field. Deprecation note added in the type docstring.
+- `self-register.test.ts` fixture dropped `kind` to match the new canonical manifest shape.
 
 ## [0.4.8-rc.4] - 2026-05-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.8-rc.4",
+  "version": "0.4.8-rc.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/module-manifest.test.ts
+++ b/src/module-manifest.test.ts
@@ -40,14 +40,13 @@ describe("module-manifest", () => {
     });
   });
 
-  test("readSelfManifest parses a valid manifest", () => {
+  test("readSelfManifest parses a valid manifest (no kind — hub#301 Phase B)", () => {
     withTempPackageRoot(
       {
         name: "vault",
         manifestName: "parachute-vault",
         displayName: "Vault",
         tagline: "Test tagline",
-        kind: "api",
         port: 1940,
         paths: ["/vault/default"],
         health: "/vault/default/health",
@@ -58,9 +57,30 @@ describe("module-manifest", () => {
         expect(m?.name).toBe("vault");
         expect(m?.manifestName).toBe("parachute-vault");
         expect(m?.displayName).toBe("Vault");
-        expect(m?.kind).toBe("api");
+        expect(m?.kind).toBeUndefined();
         expect(m?.port).toBe(1940);
         expect(m?.paths).toEqual(["/vault/default"]);
+      },
+    );
+  });
+
+  test("readSelfManifest tolerates a legacy manifest that still includes kind", () => {
+    // hub#301 Phase B retired the `kind` field, but legacy manifests on
+    // pinned installs may still include it. The reader accepts it without
+    // erroring; the field is never branched on.
+    withTempPackageRoot(
+      {
+        name: "vault",
+        manifestName: "parachute-vault",
+        kind: "api",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+      },
+      (root) => {
+        const m = readSelfManifest(root);
+        expect(m).not.toBeNull();
+        expect(m?.kind).toBe("api");
       },
     );
   });
@@ -73,7 +93,7 @@ describe("module-manifest", () => {
 
   test("readSelfManifest throws when required field missing", () => {
     withTempPackageRoot(
-      { name: "vault" /* missing manifestName / port / paths / health / kind */ },
+      { name: "vault" /* missing manifestName / port / paths / health */ },
       (root) => {
         expect(() => readSelfManifest(root)).toThrow(/missing required/);
       },
@@ -83,11 +103,12 @@ describe("module-manifest", () => {
   test("readSelfManifest reads the actual shipped manifest in the repo", () => {
     // Smoke test the real shipped file — guards against ever shipping a
     // malformed manifest. Uses the real resolvePackageRoot (which finds
-    // the repo root in tests).
+    // the repo root in tests). Post hub#301 Phase B, the shipped manifest
+    // no longer includes `kind`.
     const m = readSelfManifest();
     expect(m).not.toBeNull();
     expect(m?.manifestName).toBe("parachute-vault");
-    expect(m?.kind).toBe("api");
+    expect(m?.kind).toBeUndefined();
     expect(m?.port).toBe(1940);
   });
 });

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -36,7 +36,14 @@ export interface VaultModuleManifest {
   readonly manifestName: string;
   readonly displayName?: string;
   readonly tagline?: string;
-  readonly kind: ModuleKind;
+  /**
+   * Deprecated as of hub#301 Phase B (kind retirement, 2026-05-23). Hub's
+   * validator dropped `kind` from required-fields in hub#327; vault no
+   * longer ships the field in `.parachute/module.json`. Kept here as
+   * optional only so an older shipped manifest (pinned legacy install)
+   * still parses without throwing — the field is never branched on.
+   */
+  readonly kind?: ModuleKind;
   readonly port: number;
   readonly paths: readonly string[];
   readonly health: string;
@@ -87,8 +94,11 @@ export function readSelfManifest(
   if (typeof parsed.port !== "number" || !Array.isArray(parsed.paths)) {
     throw new Error(`${path}: manifest missing required "port" / "paths"`);
   }
-  if (typeof parsed.health !== "string" || typeof parsed.kind !== "string") {
-    throw new Error(`${path}: manifest missing required "health" / "kind"`);
+  if (typeof parsed.health !== "string") {
+    throw new Error(`${path}: manifest missing required "health"`);
   }
+  // `kind` is retired as of hub#301 Phase B — hub#327 made it optional in
+  // the hub-side validator, and vault no longer ships it. If a legacy
+  // manifest still includes the field, accept it; just don't require it.
   return parsed as unknown as VaultModuleManifest;
 }

--- a/src/self-register.test.ts
+++ b/src/self-register.test.ts
@@ -39,7 +39,6 @@ const TEST_MANIFEST: VaultModuleManifest = {
   manifestName: "parachute-vault",
   displayName: "Vault",
   tagline: "Test tagline",
-  kind: "api",
   port: 1940,
   paths: ["/vault/default"],
   health: "/vault/default/health",


### PR DESCRIPTION
## Summary

- Drops the `kind` field from `.parachute/module.json` (was `"kind": "api"`).
- Makes `kind` optional in vault's own manifest reader (`src/module-manifest.ts`) and adds a deprecation note pointing at hub#301 / hub#327. The field is kept accepted-but-optional so legacy manifests on pinned installs still parse — vault never branched on `kind`.
- Bumps `package.json` and `CHANGELOG.md`: `0.4.8-rc.4` → `0.4.8-rc.5`.
- Updates `module-manifest.test.ts`:
  - Removes `kind` from the canonical "parses a valid manifest" case.
  - Adds a new "tolerates a legacy manifest that still includes kind" case.
  - Asserts the shipped manifest's `kind` is now `undefined`.

## Why

Part of [hub#301](https://github.com/ParachuteComputer/parachute-hub/issues/301) Phase B (kind retirement). The prerequisite — [hub#327](https://github.com/ParachuteComputer/parachute-hub/pull/327) making `kind` optional in hub's validator — has landed, so vault can now ship a manifest without the field and hub's install + lifecycle paths still accept it.

The framing for why `kind` is the wrong axis lives in [`parachute-patterns/patterns/module-surfaces.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-surfaces.md): modules are uniform in shape — they ship a manifest, a port, paths, a health endpoint, optionally a management URL. Hub uses those operational fields for routing/lifecycle; `kind` was a classification metadata field that no code ever branched on.

Tracker: [hub#330](https://github.com/ParachuteComputer/parachute-hub/issues/330) (Phase B/C/D rollout — vault is one of several modules dropping the field).

## Behavior change

None. Vault's `self-register.ts` consumes manifest fields (`name`, `manifestName`, `port`, `paths`, `health`, `displayName`, `tagline`, `stripPrefix`) — `kind` was read into the type but never used. Hub's lifecycle / install / discovery paths likewise stopped branching on `kind` in hub#327.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test ./src` — 1168 pass / 0 fail
- [x] `.parachute/module.json` parses as valid JSON (verified via `bun -e`)
- [ ] Reviewer dispatch confirms no other `kind`-branching code path was missed in vault
- [ ] Reviewer confirms the deprecation note in `module-manifest.ts` reads cleanly

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>