### PR TITLE
chore(vault): drop kind from /.parachute/info endpoint response (hub#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.8-rc.6] - 2026-05-23
+
+### Removed
+
+- Dropped `kind` field from the `/.parachute/info` runtime endpoint response. Companion to vault#359's module.json drop — kind is no longer part of vault's external contract. Closes part of hub#340.
+
 ## [0.4.8-rc.5] - 2026-05-23
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.8-rc.5",
+  "version": "0.4.8-rc.6",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -911,7 +911,6 @@ describe("/.parachute/info + /.parachute/icon.svg", () => {
       tagline: string;
       version: string;
       iconUrl: string;
-      kind: string;
     };
     expect(body).toEqual({
       name: "parachute-vault",
@@ -919,8 +918,11 @@ describe("/.parachute/info + /.parachute/icon.svg", () => {
       tagline: expect.stringContaining("knowledge graph"),
       version: pkg.version,
       iconUrl: "/vault/journal/.parachute/icon.svg",
-      kind: "api",
     });
+    // `kind` retired from the info-endpoint response per hub#330 (companion
+    // to vault#359's module.json drop). Pin its absence so regressions are
+    // surfaced — the shape is a locked contract with the hub.
+    expect(body).not.toHaveProperty("kind");
   });
 
   test("info iconUrl is vault-scoped and points at a live icon handler", async () => {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -132,11 +132,11 @@ function handleParachuteInfo(vaultName: string): Response {
     tagline: "Agent-native knowledge graph — notes, tags, links, attachments over REST + MCP",
     version: pkg.version,
     iconUrl: `/vault/${vaultName}/.parachute/icon.svg`,
-    // Hub renders `kind: "api"` cards as an expandable detail panel (MCP URL,
-    // OAuth link, version) rather than navigating to the API's root. Vault
-    // has no browser UI, so navigating to it shows raw JSON — not useful.
-    kind: "api",
   };
+  // `kind` was previously emitted here (and matched module.json) to let the
+  // hub branch its card rendering on api vs ui. Retired per hub#330 — the hub
+  // now infers presentation from the response shape itself. Companion to
+  // vault#359 (manifest drop); closes part of hub#340.
   return Response.json(body, {
     headers: { "Access-Control-Allow-Origin": "*" },
   });


### PR DESCRIPTION
## Summary

Drops the `kind: "api"` field from the `/.parachute/info` runtime endpoint response. Companion cleanup to vault#359 (which dropped `kind` from the static `.parachute/module.json`) — the info endpoint is a **separate surface** from the static manifest, so it gets its own PR.

## Why this is separate from vault#359

vault#359 retired `kind` from `.parachute/module.json` (the static, vendored-or-shipped manifest hub reads at install time). This PR retires `kind` from `/.parachute/info` (the live HTTP endpoint hub fetches per service to render its portal card). Different bytes, different surface, separate cleanup. Tracked at hub#340.

## What changed

- `src/routing.ts` — `handleParachuteInfo()` no longer emits `kind`. Comment updated explaining the retirement, cross-refs hub#330 + vault#359.
- `src/routing.test.ts` — the shape-pinning test drops `kind` from the expected body and adds `expect(body).not.toHaveProperty("kind")` so regressions surface (the response is a locked contract with hub).

### Before / after

The exact diff on the info handler:

```diff
 function handleParachuteInfo(vaultName: string): Response {
   const body = {
     name: "parachute-vault",
     displayName: "Vault",
     tagline: "Agent-native knowledge graph — notes, tags, links, attachments over REST + MCP",
     version: pkg.version,
     iconUrl: `/vault/${vaultName}/.parachute/icon.svg`,
-    // Hub renders `kind: "api"` cards as an expandable detail panel (MCP URL,
-    // OAuth link, version) rather than navigating to the API's root. Vault
-    // has no browser UI, so navigating to it shows raw JSON — not useful.
-    kind: "api",
   };
+  // `kind` was previously emitted here (and matched module.json) to let the
+  // hub branch its card rendering on api vs ui. Retired per hub#330 — the hub
+  // now infers presentation from the response shape itself. Companion to
+  // vault#359 (manifest drop); closes part of hub#340.
   return Response.json(body, {
     headers: { "Access-Control-Allow-Origin": "*" },
   });
 }
```

## Cross-refs

- vault#359 — companion PR that dropped `kind` from `.parachute/module.json` (the static surface)
- hub#330 — kind retirement umbrella; hub no longer branches on the field
- hub#340 — info-endpoint cleanup tracker across all modules
- [`module-surfaces.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-surfaces.md) — pattern documenting the static manifest vs runtime info-endpoint distinction

## Version

`0.4.8-rc.5` → `0.4.8-rc.6` (rc chain continues at 0.4.8).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` — 1168/1168 pass, 0 fail (100/100 routing tests including the updated shape assertion)
- [ ] `curl http://localhost:1940/vault/default/.parachute/info` after `parachute restart vault` returns JSON without `kind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)