### PR TITLE
ci: add tag-triggered release workflow + RELEASING.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+# Release workflow — triggered by pushing a semver tag.
+#
+# Tag conventions (matches parachute-patterns governance rule 2):
+#   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.4.8-rc.7)
+#   - stable: v<X>.<Y>.<Z>          (e.g. v0.4.8)
+#
+# Release flow:
+#   1. Code-touching PR merges to main, bumping `version` in package.json
+#      (rc.N → rc.N+1 for the rc chain; or drop -rc.N suffix for stable).
+#   2. After merge, push a matching tag:
+#        git tag v$(grep '"version"' package.json | cut -d'"' -f4) && git push --tags
+#   3. CI runs tests, then publishes to npm (with provenance attestation,
+#      dist-tag = rc or latest).
+#
+# Operator setup (one-time):
+#   - npmjs.com → package @openparachute/vault → Settings → Trusted Publishers
+#     → "Add a new publisher" → GitHub Actions
+#       org=ParachuteComputer, repo=parachute-vault, workflow=release.yml,
+#       environment=(blank)
+#   - No NPM_TOKEN secret needed — the workflow uses OIDC (Trusted Publishing).
+#
+# Why tag-triggered (not push-to-main):
+#   - tag = explicit release signal; main commits without a tag don't publish.
+#   - Preserves a deliberate gate (you push the tag when you mean to ship).
+#   - Tag-as-canonical means the tag itself is the audit trail of what was
+#     released and when.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+concurrency:
+  # Don't let two releases race on the same tag.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: typecheck
+        run: bun run typecheck
+      - name: vault tests
+        # Matches package.json "test" script (bun test ./src/). The core/
+        # suite runs under vitest and is exercised separately in normal
+        # dev (see CLAUDE.md "Running"); the release gate stays on the
+        # canonical bun:test surface that covers the server + CLI.
+        run: bun test ./src/
+
+  publish-npm:
+    name: publish to npm
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm provenance attestation + Trusted Publishing OIDC.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - uses: actions/setup-node@v4
+        with:
+          # Node 24 ships npm 11.5+ which has Trusted Publishing OIDC
+          # support built in. Node 20 LTS only has npm 10 and would
+          # silently fall back to token auth (failing without NPM_TOKEN).
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: verify package.json version matches tag
+        # Defense against tag-vs-package.json drift. If they don't match,
+        # we'd publish under the wrong version.
+        run: |
+          PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) doesn't match tag ($TAG_VERSION)"
+            exit 1
+          fi
+      - name: publish
+        # Trusted Publishing: npm verifies the OIDC token from this workflow
+        # against the package's configured trusted publisher rule
+        # (org=ParachuteComputer, repo=parachute-vault, workflow=release.yml).
+        # No NPM_TOKEN secret needed; `id-token: write` permission above
+        # makes the OIDC token available to npm CLI.
+        run: |
+          # Detect rc vs stable from tag name. Tag pattern in `on:` above
+          # enforces the shape, so this is just disambiguation.
+          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
+            DIST_TAG=rc
+          else
+            DIST_TAG=latest
+          fi
+          echo "publishing with dist-tag=$DIST_TAG"
+          npm publish --tag "$DIST_TAG" --access public --provenance

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,84 @@
+# Releasing `@openparachute/vault`
+
+Releases are automated via [`.github/workflows/release.yml`](./.github/workflows/release.yml). Pushing a git tag triggers CI which:
+
+1. Runs `bun run typecheck` + `bun test ./src/`
+2. Publishes to npm (with provenance attestation, via Trusted Publishing OIDC)
+
+Vault has no container image artifact — the `ghcr.io` step that ships with the hub workflow is intentionally omitted here. If a vault image ever becomes useful, add a `publish-image` job mirroring hub's.
+
+## Tag conventions
+
+Per [parachute-patterns governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md):
+
+| Tag shape | Example | npm `dist-tag` |
+|---|---|---|
+| `vX.Y.Z-rc.N` | `v0.4.8-rc.7` | `rc` |
+| `vX.Y.Z` | `v0.4.8` | `latest` |
+
+The workflow auto-detects rc vs stable from the tag string (`-rc.` substring).
+
+## Release flow
+
+### For an rc bump (each code-touching PR merge)
+
+After your PR merges to `main` with a bumped `rc.N`:
+
+```sh
+git fetch && git checkout main && git pull --ff-only
+VERSION="v$(node -p "require('./package.json').version")"
+git tag "$VERSION"
+git push origin "$VERSION"
+```
+
+CI takes over from there — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-vault/actions).
+
+### Promoting an rc chain to stable
+
+When the rc chain is ready to release:
+
+1. Open a PR that drops the `-rc.N` suffix from `package.json` (e.g. `0.4.8-rc.7` → `0.4.8`).
+2. Reviewer + merge as usual.
+3. Tag the merged commit with the bare version: `git tag v0.4.8 && git push origin v0.4.8`.
+4. CI publishes with `dist-tag=latest`.
+
+### Doc-only PRs
+
+Per governance, doc-only PRs are EXEMPT from rc.N bumping — they merge without a version bump and get picked up by the next code-touching PR's rc bump (or by the stable promotion, whichever comes first). Don't fragment a release into many patch bumps mid-validation.
+
+If you DO need to ship a doc-only fix outside an active rc chain (i.e. main is on a stable version with no rc.N in flight), bump the next patch (`0.4.8` → `0.4.9`), tag, ship.
+
+## One-time setup (operator)
+
+Before the workflow can publish, this repo needs:
+
+1. **npm Trusted Publisher**: log into npmjs.com → package `@openparachute/vault` → Settings → Trusted Publishers → "Add a new publisher" → choose **GitHub Actions**. Fill:
+   - Organization: `ParachuteComputer`
+   - Repository name: `parachute-vault`
+   - Workflow filename: `release.yml`
+   - Environment name: (leave blank)
+
+   No `NPM_TOKEN` secret needed — the workflow uses OIDC.
+
+## Verifying a release
+
+```sh
+npm view @openparachute/vault@<version> dist.tarball
+npm view @openparachute/vault dist-tags
+```
+
+The npm tarball page links to the GitHub Actions run that produced it (provenance attestation).
+
+## Rolling back
+
+There's no "unpublish" path for npm (strict 72-hour unpublish policy that you should avoid for published packages anyway). To roll back:
+
+- Cut a new patch from a known-good commit (e.g. `0.4.8` → `0.4.9` reverting the bad change).
+- Tag + push; CI republishes with the higher version under the same dist-tag.
+
+## Troubleshooting
+
+- **Workflow doesn't trigger**: confirm the tag matches the workflow's `on.push.tags` pattern (`v[0-9]+.[0-9]+.[0-9]+` or `v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+`).
+- **`version mismatch` error in publish-npm**: package.json version differs from the tag. Re-tag the correct commit.
+- **`npm ERR! 403 You do not have permission to publish`**: Trusted Publisher rule on npm doesn't match this workflow. Verify org/repo/workflow filename are exactly `ParachuteComputer` / `parachute-vault` / `release.yml`. If the workflow file was renamed, the rule needs updating on npm.
+- **`npm ERR! 401 Unauthorized` with no OIDC token**: the workflow is missing `permissions: id-token: write` at the job level. Verify the YAML.

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "parachute-vault",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@openparachute/scope-guard": "^0.2.0",
+        "@openparachute/scope-guard": "^0.3.0",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode-terminal": "^0.12.0",
@@ -26,7 +26,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
-    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.2.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-HbL1ZFBD0Kl/IiEXbEVLEGSQXGKL9sjRltye5RtqVLdwkR7Y9qOM9SSYmxa9np7nqzbRXrwDjEbRRQubKju9xg=="],
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.3.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-3ZDgPGEeC5YDmXcZmby2+Kq8g7DozYNEQdfMMquGWEZ5h9aea4DmW1zbJ13XyeMT7U1GoXmHze4Ujjy5fz0GGg=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` + `RELEASING.md` for vault. Mirrors hub#359's pattern — the canonical release-ci shape lives in [`parachute-patterns/patterns/release-ci.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/release-ci.md), and this rollout is tracked at [parachute-patterns#91](https://github.com/ParachuteComputer/parachute-patterns/issues/91).

Tag-triggered (`v[0-9]+.[0-9]+.[0-9]+` and `v…-rc.N`). Two jobs:

- **test** — `bun run typecheck` + `bun test ./src/` (matches the canonical test gate from CLAUDE.md / `package.json` `test` script).
- **publish-npm** — `npm publish --provenance` via Trusted Publishing (OIDC, no `NPM_TOKEN`). Auto-detects rc vs stable from the tag string and picks the dist-tag (`rc` vs `latest`).

### Differences from hub's workflow

- **No `publish-image` job.** Vault doesn't ship a container image artifact; the ghcr.io step is intentionally omitted. If that need ever materializes, mirror hub's publish-image job here.
- **No `prepack` build.** Vault has no SPA bundle to assemble; npm tarball is sources + `.parachute/` + `core/` per the existing `files` array in `package.json`.
- **Trusted Publishing only** — `permissions.id-token: write` on `publish-npm`, no `env: NODE_AUTH_TOKEN`, `actions/setup-node@v4` with `node-version: '24'` (npm 11.5+ required for OIDC support).

### No version bump in this PR

Vault's `@rc` on npm currently matches the repo's `package.json` (both at `0.4.8-rc.6`). The workflow lands dormant — the next code-touching PR bumps `rc.N` and `git tag v… && git push origin v…` triggers the first run.

## Operator setup (one-time, on npmjs.com)

Trusted Publisher rule for `@openparachute/vault`:
- Organization: `ParachuteComputer`
- Repository name: `parachute-vault`
- Workflow filename: `release.yml`
- Environment name: (blank)

Aaron has already configured Trusted Publishers across the 8 packages.

## Patterns check

- Touches [`patterns/release-ci.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/release-ci.md) — conforms (tag-triggered, OIDC, version-vs-tag guard, rc/latest dist-tag derivation from tag).
- Touches [`patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md) rule 2 (RC versioning) — `RELEASING.md` documents the chain-at-target-stable + doc-only-exemption flow.
- No new patterns established.

## Test plan

- [ ] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`) — verified locally.
- [ ] Workflow does not reference `secrets.NPM_TOKEN` anywhere — verified locally.
- [ ] First real exercise will be the next rc bump after merge (no action needed in this PR).