### PR TITLE
fix(vault): ship web/ui/dist in published npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,18 @@
     "core/src",
     "core/package.json",
     ".parachute",
-    "tsconfig.json"
+    "tsconfig.json",
+    "web/ui/dist"
   ],
   "scripts": {
     "start": "bun src/server.ts",
     "cli": "bun src/cli.ts",
     "test": "bun test ./src/",
     "test:core": "cd core && node --experimental-vm-modules node_modules/vitest/dist/cli.js run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build:spa": "cd web/ui && bun install --frozen-lockfile && bun run build",
+    "postinstall": "if [ -d web/ui ]; then bun run build:spa; fi",
+    "prepack": "bun run build:spa"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",


### PR DESCRIPTION
## Bug

The published `@openparachute/vault` tarball does not include the built admin SPA bundle. Any vault installed via `bun add -g` (notably the supervised vault in Aaron's hub Render deploy) hits a 503 on `/vault/<name>/admin/*`:

> vault admin SPA bundle not found — run `bun run build` in web/ui/ to produce dist/

The 503 comes from [`src/admin-spa.ts:96-100`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/admin-spa.ts#L96-L100) — `existsSync(spaDistDir)` returns false because `defaultAdminSpaDistDir()` resolves to `<install-root>/web/ui/dist/`, but the npm tarball never shipped `web/ui/dist/`.

Root cause: `package.json` `files:` listed only `src`, `core/src`, `core/package.json`, `.parachute`, `tsconfig.json` — no SPA bundle, no `prepack` hook to build one.

## Fix

Mirrors the canonical pattern in [parachute-hub/web/ui/CLAUDE.md §"Build + dev"](https://github.com/ParachuteComputer/parachute-hub/blob/main/web/ui/CLAUDE.md#L92-L116) and [parachute-hub/package.json](https://github.com/ParachuteComputer/parachute-hub/blob/main/package.json):

- Add `"web/ui/dist"` to `files:`.
- Add `build:spa` script: `cd web/ui && bun install --frozen-lockfile && bun run build`.
- Add `postinstall` (gated on `web/ui/` existing — no-op for npm-installed consumers since the source dir isn't shipped).
- Add `prepack` so `bun pack` / `bun publish` / `npm pack` / `npm publish` always rebuild the SPA before producing the tarball.

`web/ui/dist/` is already covered by the existing `dist` entry at `.gitignore:6` — no accidental commits of build artifacts.

## Evidence

### Before
```
$ npm pack --dry-run 2>&1 | grep -iE "web|dist"
(empty — no web/ui/dist in tarball)

$ npm pack --dry-run 2>&1 | tail -5
npm notice total files: 132
npm notice package size: 613.9 kB
```

### After
```
$ npm pack --dry-run 2>&1 | grep -E "web/"
$ cd web/ui && bun install --frozen-lockfile && bun run build    ← prepack fires
npm notice 5.6kB web/ui/dist/assets/index-BOa-JJtV.css
npm notice 250.0kB web/ui/dist/assets/index-BzA5LgE3.js
npm notice 507B web/ui/dist/index.html
npm notice 562B web/ui/tsconfig.json                              ← minor side-effect (see note)
```

(Minor: the bare-filename pattern `"tsconfig.json"` in `files:` matches recursively, so `web/ui/tsconfig.json` gets picked up too once any `web/` content ships. 562 B — out of scope for this PR; would tighten with `"./tsconfig.json"` in a separate cleanup.)

## CI

[`.github/workflows/release.yml`](https://github.com/ParachuteComputer/parachute-vault/blob/main/.github/workflows/release.yml) calls `npm publish` via Trusted Publishing on tag push. `npm publish` honors `prepack`, so no workflow changes — the SPA rebuilds from source during the publish step.

## Verification

- `bun run typecheck` — clean
- `bun test ./src/` — 1168/1168 pass

## Why this PR is the right shape

- Mirrors a battle-tested pattern (hub has been shipping this way since hub#199-era).
- No behavior change for consumers running from a `bun link`-ed checkout (`postinstall` rebuilds; existing `dist/` is unchanged).
- Fixes the deployment-day failure mode for any cloud vault installed via `bun add -g`.

## Followup (separate)

Aaron's hub on Render needs a redeploy after the next vault rc publishes — hub installs vault via `bun add -g @openparachute/vault@rc` at first-wizard time, and the supervised binary doesn't auto-update.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>