### PR TITLE
fix(vault): unblock Linux-CI release — tar-in-staging + HOME-pollution

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -572,9 +572,21 @@ export async function runBackup(opts?: {
     vaultsDir: opts?.vaultsDir,
   });
 
+  // Write the tarball to a SIBLING tempdir, not inside stagingDir.
+  //
+  // Why: `assembleTarball` runs `tar -czf <out> -C <stagingDir> <entries>`
+  // where `entries = readdirSync(stagingDir)`. If the output path lives
+  // inside stagingDir (e.g. `stagingDir/__out__/...`), that subdir shows
+  // up in `entries` and tar enumerates it while ALSO writing to it.
+  // GNU tar (Linux) treats "file changed as we read it" as fatal and
+  // aborts; BSD tar (macOS) tolerates it. The sibling-tempdir layout
+  // keeps the output completely out of tar's input set on both platforms.
+  // See vault#363.
+  const outDir = mkdtempSync(join(tmpdir(), "parachute-backup-out-"));
+
   try {
     const tarName = backupFilename(timestamp);
-    const tarballPath = join(stagingDir, "__out__", tarName);
+    const tarballPath = join(outDir, tarName);
     await assembleTarball(stagingDir, tarballPath);
     const bytes = statSync(tarballPath).size;
 
@@ -594,9 +606,11 @@ export async function runBackup(opts?: {
 
     return { tarballPath, timestamp, bytes, destinations: results, contents };
   } finally {
-    // The staging dir has the only copy of the tarball that isn't at a
-    // destination; destinations have already been written. Safe to clean.
+    // The staging dir + out dir have the only copies of the tarball that
+    // aren't at a destination; destinations have already been written. Safe
+    // to clean both.
     try { rmSync(stagingDir, { recursive: true, force: true }); } catch {}
+    try { rmSync(outDir, { recursive: true, force: true }); } catch {}
   }
 }
 

--- a/src/export-watch.test.ts
+++ b/src/export-watch.test.ts
@@ -37,6 +37,25 @@ import {
 
 const CLI = path.resolve(import.meta.dir, "cli.ts");
 
+// Capture HOME / PARACHUTE_HOME at module load so `seedVaultWithNotes`'s
+// in-process env mutation (required for the deferred `vault-store.ts`
+// re-import to see PARACHUTE_HOME) can be reverted between tests. Without
+// this, the polluted HOME leaks into later tests in the same process — most
+// visibly into `resolveInstallTarget` (mcp-install.test.ts), which reads
+// `process.env.HOME` directly and would otherwise return paths under the
+// tmpdir. Linux-only failure because macOS BSD developers were less likely
+// to notice in dev; CI on Linux exposed it after the tag-triggered release
+// workflow landed (vault#361). See vault#363.
+const ORIG_HOME = process.env.HOME;
+const ORIG_PARACHUTE_HOME = process.env.PARACHUTE_HOME;
+
+function restoreHomeEnv(): void {
+  if (ORIG_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIG_HOME;
+  if (ORIG_PARACHUTE_HOME === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = ORIG_PARACHUTE_HOME;
+}
+
 // ---------------------------------------------------------------------------
 // Shared test helpers
 // ---------------------------------------------------------------------------
@@ -439,6 +458,7 @@ describe("export CLI: single-shot", () => {
     clearVaultStoreCache();
     fs.rmSync(tmp, { recursive: true, force: true });
     fs.rmSync(exportDir, { recursive: true, force: true });
+    restoreHomeEnv();
   });
 
   test("--git-commit requires an initialized git repo (clear error)", () => {
@@ -702,6 +722,7 @@ describe("export CLI: --watch", () => {
     clearVaultStoreCache();
     fs.rmSync(tmp, { recursive: true, force: true });
     fs.rmSync(exportDir, { recursive: true, force: true });
+    restoreHomeEnv();
   });
 
   test(


### PR DESCRIPTION
## Summary

Two pre-existing Linux-only test bugs blocked the `v0.4.8-rc.7` release CI (the web/ui/dist shipping fix from vault#362). rc.7 is burned. This PR fixes both bugs; a follow-up bump PR will re-tag as rc.8.

The bugs are pre-existing — they didn't surface until vault#361 landed the tag-triggered release workflow, which is the first time vault tests ran on Ubuntu CI.

## Bug 1 — `runBackup` wrote the tarball into the dir it was reading

`assembleTarball` runs `tar -czf <out> -C <stagingDir> <entries>` where `entries = readdirSync(stagingDir)`. Prior layout: `tarballPath = stagingDir/__out__/<name>.tar.gz` — so `__out__` was in `entries`, and tar enumerated the subdir while ALSO writing to it.

- **GNU tar (Linux):** fatal "file changed as we read it" → tar exits non-zero → 4 tests fail
- **BSD tar (macOS):** tolerates the race → tests pass locally

**Fix** (`src/backup.ts:560-616`): write the tarball to a sibling tempdir (`mkdtempSync` under `tmpdir()`) instead of inside the staging dir. The output is now completely outside tar's input set on both platforms. The new out dir is cleaned up alongside stagingDir in the `finally`. No public-API change — `BackupResult.tarballPath` field still exists, just points at a sibling rather than a subdir; no caller depends on the location.

**Affects:** 3 backup integration tests (`backup — runBackup end-to-end`) + 1 `vault backup` CLI test = 4 of the 6 Linux-CI failures.

## Bug 2 — `seedVaultWithNotes` polluted `process.env.HOME` without restoring it

The helper sets `process.env.HOME = parachuteHome` so the deferred re-import of `vault-store.ts` reads the test's isolated `PARACHUTE_HOME`. But it never restored either env var, so the polluted value leaked into subsequent tests in the same process.

Victim: `resolveInstallTarget` (`src/mcp-install.test.ts:318, 337`) — that function reads `process.env.HOME` directly (Bun caches `os.homedir()` at process start, so the test's reference value differs from the runtime-mutated value the function reads). On Linux CI the test ordering exposed the leak; macOS happened to order differently and dodged it.

**Fix** (`src/export-watch.test.ts:40-57, 461, 725`): capture `ORIG_HOME`/`ORIG_PARACHUTE_HOME` at module load, call a `restoreHomeEnv()` helper in the `afterEach` of every describe that uses `seedVaultWithNotes` (single-shot + --watch). Root-cause fix at the polluting site, not a workaround in the consumer.

**Affects:** 2 install-target tests (`resolveInstallTarget` user scope + local scope).

## Why these bugs only surfaced now

vault#361 (tag-triggered release workflow, merged 2026-05-24) is the first vault CI surface that runs `bun test ./src/` on Ubuntu. The dev loop on macOS hides both: BSD tar tolerates the tar-in-staging race; Bun on macOS happens to order tests such that the HOME leak didn't bite. Pushing `v0.4.8-rc.7` was the first time the tests ran on Linux at all — and they surfaced 6 failures (4 backup + 2 install-target).

## Test plan

Local verification (macOS; Linux-only bugs don't repro locally, so the fix is verified by reading the changed code paths carefully):

- [x] `bun run typecheck` — clean
- [x] `bun test ./src/backup.test.ts` — 30/30 pass
- [x] `bun test ./src/export-watch.test.ts` — 33/33 pass
- [x] `bun test ./src/mcp-install.test.ts` — 57/57 pass
- [x] `bun test ./src/` (matches CI gate exactly) — 1168/1168 pass
- [x] `bun test` (full suite incl. core) — 1742 pass / 3 skip / 0 fail
- [ ] **The real verification: Ubuntu CI on this PR.** If green, the bugs are fixed.

## After merge

1. Open a follow-up PR: bump `package.json` version 0.4.8-rc.7 → 0.4.8-rc.8 + CHANGELOG entry.
2. After that bump PR merges, tag `v0.4.8-rc.8` on post-merge main, push tag.
3. Release CI runs (now green) → `npm publish @openparachute/vault@0.4.8-rc.8 --tag rc`.
4. Aaron redeploys Render hub to pick up the new vault version at runtime.

Related: vault#361 (release workflow), vault#362 (web/ui/dist shipping fix — the original payload this rc chain is delivering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)