### PR TITLE
chore(release): bump vault to 0.4.8-rc.8 (re-issue rc.7 with Linux-CI fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ to `@latest`.
 
 ## [Unreleased]
 
+## [0.4.8-rc.8] - 2026-05-25
+
+### Fixed
+
+- Unblock Linux release CI for the `web/ui/dist` shipping fix (rc.7 was burned — release CI failed at the test gate before publish; rc.8 re-issues the same payload with the test fixes below). Two pre-existing Linux-only test bugs that had never surfaced because vault tests had never run on Linux until vault#361's tag-triggered workflow landed:
+  - **`runBackup` wrote the tarball into the directory it was reading.** `assembleTarball` runs `tar -czf <out> -C <stagingDir> <entries>` where `entries = readdirSync(stagingDir)`. The prior layout put the output at `stagingDir/__out__/<name>.tar.gz`, so `__out__` was in `entries` and tar enumerated the subdir while also writing to it. GNU tar (Linux) treats "file changed as we read it" as fatal; BSD tar (macOS) tolerates the race. Fix: write the tarball to a sibling tempdir, completely outside tar's input set. Affects 3 backup integration tests + 1 `vault backup` CLI test.
+  - **`seedVaultWithNotes` polluted `process.env.HOME` without restoring it.** The helper sets HOME so the deferred re-import of `vault-store.ts` reads the test's isolated PARACHUTE_HOME. It never restored either env var, so the polluted value leaked into `resolveInstallTarget` tests in the same process — that function reads `process.env.HOME` directly (Bun caches `os.homedir()` at process start). Fix: capture HOME/PARACHUTE_HOME at module load, restore in afterEach of every describe that calls `seedVaultWithNotes`. Affects 2 install-target tests.
+
+  Closes vault#363.
+
 ## [0.4.8-rc.7] - 2026-05-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.8-rc.7",
+  "version": "0.4.8-rc.8",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `version` 0.4.8-rc.7 → 0.4.8-rc.8 in `package.json`.
- CHANGELOG entry narrating the rc.7 burn + the two Linux-CI bug fixes from vault#363 that unblock rc.8.

rc.7 was burned: its tag-triggered release CI failed at the test gate, so npm publish never ran (`npm view @openparachute/vault@0.4.8-rc.7 version` returns 404). vault#363 (just merged) fixes the two pre-existing Linux-only test bugs that caused the failure. rc.8 re-issues the same shipping payload (the web/ui/dist fix from vault#362) now that the test gate is green.

No code changes since rc.7 other than vault#363's test/test-helper fixes.

## Test plan

- [x] `bun run typecheck` clean
- [x] vault#363 verified via Docker (oven/bun:1.3 + GNU tar 1.35 + non-root user + git): all 6 originally-failing tests now pass
- [ ] After merge, push `v0.4.8-rc.8` tag → release CI runs full test suite + npm publish (with provenance, dist-tag=rc)
- [ ] Verify `npm view @openparachute/vault@0.4.8-rc.8 version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)