### PR TITLE
feat(vault): declare uiUrl per design-system + module-ui-declaration (workstream C)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -7,6 +7,7 @@
   "paths": ["/vault/default"],
   "health": "/vault/default/health",
   "managementUrl": "/admin/",
+  "uiUrl": "/admin/",
   "startCmd": ["parachute-vault", "serve"],
   "scopes": {
     "defines": ["vault:read", "vault:write", "vault:admin"]


### PR DESCRIPTION
## Summary

Adds `"uiUrl": "/admin/"` to `.parachute/module.json` (multi-instance form), following the pattern legitimized in [parachute-patterns#96](https://github.com/ParachuteComputer/parachute-patterns/pull/96) (merged at `aa55fb5` on patterns `main`).

The prior framing — "vault has no `uiUrl` because vault content browses via Notes" — collapsed two audiences:

- **End users** browse vault data via Notes (Notes' `uiUrl` covers this).
- **Operators** administer vaults via the per-vault admin SPA at `/vault/<name>/admin/` (per-vault tokens, config, MCP inspection).

Both audiences deserve discovery presence. See [`patterns/module-ui-declaration.md` §"Use vs admin — both can be true"](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md#use-vs-admin--both-can-be-true).

## Shape

- `uiUrl: "/admin/"` is the **per-instance path relative to the vault mount**, NOT relative to hub's origin. Hub prefixes with `/vault/<name>/` during well-known fan-out (one tile per vault instance).
- Trailing slash is intentional — vault's admin SPA basename detection expects it.
- Mirrors the existing `managementUrl: "/admin/"` (same path, different surface — discovery tile vs hub admin SPA "Manage" link).

## Hub-side completion (out of scope)

This declaration is the contract; hub-side wiring is workstream C PR 4 (the next-but-one PR). Specifically:

1. `parachute-hub/src/hub-server.ts` `loadServiceUiMetadata` currently *skips* vault entries (line 751) — that skip lifts.
2. `parachute-hub/src/well-known.ts` `buildWellKnown` currently resolves `uiUrl` relative to hub origin only — for vault entries it must prepend the per-instance mount path.
3. The hardcoded "Browse Vault" tile in `parachute-hub/src/hub.ts` `renderGetStarted` (added in hub#342 as a stopgap) retires once the data-driven Services tile renders for vault.

Until then this declaration is inert at the well-known layer — but it's the field the hub will read.

## Test plan

- [x] `bun run typecheck` (clean)
- [x] `bun test ./src/` → 1091 pass / 0 fail / 2970 expect calls
- [x] `cd web/ui && bunx vitest run` → 61 pass / 0 fail
- [x] No test changes required — `module-manifest.test.ts` shape tests don't assert on `uiUrl`'s absence; adding an optional field is backwards-compat
- [ ] Reviewer subagent — focus: JSON shape matches pattern doc multi-instance example exactly; hub's fan-out composes correctly (cite hub:line); any tests asserting absence of `uiUrl` (none found, but reviewer should sanity-check)

## References

- parachute-patterns#96 (merged at `aa55fb5`) — the pattern doc this honors
- [`patterns/module-ui-declaration.md` §"Examples" — vault row](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md#examples)
- [`patterns/module-ui-declaration.md` §"Multi-instance services (vault)"](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md#multi-instance-services-vault)
- `parachute-hub/AUDIT-UI-UX.md` §5 row C — the audit row this closes (vault side)

## Workstream C arc

- PR 1: parachute-patterns#96 — legitimize vault `uiUrl` in `module-ui-declaration.md` — **MERGED**
- PR 2: this PR — vault declares `uiUrl`
- PR 3: parachute-scribe — scribe declares `uiUrl: "/scribe/admin"`
- PR 4: parachute-hub — lift `loadServiceUiMetadata` vault-skip + per-instance prefix in `buildWellKnown` + retire hardcoded `Browse Vault` tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)