### PR TITLE
fix(self-register): derive health path from primary vault (vault#369)

### DIFF
--- a/src/self-register.test.ts
+++ b/src/self-register.test.ts
@@ -117,6 +117,39 @@ describe("self-register", () => {
     });
   });
 
+  test("health path follows the primary vault name (closes vault#369)", () => {
+    // Regression: pre-fix self-register used `manifest.health` verbatim
+    // (which is `/vault/default/health`) regardless of the actual vault
+    // name. A hub-bundled wizard that lets the operator name their vault
+    // `notes` produced a services.json entry with `paths: ["/vault/notes"]`
+    // but `health: "/vault/default/health"`, so hub's per-module health
+    // probe hit a 404 even on a healthy vault. The fix derives health from
+    // paths[0]. Caught in the wild on a Render rebuild walkthrough.
+    withParachuteHome((home) => {
+      const { log, warn } = captureLogs();
+      selfRegister({
+        version: "0.4.8-rc.3",
+        log,
+        warn,
+        readManifest: () => TEST_MANIFEST,
+        resolvePackageRoot: () => "/fake/install/dir",
+        // Vault named something other than "default" — the manifest fallback
+        // path `/vault/default` should NOT leak into the health URL.
+        listVaults: () => ["notes"],
+        readGlobalConfig: () => ({ port: 1940, default_vault: "notes" }),
+      });
+      const parsed = JSON.parse(readFileSync(join(home, "services.json"), "utf8")) as {
+        services: { paths: string[]; health: string }[];
+      };
+      const row = parsed.services[0];
+      expect(row.paths).toEqual(["/vault/notes"]);
+      expect(row.health).toBe("/vault/notes/health");
+      // Sanity: health should never be the literal manifest template
+      // when a real vault exists with a different name.
+      expect(row.health).not.toBe("/vault/default/health");
+    });
+  });
+
   test("idempotent — re-running reports no changes", () => {
     withParachuteHome(() => {
       const { log, warn } = captureLogs();

--- a/src/self-register.ts
+++ b/src/self-register.ts
@@ -163,6 +163,19 @@ export function selfRegister(deps: SelfRegisterDeps): SelfRegisterResult {
   const paths = buildVaultServicePaths(globalConfig.default_vault, vaults, manifest.paths);
   const port = globalConfig.port ?? DEFAULT_PORT;
 
+  // Derive the health path from the primary path (paths[0]) rather than
+  // using `manifest.health` verbatim. The manifest's `health` is
+  // `/vault/default/health` — a template literal where `default` is the
+  // placeholder vault name. When the operator named their vault something
+  // other than `default` (e.g. `notes`, `journal`, or — caught in the wild
+  // on a Render rebuild — just `vault`), the manifest's `default` doesn't
+  // get rewritten and the hub's per-module health probe ends up hitting
+  // `/vault/default/health` against a vault that lives at `/vault/<other>/`,
+  // returning 404 even when the vault is healthy. Build health off paths[0]
+  // so the path follows the primary vault by construction. Closes vault#369.
+  const primaryPath = paths[0] ?? "/vault/default";
+  const health = `${primaryPath}/health`;
+
   // Build the entry with manifest-sourced metadata (displayName, tagline,
   // stripPrefix) layered on top of the operationally-determined fields
   // (port from config, paths from current vault list, version from
@@ -178,7 +191,7 @@ export function selfRegister(deps: SelfRegisterDeps): SelfRegisterResult {
     name: manifest.manifestName,
     port,
     paths,
-    health: manifest.health,
+    health,
     version: deps.version,
     installDir,
   };
@@ -212,7 +225,7 @@ export function selfRegister(deps: SelfRegisterDeps): SelfRegisterResult {
     priorRow.version !== deps.version ||
     priorRow.port !== port ||
     JSON.stringify(priorRow.paths) !== JSON.stringify(paths) ||
-    priorRow.health !== manifest.health ||
+    priorRow.health !== health ||
     (priorRow as { displayName?: string }).displayName !== manifest.displayName ||
     (priorRow as { tagline?: string }).tagline !== manifest.tagline ||
     (priorRow as { stripPrefix?: boolean }).stripPrefix !== manifest.stripPrefix;


### PR DESCRIPTION
## Summary

\`selfRegister\` wrote \`health: manifest.health\` verbatim — where \`manifest.health\` is the placeholder template \`/vault/default/health\` from \`.parachute/module.json\`. \`paths\` was already dynamic (via \`buildVaultServicePaths\`), so a vault named anything other than \`default\` produced a services.json entry where \`paths\` and \`health\` disagreed:

\`\`\`json
{
  "paths": ["/vault/notes"],
  "health": "/vault/default/health"
}
\`\`\`

Hub's per-module health probe hits the configured \`health\` URL — under this shape, every probe 404'd against a perfectly healthy vault.

## Reproduction

Caught 2026-05-26 during a no-delay Render rebuild walkthrough (Aaron's "from totally from scratch" test). Vault was named \`vault\` (not \`default\`); hub flap appeared post-wizard. SSH'd into the container and read services.json — found the mismatch.

The flap itself is tracked at hub#399; this fix removes one likely contributing symptom. The Render proxy / port-detector interaction may still need additional gating.

## Fix

Derive \`health\` from \`paths[0] + "/health"\`. The first path is the default vault by \`buildVaultServicePaths\` construction (\`default\` first when present; otherwise the first listed vault), so this preserves the "primary vault first" invariant the rest of the pipeline relies on.

Also updates the change-detection comparison to compare against the derived \`health\` (not \`manifest.health\`) — otherwise re-registration would always think the row had changed.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test ./src\` — 1092/1092 pass (+1 regression test)
- [x] New test exercises a vault named \`notes\` → expects \`/vault/notes/health\`, asserts it's NOT \`/vault/default/health\`
- [ ] Reviewer dispatch (mandatory)
- [ ] After merge + npm publish: rebuild Render + re-run no-delay walk; confirm hub flap is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)