### PR TITLE
chore(release): 0.4.9-rc.1 — auto-transcribe defaults ON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.8",
+  "version": "0.4.9-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump to 0.4.9-rc.1. Aaron-authorized 2026-05-27 ("push all things up to rc").

Code-touching PR since v0.4.8:

- #373 feat: auto-transcribe defaults ON (opt-out instead of opt-in)

Next patch from v0.4.8 stable per parachute-patterns governance rule 2.

## Test plan

- [x] #373 already merged with green CI
- [ ] Tag push v0.4.9-rc.1 after merge → CI publishes to npm @rc

🤖 Generated with [Claude Code](https://claude.com/claude-code)