### PR TITLE
fix(test): isolate routing.test.ts env vars + bump 0.4.9-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.1",
+  "version": "0.4.9-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -17,7 +17,7 @@
  * never touch ~/.parachute.
  */
 
-import { describe, test, expect, beforeEach, afterEach, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, beforeEach, afterEach, afterAll } from "bun:test";
 import { rmSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -605,6 +605,24 @@ describe("MCP 401 WWW-Authenticate challenge (RFC 9728)", () => {
 // ---------------------------------------------------------------------------
 
 const HUB_ORIGIN = "http://127.0.0.1:1939";
+
+// Process-env isolation: sibling test files (tokens-routes.test.ts,
+// auth-hub-jwt.test.ts) set PARACHUTE_HUB_ORIGIN in their own beforeAll
+// hooks. Bun's test runner shares a single process across test files,
+// and when file-ordering puts those before this one, their hook-set
+// value can still be live when our tests run. Restore the default
+// (unset) here so we test against `DEFAULT_HUB_LOOPBACK`. Caught when
+// vault rc.1 release CI failed with "Received: http://127.0.0.1:34295"
+// — a leaked ephemeral port from another test's fixture.
+let _prevHubOriginRouting: string | undefined;
+beforeAll(() => {
+  _prevHubOriginRouting = process.env.PARACHUTE_HUB_ORIGIN;
+  delete process.env.PARACHUTE_HUB_ORIGIN;
+});
+afterAll(() => {
+  if (_prevHubOriginRouting === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = _prevHubOriginRouting;
+});
 
 describe("per-vault OAuth discovery (hub-rooted after workstream E)", () => {
   test("AS metadata names the hub as issuer + endpoints", async () => {


### PR DESCRIPTION
## Summary

vault rc.1 release CI failed deterministically with 10 OAuth-discovery tests asserting `Expected: http://127.0.0.1:1939` getting `Received: http://127.0.0.1:34295` (or 44499 on rerun — different ephemeral port).

Root cause: sibling test files (`tokens-routes.test.ts`, `auth-hub-jwt.test.ts`) set `PARACHUTE_HUB_ORIGIN` in their `beforeAll` for their own fixtures. Bun shares process across files, so when file-ordering put those before `routing.test.ts`, the leaked ephemeral port was still live when our OAuth-discovery tests ran. Not a code regression — just luck-of-the-ordering across prior tag pushes.

**Fix:** `routing.test.ts` `beforeAll` stashes + deletes `PARACHUTE_HUB_ORIGIN` so the OAuth-discovery suite tests against `DEFAULT_HUB_LOOPBACK` in `hub-jwt.ts`. `afterAll` restores.

**Bumps to 0.4.9-rc.2** to re-trigger the release publish.

## Test plan

- [x] `bun test src/routing.test.ts` → 101/101 pass with deliberately polluted env var (`PARACHUTE_HUB_ORIGIN="http://127.0.0.1:99999"`)
- [x] Local typecheck clean
- [ ] Tag push `v0.4.9-rc.2` after merge → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)