### PR TITLE
fix(admin-spa): mint admin token from hub session cookie when no fragment token

### DIFF
--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -4,8 +4,14 @@
  * `history.pushState` is the only reliable way to clean it without
  * reloading.
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { _setTokenForTest, captureTokenFromFragment, clearToken, getToken } from "./auth.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _setTokenForTest,
+  captureTokenFromFragment,
+  clearToken,
+  getToken,
+  tryMintTokenFromHubSession,
+} from "./auth.ts";
 
 describe("captureTokenFromFragment", () => {
   beforeEach(() => {
@@ -55,5 +61,106 @@ describe("captureTokenFromFragment", () => {
 
     expect(getToken()).toBeNull();
     expect(window.location.hash).toBe("#section=stats");
+  });
+});
+
+describe("tryMintTokenFromHubSession", () => {
+  // The vault SPA boots without a token whenever the operator clicked a
+  // surface that doesn't pre-mint one — notably hub's discovery-page vault
+  // tile (rendered as a plain anchor from `module.json:uiUrl`). Bypass
+  // path: same-origin GET against the hub's session-gated mint endpoint.
+  beforeEach(() => {
+    _setTokenForTest(null);
+  });
+
+  afterEach(() => {
+    clearToken();
+    vi.restoreAllMocks();
+  });
+
+  it("stashes the token returned by the hub session-mint endpoint on 200", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "minted.jwt.abc",
+          expires_at: "2026-01-01T00:00:00.000Z",
+          scopes: ["vault:work:admin"],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await tryMintTokenFromHubSession("work");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/admin/vault-admin-token/work",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+    expect(getToken()).toBe("minted.jwt.abc");
+  });
+
+  it("leaves the token unset on 401 (operator has no hub session)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthenticated" }), { status: 401 }),
+    );
+
+    await tryMintTokenFromHubSession("work");
+
+    expect(getToken()).toBeNull();
+  });
+
+  it("leaves the token unset on 403 (signed-in but not the hub admin)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "not_admin" }), { status: 403 }),
+    );
+
+    await tryMintTokenFromHubSession("work");
+
+    expect(getToken()).toBeNull();
+  });
+
+  it("swallows network errors silently (no throw)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("network down"));
+
+    await expect(tryMintTokenFromHubSession("work")).resolves.toBeUndefined();
+    expect(getToken()).toBeNull();
+  });
+
+  it("URL-encodes the vault name segment", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ token: "x.y.z", expires_at: "2026", scopes: [] }), {
+        status: 200,
+      }),
+    );
+
+    await tryMintTokenFromHubSession("name with spaces");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/admin/vault-admin-token/name%20with%20spaces",
+      expect.anything(),
+    );
+  });
+
+  it("is a no-op when a token is already cached (fragment path won — don't reset to a stale mint)", async () => {
+    _setTokenForTest("from-fragment.jwt");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await tryMintTokenFromHubSession("work");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(getToken()).toBe("from-fragment.jwt");
+  });
+
+  it("leaves the token unset when the 200 body has no `token` field", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ expires_at: "2026" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await tryMintTokenFromHubSession("work");
+
+    expect(getToken()).toBeNull();
   });
 });

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -68,3 +68,58 @@ export function clearToken(): void {
 export function _setTokenForTest(token: string | null): void {
   cachedToken = token;
 }
+
+/**
+ * Fallback bootstrap path: when the SPA loads at `/vault/<name>/admin/`
+ * without a `#token=...` fragment (i.e. the operator clicked the vault tile
+ * on hub's discovery page, or refreshed an authenticated tab), attempt to
+ * mint a token from the hub-issued session cookie.
+ *
+ * The hub exposes `GET /admin/vault-admin-token/<name>` for exactly this
+ * trade: it reads the `parachute_hub_session` cookie, verifies the operator
+ * is the first admin, and returns a short-lived `vault:<name>:admin` JWT.
+ * Same-origin fetch carries the cookie automatically (hub serves both `/`
+ * and `/vault/<name>/admin/` from the same origin via its reverse proxy).
+ *
+ * Behavior:
+ *   - On 200: cache the token (same module-scoped slot
+ *     `captureTokenFromFragment` writes to). Subsequent `getToken()` calls
+ *     return it.
+ *   - On 401/403/404 or network error: leave the cache empty. The SPA
+ *     proceeds to its existing `auth-required` empty state, which tells
+ *     the operator to open the page from hub's directory. (404 should be
+ *     impossible — the operator wouldn't have a tile to click for a vault
+ *     that isn't installed — but treat it the same as 401 for safety.)
+ *
+ * Why fragment-first, cookie-second: the `Manage` button mints via fragment
+ * because it doesn't depend on the SPA's mount being same-origin with the
+ * token issuer. The cookie fallback works only when hub and the SPA share
+ * an origin, which is the canonical owner-operated deploy shape but not
+ * universal. Keep both paths — they're complementary, not redundant.
+ *
+ * Idempotent — safe to call multiple times, only sets the cache on a fresh
+ * successful mint.
+ */
+export async function tryMintTokenFromHubSession(vaultName: string): Promise<void> {
+  if (typeof window === "undefined") return;
+  if (cachedToken) return;
+  try {
+    const res = await fetch(
+      `/admin/vault-admin-token/${encodeURIComponent(vaultName)}`,
+      {
+        method: "GET",
+        headers: { accept: "application/json" },
+        credentials: "same-origin",
+      },
+    );
+    if (!res.ok) return;
+    const body = (await res.json()) as { token?: string };
+    if (typeof body.token === "string" && body.token.length > 0) {
+      cachedToken = body.token;
+    }
+  } catch (_e) {
+    // Network / CORS / parse error — silent fallback to the existing
+    // auth-required empty state. The SPA still renders; the operator gets
+    // a clear message to open from the hub directory.
+  }
+}

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -2,13 +2,14 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App.tsx";
-import { captureTokenFromFragment } from "./lib/auth.ts";
-import { getBasename } from "./lib/mount.ts";
+import { captureTokenFromFragment, tryMintTokenFromHubSession } from "./lib/auth.ts";
+import { getBasename, getMountedVaultName } from "./lib/mount.ts";
 import "./styles.css";
 
 // Capture a hub-issued JWT from the URL fragment if present (e.g. when the
-// operator clicked "Manage Vault" in the hub directory). Strip it from the
-// visible URL so a refresh, copy/paste, or screenshot can't leak the token.
+// operator clicked "Manage Vault" in the hub admin SPA's vault list). Strip
+// it from the visible URL so a refresh, copy/paste, or screenshot can't
+// leak the token.
 captureTokenFromFragment();
 
 const root = document.getElementById("root");
@@ -20,10 +21,38 @@ if (!root) throw new Error("#root not found");
 // resolve under whichever path served `index.html`; React Router needs the
 // matching runtime mount so `<Link to="/vault/foo/tokens">` resolves under
 // `/vault/<name>/admin/...` rather than at the origin root.
-createRoot(root).render(
-  <StrictMode>
-    <BrowserRouter basename={getBasename()}>
-      <App />
-    </BrowserRouter>
-  </StrictMode>,
-);
+function mount(): void {
+  createRoot(root!).render(
+    <StrictMode>
+      <BrowserRouter basename={getBasename()}>
+        <App />
+      </BrowserRouter>
+    </StrictMode>,
+  );
+}
+
+// Fallback bootstrap path (closes vault#XXX / hub-side discovery-tile bug):
+// when the operator clicked the **discovery-page** vault tile (hub.ts
+// renders one per vault via `uiUrl: "/admin/"`), the browser landed here
+// without a `#token=...` fragment — the discovery tile is a plain anchor,
+// not a Manage-flow button. Without a token the SPA boots into the
+// "auth-required" empty state ("Open this page from the hub's directory"),
+// which is exactly what the operator just *did*. So if we're under a
+// per-vault mount AND the fragment didn't carry a token, try to mint one
+// from the hub session cookie before mounting React. The hub exposes
+// `/admin/vault-admin-token/<name>` for exactly this trade; same-origin
+// fetch carries the cookie automatically. Silent failure → fall through to
+// the existing auth-required empty state.
+//
+// We chain off a Promise instead of top-level `await` because Vite's
+// default esbuild target (chrome87/safari14) doesn't transpile TLA, and
+// the bundle would fail to build. The mount happens in a `.then()`/
+// `.catch()` continuation; the brief delay between document-ready and
+// React mount is invisible to the operator (no static skeleton renders
+// in `#root` — it's empty until React takes it).
+const mountedVault = getMountedVaultName();
+if (mountedVault) {
+  tryMintTokenFromHubSession(mountedVault).then(mount, mount);
+} else {
+  mount();
+}


### PR DESCRIPTION
## Summary

The vault admin SPA shows the **\"Open this page from the hub's directory\"** error after the operator did exactly that — clicked the vault tile on hub's discovery page (`/`). The discovery tile is rendered from `module.json:uiUrl` (\"/admin/\") as a plain anchor, so navigation lands at `/vault/<name>/admin/` with **no `#token=...` fragment**. The SPA boots without a token and falls straight into the auth-required empty state.

Per [module-ui-declaration.md](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md), this is the intended discovery shape — vault declares both `uiUrl` and `managementUrl: \"/admin/\"`. The `Manage` button on hub's `/admin/vaults` page does the mint-and-redirect dance, but the discovery tile doesn't and can't (discovery is unauthenticated JS).

## Fix

Add a cookie-fallback bootstrap path. When `captureTokenFromFragment()` finds no token AND the SPA is mounted under a per-vault path, fetch `/admin/vault-admin-token/<name>` with `credentials: \"same-origin\"`. The hub endpoint trades the `parachute_hub_session` cookie for the same short-lived `vault:<name>:admin` JWT the Manage button mints — existing endpoint, existing scope, no protocol change.

Silent failure on 401/403/network falls through to the existing auth-required state so the operator who genuinely lacks a hub session still sees a useful message.

Why fragment-first, cookie-second:
- **Manage button** mints cross-origin (the hub admin SPA may live on a different origin from the vault); cookies wouldn't carry.
- **Cookie fallback** works same-origin (the canonical owner-operated deploy shape).

Both paths are complementary.

## Implementation note

Chained off a Promise instead of top-level `await` because Vite's default esbuild target (chrome87/safari14) doesn't transpile TLA. The mount happens in a `.then()` continuation — invisible delay since `#root` is empty until React takes it.

## Test plan

- [x] `cd web/ui && bun run test` — 68 pass (was 61; +7 new tests covering 200/401/403/network/URL-encoding/cached/missing-token shapes)
- [x] `cd web/ui && bun run typecheck` clean
- [x] `cd web/ui && bun run build` clean (verify-base passes)
- [x] `bun test ./src` — 1092 pass server-side
- [x] `bun test ./core/src` — 574 pass core
- [x] `bun run typecheck` clean (server)
- [ ] Aaron clicks vault tile on hub's discovery page → SPA loads with vault detail page (no auth-required banner)
- [ ] Aaron clicks Manage on hub's `/admin/vaults` → SPA loads with vault detail page (fragment path still works — token captured first, cookie mint short-circuited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)