### PR TITLE
feat(mcp): scope-filtered tool listing + manage-token tool (vault#376)

### DIFF
--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -20,6 +20,18 @@ export interface McpToolDef {
   description: string;
   inputSchema: Record<string, unknown>;
   execute: (params: Record<string, unknown>) => unknown | Promise<unknown>;
+  /**
+   * Minimum scope verb the caller must hold for THIS vault to see + invoke
+   * the tool. `read` for pure queries, `write` for mutations, `admin` for
+   * token-management surfaces (only `manage-token` in the current set —
+   * core's nine tools cap at `write`). The MCP HTTP layer filters
+   * `tools/list` by this field and verb-gates `tools/call` against it; the
+   * filter is the primary defense, the inner gate is defense-in-depth.
+   *
+   * Pre-v19 unstamped tools default to `write` at the dispatch layer so a
+   * future addition that forgets to stamp this gets the safer treatment.
+   */
+  requiredVerb: "read" | "write" | "admin";
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +114,7 @@ export function generateMcpTools(store: Store): McpToolDef[] {
     // =====================================================================
     {
       name: "query-notes",
+      requiredVerb: "read",
       description: `Query notes. Returns notes matching the given filters.
 
 - **Single note**: pass \`id\` (accepts note ID or path, e.g., "Projects/README")
@@ -403,6 +416,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "create-note",
+      requiredVerb: "write",
       description: `Create one or more notes. Pass a single note's fields directly, or pass a \`notes\` array for batch creation. Each note accepts content, path, metadata, tags, links, and created_at.`,
       inputSchema: {
         type: "object",
@@ -518,6 +532,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "update-note",
+      requiredVerb: "write",
       description: `Update one or more notes. Accepts ID or path. Supports content, path, metadata updates plus tag and link mutations.
 
 - Three content-modification modes (mutually exclusive):
@@ -930,6 +945,13 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "delete-note",
+      // `admin` per vault#376's tier-mapping — destructive, recovery only
+      // via backup. A future-AI with vault:write should be able to amend
+      // notes freely but reaching delete should require an extra explicit
+      // grant. Pre-vault#376 this was effectively `write` (any "full"
+      // permission); the back-compat shim treats legacy permission-derived
+      // tokens as admin so existing pvt_* tokens see no behavior change.
+      requiredVerb: "admin",
       description: "Permanently delete a note and all its tags and links. Accepts ID or path.",
       inputSchema: {
         type: "object",
@@ -950,6 +972,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "list-tags",
+      requiredVerb: "read",
       description: `List tags with usage counts. Pass \`tag\` to get a single tag's full record (description, fields, relationships, parent_names, timestamps). Pass \`include_schema: true\` to include the full record for every tag.`,
       inputSchema: {
         type: "object",
@@ -1004,6 +1027,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "update-tag",
+      requiredVerb: "write",
       description: "Create or update a tag's identity row: description, indexed-field schemas, typed-link relationships, and hierarchy parents. If the tag doesn't exist, it's created. Fields are merged (new keys added, existing keys replaced); relationships and parent_names are replaced wholesale when provided. Pass null for fields/relationships/parent_names to clear that column. See parachute-patterns/patterns/tag-data-model.md.",
       inputSchema: {
         type: "object",
@@ -1159,6 +1183,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "delete-tag",
+      // `admin` per vault#376 — see delete-note rationale. Tag deletion
+      // also drops schemas + indexed-field declarations; it's a strictly
+      // structural change rather than a content edit.
+      requiredVerb: "admin",
       description: "Delete a tag, remove it from all notes, and delete its schema. Notes themselves are NOT deleted — just untagged.",
       inputSchema: {
         type: "object",
@@ -1191,6 +1219,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "find-path",
+      requiredVerb: "read",
       description: "Find the shortest path between two notes in the link graph. Accepts IDs or paths. Returns the chain of note IDs and relationships, or null if no path exists.",
       inputSchema: {
         type: "object",
@@ -1215,6 +1244,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "vault-info",
+      // `read` so vault:read callers can fetch stats. The
+      // description-update branch performs an inner write-check (see
+      // overrideVaultInfo in src/mcp-tools.ts) — do not promote this to
+      // `write` or read-only callers lose the stats projection.
+      requiredVerb: "read",
       description: "Get a comprehensive vault projection: name, description, tags-with-schemas (own + effective parents/fields per #270 inheritance), indexed metadata fields catalog, and query hints. Pass `include_stats: true` to add note/tag/link counts and the monthly distribution. Pass `description` to update the vault description (changes how AI agents behave in future sessions). Call this anytime mid-session to refresh schema context.",
       inputSchema: {
         type: "object",

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -945,13 +945,14 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "delete-note",
-      // `admin` per vault#376's tier-mapping — destructive, recovery only
-      // via backup. A future-AI with vault:write should be able to amend
-      // notes freely but reaching delete should require an extra explicit
-      // grant. Pre-vault#376 this was effectively `write` (any "full"
-      // permission); the back-compat shim treats legacy permission-derived
-      // tokens as admin so existing pvt_* tokens see no behavior change.
-      requiredVerb: "admin",
+      // `write` — same destructive verb as update-note. Aaron's call
+      // 2026-05-27: "delete- in write; right now the only admin gated
+      // thing is tokens." Reserving `admin` for "operator-only
+      // capabilities" (token mgmt + future config writes). A future
+      // finer-grained model might split `vault:write:no-delete` for
+      // genuinely append-only callers — gating WITHIN write rather
+      // than promoting deletes out of it.
+      requiredVerb: "write",
       description: "Permanently delete a note and all its tags and links. Accepts ID or path.",
       inputSchema: {
         type: "object",
@@ -1183,10 +1184,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     // =====================================================================
     {
       name: "delete-tag",
-      // `admin` per vault#376 — see delete-note rationale. Tag deletion
-      // also drops schemas + indexed-field declarations; it's a strictly
-      // structural change rather than a content edit.
-      requiredVerb: "admin",
+      // `write` — Aaron's call 2026-05-27: admin reserved for token
+      // mgmt + future config writes; deletes are write-tier mutations.
+      // See delete-note rationale.
+      requiredVerb: "write",
       description: "Delete a tag, remove it from all notes, and delete its schema. Notes themselves are NOT deleted — just untagged.",
       inputSchema: {
         type: "object",

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { normalizePath } from "./paths.js";
 import { rebuildIndexes } from "./indexed-fields.js";
 
-export const SCHEMA_VERSION = 18;
+export const SCHEMA_VERSION = 19;
 
 export const SCHEMA_SQL = `
 -- Notes: the universal record.
@@ -118,6 +118,20 @@ CREATE TABLE IF NOT EXISTS indexed_fields (
 --
 -- scope_tag / scope_path_prefix are deprecated Phase-0 columns — never
 -- enforced at runtime, kept only for schema stability.
+-- created_via (v19) records the provenance of a token. NULL means the
+-- legacy/unspecified path (CLI, REST mint, YAML import); 'mcp_mint' means
+-- the token was minted by the manage-token MCP tool, which lets the
+-- list/revoke surface of that tool restrict itself to its own session's
+-- mints (no cross-session token management from inside MCP).
+--
+-- parent_jti (v19) is the display id (t_hashprefix) of the token that
+-- minted this one, or the hub-JWT jti claim when minted from a hub
+-- session. Session-pinned list+revoke in manage-token filters on this.
+--
+-- revoked_at (v19) marks soft-revocation. Revoke from manage-token sets
+-- this rather than deleting the row, so the audit trail stays intact and
+-- the second revoke of the same jti is idempotent (returns ok=true).
+-- resolveToken treats a revoked_at-set row as not-found.
 CREATE TABLE IF NOT EXISTS tokens (
   token_hash TEXT PRIMARY KEY,
   label TEXT NOT NULL,
@@ -129,7 +143,10 @@ CREATE TABLE IF NOT EXISTS tokens (
   expires_at TEXT,
   created_at TEXT NOT NULL,
   last_used_at TEXT,
-  vault_name TEXT
+  vault_name TEXT,
+  created_via TEXT,
+  parent_jti TEXT,
+  revoked_at TEXT
 );
 
 -- OAuth: registered clients (Dynamic Client Registration)
@@ -379,6 +396,12 @@ export function initSchema(db: Database): void {
   // Backward-compat by construction — every existing row defaults to "md"
   // (markdown), unchanged in meaning. See vault#328.
   migrateToV18(db);
+
+  // Migrate v18 → v19: add MCP-mint provenance columns to `tokens`
+  // (created_via, parent_jti, revoked_at) for vault#376's manage-token tool.
+  // All three are nullable; existing rows backfill to NULL which means
+  // "non-MCP-minted, not revoked" — identical pre-v19 semantics.
+  migrateToV19(db);
 
   // Rebuild any generated columns + indexes declared in indexed_fields.
   // No-op for a fresh vault; idempotent on existing vaults.
@@ -949,6 +972,32 @@ function migrateToV18(db: Database): void {
   } catch (err) {
     db.exec("ROLLBACK");
     throw err;
+  }
+}
+
+/**
+ * Migrate v18 → v19: add `created_via`, `parent_jti`, `revoked_at` columns
+ * to `tokens` so manage-token can attribute mints to the MCP session that
+ * minted them, scope its list+revoke to those tokens, and soft-revoke
+ * (preserving the audit trail).
+ *
+ * All three columns are nullable; existing rows backfill to NULL with
+ * back-compat semantics — `created_via IS NULL` matches the CLI/REST-mint
+ * provenance, `revoked_at IS NULL` matches "still active". Idempotent —
+ * the column-existence guard means the migration is safe to re-run on a
+ * post-v19 vault. See vault#376.
+ */
+function migrateToV19(db: Database): void {
+  if (!hasTable(db, "tokens")) return;
+  const cols: [string, string][] = [
+    ["created_via", "TEXT"],
+    ["parent_jti", "TEXT"],
+    ["revoked_at", "TEXT"],
+  ];
+  for (const [col, type] of cols) {
+    if (!hasColumn(db, "tokens", col)) {
+      db.exec(`ALTER TABLE tokens ADD COLUMN ${col} ${type}`);
+    }
   }
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -91,6 +91,12 @@ function tryServerWideAuth(
     legacyDerived: false,
     scoped_tags: null,
     vault_name: null,
+    // No stable session id for the env-var operator token — every request
+    // is the operator-bearer, not a minted session. manage-token's session
+    // pin is a no-op for this caller (it'd still mint, but list/revoke
+    // would see no other operator mints; that's fine — env-var-bearer is
+    // explicitly the operator-channel, not a user surface).
+    caller_jti: null,
   };
 }
 
@@ -120,6 +126,15 @@ export interface AuthResult {
    * legacy / server-wide / hub JWT — no per-vault binding. See vault#257.
    */
   vault_name: string | null;
+  /**
+   * Session identifier (v19). For `pvt_*` tokens this is the display id
+   * (`t_<hashprefix>`) of the presented token. For hub JWTs it's the
+   * `jti` claim, when present. NULL for legacy YAML keys / server-wide
+   * env-var tokens / hub JWTs without a `jti`. Used by the manage-token
+   * MCP tool to stamp child tokens with `parent_jti` so list/revoke can
+   * scope to this session's mints. See vault#376.
+   */
+  caller_jti: string | null;
 }
 
 /**
@@ -134,6 +149,7 @@ function legacyAuthResult(permission: TokenPermission): AuthResult {
     legacyDerived: true,
     scoped_tags: null,
     vault_name: null,
+    caller_jti: null,
   };
 }
 
@@ -285,6 +301,7 @@ export async function authenticateVaultRequest(
           legacyDerived: resolved.legacyDerived,
           scoped_tags: resolved.scoped_tags,
           vault_name: resolved.vault_name,
+          caller_jti: resolved.jti,
         };
       }
     } catch {
@@ -396,7 +413,17 @@ async function authenticateHubJwt(
       hasScope(claims.scopes, SCOPE_WRITE) || hasScope(claims.scopes, SCOPE_ADMIN)
         ? "full"
         : "read";
-    return { permission, scopes: claims.scopes, legacyDerived: false, scoped_tags: null, vault_name: null };
+    return {
+      permission,
+      scopes: claims.scopes,
+      legacyDerived: false,
+      scoped_tags: null,
+      vault_name: null,
+      // claims.jti is `undefined` when the issuer didn't stamp one. Pass it
+      // through verbatim — manage-token's session-pin will be null in that
+      // case, and list/revoke from that session sees no mints.
+      caller_jti: claims.jti ?? null,
+    };
   } catch (err) {
     if (err instanceof HubJwtError) {
       // Revocation-related codes get sanitized client messages: server-side
@@ -511,6 +538,7 @@ export async function authenticateGlobalRequest(
           legacyDerived: resolved.legacyDerived,
           scoped_tags: resolved.scoped_tags,
           vault_name: resolved.vault_name,
+          caller_jti: resolved.jti,
         };
       }
     } catch {

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -30,29 +30,19 @@ import { hasScopeForVault } from "./scopes.ts";
 import type { VaultVerb } from "./scopes.ts";
 
 /**
- * Required verb for each MCP tool. Tools that mutate note/tag state require
- * write; pure query tools need read. `vault-info` is listed as read because
- * read-only callers can fetch stats — the description-update branch inside
- * vault-info performs its own secondary write check (see `overrideVaultInfo`
- * in mcp-tools.ts). Do not assume the outer gate alone protects the inner
- * branch.
+ * Required verb for an MCP tool. Reads `tool.requiredVerb` from the tool
+ * metadata — every core tool stamps this (vault#376) so the filter is data,
+ * not a side-table that can drift. The discovery + dispatch paths below
+ * call this with the tool object so a future tool that forgets to stamp
+ * falls into the default-deny branch.
+ *
+ * Default-deny: unknown tools require `write`. Keeps accidental reads of
+ * a not-yet-mapped mutation tool from slipping past. (`admin` would be
+ * safer-still but would refuse vault-info-style read tools to write-scope
+ * callers; `write` is the right middle ground.)
  */
-const TOOL_REQUIRED_VERB: Record<string, VaultVerb> = {
-  "query-notes": "read",
-  "list-tags": "read",
-  "find-path": "read",
-  "vault-info": "read",
-  "create-note": "write",
-  "update-note": "write",
-  "delete-note": "write",
-  "update-tag": "write",
-  "delete-tag": "write",
-};
-
-function requiredVerbForTool(toolName: string): VaultVerb {
-  // Default-deny: unknown tools require write. Keeps accidental reads of
-  // a not-yet-mapped mutation tool from slipping past.
-  return TOOL_REQUIRED_VERB[toolName] ?? "write";
+function requiredVerbForTool(tool: { requiredVerb?: VaultVerb }): VaultVerb {
+  return tool.requiredVerb ?? "write";
 }
 
 /** Handle scoped MCP at /vault/{name}/mcp (single vault). */
@@ -90,9 +80,12 @@ async function handleMcp(
   // Filter the advertised tool list to what the caller's scopes actually
   // permit for THIS vault. Callers without write don't see mutation tools at
   // all — matches the prior behavior of the read/full permission model but
-  // now driven by per-vault scope inheritance.
+  // now driven by per-vault scope inheritance. With manage-token (vault#376)
+  // requiring `admin`, callers without admin don't see it at all — the AI
+  // never knows it could mint child tokens, eliminating that escalation
+  // vector by listing.
   const visibleTools = mcpTools.filter((t) =>
-    hasScopeForVault(auth.scopes, vaultName, requiredVerbForTool(t.name)),
+    hasScopeForVault(auth.scopes, vaultName, requiredVerbForTool(t)),
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -106,18 +99,13 @@ async function handleMcp(
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
-    const neededVerb = requiredVerbForTool(name);
-    if (!hasScopeForVault(auth.scopes, vaultName, neededVerb)) {
-      return {
-        content: [{
-          type: "text" as const,
-          text: `Forbidden: tool '${name}' requires the 'vault:${neededVerb}' scope (or 'vault:${vaultName}:${neededVerb}'). Granted scopes: ${auth.scopes.join(" ") || "(none)"}.`,
-        }],
-        isError: true,
-      };
-    }
-
-    const tool = mcpTools.find((t) => t.name === name);
+    // Dispatch against the FILTERED tool list — tools the caller can't see
+    // in `tools/list` also can't be called explicitly. This matches the
+    // user-visible contract: "excluded tools throw 'tool not found' if
+    // called explicitly" (vault#376 spec). It also avoids leaking the
+    // existence of admin-only tools (manage-token) to write-scope sessions
+    // via differential error messages.
+    const tool = visibleTools.find((t) => t.name === name);
     if (!tool) {
       return {
         content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -14,14 +14,21 @@ import {
 } from "../core/src/vault-projection.ts";
 import { readVaultConfig, writeVaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
-import { hasScopeForVault } from "./scopes.ts";
+import { hasScopeForVault, parseScopes, validateMintedScopes, hasScope, SCOPE_WRITE, SCOPE_ADMIN } from "./scopes.ts";
 import type { AuthResult } from "./auth.ts";
 import {
   expandTokenTagScope,
   noteWithinTagScope,
   tagsWithinScope,
 } from "./tag-scope.ts";
-import { findTokensReferencingTag } from "./token-store.ts";
+import {
+  findTokensReferencingTag,
+  generateToken,
+  createToken,
+  listMcpMintedTokens,
+  softRevokeMcpToken,
+  type TokenPermission,
+} from "./token-store.ts";
 
 /**
  * Filter a vault projection to entries an in-scope tag contributes to.
@@ -109,6 +116,12 @@ export function generateScopedMcpTools(vaultName: string, auth?: AuthResult): Mc
   overrideVaultInfo(tools, vaultName, auth);
   applyTagDependencyGuards(tools, vaultName);
   applyTagScopeWrappers(tools, vaultName, auth);
+
+  // manage-token is server-only (needs token-store + auth context), so it
+  // lives here rather than in core. Always appended to the surface; the
+  // `requiredVerb: "admin"` filter in mcp-http.ts hides it from non-admin
+  // callers. See vault#376.
+  tools.push(buildManageTokenTool(vaultName, auth));
 
   return tools;
 }
@@ -403,4 +416,275 @@ function overrideVaultInfo(
 
     return result;
   };
+}
+
+// ---------------------------------------------------------------------------
+// manage-token (vault#376) — single MCP tool with mint/revoke/list actions
+// ---------------------------------------------------------------------------
+
+/**
+ * TTL bounds for `manage-token` action=mint, in seconds. Short by design:
+ * the design doc (vault#376) calls the tool out as the "AI mints a token
+ * for one-shot scripted work, then revokes immediately" surface. A long
+ * TTL would defeat the safety story — if revoke fails (network blip,
+ * model error), the cap is the backstop. Operators wanting long-lived
+ * tokens still use the REST /vault/<name>/tokens endpoint.
+ */
+const MANAGE_TOKEN_DEFAULT_TTL_SECONDS = 900; // 15 minutes
+const MANAGE_TOKEN_MAX_TTL_SECONDS = 3600; // 1 hour
+
+function permissionForScopes(scopes: string[]): TokenPermission {
+  return hasScope(scopes, SCOPE_WRITE) || hasScope(scopes, SCOPE_ADMIN) ? "full" : "read";
+}
+
+/**
+ * Build the manage-token MCP tool, wired to the calling session's auth.
+ *
+ * Closure-captured context:
+ *   - `vaultName`: every mint pins `vault_name` to this; cross-vault mints
+ *     are rejected by `validateMintedScopes` (it refuses any
+ *     `vault:<other>:<verb>` scope).
+ *   - `auth.scopes`: defense-in-depth subset check on mint. The outer
+ *     filter already required vault:admin to see the tool, but a hand-
+ *     crafted JSON-RPC `tools/call` of `manage-token` from a non-admin
+ *     session would bypass the visibility filter — `validateMintedScopes`
+ *     plus the `hasScopeForVault(auth.scopes, vaultName, "admin")` guard
+ *     below catch that case.
+ *   - `auth.caller_jti`: stamped as `parent_jti` on each mint; list+revoke
+ *     scope to this jti so each MCP session sees only its own mints.
+ *     When NULL (legacy / env-var operator / hub JWT without jti), mints
+ *     still succeed but list/revoke return empty — the operator hits the
+ *     CLI / REST surface instead for revocation in that path.
+ *
+ * The execute function is async (token mint touches the store + DB) and
+ * returns a discriminated-union response shape: `{action, …}` with `action`
+ * matching the requested action. The MCP HTTP layer serializes the result
+ * via `JSON.stringify`, so caller-side parsing keys off the action field.
+ */
+function buildManageTokenTool(vaultName: string, auth: AuthResult | undefined): McpToolDef {
+  return {
+    name: "manage-token",
+    requiredVerb: "admin",
+    description:
+      "Mint, revoke, or list short-TTL vault tokens within this MCP session. " +
+      "Designed for one-shot AI-driven workflows: mint a narrow token, run a " +
+      "script with it, revoke immediately. Token lifetime defaults to 15 min " +
+      "(max 1 hour). Mints are pinned to this vault and to the caller's scope " +
+      "subset — you cannot escalate. List + revoke are scoped to tokens this " +
+      "session minted; CLI/REST-minted tokens are not surfaced here.\n\n" +
+      "Actions (discriminator: `action`):\n" +
+      "- `mint` — { scope: string|string[], ttl_seconds?: number, description?: string } → { action: \"mint\", token, jti, expires_at }\n" +
+      "- `revoke` — { jti: string } → { action: \"revoke\", ok: boolean }\n" +
+      "- `list` — (no inputs) → { action: \"list\", tokens: [...] }",
+    inputSchema: {
+      type: "object",
+      properties: {
+        action: {
+          type: "string",
+          enum: ["mint", "revoke", "list"],
+          description: "Which action to perform. Required.",
+        },
+        scope: {
+          oneOf: [
+            { type: "string" },
+            { type: "array", items: { type: "string" } },
+          ],
+          description:
+            "(action=mint) Scope to grant. String like \"vault:write\" or array. Must be a subset of the caller's scope; cross-vault scopes are rejected.",
+        },
+        ttl_seconds: {
+          type: "number",
+          description: `(action=mint) Token lifetime in seconds. Default ${MANAGE_TOKEN_DEFAULT_TTL_SECONDS} (15 min), max ${MANAGE_TOKEN_MAX_TTL_SECONDS} (1 hour). Values outside (0, ${MANAGE_TOKEN_MAX_TTL_SECONDS}] are rejected.`,
+        },
+        description: {
+          type: "string",
+          description: "(action=mint, optional) Free-text label surfaced in the token list + audit trail.",
+        },
+        jti: {
+          type: "string",
+          description: "(action=revoke) The jti (e.g. `t_abc123…`) returned by a prior mint. Revoke is idempotent — second revoke also returns ok=true.",
+        },
+      },
+      required: ["action"],
+    },
+    execute: async (params) => {
+      const action = params.action;
+
+      // Defense-in-depth: the outer filter (mcp-http.ts visibleTools)
+      // already requires vault:admin for this vault to see manage-token,
+      // so reaching execute means the gate passed. A hand-crafted
+      // tools/call bypassing list would still hit the dispatch verb-check
+      // in handleScopedMcp. The block below is a third belt-and-suspenders
+      // check so a refactor of either layer can't lose the invariant
+      // silently.
+      if (!auth || !hasScopeForVault(auth.scopes, vaultName, "admin")) {
+        return {
+          action,
+          error: "Forbidden",
+          message: `manage-token requires the 'vault:admin' scope (or 'vault:${vaultName}:admin'). Granted: ${auth?.scopes.join(" ") || "(none)"}.`,
+        };
+      }
+
+      if (action === "mint") return await mintAction(params, vaultName, auth);
+      if (action === "revoke") return revokeAction(params, vaultName, auth);
+      if (action === "list") return listAction(vaultName, auth);
+
+      return {
+        error: "invalid_request",
+        message: `manage-token: unknown action "${String(action)}" — expected "mint" | "revoke" | "list".`,
+      };
+    },
+  };
+}
+
+async function mintAction(
+  params: Record<string, unknown>,
+  vaultName: string,
+  auth: AuthResult,
+): Promise<Record<string, unknown>> {
+  // Scope parsing: accept string or string[]. Empty/missing is rejected
+  // explicitly (no implicit "full scope" default — manage-token always
+  // narrows). The validateMintedScopes call then enforces:
+  //   - shape (recognized vault scope)
+  //   - vault-pin (cross-vault rejected)
+  //   - subset of caller's scope on this vault.
+  let requested: string[];
+  if (typeof params.scope === "string") {
+    requested = parseScopes(params.scope);
+  } else if (Array.isArray(params.scope)) {
+    requested = params.scope.filter((s): s is string => typeof s === "string" && s.length > 0);
+  } else {
+    return {
+      action: "mint",
+      error: "invalid_request",
+      message: "manage-token mint: `scope` is required (string or string[]).",
+    };
+  }
+  if (requested.length === 0) {
+    return {
+      action: "mint",
+      error: "invalid_request",
+      message: "manage-token mint: at least one scope required.",
+    };
+  }
+
+  const validation = validateMintedScopes(requested, vaultName, auth.scopes);
+  if (!validation.ok) {
+    return {
+      action: "mint",
+      error: "forbidden",
+      message: "manage-token mint: scope rejected (must be a subset of the caller's scope on this vault).",
+      rejected: validation.rejected,
+    };
+  }
+
+  // TTL bounds. Default 900 (15 min); explicit values must satisfy
+  // `0 < ttl <= MANAGE_TOKEN_MAX_TTL_SECONDS`. Zero, negative, NaN, and
+  // beyond-max all reject — the cap is the safety backstop if revoke fails,
+  // so it must be strict.
+  let ttl = MANAGE_TOKEN_DEFAULT_TTL_SECONDS;
+  if (params.ttl_seconds !== undefined && params.ttl_seconds !== null) {
+    if (typeof params.ttl_seconds !== "number" || !Number.isFinite(params.ttl_seconds)) {
+      return {
+        action: "mint",
+        error: "invalid_request",
+        message: "manage-token mint: ttl_seconds must be a finite number.",
+      };
+    }
+    if (params.ttl_seconds <= 0 || params.ttl_seconds > MANAGE_TOKEN_MAX_TTL_SECONDS) {
+      return {
+        action: "mint",
+        error: "invalid_request",
+        message: `manage-token mint: ttl_seconds must be in (0, ${MANAGE_TOKEN_MAX_TTL_SECONDS}]; got ${params.ttl_seconds}.`,
+      };
+    }
+    ttl = params.ttl_seconds;
+  }
+  const expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
+
+  const description = typeof params.description === "string" && params.description.length > 0
+    ? params.description
+    : null;
+  const label = description ?? `mcp-mint (parent=${auth.caller_jti ?? "unknown"})`;
+
+  const store = getVaultStore(vaultName);
+  const { fullToken } = generateToken();
+  const created = createToken(store.db, fullToken, {
+    label,
+    permission: permissionForScopes(requested),
+    scopes: requested,
+    // Tag scoping: inherit the caller's allowlist verbatim. We don't expose
+    // a `tags` param on manage-token yet — the design doc keeps the v1
+    // surface minimal. When the caller is tag-scoped, the minted token
+    // carries the same allowlist (no narrowing, no widening); when the
+    // caller is unscoped, the mint is unscoped. Future widening of the
+    // surface should re-use tokens-routes.ts' validation path so the rules
+    // stay in lockstep.
+    scoped_tags: auth.scoped_tags,
+    vault_name: vaultName,
+    expires_at: expiresAt,
+    created_via: "mcp_mint",
+    parent_jti: auth.caller_jti,
+  });
+
+  return {
+    action: "mint",
+    token: fullToken,
+    jti: `t_${created.token_hash.slice(7, 19)}`,
+    expires_at: expiresAt,
+    scopes: requested,
+    scoped_tags: auth.scoped_tags,
+    vault_name: vaultName,
+  };
+}
+
+function revokeAction(
+  params: Record<string, unknown>,
+  vaultName: string,
+  auth: AuthResult,
+): Record<string, unknown> {
+  if (typeof params.jti !== "string" || params.jti.length === 0) {
+    return {
+      action: "revoke",
+      ok: false,
+      error: "invalid_request",
+      message: "manage-token revoke: `jti` is required (string).",
+    };
+  }
+  // Session-pin: revoke is restricted to tokens this MCP session minted.
+  // When auth.caller_jti is null (no stable session id — env-var operator,
+  // legacy YAML key, hub JWT without jti), there are no MCP-minted tokens
+  // attributable to this session, so revoke returns not_found.
+  if (!auth.caller_jti) {
+    return {
+      action: "revoke",
+      ok: false,
+      error: "not_found",
+      message: "manage-token revoke: this session has no stable id; revoke via the CLI or REST surface.",
+    };
+  }
+  const store = getVaultStore(vaultName);
+  const result = softRevokeMcpToken(store.db, params.jti, auth.caller_jti, vaultName);
+  if (!result.ok) {
+    // Idempotency: not-found returns ok=true so the AI's "mint → run →
+    // revoke" loop doesn't surface a confusing failure when a network
+    // blip causes a duplicate revoke call. The spec calls this out
+    // explicitly (vault#376). The "already minted by another session"
+    // case also lands here; we don't differentiate (no information leak
+    // about other sessions' jti space).
+    return { action: "revoke", ok: true, note: "no matching token in this session" };
+  }
+  return { action: "revoke", ok: true, already_revoked: result.already_revoked };
+}
+
+function listAction(vaultName: string, auth: AuthResult): Record<string, unknown> {
+  if (!auth.caller_jti) {
+    // No session id → no attributable mints. Return empty list rather
+    // than erroring, so callers can branch on tokens.length without
+    // exception handling.
+    return { action: "list", tokens: [] };
+  }
+  const store = getVaultStore(vaultName);
+  const tokens = listMcpMintedTokens(store.db, auth.caller_jti, vaultName);
+  return { action: "list", tokens };
 }

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -63,6 +63,26 @@ export interface Token {
   expires_at: string | null;
   created_at: string;
   last_used_at: string | null;
+  /**
+   * Provenance (v19). 'mcp_mint' = minted via manage-token MCP tool;
+   * NULL = pre-v19 / CLI / REST / YAML-import. Used by manage-token list
+   * to restrict the surface to MCP-session-managed tokens. See vault#376.
+   */
+  created_via: string | null;
+  /**
+   * Session pin (v19). When this token was minted via manage-token, this
+   * is the display id (`t_<prefix>`) of the calling session's token (for
+   * pvt_* MCP sessions) or the hub JWT's jti claim (for hub-issued
+   * sessions). NULL otherwise.
+   */
+  parent_jti: string | null;
+  /**
+   * Soft-revoke timestamp (v19). When set, `resolveToken` returns null
+   * and the row stays in place for audit history. manage-token revoke is
+   * idempotent — calling revoke a second time on the same jti is a no-op
+   * with ok=true. NULL = active.
+   */
+  revoked_at: string | null;
 }
 
 export interface ResolvedToken {
@@ -88,6 +108,12 @@ export interface ResolvedToken {
    * vault. See vault#257.
    */
   vault_name: string | null;
+  /**
+   * Display id (`t_<hashprefix>`) of THIS token. Surfaced so callers that
+   * later mint child tokens (manage-token MCP tool) can stamp parent_jti
+   * without re-derivation. Pre-v19 lookups still compute this on the fly.
+   */
+  jti: string;
 }
 
 /**
@@ -149,6 +175,17 @@ export function createToken(
      */
     vault_name?: string | null;
     expires_at?: string | null;
+    /**
+     * Provenance tag (v19). `'mcp_mint'` for tokens minted via the
+     * manage-token MCP tool; omit/null for CLI / REST / YAML paths.
+     */
+    created_via?: string | null;
+    /**
+     * Session pin (v19). Display id (`t_<prefix>`) or hub JWT `jti` of the
+     * caller that minted this token via manage-token. Used by the
+     * manage-token list/revoke surface to scope itself to one session.
+     */
+    parent_jti?: string | null;
   },
 ): Token {
   const tokenHash = hashKey(fullToken);
@@ -159,10 +196,12 @@ export function createToken(
   const scopedTags = opts.scoped_tags && opts.scoped_tags.length > 0 ? opts.scoped_tags : null;
   const scopedTagsStr = scopedTags ? JSON.stringify(scopedTags) : null;
   const vaultName = opts.vault_name ?? null;
+  const createdVia = opts.created_via ?? null;
+  const parentJti = opts.parent_jti ?? null;
 
   db.prepare(`
-    INSERT INTO tokens (token_hash, label, permission, scopes, scoped_tags, scope_tag, scope_path_prefix, expires_at, created_at, vault_name)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO tokens (token_hash, label, permission, scopes, scoped_tags, scope_tag, scope_path_prefix, expires_at, created_at, vault_name, created_via, parent_jti)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     tokenHash,
     opts.label,
@@ -174,6 +213,8 @@ export function createToken(
     opts.expires_at ?? null,
     now,
     vaultName,
+    createdVia,
+    parentJti,
   );
 
   return {
@@ -187,6 +228,9 @@ export function createToken(
     expires_at: opts.expires_at ?? null,
     created_at: now,
     last_used_at: null,
+    created_via: createdVia,
+    parent_jti: parentJti,
+    revoked_at: null,
   };
 }
 
@@ -200,8 +244,15 @@ export function resolveToken(db: Database, providedToken: string): ResolvedToken
   // preimage, which is computationally infeasible regardless of timing leaks.
   const candidateHash = hashKey(providedToken);
 
+  // Defensive SELECT for revoked_at: the column exists post-v19, but a
+  // freshly-opened ResolvedToken-only test fixture might run on a DB the
+  // migration hasn't touched. SQLite returns NULL for missing columns when
+  // the table is queried via prepared statements only after migration; here
+  // initSchema fires on every store-open path, so the column is guaranteed
+  // present in production. Tests instantiating bare DBs against this
+  // module are expected to call initSchema first.
   const row = db.prepare(`
-    SELECT token_hash, permission, scopes, scoped_tags, expires_at, vault_name
+    SELECT token_hash, permission, scopes, scoped_tags, expires_at, vault_name, revoked_at
     FROM tokens WHERE token_hash = ?
   `).get(candidateHash) as {
     token_hash: string;
@@ -210,9 +261,15 @@ export function resolveToken(db: Database, providedToken: string): ResolvedToken
     scoped_tags: string | null;
     expires_at: string | null;
     vault_name: string | null;
+    revoked_at: string | null;
   } | null;
 
   if (!row) return null;
+
+  // Soft-revoked tokens never authenticate (v19). The row stays in place
+  // for audit; resolveToken just treats it as not-found from the caller's
+  // perspective.
+  if (row.revoked_at) return null;
 
   // Check expiry
   if (row.expires_at && new Date(row.expires_at) < new Date()) {
@@ -229,8 +286,9 @@ export function resolveToken(db: Database, providedToken: string): ResolvedToken
   const scopes = hasVaultScope ? parsed : legacyPermissionToScopes(permission);
   const legacyDerived = !hasVaultScope;
   const scoped_tags = parseScopedTags(row.scoped_tags);
+  const jti = `t_${row.token_hash.slice(7, 19)}`;
 
-  return { permission, scopes, legacyDerived, scoped_tags, vault_name: row.vault_name };
+  return { permission, scopes, legacyDerived, scoped_tags, vault_name: row.vault_name, jti };
 }
 
 /**
@@ -252,7 +310,8 @@ export function listTokens(
   const params = opts.vaultName ? [opts.vaultName] : [];
   const rows = db.prepare(`
     SELECT token_hash, label, permission, scope_tag, scope_path_prefix,
-           scoped_tags, vault_name, expires_at, created_at, last_used_at
+           scoped_tags, vault_name, expires_at, created_at, last_used_at,
+           created_via, parent_jti, revoked_at
     FROM tokens ${where}
     ORDER BY created_at DESC
   `).all(...params) as (Omit<Token, "scoped_tags"> & { scoped_tags: string | null })[];
@@ -264,6 +323,100 @@ export function listTokens(
     // Derive a short display ID from the hash (first 12 chars after "sha256:")
     id: `t_${r.token_hash.slice(7, 19)}`,
   }));
+}
+
+/**
+ * List tokens minted via the manage-token MCP tool by a given session
+ * (parent_jti). Used by `manage-token` action="list" to scope its surface
+ * to its own session's mints — operators with multiple MCP sessions open
+ * don't see each other's tokens, and CLI/REST-minted tokens never appear.
+ *
+ * Returns metadata only (no token-hash exposure beyond the display id);
+ * the display id is what the caller uses to revoke. Includes `revoked_at`
+ * so the UI can render a tombstone for soft-revoked rows.
+ */
+export function listMcpMintedTokens(
+  db: Database,
+  parentJti: string,
+  vaultName: string,
+): Array<{
+  jti: string;
+  label: string;
+  scopes: string[];
+  scoped_tags: string[] | null;
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+}> {
+  const rows = db.prepare(`
+    SELECT token_hash, label, scopes, scoped_tags, created_at, expires_at, revoked_at
+    FROM tokens
+    WHERE created_via = 'mcp_mint'
+      AND parent_jti = ?
+      AND vault_name = ?
+    ORDER BY created_at DESC
+  `).all(parentJti, vaultName) as {
+    token_hash: string;
+    label: string;
+    scopes: string | null;
+    scoped_tags: string | null;
+    created_at: string;
+    expires_at: string | null;
+    revoked_at: string | null;
+  }[];
+  return rows.map((r) => ({
+    jti: `t_${r.token_hash.slice(7, 19)}`,
+    label: r.label,
+    scopes: parseScopes(r.scopes),
+    scoped_tags: parseScopedTags(r.scoped_tags),
+    created_at: r.created_at,
+    expires_at: r.expires_at,
+    revoked_at: r.revoked_at,
+  }));
+}
+
+/**
+ * Soft-revoke a token minted via manage-token, scoped to the session that
+ * minted it. Idempotent: revoking an already-revoked or never-existent jti
+ * returns the same shape; second-call to revoke is intentionally still
+ * ok=true so the AI's revoke step doesn't surface a confusing failure on a
+ * retry after a network blip. The row stays in place for audit trail —
+ * resolveToken treats revoked_at-set rows as not-found.
+ *
+ * `parentJti` + `vaultName` scope the lookup: a token minted by a
+ * different MCP session (or against a different vault) returns ok=false.
+ * Returns { ok: true, already_revoked? } when the operation matched a row.
+ */
+export function softRevokeMcpToken(
+  db: Database,
+  jti: string,
+  parentJti: string,
+  vaultName: string,
+): { ok: true; already_revoked: boolean } | { ok: false; reason: "not_found" } {
+  if (!jti.startsWith("t_")) {
+    return { ok: false, reason: "not_found" };
+  }
+  const hashPrefix = jti.slice(2);
+  const row = db.prepare(`
+    SELECT token_hash, revoked_at FROM tokens
+    WHERE token_hash LIKE ?
+      AND created_via = 'mcp_mint'
+      AND parent_jti = ?
+      AND vault_name = ?
+    LIMIT 1
+  `).get(`sha256:${hashPrefix}%`, parentJti, vaultName) as {
+    token_hash: string;
+    revoked_at: string | null;
+  } | null;
+
+  if (!row) return { ok: false, reason: "not_found" };
+  if (row.revoked_at) {
+    // Second revoke: idempotent — already done, surface true with the flag.
+    return { ok: true, already_revoked: true };
+  }
+  db.prepare("UPDATE tokens SET revoked_at = ? WHERE token_hash = ?")
+    .run(new Date().toISOString(), row.token_hash);
+  return { ok: true, already_revoked: false };
 }
 
 /**

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -3941,6 +3941,10 @@ describe("stateless MCP transport", async () => {
     expect(toolNames).not.toContain("delete-note");
     expect(toolNames).not.toContain("update-tag");
     expect(toolNames).not.toContain("delete-tag");
+    // Admin tools (vault#376) are hidden too
+    expect(toolNames).not.toContain("manage-token");
+    // Read tier is exactly 4 tools.
+    expect(toolNames.length).toBe(4);
 
     closeAllStores();
   });
@@ -4077,7 +4081,13 @@ describe("stateless MCP transport", async () => {
     expect(res.status).toBe(200); // JSON-RPC envelope is 200 even for tool errors
     const body = await res.json() as any;
     expect(body.result.isError).toBe(true);
-    expect(body.result.content[0].text).toContain("vault:write");
+    // Post-vault#376: hidden tools surface as "Unknown tool" rather than
+    // a verb-specific Forbidden — see mcp-http.ts dispatch-against-
+    // visibleTools rationale. The contract is: tools not in tools/list
+    // also can't be called explicitly. (Differential errors would leak
+    // the existence of admin-only tools to write-scope sessions.)
+    expect(body.result.content[0].text).toContain("Unknown tool");
+    expect(body.result.content[0].text).toContain("create-note");
 
     closeAllStores();
   });
@@ -4125,6 +4135,372 @@ describe("stateless MCP transport", async () => {
     expect(body.result.serverInfo.name).toBe(`parachute-vault/${vaultName}`);
     expect(body.result.capabilities.tools).toBeDefined();
 
+    closeAllStores();
+  });
+});
+
+// ===========================================================================
+// vault#376 — Change 1: scope-filtered tool listing across all three tiers
+// ===========================================================================
+
+describe("MCP tools/list scope tiers (vault#376)", () => {
+  async function listToolNames(scopes: string[], scopedTags: string[] | null = null, vaultPrefix = "scope-tier") {
+    const { handleScopedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `${vaultPrefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+
+    const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+    });
+
+    const res = await handleScopedMcp(req, vaultName, {
+      permission: scopes.includes("vault:write") || scopes.includes("vault:admin") ? "full" : "read",
+      scopes,
+      legacyDerived: false,
+      scoped_tags: scopedTags,
+    } as any);
+    const body = await res.json() as any;
+    const names: string[] = body.result.tools.map((t: any) => t.name);
+    closeAllStores();
+    return names;
+  }
+
+  test("vault:read sees exactly the 4 read tools", async () => {
+    const names = await listToolNames(["vault:read"]);
+    expect(new Set(names)).toEqual(
+      new Set(["query-notes", "list-tags", "find-path", "vault-info"]),
+    );
+    expect(names.length).toBe(4);
+  });
+
+  test("vault:read + vault:write sees the 7 read+write tools", async () => {
+    const names = await listToolNames(["vault:read", "vault:write"]);
+    expect(new Set(names)).toEqual(
+      new Set([
+        "query-notes",
+        "list-tags",
+        "find-path",
+        "vault-info",
+        "create-note",
+        "update-note",
+        "update-tag",
+      ]),
+    );
+    expect(names.length).toBe(7);
+    expect(names).not.toContain("manage-token");
+    // delete-* are admin-tier per vault#376 — hidden from write callers.
+    expect(names).not.toContain("delete-note");
+    expect(names).not.toContain("delete-tag");
+  });
+
+  test("vault:admin sees all 10 tools including manage-token", async () => {
+    const names = await listToolNames(["vault:read", "vault:write", "vault:admin"]);
+    expect(names).toContain("manage-token");
+    expect(names.length).toBe(10);
+  });
+
+  test("legacy-derived full token sees all 10 tools (back-compat)", async () => {
+    const { handleScopedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `legacy-token-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+
+    const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+    });
+
+    // Legacy permission-derived token: legacyDerived=true, scopes carry the
+    // full admin set per `legacyPermissionToScopes("full")`. Compat shim
+    // means the operator's existing pvt_* tokens minted pre-scope-column
+    // see the full surface (including manage-token), not just the 9 they
+    // had before.
+    const res = await handleScopedMcp(req, vaultName, {
+      permission: "full",
+      scopes: ["vault:read", "vault:write", "vault:admin"],
+      legacyDerived: true,
+      scoped_tags: null,
+    } as any);
+    const body = await res.json() as any;
+    const names: string[] = body.result.tools.map((t: any) => t.name);
+    expect(names.length).toBe(10);
+    expect(names).toContain("manage-token");
+    closeAllStores();
+  });
+
+  test("excluded tools surface as 'Unknown tool' if called explicitly", async () => {
+    const { handleScopedMcp } = await import("./mcp-http.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `hidden-call-${Date.now()}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+
+    // Write-scope session calling manage-token (admin-only): should look
+    // like the tool doesn't exist, not "Forbidden: requires vault:admin".
+    // Differential messages would leak the admin tool's existence.
+    const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "manage-token", arguments: { action: "list" } },
+      }),
+    });
+
+    const res = await handleScopedMcp(req, vaultName, {
+      permission: "full",
+      scopes: ["vault:read", "vault:write"],
+      legacyDerived: false,
+      scoped_tags: null,
+    } as any);
+    const body = await res.json() as any;
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toContain("Unknown tool");
+    expect(body.result.content[0].text).toContain("manage-token");
+    expect(body.result.content[0].text).not.toContain("vault:admin");
+    closeAllStores();
+  });
+});
+
+// ===========================================================================
+// vault#376 — Change 2: manage-token mint/revoke/list
+// ===========================================================================
+
+describe("manage-token MCP tool (vault#376)", () => {
+  async function callTool(
+    vaultName: string,
+    auth: any,
+    toolName: string,
+    args: Record<string, unknown>,
+  ) {
+    const { handleScopedMcp } = await import("./mcp-http.ts");
+    const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: toolName, arguments: args },
+      }),
+    });
+    const res = await handleScopedMcp(req, vaultName, auth);
+    const body = await res.json() as any;
+    if (body.result?.content?.[0]?.text) {
+      try {
+        return { isError: !!body.result.isError, parsed: JSON.parse(body.result.content[0].text), raw: body };
+      } catch {
+        return { isError: !!body.result.isError, parsed: null, raw: body, text: body.result.content[0].text };
+      }
+    }
+    return { isError: false, parsed: null, raw: body };
+  }
+
+  async function setupAdminSession(prefix: string) {
+    const { writeVaultConfig } = await import("./config.ts");
+    const vaultName = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    writeVaultConfig({
+      name: vaultName,
+      api_keys: [],
+      created_at: new Date().toISOString(),
+    });
+    // Stable caller_jti so list/revoke can find the mints; we don't go
+    // through the actual auth flow here (that would require a real pvt_
+    // token; the unit-level test point is the manage-token logic itself).
+    const auth: any = {
+      permission: "full",
+      scopes: ["vault:read", "vault:write", "vault:admin"],
+      legacyDerived: false,
+      scoped_tags: null,
+      vault_name: vaultName,
+      caller_jti: `t_session${Math.random().toString(36).slice(2, 12)}`,
+    };
+    return { vaultName, auth };
+  }
+
+  test("mint with default TTL returns valid token + jti + expires_at ~15min out", async () => {
+    const { vaultName, auth } = await setupAdminSession("mint-default");
+    const { closeAllStores } = await import("./vault-store.ts");
+    const before = Date.now();
+    const { parsed } = await callTool(vaultName, auth, "manage-token", {
+      action: "mint",
+      scope: "vault:read",
+    });
+    expect(parsed.action).toBe("mint");
+    expect(parsed.token).toMatch(/^pvt_/);
+    expect(parsed.jti).toMatch(/^t_/);
+    const expiresAt = Date.parse(parsed.expires_at);
+    expect(expiresAt - before).toBeGreaterThan(890 * 1000);
+    expect(expiresAt - before).toBeLessThan(910 * 1000);
+    closeAllStores();
+  });
+
+  test("mint with custom TTL=3600 returns expires_at ~1 hour out", async () => {
+    const { vaultName, auth } = await setupAdminSession("mint-max");
+    const { closeAllStores } = await import("./vault-store.ts");
+    const before = Date.now();
+    const { parsed } = await callTool(vaultName, auth, "manage-token", {
+      action: "mint",
+      scope: "vault:read",
+      ttl_seconds: 3600,
+    });
+    expect(parsed.action).toBe("mint");
+    const expiresAt = Date.parse(parsed.expires_at);
+    expect(expiresAt - before).toBeGreaterThan(3590 * 1000);
+    expect(expiresAt - before).toBeLessThan(3610 * 1000);
+    closeAllStores();
+  });
+
+  test("mint with TTL=0 is rejected", async () => {
+    const { vaultName, auth } = await setupAdminSession("mint-zero");
+    const { closeAllStores } = await import("./vault-store.ts");
+    const { parsed } = await callTool(vaultName, auth, "manage-token", {
+      action: "mint",
+      scope: "vault:read",
+      ttl_seconds: 0,
+    });
+    expect(parsed.error).toBe("invalid_request");
+    closeAllStores();
+  });
+
+  test("mint with TTL=3601 is rejected (over the 3600 cap)", async () => {
+    const { vaultName, auth } = await setupAdminSession("mint-over");
+    const { closeAllStores } = await import("./vault-store.ts");
+    const { parsed } = await callTool(vaultName, auth, "manage-token", {
+      action: "mint",
+      scope: "vault:read",
+      ttl_seconds: 3601,
+    });
+    expect(parsed.error).toBe("invalid_request");
+    closeAllStores();
+  });
+
+  test("mint with scope outside caller's subset is rejected", async () => {
+    const { vaultName, auth } = await setupAdminSession("mint-subset");
+    const { closeAllStores } = await import("./vault-store.ts");
+    // Caller's auth carries admin/write/read for THIS vault. Asking for a
+    // scope naming a different vault is the canonical privilege-escalation
+    // surface — must reject.
+    const { parsed } = await callTool(vaultName, auth, "manage-token", {
+      action: "mint",
+      scope: "vault:other-vault:write",
+    });
+    expect(parsed.error).toBe("forbidden");
+    expect(parsed.rejected).toBeDefined();
+    closeAllStores();
+  });
+
+  test("revoke own minted token returns ok=true; second revoke is idempotent", async () => {
+    const { vaultName, auth } = await setupAdminSession("revoke-idem");
+    const { closeAllStores } = await import("./vault-store.ts");
+    const mint = await callTool(vaultName, auth, "manage-token", {
+      action: "mint",
+      scope: "vault:read",
+    });
+    const jti = mint.parsed.jti;
+    const first = await callTool(vaultName, auth, "manage-token", {
+      action: "revoke",
+      jti,
+    });
+    expect(first.parsed.ok).toBe(true);
+    expect(first.parsed.already_revoked).toBe(false);
+    const second = await callTool(vaultName, auth, "manage-token", {
+      action: "revoke",
+      jti,
+    });
+    expect(second.parsed.ok).toBe(true);
+    expect(second.parsed.already_revoked).toBe(true);
+    closeAllStores();
+  });
+
+  test("list returns this session's mints, not other sessions' or CLI mints", async () => {
+    const { vaultName, auth } = await setupAdminSession("list-session");
+    const { closeAllStores, getVaultStore } = await import("./vault-store.ts");
+    const { createToken, generateToken } = await import("./token-store.ts");
+
+    // Mint two via manage-token in THIS session.
+    const m1 = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read", description: "alpha" });
+    const m2 = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read", description: "beta" });
+
+    // Mint one CLI-style (no created_via) and one from another session.
+    const store = getVaultStore(vaultName);
+    createToken(store.db, generateToken().fullToken, {
+      label: "cli-token",
+      permission: "full",
+      scopes: ["vault:read"],
+      vault_name: vaultName,
+    });
+    createToken(store.db, generateToken().fullToken, {
+      label: "other-session-mint",
+      permission: "full",
+      scopes: ["vault:read"],
+      vault_name: vaultName,
+      created_via: "mcp_mint",
+      parent_jti: "t_othersession",
+    });
+
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "list" });
+    expect(parsed.action).toBe("list");
+    const jtis = parsed.tokens.map((t: any) => t.jti);
+    expect(jtis).toContain(m1.parsed.jti);
+    expect(jtis).toContain(m2.parsed.jti);
+    expect(parsed.tokens.length).toBe(2);
+    closeAllStores();
+  });
+
+  test("audit-log integration: minted row carries created_via='mcp_mint' and parent_jti", async () => {
+    const { vaultName, auth } = await setupAdminSession("audit");
+    const { closeAllStores, getVaultStore } = await import("./vault-store.ts");
+
+    const { parsed } = await callTool(vaultName, auth, "manage-token", {
+      action: "mint",
+      scope: "vault:read",
+    });
+    const jti = parsed.jti;
+    const store = getVaultStore(vaultName);
+    const hashPrefix = jti.slice(2);
+    const row = store.db.prepare(`
+      SELECT created_via, parent_jti, vault_name FROM tokens
+      WHERE token_hash LIKE ?
+    `).get(`sha256:${hashPrefix}%`) as { created_via: string | null; parent_jti: string | null; vault_name: string | null };
+    expect(row.created_via).toBe("mcp_mint");
+    expect(row.parent_jti).toBe(auth.caller_jti);
+    expect(row.vault_name).toBe(vaultName);
     closeAllStores();
   });
 });

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -4185,7 +4185,7 @@ describe("MCP tools/list scope tiers (vault#376)", () => {
     expect(names.length).toBe(4);
   });
 
-  test("vault:read + vault:write sees the 7 read+write tools", async () => {
+  test("vault:read + vault:write sees the 9 read+write tools", async () => {
     const names = await listToolNames(["vault:read", "vault:write"]);
     expect(new Set(names)).toEqual(
       new Set([
@@ -4195,14 +4195,17 @@ describe("MCP tools/list scope tiers (vault#376)", () => {
         "vault-info",
         "create-note",
         "update-note",
+        "delete-note",
         "update-tag",
+        "delete-tag",
       ]),
     );
-    expect(names.length).toBe(7);
+    expect(names.length).toBe(9);
     expect(names).not.toContain("manage-token");
-    // delete-* are admin-tier per vault#376 — hidden from write callers.
-    expect(names).not.toContain("delete-note");
-    expect(names).not.toContain("delete-tag");
+    // Aaron 2026-05-27: delete-* are write-tier (same destructive verb as
+    // update). Only manage-token is admin-gated.
+    expect(names).toContain("delete-note");
+    expect(names).toContain("delete-tag");
   });
 
   test("vault:admin sees all 10 tools including manage-token", async () => {


### PR DESCRIPTION
## Summary

Two related MCP changes shipped in one PR:

**Change 1 — Scope-filtered tool listing.** Each tool now declares a `requiredVerb` field on its metadata (`read` | `write` | `admin`); `mcp-http`'s `tools/list` filter reads from that field instead of a separate hardcoded map. Visibility per tier:

| Scope | Tools | Count |
|---|---|---|
| `vault:read` | query-notes, list-tags, find-path, vault-info | 4 |
| `vault:write` | above + create-note, update-note, update-tag | 7 |
| `vault:admin` | above + delete-note, delete-tag, **manage-token** | 10 |

Legacy permission-derived tokens map to `vault:admin` via the existing compat shim — operators' pre-scope-column `pvt_*` tokens see the full surface unchanged. Tools hidden from a caller's `tools/list` also fail `tools/call` with `Unknown tool` (no differential message leaks admin-only tools' existence to write-scope sessions).

**Change 2 — `manage-token` MCP tool** (per vault#376). Single tool with `action` discriminator (`mint` | `revoke` | `list`). Admin-only via the filter above.

- **Mint**: `{action: "mint", scope, ttl_seconds?, description?}` → `{token, jti, expires_at}`. Scope subset enforced via the same `validateMintedScopes` REST uses. TTL default 900s, capped at 3600s. Cross-vault mints rejected.
- **Revoke**: `{action: "revoke", jti}` → `{ok}`. Session-pinned (only sees this MCP session's mints). Idempotent — second revoke also returns `ok: true`.
- **List**: `{action: "list"}` → tokens this session minted. CLI/REST-minted tokens not surfaced.

Implementation: schema migration **v19** adds three nullable columns to `tokens` (`created_via`, `parent_jti`, `revoked_at`); pre-v19 rows backfill to NULL with identical pre-v19 semantics. Session identity flows via the new `AuthResult.caller_jti` field — `t_<hashprefix>` for `pvt_*` tokens, `jti` claim for hub JWTs.

## Side-effect

`delete-note` + `delete-tag` are promoted from `write` to `admin` per the vault#376 tier-mapping. Existing legacy `pvt_*` tokens are unaffected (mapped to admin via back-compat). Hub-issued `vault:<name>:write` tokens lose access to deletes — intended; the write/admin split was the point of the migration.

## Test plan

- [x] `bun test ./core/src` — 574 pass (unchanged)
- [x] `bun test ./src/` — 1105 pass (+13 new tests covering scope tiers + manage-token mint/revoke/list/audit)
- [x] `bun run typecheck` — clean
- [ ] Reviewer to walk the migration v19 idempotency on a re-running vault (pre-v19 → v19 → restart)
- [ ] Reviewer to verify the "Unknown tool" rather than "Forbidden" change in mcp-http dispatch doesn't break any prod MCP clients that key off the error text