### PR TITLE
feat(vault): admin SPA UI for git-mirror config + manual-trigger endpoint

### DIFF
--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -16,7 +16,11 @@ import {
   MirrorManager,
   type MirrorDeps,
 } from "./mirror-manager.ts";
-import { handleMirrorGet, handleMirrorPut } from "./mirror-routes.ts";
+import {
+  handleMirrorGet,
+  handleMirrorPut,
+  handleMirrorRunNow,
+} from "./mirror-routes.ts";
 
 // Same env-restore pattern as mirror-manager.test.ts — keeps HOME +
 // PARACHUTE_HOME from leaking between test files.
@@ -375,6 +379,60 @@ describe("handleMirrorPut", () => {
     expect(status.enabled).toBe(true);
     expect(status.watch_running).toBe(true);
     expect(manager.getConfig().interval_seconds).toBe(2);
+    await manager.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /.parachute/mirror/run-now
+// ---------------------------------------------------------------------------
+
+describe("handleMirrorRunNow", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("returns 400 when mirror is disabled (avoids stale-status no-op)", async () => {
+    home = tmp("mirror-runnow-disabled-");
+    const { manager, exportCalls } = makeManager(home);
+    const res = await handleMirrorRunNow(manager);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toContain("not enabled");
+    // The disabled-guard short-circuits BEFORE manager.runNow(), so no
+    // export attempt happens — pinning this distinguishes the guard from
+    // a "200 with stale status" pass-through that would have looked
+    // identical to the operator.
+    expect(exportCalls()).toHaveLength(0);
+  });
+
+  test("fires an export pass and returns the updated config+status on success", async () => {
+    home = tmp("mirror-runnow-happy-");
+    const { manager, deps, exportCalls } = makeManager(home);
+    deps.writeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "internal",
+      watch: false,
+      auto_commit: false,
+    });
+    await manager.start();
+    // The initial export from start() already ran once. We pin the
+    // delta — run-now must trigger a SECOND export pass and the
+    // response must carry the updated status.
+    const exportsBefore = exportCalls().length;
+    const res = await handleMirrorRunNow(manager);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      config: MirrorConfig;
+      status: { enabled: boolean; last_export_at: string | null; mirror_path: string };
+    };
+    expect(body.config.enabled).toBe(true);
+    expect(body.status.enabled).toBe(true);
+    expect(body.status.last_export_at).not.toBeNull();
+    expect(body.status.mirror_path).toContain("mirror");
+    expect(exportCalls().length).toBe(exportsBefore + 1);
     await manager.stop();
   });
 });

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -1,8 +1,9 @@
 /**
  * HTTP surface for the mirror lifecycle.
  *
- *   GET  /vault/<name>/.parachute/mirror — read current config + runtime status
- *   PUT  /vault/<name>/.parachute/mirror — update config + reload watch loop
+ *   GET  /vault/<name>/.parachute/mirror         — read current config + runtime status
+ *   PUT  /vault/<name>/.parachute/mirror         — update config + reload watch loop
+ *   POST /vault/<name>/.parachute/mirror/run-now — fire a one-shot export+commit+push pass
  *
  * URL note: the design doc names this `/admin/mirror`, but vault's
  * existing routing already mounts the admin SPA's static-file bundle at
@@ -132,6 +133,44 @@ export async function handleMirrorPut(
     {
       config: manager.getConfig(),
       status,
+    },
+    { headers: { "Access-Control-Allow-Origin": "*" } },
+  );
+}
+
+/**
+ * `POST /vault/<name>/.parachute/mirror/run-now` — fire a one-shot export
+ * cycle right now (export → optional commit → optional push), using the
+ * persisted config. Same response shape as GET so the admin SPA reuses
+ * one decoder for both initial-load and after-trigger refresh.
+ *
+ * Refuses to fire (400) when the mirror is disabled: `runNow()` would
+ * already no-op in that case, but returning a 200 with stale status
+ * lets a misclick look successful. The 400 is the actionable surface
+ * — "enable the mirror first, then re-trigger."
+ *
+ * Mutating verb, vault:admin-gated upstream in `routing.ts` (alongside
+ * the GET/PUT). Auth is already enforced by the time this handler runs.
+ */
+export async function handleMirrorRunNow(
+  manager: MirrorManager,
+): Promise<Response> {
+  const status = manager.getStatus();
+  if (!status.enabled) {
+    return Response.json(
+      {
+        error: "Mirror not enabled",
+        message:
+          "Mirror must be enabled (and successfully bootstrapped) before a manual run can fire. Enable it via PUT /.parachute/mirror first.",
+      },
+      { status: 400 },
+    );
+  }
+  const updated = await manager.runNow();
+  return Response.json(
+    {
+      config: manager.getConfig(),
+      status: updated,
     },
     { headers: { "Access-Control-Allow-Origin": "*" } },
   );

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -1822,3 +1822,76 @@ describe("/vault/<name>/.parachute/mirror — auth + dispatch", () => {
     expect([405, 503]).toContain(res.status);
   });
 });
+
+// ---------------------------------------------------------------------------
+// /vault/<name>/.parachute/mirror/run-now — manual-trigger endpoint added
+// alongside the SPA UI. Tests pin the auth gate matches the parent
+// endpoint; handler-shape coverage lives in mirror-routes.test.ts.
+// ---------------------------------------------------------------------------
+
+describe("/vault/<name>/.parachute/mirror/run-now — auth + dispatch", () => {
+  test("unauthenticated → 401", async () => {
+    createVault("journal");
+    const p = "/vault/journal/.parachute/mirror/run-now";
+    const res = await route(
+      new Request(`http://localhost:1940${p}`, { method: "POST" }),
+      p,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("vault:read token → 403 insufficient_scope", async () => {
+    createVault("journal");
+    const store = getVaultStore("journal");
+    const { fullToken } = generateToken();
+    createToken(store.db, fullToken, {
+      label: "reader",
+      permission: "read",
+      scopes: ["vault:read"],
+    });
+    const p = "/vault/journal/.parachute/mirror/run-now";
+    const res = await route(
+      new Request(`http://localhost:1940${p}`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${fullToken}` },
+      }),
+      p,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error_type?: string; required_scope?: string };
+    expect(body.error_type).toBe("insufficient_scope");
+    expect(body.required_scope).toBe("vault:admin");
+  });
+
+  test("admin token reaches the handler — 503 when manager not wired, 400 when wired+disabled", async () => {
+    // Mirrors the parent endpoint's harness behavior: test ordering
+    // determines whether a previous test wired a manager. Either way
+    // the auth gate passed, which is what this routing-level test pins.
+    createVault("journal");
+    const token = createAdminToken("journal");
+    const p = "/vault/journal/.parachute/mirror/run-now";
+    const res = await route(
+      new Request(`http://localhost:1940${p}`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      p,
+    );
+    expect([400, 503]).toContain(res.status);
+  });
+
+  test("non-POST methods return 405 when manager is wired", async () => {
+    createVault("journal");
+    const token = createAdminToken("journal");
+    const p = "/vault/journal/.parachute/mirror/run-now";
+    const res = await route(
+      new Request(`http://localhost:1940${p}`, {
+        method: "GET",
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      p,
+    );
+    // 503 short-circuits the method check when no manager is wired.
+    expect([405, 503]).toContain(res.status);
+  });
+});

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -72,7 +72,7 @@ import {
 } from "./oauth-discovery.ts";
 import { handleConfigSchema, handleConfig } from "./module-config.ts";
 import { buildAuthStatus } from "./auth-status.ts";
-import { handleMirrorGet, handleMirrorPut } from "./mirror-routes.ts";
+import { handleMirrorGet, handleMirrorPut, handleMirrorRunNow } from "./mirror-routes.ts";
 import { getMirrorManager } from "./mirror-registry.ts";
 
 /**
@@ -508,6 +508,39 @@ export async function route(
     }
     if (req.method === "GET") return handleMirrorGet(manager);
     if (req.method === "PUT") return handleMirrorPut(req, manager);
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  // /.parachute/mirror/run-now — fire a one-shot export+commit+push pass.
+  // Same admin gate as the GET/PUT above; same manager presence check.
+  // POST-only — a GET would imply "read the result of running" which
+  // isn't the verb (the rolling status is already available on the
+  // parent GET endpoint).
+  if (subpath === "/.parachute/mirror/run-now") {
+    if (!hasScopeForVault(auth.scopes, vaultName, "admin")) {
+      return Response.json(
+        {
+          error: "Forbidden",
+          error_type: "insufficient_scope",
+          message: `This endpoint requires the '${SCOPE_ADMIN}' scope (or '${SCOPE_ADMIN.replace("vault:", `vault:${vaultName}:`)}').`,
+          required_scope: SCOPE_ADMIN,
+          granted_scopes: auth.scopes,
+        },
+        { status: 403 },
+      );
+    }
+    const manager = getMirrorManager();
+    if (!manager) {
+      return Response.json(
+        {
+          error: "Mirror manager not initialized",
+          message:
+            "The vault server hasn't wired a mirror manager yet (no vaults exist, or boot failed). Check logs for [mirror] entries.",
+        },
+        { status: 503 },
+      );
+    }
+    if (req.method === "POST") return handleMirrorRunNow(manager);
     return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { Link, Route, Routes } from "react-router-dom";
 import { getMountedVaultName } from "./lib/mount.ts";
 import { VaultDetail } from "./routes/VaultDetail.tsx";
+import { VaultMirror } from "./routes/VaultMirror.tsx";
 import { VaultTokens } from "./routes/VaultTokens.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
@@ -44,6 +45,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<VaultDetail vaultName={mountedVault} />} />
           <Route path="/tokens" element={<VaultTokens vaultName={mountedVault} />} />
+          <Route path="/mirror" element={<VaultMirror vaultName={mountedVault} />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       ) : (
@@ -51,6 +53,7 @@ export function App() {
           <Route path="/" element={<VaultsList />} />
           <Route path="/vault/:name" element={<VaultDetail />} />
           <Route path="/vault/:name/tokens" element={<VaultTokens />} />
+          <Route path="/vault/:name/mirror" element={<VaultMirror />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       )}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -90,6 +90,118 @@ export async function getVaultDetail(name: string): Promise<VaultDetailResult> {
   return (await res.json()) as VaultDetailResult;
 }
 
+// ---------------------------------------------------------------------------
+// Mirror — `/vault/<name>/.parachute/mirror[/run-now]`
+//
+// The backend's persisted config + runtime status shape, mirrored as
+// TypeScript so the SPA reads/writes the same JSON the server emits.
+// Field semantics live in `src/mirror-config.ts:MirrorConfig` and
+// `src/mirror-manager.ts:MirrorStatus`; the comments here just sketch
+// what each field controls so a reader of the SPA doesn't have to
+// jump out to the backend module.
+// ---------------------------------------------------------------------------
+
+export type MirrorLocation = "internal" | "external";
+
+export interface MirrorConfig {
+  enabled: boolean;
+  /** "internal" → hidden under vault data dir; "external" → operator-picked path. */
+  location: MirrorLocation;
+  /** Required when location=external + enabled. Must exist + be a git repo. */
+  external_path: string | null;
+  /** When true, the manager runs the watch loop in-process. */
+  watch: boolean;
+  /** Per-pass `git add -A && git commit` if true. */
+  auto_commit: boolean;
+  /** Per-commit `git push` if true. Failures non-fatal. */
+  auto_push: boolean;
+  /** Verbatim template; reuses the CLI's variable set (`{{date}}` etc.). */
+  commit_template: string;
+  /** Watch-loop poll interval in seconds. */
+  interval_seconds: number;
+}
+
+export interface MirrorStatus {
+  enabled: boolean;
+  watch_running: boolean;
+  mirror_path: string | null;
+  last_export_at: string | null;
+  last_export_notes_count: number | null;
+  last_commit_sha: string | null;
+  last_error: string | null;
+}
+
+export interface MirrorSnapshot {
+  config: MirrorConfig;
+  status: MirrorStatus;
+}
+
+function mirrorAuthHeaders(): Record<string, string> {
+  const token = getToken();
+  if (!token) {
+    throw new HttpError(401, "no admin token — open this page from the hub directory");
+  }
+  return {
+    accept: "application/json",
+    authorization: `Bearer ${token}`,
+  };
+}
+
+/** GET the persisted mirror config + the current runtime status snapshot. */
+export async function getMirror(vaultName: string): Promise<MirrorSnapshot> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror`,
+    { headers: mirrorAuthHeaders() },
+  );
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as MirrorSnapshot;
+}
+
+/**
+ * PUT a new config. The server validates shape (400 on type errors with a
+ * `field`-localized message), filesystem-validates external paths when
+ * enabling, then persists + restarts the lifecycle. Returns the updated
+ * snapshot.
+ */
+export async function putMirror(
+  vaultName: string,
+  config: Partial<MirrorConfig>,
+): Promise<MirrorSnapshot> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror`,
+    {
+      method: "PUT",
+      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      body: JSON.stringify(config),
+    },
+  );
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as MirrorSnapshot;
+}
+
+/**
+ * POST a manual "run export now" trigger. Returns the updated snapshot.
+ * Server returns 400 if the mirror isn't enabled — the SPA surfaces that
+ * as the configured-but-disabled hint rather than a generic error.
+ */
+export async function runMirrorNow(vaultName: string): Promise<MirrorSnapshot> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/run-now`,
+    {
+      method: "POST",
+      headers: mirrorAuthHeaders(),
+    },
+  );
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as MirrorSnapshot;
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -35,6 +35,7 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
   const name = vaultName ?? params.name;
   const isPerVaultMount = vaultName !== undefined;
   const tokensHref = isPerVaultMount ? "/tokens" : `/vault/${encodeURIComponent(name ?? "")}/tokens`;
+  const mirrorHref = isPerVaultMount ? "/mirror" : `/vault/${encodeURIComponent(name ?? "")}/mirror`;
   const [state, setState] = useState<State>({ kind: "loading" });
 
   useEffect(() => {
@@ -188,6 +189,10 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
           <li>
             <Link to={tokensHref}>Tokens →</Link>
             <span className="dim"> mint, list, and revoke <code>pvt_*</code> tokens</span>
+          </li>
+          <li>
+            <Link to={mirrorHref}>Git backup →</Link>
+            <span className="dim"> mirror this vault to a git repository on a schedule, or on demand</span>
           </li>
           <PermissionsLink vaultName={vault.name} />
         </ul>

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -1,0 +1,336 @@
+/**
+ * VaultMirror smoke tests — loading state, status render, preset apply,
+ * save → PUT, manual run → POST, auth-required redirect.
+ *
+ * `lib/api.ts` is mocked for the wire surface; `lib/scope.ts` is mocked
+ * so admin-vs-read gating is controllable per test without crafting JWTs.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import * as scope from "../lib/scope.ts";
+import { VaultMirror } from "./VaultMirror.tsx";
+
+// Preserve HttpError as a real class so the component's `err instanceof
+// HttpError` branches still match instances we throw in tests; everything
+// else is auto-stubbed. (vi.mock's single-arg form replaces the entire
+// module — we'd lose the class identity and the auth-required path
+// wouldn't trigger.)
+vi.mock("../lib/api.ts", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api.ts")>(
+    "../lib/api.ts",
+  );
+  return {
+    ...actual,
+    getMirror: vi.fn(),
+    putMirror: vi.fn(),
+    runMirrorNow: vi.fn(),
+  };
+});
+vi.mock("../lib/scope.ts");
+
+const snapshotFixture = (
+  over: Partial<api.MirrorConfig & api.MirrorStatus> = {},
+): api.MirrorSnapshot => {
+  const config: api.MirrorConfig = {
+    enabled: false,
+    location: "internal",
+    external_path: null,
+    watch: false,
+    auto_commit: true,
+    auto_push: false,
+    commit_template:
+      "export: {{date}} ({{notes_changed}} note{{plural}})",
+    interval_seconds: 5,
+    // override any config-typed fields if passed
+    ...Object.fromEntries(
+      Object.entries(over).filter(([k]) =>
+        [
+          "enabled",
+          "location",
+          "external_path",
+          "watch",
+          "auto_commit",
+          "auto_push",
+          "commit_template",
+          "interval_seconds",
+        ].includes(k),
+      ),
+    ),
+  } as api.MirrorConfig;
+  const status: api.MirrorStatus = {
+    enabled: config.enabled,
+    watch_running: false,
+    mirror_path: null,
+    last_export_at: null,
+    last_export_notes_count: null,
+    last_commit_sha: null,
+    last_error: null,
+    ...Object.fromEntries(
+      Object.entries(over).filter(([k]) =>
+        [
+          "watch_running",
+          "mirror_path",
+          "last_export_at",
+          "last_export_notes_count",
+          "last_commit_sha",
+          "last_error",
+        ].includes(k),
+      ),
+    ),
+  } as api.MirrorStatus;
+  return { config, status };
+};
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={["/vault/work/mirror"]}>
+      <Routes>
+        <Route path="/vault/:name/mirror" element={<VaultMirror />} />
+        <Route path="/vault/:name" element={<div>detail</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("VaultMirror — admin scope", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(true);
+  });
+
+  it("shows a loading state then renders the status card", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        location: "internal",
+        watch: true,
+        watch_running: true,
+        mirror_path: "/tmp/vault/mirror",
+        last_export_at: "2026-05-27T10:00:00.000Z",
+        last_export_notes_count: 3,
+        last_commit_sha: "abc1234567890def",
+      }),
+    );
+
+    renderRoute();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Status/i })).toBeInTheDocument(),
+    );
+    // Status fields render
+    expect(screen.getByText("/tmp/vault/mirror")).toBeInTheDocument();
+    expect(screen.getByText("2026-05-27T10:00:00.000Z")).toBeInTheDocument();
+    // Short sha (first 10)
+    expect(screen.getByText("abc1234567")).toBeInTheDocument();
+    expect(screen.getByText(/3 notes/)).toBeInTheDocument();
+  });
+
+  it("surfaces last_error in red when present", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        last_error: "external path went missing",
+      }),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/external path went missing/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("clicking a preset card pre-fills the form fields", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+
+    // Apply "History" preset → enabled, internal, watch on, interval 5
+    await user.click(
+      screen.getByRole("button", { name: /Apply History preset/i }),
+    );
+
+    const enableCheckbox = screen.getByLabelText(/Enable mirror/i) as HTMLInputElement;
+    expect(enableCheckbox.checked).toBe(true);
+
+    // Schedule resolves to "Live (every 5s)" for interval=5 + watch=true
+    const scheduleSelect = screen.getByLabelText(/Schedule/i) as HTMLSelectElement;
+    expect(scheduleSelect.value).toBe("live");
+
+    // Internal radio selected
+    const internalRadio = screen.getByLabelText(
+      /Internal/i,
+    ) as HTMLInputElement;
+    expect(internalRadio.checked).toBe(true);
+  });
+
+  it("clicking Live Mirror preset switches to external location + reveals path field", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Apply Live Mirror preset/i }),
+    );
+
+    // External-path input now visible
+    expect(screen.getByLabelText(/External path/i)).toBeInTheDocument();
+    expect(screen.getByText(/Path must exist AND be a git repo/i)).toBeInTheDocument();
+  });
+
+  it("Save button calls PUT with the current config", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
+    vi.mocked(api.putMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal", watch: true }),
+    );
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+
+    // Flip the master switch on, save.
+    await user.click(screen.getByLabelText(/Enable mirror/i));
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(api.putMirror).toHaveBeenCalled();
+    });
+    const [vaultArg, configArg] = vi.mocked(api.putMirror).mock.calls[0]!;
+    expect(vaultArg).toBe("work");
+    expect((configArg as api.MirrorConfig).enabled).toBe(true);
+  });
+
+  it("Run export now triggers POST and refreshes status", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+    vi.mocked(api.runMirrorNow).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        location: "internal",
+        last_export_at: "2026-05-27T11:00:00.000Z",
+        last_export_notes_count: 7,
+      }),
+    );
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Run export now/i }),
+      ).toBeInTheDocument(),
+    );
+    const runBtn = screen.getByRole("button", { name: /Run export now/i });
+    expect(runBtn).not.toBeDisabled();
+
+    await user.click(runBtn);
+
+    await waitFor(() => {
+      expect(api.runMirrorNow).toHaveBeenCalledWith("work");
+    });
+    // Status pulled from the returned snapshot.
+    await waitFor(() =>
+      expect(screen.getByText("2026-05-27T11:00:00.000Z")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/7 notes/)).toBeInTheDocument();
+  });
+
+  it("Run export now is disabled when status.enabled is false", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: false }),
+    );
+
+    renderRoute();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Run export now/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Run export now/i })).toBeDisabled();
+  });
+
+  it("surfaces a PUT error from the server next to the form", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
+    vi.mocked(api.putMirror).mockRejectedValue(
+      new api.HttpError(
+        400,
+        '`external_path` is required when `location` is "external"',
+      ),
+    );
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/external_path/)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("VaultMirror — auth-required path", () => {
+  it("shows the auth banner on 401 from getMirror", async () => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(false);
+    // The real HttpError class is preserved via the vi.mock factory above
+    // — `err instanceof HttpError` in the component matches a real
+    // instance thrown here.
+    vi.mocked(api.getMirror).mockRejectedValue(
+      new api.HttpError(401, "no admin token"),
+    );
+
+    renderRoute();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Open this page from the hub's directory/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("VaultMirror — read scope", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(false);
+  });
+
+  it("disables save + run buttons and shows the read-only banner", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText(/read-only token/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Save$/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Run export now/i })).toBeDisabled();
+  });
+});

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -196,6 +196,45 @@ describe("VaultMirror — admin scope", () => {
     expect(screen.getByText(/Path must exist AND be a git repo/i)).toBeInTheDocument();
   });
 
+  it("hides the Push-after-commit checkbox when location is internal", async () => {
+    // Auto-push is meaningless for internal mirrors (no configured remote).
+    // The form should hide the checkbox entirely rather than show a disabled
+    // one — anything else is confusing UX. Reviewer-flagged on #380.
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+
+    // Default fixture is location=internal — the Push checkbox should be absent.
+    expect(screen.queryByLabelText(/Push after each commit/i)).not.toBeInTheDocument();
+
+    // Flip to external via the Live Mirror preset — the checkbox appears.
+    await user.click(screen.getByRole("button", { name: /Apply Live Mirror preset/i }));
+    expect(screen.getByLabelText(/Push after each commit/i)).toBeInTheDocument();
+  });
+
+  it("shows a cursor-advance hint when auto_commit is unchecked", async () => {
+    // Unchecking Commit-after-each-export doesn't disable the export cursor —
+    // it just suppresses the commit. An operator clicking Run-now expecting
+    // a full snapshot would be surprised; the hint surfaces that gotcha.
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+
+    // No hint while auto_commit is the default (true).
+    expect(screen.queryByText(/export cursor still advances/i)).not.toBeInTheDocument();
+    // Uncheck — hint appears.
+    await user.click(screen.getByLabelText(/Commit after each export/i));
+    expect(screen.getByText(/export cursor still advances/i)).toBeInTheDocument();
+  });
+
   it("Save button calls PUT with the current config", async () => {
     vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
     vi.mocked(api.putMirror).mockResolvedValue(

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -1,0 +1,668 @@
+/**
+ * `/vault/:name/mirror` — admin SPA UI for the git-mirror lifecycle.
+ *
+ * Backend (already shipped pre-Phase A2 — see `src/mirror-config.ts`,
+ * `src/mirror-manager.ts`, `src/mirror-routes.ts` + the design doc at
+ * `parachute.computer/design/2026-05-20-vault-as-git-projection.md`)
+ * already handles persistence, lifecycle, and HTTP. This route fills
+ * the operator-facing gap so the "really good UI" for backing the
+ * vault up to a git repository — one of the launch-era asks — has a
+ * home that doesn't require curl + YAML editing.
+ *
+ * Layout: status card → manual-trigger button → preset cards → detailed
+ * config form. The presets pre-fill the form (matching the three the
+ * design doc names — "History" / "Live Mirror" / "Manual Export") so
+ * an operator who knows what shape they want gets there in one click.
+ * The detailed fields below the presets let custom shapes through
+ * without bypassing the form's validation.
+ *
+ * Schedule preset → `interval_seconds` mapping: friendly labels (Live /
+ * Every minute / Hourly / Daily / Manual only) on the picker, the
+ * backend's existing integer-seconds field on the wire. "Manual only"
+ * is the special case that sets `watch: false` — every other choice
+ * implies `watch: true` since the value's meaningless when the watch
+ * loop isn't running.
+ */
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  HttpError,
+  type MirrorConfig,
+  type MirrorSnapshot,
+  type MirrorStatus,
+  getMirror,
+  putMirror,
+  runMirrorNow,
+} from "../lib/api.ts";
+import { hasAdminScope } from "../lib/scope.ts";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ok"; snapshot: MirrorSnapshot }
+  | { kind: "auth-required" }
+  | { kind: "error"; message: string };
+
+/**
+ * Schedule presets — friendly labels operators recognize, mapped to the
+ * backend's `interval_seconds` integer. "Manual only" is the odd one
+ * out: it sets `watch: false` instead of choosing an interval, because
+ * the interval value is meaningless when the watch loop isn't armed.
+ */
+const SCHEDULE_OPTIONS: ReadonlyArray<{
+  value: string;
+  label: string;
+  interval?: number;
+  watch: boolean;
+}> = [
+  { value: "live", label: "Live (every 5s)", interval: 5, watch: true },
+  { value: "minute", label: "Every minute", interval: 60, watch: true },
+  { value: "10min", label: "Every 10 minutes", interval: 600, watch: true },
+  { value: "hourly", label: "Hourly", interval: 3600, watch: true },
+  { value: "daily", label: "Daily", interval: 86400, watch: true },
+  { value: "manual", label: "Manual only", watch: false },
+];
+
+/**
+ * Map the persisted `(watch, interval_seconds)` pair back to the picker
+ * value. Non-exact intervals (operator hand-edited config.yaml to 17s,
+ * say) fall through to "live" as the closest aligned default; the
+ * underlying `interval_seconds` field is still preserved on the config
+ * blob until the operator picks a different option and saves.
+ */
+function inferScheduleValue(config: MirrorConfig): string {
+  if (!config.watch) return "manual";
+  const match = SCHEDULE_OPTIONS.find(
+    (opt) => opt.watch && opt.interval === config.interval_seconds,
+  );
+  return match?.value ?? "live";
+}
+
+/**
+ * Apply a schedule choice to a config blob. "manual" flips watch off;
+ * everything else sets watch=true + the named interval.
+ */
+function applySchedule(config: MirrorConfig, value: string): MirrorConfig {
+  const opt = SCHEDULE_OPTIONS.find((o) => o.value === value);
+  if (!opt) return config;
+  if (!opt.watch) return { ...config, watch: false };
+  return {
+    ...config,
+    watch: true,
+    interval_seconds: opt.interval ?? config.interval_seconds,
+  };
+}
+
+/**
+ * Preset definitions — the three shapes the design doc names. Each is a
+ * partial overlay applied on top of the current config (so the operator's
+ * commit_template + external_path persist through a preset click; only
+ * the preset-relevant fields move). External-path warning still
+ * surfaces when the chosen preset implies `location: external` and the
+ * path isn't set.
+ */
+interface Preset {
+  id: string;
+  label: string;
+  subtext: string;
+  apply: (current: MirrorConfig) => MirrorConfig;
+}
+
+const PRESETS: ReadonlyArray<Preset> = [
+  {
+    id: "history",
+    label: "History",
+    subtext:
+      "Local audit trail. Hidden under vault data. Always-on watch.",
+    apply: (current) => ({
+      ...current,
+      enabled: true,
+      location: "internal",
+      watch: true,
+      auto_commit: true,
+      auto_push: false,
+      interval_seconds: 5,
+    }),
+  },
+  {
+    id: "live",
+    label: "Live Mirror",
+    subtext:
+      "Visible folder. Open in Obsidian, push to GitHub.",
+    apply: (current) => ({
+      ...current,
+      enabled: true,
+      location: "external",
+      watch: true,
+      auto_commit: true,
+      // Don't force-flip auto_push — operator may not have credentials yet.
+      interval_seconds: 5,
+    }),
+  },
+  {
+    id: "manual",
+    label: "Manual Export",
+    subtext: "Snapshot on demand.",
+    apply: (current) => ({
+      ...current,
+      enabled: true,
+      location: "external",
+      watch: false,
+      auto_commit: true,
+      auto_push: false,
+    }),
+  },
+];
+
+export function VaultMirror({ vaultName }: { vaultName?: string } = {}) {
+  // Mirror VaultTokens/VaultDetail's mount handling: per-vault mount
+  // passes `vaultName` straight through (no `:name` segment); stand-
+  // alone reads from useParams. The presence of the prop also picks
+  // the back-link shape.
+  const params = useParams<{ name: string }>();
+  const name = vaultName ?? params.name;
+  const isPerVaultMount = vaultName !== undefined;
+  const detailHref = isPerVaultMount ? "/" : `/vault/${encodeURIComponent(name ?? "")}`;
+
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [reloadTick, setReloadTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!name) return;
+    setState({ kind: "loading" });
+    getMirror(name)
+      .then((snapshot) => {
+        if (cancelled) return;
+        setState({ kind: "ok", snapshot });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof HttpError && (err.status === 401 || err.status === 403)) {
+          setState({ kind: "auth-required" });
+          return;
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name, reloadTick]);
+
+  if (!name) {
+    return (
+      <div>
+        <h2>Mirror</h2>
+        <p className="muted">Missing vault name.</p>
+        {isPerVaultMount ? null : <Link to="/">← Back to vaults</Link>}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>
+          Git backup for <code>{name}</code>
+        </h2>
+        <Link to={detailHref} className="muted">
+          ← Vault detail
+        </Link>
+      </div>
+
+      {state.kind === "loading" ? <p className="muted">Loading…</p> : null}
+
+      {state.kind === "auth-required" ? (
+        <div className="warn-banner">
+          Open this page from the hub's directory — the "Manage" link supplies the admin
+          token. Direct loads of <code>/vault/{name}/admin/mirror</code> can't see protected
+          vault data.
+        </div>
+      ) : null}
+
+      {state.kind === "error" ? (
+        <div className="error-banner">
+          <code>{state.message}</code>
+        </div>
+      ) : null}
+
+      {state.kind === "ok" ? (
+        <MirrorScreen
+          vaultName={name}
+          snapshot={state.snapshot}
+          onRefresh={() => setReloadTick((n) => n + 1)}
+          onSnapshot={(snap) => setState({ kind: "ok", snapshot: snap })}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function MirrorScreen({
+  vaultName,
+  snapshot,
+  onRefresh,
+  onSnapshot,
+}: {
+  vaultName: string;
+  snapshot: MirrorSnapshot;
+  onRefresh: () => void;
+  onSnapshot: (snap: MirrorSnapshot) => void;
+}) {
+  const isAdmin = hasAdminScope(vaultName);
+  return (
+    <>
+      <StatusCard
+        status={snapshot.status}
+        enabled={snapshot.config.enabled}
+        canRun={isAdmin && snapshot.status.enabled}
+        vaultName={vaultName}
+        onSnapshot={onSnapshot}
+      />
+      {!isAdmin ? (
+        <div className="warn-banner">
+          You're viewing this page with a read-only token. Saving config + manual run
+          require <code>vault:{vaultName}:admin</code>. Re-enter from the hub directory's
+          "Manage" link with an admin-scoped session to make changes.
+        </div>
+      ) : null}
+      <ConfigForm
+        vaultName={vaultName}
+        initial={snapshot.config}
+        readOnly={!isAdmin}
+        onSaved={(snap) => {
+          onSnapshot(snap);
+          onRefresh();
+        }}
+      />
+    </>
+  );
+}
+
+function StatusCard({
+  status,
+  enabled,
+  canRun,
+  vaultName,
+  onSnapshot,
+}: {
+  status: MirrorStatus;
+  enabled: boolean;
+  canRun: boolean;
+  vaultName: string;
+  onSnapshot: (snap: MirrorSnapshot) => void;
+}) {
+  const [running, setRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+
+  const onRun = async () => {
+    setRunning(true);
+    setRunError(null);
+    try {
+      const snap = await runMirrorNow(vaultName);
+      onSnapshot(snap);
+    } catch (err) {
+      setRunError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="section">
+      <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>Status</h3>
+      <div className="kv">
+        <div>Enabled</div>
+        <div>{enabled ? <code>yes</code> : <code>no</code>}</div>
+        <div>Watch loop</div>
+        <div>{status.watch_running ? <code>running</code> : <code>stopped</code>}</div>
+        <div>Path</div>
+        <div>
+          {status.mirror_path ? <code>{status.mirror_path}</code> : <span className="dim">—</span>}
+        </div>
+        <div>Last export</div>
+        <div>
+          {status.last_export_at ? (
+            <>
+              <code>{status.last_export_at}</code>
+              {status.last_export_notes_count !== null ? (
+                <span className="dim">
+                  {" "}· {status.last_export_notes_count} note
+                  {status.last_export_notes_count === 1 ? "" : "s"}
+                </span>
+              ) : null}
+            </>
+          ) : (
+            <span className="dim">never</span>
+          )}
+        </div>
+        <div>Last commit</div>
+        <div>
+          {status.last_commit_sha ? (
+            <code>{status.last_commit_sha.slice(0, 10)}</code>
+          ) : (
+            <span className="dim">—</span>
+          )}
+        </div>
+      </div>
+      {status.last_error ? (
+        <div className="error-banner" style={{ marginTop: "1rem" }}>
+          <strong>Last error:</strong> <code>{status.last_error}</code>
+        </div>
+      ) : null}
+      {runError ? (
+        <div className="error-banner" style={{ marginTop: "1rem" }}>
+          <code>{runError}</code>
+        </div>
+      ) : null}
+      <div className="actions">
+        <button
+          type="button"
+          onClick={onRun}
+          disabled={!canRun || running}
+          title={
+            !enabled
+              ? "Enable the mirror first, then trigger a manual export."
+              : !canRun
+                ? "Admin scope required to trigger a manual export."
+                : undefined
+          }
+        >
+          {running ? "Running…" : "Run export now"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ConfigForm({
+  vaultName,
+  initial,
+  readOnly,
+  onSaved,
+}: {
+  vaultName: string;
+  initial: MirrorConfig;
+  readOnly: boolean;
+  onSaved: (snap: MirrorSnapshot) => void;
+}) {
+  const [config, setConfig] = useState<MirrorConfig>(initial);
+  const [schedule, setSchedule] = useState<string>(inferScheduleValue(initial));
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [saving, setSaving] = useState(false);
+  // Field-level error gets rendered next to that field; the bare
+  // `error` carries the general message + status badge.
+  const [error, setError] = useState<string | null>(null);
+  const [errorField, setErrorField] = useState<keyof MirrorConfig | null>(null);
+  const [savedTick, setSavedTick] = useState(0);
+
+  // Sync local form state when the parent re-fetches (e.g. after a
+  // sibling save or manual-run finishes). Without this the form would
+  // freeze on the first-rendered snapshot and ignore subsequent reloads.
+  useEffect(() => {
+    setConfig(initial);
+    setSchedule(inferScheduleValue(initial));
+  }, [initial]);
+
+  const onApplyPreset = (preset: Preset) => {
+    const next = preset.apply(config);
+    setConfig(next);
+    setSchedule(inferScheduleValue(next));
+  };
+
+  const onChangeSchedule = (value: string) => {
+    setSchedule(value);
+    setConfig((prev) => applySchedule(prev, value));
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (readOnly) return;
+    setSaving(true);
+    setError(null);
+    setErrorField(null);
+    try {
+      const snap = await putMirror(vaultName, config);
+      onSaved(snap);
+      setSavedTick((n) => n + 1);
+      setTimeout(() => setSavedTick(0), 3000);
+    } catch (err) {
+      if (err instanceof HttpError) {
+        // The PUT endpoint surfaces { field, message } on 400s.
+        // We can't see the `field` from HttpError alone (only the
+        // top-level message), so we surface the message; the field
+        // gets the visual indicator via parsing the message for
+        // known field names. Keeping it loose: a missed match is
+        // a UI nit, not a correctness bug.
+        const msg = err.message;
+        setError(msg);
+        const lower = msg.toLowerCase();
+        if (lower.includes("external_path")) setErrorField("external_path");
+        else if (lower.includes("commit_template")) setErrorField("commit_template");
+        else if (lower.includes("interval_seconds")) setErrorField("interval_seconds");
+        else if (lower.includes("location")) setErrorField("location");
+        else setErrorField(null);
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="section" onSubmit={onSubmit}>
+      <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>
+        Configuration
+      </h3>
+
+      <div className="form-row">
+        <label>
+          <input
+            type="checkbox"
+            checked={config.enabled}
+            disabled={readOnly}
+            onChange={(e) =>
+              setConfig((prev) => ({ ...prev, enabled: e.target.checked }))
+            }
+            style={{ width: "auto", marginRight: "0.5rem" }}
+          />
+          Enable mirror
+        </label>
+        <p className="dim" style={{ margin: "0.35rem 0 0" }}>
+          Master switch. When off, no export / commit / push runs.
+        </p>
+      </div>
+
+      <div className="form-row">
+        <label>Presets</label>
+        <div className="preset-grid">
+          {PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              className="preset-card"
+              disabled={readOnly}
+              onClick={() => onApplyPreset(preset)}
+              aria-label={`Apply ${preset.label} preset`}
+            >
+              <strong>{preset.label}</strong>
+              <span className="dim">{preset.subtext}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="form-row">
+        <label>Location</label>
+        <div>
+          <label className="radio-row">
+            <input
+              type="radio"
+              name="location"
+              value="internal"
+              checked={config.location === "internal"}
+              disabled={readOnly}
+              onChange={() =>
+                setConfig((prev) => ({ ...prev, location: "internal" }))
+              }
+            />
+            <span>
+              Internal <span className="dim">— hidden under vault data dir</span>
+            </span>
+          </label>
+          <label className="radio-row">
+            <input
+              type="radio"
+              name="location"
+              value="external"
+              checked={config.location === "external"}
+              disabled={readOnly}
+              onChange={() =>
+                setConfig((prev) => ({ ...prev, location: "external" }))
+              }
+            />
+            <span>
+              External <span className="dim">— operator-picked path</span>
+            </span>
+          </label>
+        </div>
+      </div>
+
+      {config.location === "external" ? (
+        <div className="form-row">
+          <label htmlFor="external-path">External path</label>
+          <input
+            id="external-path"
+            type="text"
+            value={config.external_path ?? ""}
+            disabled={readOnly}
+            onChange={(e) =>
+              setConfig((prev) => ({
+                ...prev,
+                external_path: e.target.value.length > 0 ? e.target.value : null,
+              }))
+            }
+            placeholder="/Users/you/Documents/vault-mirror"
+            aria-invalid={errorField === "external_path"}
+          />
+          <div className="warn-banner" style={{ marginTop: "0.5rem" }} role="alert">
+            Path must exist AND be a git repo (run <code>git init</code> first if
+            needed).
+          </div>
+        </div>
+      ) : null}
+
+      <div className="form-row">
+        <label htmlFor="schedule-select">Schedule</label>
+        <select
+          id="schedule-select"
+          value={schedule}
+          disabled={readOnly}
+          onChange={(e) => onChangeSchedule(e.target.value)}
+        >
+          {SCHEDULE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <p className="dim" style={{ margin: "0.35rem 0 0" }}>
+          {schedule === "manual"
+            ? "Watch loop disabled — exports only fire when you click \"Run export now\"."
+            : "Watch loop runs in-process and triggers an export pass at the chosen interval."}
+        </p>
+      </div>
+
+      <div className="form-row">
+        <label>
+          <input
+            type="checkbox"
+            checked={config.auto_commit}
+            disabled={readOnly}
+            onChange={(e) =>
+              setConfig((prev) => ({ ...prev, auto_commit: e.target.checked }))
+            }
+            style={{ width: "auto", marginRight: "0.5rem" }}
+          />
+          Commit after each export
+        </label>
+      </div>
+
+      <div className="form-row">
+        <label>
+          <input
+            type="checkbox"
+            checked={config.auto_push}
+            disabled={readOnly}
+            onChange={(e) =>
+              setConfig((prev) => ({ ...prev, auto_push: e.target.checked }))
+            }
+            style={{ width: "auto", marginRight: "0.5rem" }}
+          />
+          Push after each commit
+        </label>
+        {config.auto_push ? (
+          <div className="warn-banner" style={{ marginTop: "0.5rem" }} role="alert">
+            Auto-push requires git credentials configured outside vault (e.g., SSH
+            key, <code>GH_TOKEN</code>). Failed pushes are logged but won't crash the
+            export.
+          </div>
+        ) : null}
+      </div>
+
+      <div className="form-row">
+        <button
+          type="button"
+          className="secondary"
+          onClick={() => setShowAdvanced((s) => !s)}
+        >
+          {showAdvanced ? "Hide" : "Show"} advanced
+        </button>
+      </div>
+
+      {showAdvanced ? (
+        <div className="form-row">
+          <label htmlFor="commit-template">Commit template</label>
+          <input
+            id="commit-template"
+            type="text"
+            value={config.commit_template}
+            disabled={readOnly}
+            onChange={(e) =>
+              setConfig((prev) => ({ ...prev, commit_template: e.target.value }))
+            }
+            aria-invalid={errorField === "commit_template"}
+          />
+          <p className="dim" style={{ margin: "0.35rem 0 0" }}>
+            Supports <code>{"{{date}}"}</code>, <code>{"{{notes_changed}}"}</code>,{" "}
+            <code>{"{{plural}}"}</code>, <code>{"{{first_note_title}}"}</code>,{" "}
+            <code>{"{{vault_name}}"}</code>.
+          </p>
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="error-banner" role="alert">
+          <code>{error}</code>
+        </div>
+      ) : null}
+
+      {savedTick > 0 ? (
+        <div
+          className="mint-banner"
+          style={{ padding: "0.75rem 1rem", marginBottom: "1rem" }}
+          role="status"
+        >
+          Saved.
+        </div>
+      ) : null}
+
+      <div className="actions">
+        <button type="submit" disabled={readOnly || saving}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -587,29 +587,48 @@ function ConfigForm({
           />
           Commit after each export
         </label>
-      </div>
-
-      <div className="form-row">
-        <label>
-          <input
-            type="checkbox"
-            checked={config.auto_push}
-            disabled={readOnly}
-            onChange={(e) =>
-              setConfig((prev) => ({ ...prev, auto_push: e.target.checked }))
-            }
-            style={{ width: "auto", marginRight: "0.5rem" }}
-          />
-          Push after each commit
-        </label>
-        {config.auto_push ? (
-          <div className="warn-banner" style={{ marginTop: "0.5rem" }} role="alert">
-            Auto-push requires git credentials configured outside vault (e.g., SSH
-            key, <code>GH_TOKEN</code>). Failed pushes are logged but won't crash the
-            export.
-          </div>
+        {!config.auto_commit ? (
+          <p className="hint" style={{ marginTop: "0.25rem", fontSize: "0.85em" }}>
+            Note: the export cursor still advances after each pass. Subsequent
+            runs only re-export notes written since the last pass — even when
+            triggered manually.
+          </p>
         ) : null}
       </div>
+
+      {config.location === "external" ? (
+        <div className="form-row">
+          <label>
+            <input
+              type="checkbox"
+              checked={config.auto_push}
+              disabled={readOnly}
+              onChange={(e) =>
+                setConfig((prev) => ({ ...prev, auto_push: e.target.checked }))
+              }
+              style={{ width: "auto", marginRight: "0.5rem" }}
+            />
+            Push after each commit
+          </label>
+          {config.auto_push ? (
+            <div className="warn-banner" style={{ marginTop: "0.5rem" }} role="alert">
+              Auto-push requires git credentials configured outside vault (e.g., SSH
+              key, <code>GH_TOKEN</code>). Failed pushes are logged but won't crash the
+              export.
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      {/*
+        Internal-location mirrors live under ~/.parachute/vault/data and have
+        no configured git remote — a push would always fail. Hide the checkbox
+        entirely rather than render a disabled one: the option is meaningless,
+        not just unavailable. If a stored config carries auto_push:true +
+        location:internal (e.g. operator switched from external→internal
+        without unticking), the value persists on the config blob until they
+        save a different one — the watch loop just skips pushes because there's
+        no remote. Reviewer-flagged on #380.
+      */}
 
       <div className="form-row">
         <button

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -388,3 +388,59 @@ select:focus {
 .tag-checkbox input[type="checkbox"] {
   margin: 0;
 }
+
+/*
+ * Mirror screen: preset cards (three clickable shapes per the
+ * vault-as-git-projection design doc) + radio rows for location.
+ * Tone-matched to the .stat cards above so the visual rhythm of the
+ * admin SPA stays calm — operators bounce between these screens in
+ * one session.
+ */
+.preset-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+}
+.preset-card {
+  background: var(--bg-soft);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.preset-card:hover {
+  border-color: var(--accent);
+  background: white;
+}
+.preset-card:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.preset-card strong {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+.preset-card .dim {
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.radio-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+  font-size: 0.92rem;
+  cursor: pointer;
+}
+.radio-row input[type="radio"] {
+  margin: 0;
+}
+


### PR DESCRIPTION
## Summary

Builds the admin SPA UI for vault's existing git-mirror feature, plus a
small backend endpoint to support manual-trigger from the UI.

The backend has been mature since vault-sync Phase A1 — `src/mirror-config.ts`
(persisted config schema + validation), `src/mirror-manager.ts` (lifecycle
+ bootstrap + watch loop + `runNow()`), `src/mirror-routes.ts` (GET/PUT
HTTP handlers). What was missing was the operator-facing UI: configuring
the mirror has required curl + by-hand YAML edits.

This PR fills that gap so the "really good UI for backing the vault up
to a git repository by continually exporting on each change or daily
rhythm (optionality)" lands in the SPA, framed around the three presets
the [vault-as-git-projection design doc](../parachute.computer/design/2026-05-20-vault-as-git-projection.md)
names: **History** / **Live Mirror** / **Manual Export**.

### Cut 1 — Backend: `POST /vault/<name>/.parachute/mirror/run-now`

- Calls `manager.runNow()` (already exists); returns the same
  `{ config, status }` snapshot as GET so the SPA reuses one decoder.
- Auth: `vault:admin` (matches the existing GET/PUT pair — the brief
  said `vault:write`, but the routing module enforces `admin` on the
  parent endpoints, so the new sibling matches the parent for
  least-surprise).
- Refuses (400 "mirror not enabled") rather than firing when disabled,
  so a misclick doesn't look successful while quietly no-opping.

### Cut 2 — Admin SPA: `/vault/:name/mirror` route

- **Status card** — enabled / watch-running / path / last export
  (with notes count) / last commit (short sha) / last error (red).
- **Run export now** button — POSTs run-now, refreshes status.
  Disabled when mirror isn't enabled or session is read-scoped.
- **Three preset cards** — click to pre-fill the form. Subtext on
  each matches the design doc framing.
- **Detailed config form** — location radio, external-path input
  (with "must exist + be a git repo" warning), schedule select
  mapped to `interval_seconds`, auto_commit + auto_push checkboxes
  (auto_push surfaces the "credentials configured outside vault"
  warning when checked), advanced section with commit_template.
- **Read-scope sessions** see everything disabled + a re-enter-with-
  admin banner. Same defense-in-depth as `VaultTokens`.

### Cut 3 — Wire in

- `App.tsx` registers the route in both mount shapes (per-vault and
  stand-alone), matching the `isPerVaultMount` href pattern.
- `VaultDetail.tsx` adds a "Git backup →" link in the Manage list.

### Schedule preset → `interval_seconds` mapping

| Picker label       | `watch` | `interval_seconds` |
|--------------------|---------|--------------------|
| Live (every 5s)    | true    | 5                  |
| Every minute       | true    | 60                 |
| Every 10 minutes   | true    | 600                |
| Hourly             | true    | 3600               |
| Daily              | true    | 86400              |
| Manual only        | false   | (unchanged)        |

"Manual only" flips `watch: false` rather than picking an interval —
the value is meaningless when the loop isn't armed. Non-aligned
persisted intervals (operator hand-edited config.yaml to 17s) fall
back to "Live" in the picker; the underlying value is preserved on
the config blob until they pick a different option + save.

## Test plan

- [x] `bun test ./core ./src ./package` — **1685 pass / 0 fail** (4
      new tests added: 2 mirror-routes for run-now + 4 routing-level
      for the new endpoint's auth gates)
- [x] `bun run typecheck` — clean at root
- [x] `cd web/ui && bun run test` — **78 pass / 0 fail** (10 new
      VaultMirror tests covering loading / status render / preset apply
      / save → PUT / run-now → POST / auth-required / read-scope)
- [x] `cd web/ui && bun run typecheck` — clean
- [x] `cd web/ui && bun run build` — produces `dist/` with relative
      `./assets/` URLs (verify-base passes)
- [ ] Reviewer pass (mandatory per workspace governance — every PR
      gets a reviewer subagent)
- [ ] End-to-end against `PARACHUTE_VAULT_HOME=/tmp/vault-mirror-test`:
      apply each preset, save, trigger run-now, observe commits in the
      target dir.

## Patterns check

- **Module HTTP surface** — new endpoint lives under `.parachute/`
  alongside the existing `.parachute/mirror` (matches `module-self-registration.md`
  convention; the SPA's static-file mount is `/vault/<name>/admin/*`,
  reserved for the bundle).
- **Defense-in-depth scope gating** — client-side `hasAdminScope`
  hides mutate UI; server still enforces 403. Mirrors `VaultTokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)