### PR TITLE
chore(release): 0.4.9-rc.4 — admin SPA git-mirror UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.3",
+  "version": "0.4.9-rc.4",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump only. Picks up #380 (vault git-backup admin UI):
- Backend: `POST /vault/<name>/.parachute/mirror/run-now` (manual trigger)
- Admin SPA: new `/vault/:name/mirror` route with status card, three preset cards, schedule picker (Live/Minute/10min/Hourly/Daily/Manual), auto-push warning, cursor-advance hint

## Test plan

- [x] `bun test ./core ./src ./package` — 1685 pass / 0 fail
- [x] `cd web/ui && bunx vitest run` — 80 pass / 0 fail
- [x] `bun run typecheck` — clean (both roots)
- [ ] After merge: tag `v0.4.9-rc.4` + push → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)