### PR TITLE
feat(vault): event-driven mirror exports + deletion handling + sync_mode UX

### DIFF
--- a/core/src/hooks.test.ts
+++ b/core/src/hooks.test.ts
@@ -362,7 +362,7 @@ describe("HookRegistry — HOOK_CONCURRENCY env var parsing", async () => {
 
 // ---------------------------------------------------------------------------
 // New event types — deleted notes, tag mutations, deleted attachments
-// (vault#XXX — event-driven git-mirror foundation)
+// (vault#382 — event-driven git-mirror foundation)
 // ---------------------------------------------------------------------------
 
 describe("HookRegistry — deleted note events", () => {

--- a/core/src/hooks.test.ts
+++ b/core/src/hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { SqliteStore } from "./store.js";
-import { HookRegistry } from "./hooks.js";
+import { HookRegistry, type DeletedNoteRef, type DeletedAttachmentRef } from "./hooks.js";
 import type { Note } from "./types.js";
 
 let db: Database;
@@ -357,5 +357,324 @@ describe("HookRegistry — HOOK_CONCURRENCY env var parsing", async () => {
     await r.drain();
     expect(maxConcurrent).toBe(1);
     restore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// New event types — deleted notes, tag mutations, deleted attachments
+// (vault#XXX — event-driven git-mirror foundation)
+// ---------------------------------------------------------------------------
+
+describe("HookRegistry — deleted note events", () => {
+  let db: Database;
+  let hooks: HookRegistry;
+  let store: SqliteStore;
+  beforeEach(() => {
+    db = new Database(":memory:");
+    hooks = new HookRegistry({ concurrency: 4, logger: silentLogger });
+    store = new SqliteStore(db, { hooks });
+  });
+
+  async function settle(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await hooks.drain();
+  }
+
+  it("default subscription doesn't include 'deleted'", async () => {
+    // Existing hooks pre-deleted-event don't suddenly start receiving
+    // delete shapes they weren't typed for.
+    const fired: string[] = [];
+    hooks.onNote({
+      handler: (note) => {
+        fired.push(note.id);
+      },
+    });
+
+    const note = await store.createNote("hi");
+    await settle();
+    fired.length = 0;
+    await store.deleteNote(note.id);
+    await settle();
+    expect(fired).toEqual([]);
+  });
+
+  it("explicit 'deleted' subscription receives DeletedNoteRef on store.deleteNote", async () => {
+    const seen: Array<{ event: string; id: string; path?: string }> = [];
+    hooks.onNote({
+      event: "deleted",
+      handler: (payload, _store, event) => {
+        // payload here is a DeletedNoteRef (we subscribed to deleted only).
+        const ref = payload as DeletedNoteRef;
+        seen.push({ event: event ?? "deleted", id: ref.id, path: ref.path });
+      },
+    });
+
+    const note = await store.createNote("doomed", { path: "to-delete" });
+    await settle();
+    await store.deleteNote(note.id);
+    await settle();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.event).toBe("deleted");
+    expect(seen[0]!.id).toBe(note.id);
+    expect(seen[0]!.path).toBe("to-delete");
+  });
+
+  it("DeletedNoteRef has no metadata/tags/content (predicate authors take note)", async () => {
+    const observedPayloads: unknown[] = [];
+    hooks.onNote({
+      event: "deleted",
+      handler: (payload) => {
+        observedPayloads.push(payload);
+      },
+    });
+    const n = await store.createNote("with tags", { tags: ["one", "two"], metadata: { color: "blue" } });
+    await settle();
+    await store.deleteNote(n.id);
+    await settle();
+    expect(observedPayloads).toHaveLength(1);
+    const p = observedPayloads[0] as Record<string, unknown>;
+    expect(p.id).toBe(n.id);
+    // Strictly minimal shape — no full Note fields leak through.
+    expect(p.content).toBeUndefined();
+    expect(p.metadata).toBeUndefined();
+    expect(p.tags).toBeUndefined();
+  });
+
+  it("array events allow subscribing to created+updated+deleted in one hook", async () => {
+    const events: string[] = [];
+    hooks.onNote({
+      event: ["created", "updated", "deleted"],
+      handler: (_n, _s, ev) => {
+        events.push(ev ?? "?");
+      },
+    });
+    const n = await store.createNote("lifecycle");
+    await settle();
+    await store.updateNote(n.id, { content: "v2" });
+    await settle();
+    await store.deleteNote(n.id);
+    await settle();
+    expect(events).toEqual(["created", "updated", "deleted"]);
+  });
+
+  it("predicate on a deleted event receives DeletedNoteRef and can filter on path", async () => {
+    const fired: string[] = [];
+    hooks.onNote({
+      event: "deleted",
+      when: (payload) => {
+        const ref = payload as DeletedNoteRef;
+        return ref.path?.startsWith("keep/") === true;
+      },
+      handler: (payload) => {
+        fired.push((payload as DeletedNoteRef).id);
+      },
+    });
+    const a = await store.createNote("a", { path: "keep/one" });
+    const b = await store.createNote("b", { path: "skip/two" });
+    await settle();
+    await store.deleteNote(a.id);
+    await store.deleteNote(b.id);
+    await settle();
+    expect(fired).toEqual([a.id]);
+  });
+});
+
+describe("HookRegistry — tag events", () => {
+  let db: Database;
+  let hooks: HookRegistry;
+  let store: SqliteStore;
+  beforeEach(() => {
+    db = new Database(":memory:");
+    hooks = new HookRegistry({ concurrency: 4, logger: silentLogger });
+    store = new SqliteStore(db, { hooks });
+  });
+
+  async function settle(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await hooks.drain();
+  }
+
+  it("upsertTagRecord dispatches 'upserted'", async () => {
+    const seen: Array<{ tag: string; event: string }> = [];
+    hooks.onTag({
+      handler: (tag, _store, event) => {
+        seen.push({ tag, event: event ?? "?" });
+      },
+    });
+    await store.upsertTagRecord("project", { description: "a project" });
+    await settle();
+    expect(seen).toEqual([{ tag: "project", event: "upserted" }]);
+  });
+
+  it("upsertTagSchema dispatches 'upserted'", async () => {
+    const seen: string[] = [];
+    hooks.onTag({
+      event: "upserted",
+      handler: (tag) => {
+        seen.push(tag);
+      },
+    });
+    await store.upsertTagSchema("meeting", {
+      fields: { duration: { type: "number" } },
+    });
+    await settle();
+    expect(seen).toEqual(["meeting"]);
+  });
+
+  it("deleteTag dispatches 'deleted' only when the tag actually existed", async () => {
+    const seen: string[] = [];
+    hooks.onTag({
+      event: "deleted",
+      handler: (tag) => {
+        seen.push(tag);
+      },
+    });
+    const note = await store.createNote("tagged", { tags: ["mytag"] });
+    await settle();
+
+    // Delete the tag — fires.
+    await store.deleteTag("mytag");
+    await settle();
+    expect(seen).toEqual(["mytag"]);
+
+    // Delete a tag that doesn't exist — no fire.
+    await store.deleteTag("never-existed");
+    await settle();
+    expect(seen).toEqual(["mytag"]);
+    void note; // silence unused
+  });
+
+  it("renameTag dispatches deleted(old) + upserted(new)", async () => {
+    const events: Array<{ tag: string; event: string }> = [];
+    hooks.onTag({
+      handler: (tag, _store, event) => {
+        events.push({ tag, event: event ?? "?" });
+      },
+    });
+    await store.createNote("tagged", { tags: ["old-name"] });
+    await settle();
+    await store.renameTag("old-name", "new-name");
+    await settle();
+    // Order is implementation-defined; assert the set instead.
+    expect(events).toContainEqual({ tag: "old-name", event: "deleted" });
+    expect(events).toContainEqual({ tag: "new-name", event: "upserted" });
+  });
+
+  it("mergeTags dispatches deleted for each source + upserted for target", async () => {
+    const events: Array<{ tag: string; event: string }> = [];
+    hooks.onTag({
+      handler: (tag, _store, event) => {
+        events.push({ tag, event: event ?? "?" });
+      },
+    });
+    await store.createNote("a", { tags: ["src1"] });
+    await store.createNote("b", { tags: ["src2"] });
+    await settle();
+    events.length = 0;
+    await store.mergeTags(["src1", "src2"], "target");
+    await settle();
+    expect(events).toContainEqual({ tag: "src1", event: "deleted" });
+    expect(events).toContainEqual({ tag: "src2", event: "deleted" });
+    expect(events).toContainEqual({ tag: "target", event: "upserted" });
+  });
+
+  it("deleteTagSchema fires 'deleted' for the schema slot", async () => {
+    const seen: string[] = [];
+    hooks.onTag({
+      event: "deleted",
+      handler: (tag) => {
+        seen.push(tag);
+      },
+    });
+    await store.upsertTagSchema("foo", { description: "x" });
+    await settle();
+    const ok = await store.deleteTagSchema("foo");
+    await settle();
+    expect(ok).toBe(true);
+    expect(seen).toEqual(["foo"]);
+  });
+
+  it("predicate filters tag events by name", async () => {
+    const seen: string[] = [];
+    hooks.onTag({
+      when: (tag) => tag.startsWith("_"),
+      handler: (tag) => {
+        seen.push(tag);
+      },
+    });
+    await store.upsertTagRecord("public-tag", { description: "x" });
+    await store.upsertTagRecord("_private-tag", { description: "y" });
+    await settle();
+    expect(seen).toEqual(["_private-tag"]);
+  });
+});
+
+describe("HookRegistry — deleted attachment events", () => {
+  let db: Database;
+  let hooks: HookRegistry;
+  let store: SqliteStore;
+  beforeEach(() => {
+    db = new Database(":memory:");
+    hooks = new HookRegistry({ concurrency: 4, logger: silentLogger });
+    store = new SqliteStore(db, { hooks });
+  });
+
+  async function settle(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await hooks.drain();
+  }
+
+  it("deleteAttachment dispatches 'deleted' with DeletedAttachmentRef", async () => {
+    const seen: DeletedAttachmentRef[] = [];
+    hooks.onAttachment({
+      event: "deleted",
+      handler: (payload) => {
+        seen.push(payload as DeletedAttachmentRef);
+      },
+    });
+    const note = await store.createNote("with-att");
+    const att = await store.addAttachment(note.id, "audio/voice.m4a", "audio/mp4");
+    await settle();
+    await store.deleteAttachment(note.id, att.id);
+    await settle();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.id).toBe(att.id);
+    expect(seen[0]!.noteId).toBe(note.id);
+    expect(seen[0]!.path).toBe("audio/voice.m4a");
+  });
+
+  it("default attachment subscription doesn't include 'deleted' (back-compat)", async () => {
+    const fired: string[] = [];
+    hooks.onAttachment({
+      handler: (att) => {
+        // payload is Attachment | DeletedAttachmentRef; we know default
+        // events doesn't include deleted, so this only sees created.
+        fired.push(att.id);
+      },
+    });
+    const note = await store.createNote("hi");
+    const att = await store.addAttachment(note.id, "f.txt", "text/plain");
+    await settle();
+    fired.length = 0;
+    await store.deleteAttachment(note.id, att.id);
+    await settle();
+    expect(fired).toEqual([]);
+  });
+
+  it("non-existent attachment delete does not dispatch", async () => {
+    const fired: string[] = [];
+    hooks.onAttachment({
+      event: "deleted",
+      handler: (a) => fired.push(a.id),
+    });
+    const note = await store.createNote("hi");
+    await settle();
+    const result = await store.deleteAttachment(note.id, "never-existed-id");
+    await settle();
+    expect(result.deleted).toBe(false);
+    expect(fired).toEqual([]);
   });
 });

--- a/core/src/hooks.ts
+++ b/core/src/hooks.ts
@@ -47,7 +47,34 @@
 
 import type { Note, Store, Attachment } from "./types.js";
 
-export type HookEvent = "created" | "updated";
+/**
+ * Note-mutation events. `"created"` and `"updated"` carry the full post-write
+ * `Note`; `"deleted"` carries only `{ id, path }` — the row is gone by
+ * dispatch time, so handlers can't re-read it. Down-stream consumers (e.g.
+ * the git-mirror) match by id/path and react (remove file, etc.). Predicate
+ * authors writing a `when(note)` for `"deleted"` should rely on `note.id` /
+ * `note.path` only; everything else is undefined for the deleted shape.
+ */
+export type HookEvent = "created" | "updated" | "deleted";
+
+/**
+ * Minimal identity payload for a deleted note. The row is gone by dispatch
+ * time, so handlers can't go back to the store for the rest. Path is
+ * optional because notes without a path are legal (e.g. fragments captured
+ * via API without a target slot).
+ */
+export interface DeletedNoteRef {
+  id: string;
+  path?: string;
+}
+
+/**
+ * What a hook handler receives. For `"created"` / `"updated"` it's the full
+ * `Note` row; for `"deleted"` only the id/path remain. This union keeps the
+ * common predicates (path-prefix gates, tag checks for non-deleted shapes)
+ * working unchanged while making the "deleted has less" reality type-safe.
+ */
+export type NoteHookPayload = Note | DeletedNoteRef;
 
 export interface NoteHook {
   /** Events this hook listens for. Defaults to ["created", "updated"]. */
@@ -57,10 +84,26 @@ export interface NoteHook {
    * Should be cheap and synchronous. Idempotency lives here: check
    * whether a marker (e.g. `metadata.audio_rendered_at`) is already set
    * and return false if so.
+   *
+   * For `"deleted"` events the payload is a `DeletedNoteRef` — only
+   * `id` / `path` are populated; tag/metadata/content fields are
+   * undefined. Predicates that read those fields effectively skip
+   * the deleted shape unless they handle the narrower payload.
    */
-  when?: (note: Note) => boolean;
-  /** Handler — runs async, off the request path. Third arg is the event type. */
-  handler: (note: Note, store: Store, event?: HookEvent) => Promise<void> | void;
+  when?: (note: NoteHookPayload) => boolean;
+  /**
+   * Handler — runs async, off the request path. Third arg is the event
+   * type. For `"deleted"` the payload is a `DeletedNoteRef`, not a full
+   * `Note` — the row is gone by dispatch time, so the store can't be
+   * queried for it. Handlers needing more context should stash it ahead
+   * of time on the note's `metadata` and read off the predicate / the
+   * tracking shape rather than re-querying.
+   */
+  handler: (
+    note: NoteHookPayload,
+    store: Store,
+    event?: HookEvent,
+  ) => Promise<void> | void;
   /** Optional label for logs. */
   name?: string;
 }
@@ -70,22 +113,46 @@ interface RegisteredHook extends NoteHook {
 }
 
 /**
- * Attachment-mutation events. Today only `"created"` is dispatched — the
- * transcription worker (and any future attachment-aware feature) registers
- * here to move off its poll-driven steady state and onto the same event bus
- * that note hooks use. Keeping attachments separate from notes means a
- * `NoteHook` predicate doesn't have to learn a second argument shape.
+ * Attachment-mutation events. `"created"` carries the full attachment;
+ * `"deleted"` carries only `{ id, note_id, path }` (the row is gone by
+ * dispatch time, same shape rule as deleted notes).
+ *
+ * Consumers (transcription worker, git-mirror) subscribe here to react to
+ * lifecycle changes without polling. Keeping attachments separate from
+ * notes means a `NoteHook` predicate doesn't have to learn a second
+ * argument shape.
  */
-export type AttachmentHookEvent = "created";
+export type AttachmentHookEvent = "created" | "deleted";
+
+/**
+ * Identity payload for a deleted attachment. The DB row is gone by
+ * dispatch time, so handlers can only react to id/note_id/path; metadata
+ * and timestamps are not preserved.
+ */
+export interface DeletedAttachmentRef {
+  id: string;
+  noteId: string;
+  path: string;
+}
+
+/** Union over what an attachment hook handler may receive. */
+export type AttachmentHookPayload = Attachment | DeletedAttachmentRef;
 
 export interface AttachmentHook {
   /** Events this hook listens for. Defaults to ["created"]. */
   event?: AttachmentHookEvent | AttachmentHookEvent[];
-  /** Sync predicate. Same idempotency contract as `NoteHook.when`. */
-  when?: (attachment: Attachment) => boolean;
-  /** Handler — runs async, off the request path. */
+  /**
+   * Sync predicate. Same idempotency contract as `NoteHook.when`. For
+   * `"deleted"` the payload is a `DeletedAttachmentRef` — predicates
+   * relying on `metadata` / `createdAt` will see `undefined`.
+   */
+  when?: (attachment: AttachmentHookPayload) => boolean;
+  /**
+   * Handler — runs async, off the request path. For `"deleted"` the
+   * payload is a `DeletedAttachmentRef`, not a full `Attachment`.
+   */
   handler: (
-    attachment: Attachment,
+    attachment: AttachmentHookPayload,
     store: Store,
     event?: AttachmentHookEvent,
   ) => Promise<void> | void;
@@ -95,6 +162,37 @@ export interface AttachmentHook {
 
 interface RegisteredAttachmentHook extends AttachmentHook {
   events: Set<AttachmentHookEvent>;
+}
+
+/**
+ * Tag-mutation events. `"upserted"` fires on tag-record create/update
+ * (description, fields, relationships, parent_names — any mutation that
+ * could change the schema sidecar that the git-mirror writes). `"deleted"`
+ * fires when the tag row is removed.
+ *
+ * Why this exists: the export sidecars at `.parachute/schemas/<tag>.yaml`
+ * are part of the mirror's output. Without a tag-mutation event the mirror
+ * has no signal that those files might need to change.
+ */
+export type TagHookEvent = "upserted" | "deleted";
+
+export interface TagHook {
+  /** Events this hook listens for. Defaults to ["upserted", "deleted"]. */
+  event?: TagHookEvent | TagHookEvent[];
+  /** Sync predicate keyed on the tag name. */
+  when?: (tag: string) => boolean;
+  /** Handler — runs async, off the request path. */
+  handler: (
+    tag: string,
+    store: Store,
+    event?: TagHookEvent,
+  ) => Promise<void> | void;
+  /** Optional label for logs. */
+  name?: string;
+}
+
+interface RegisteredTagHook extends TagHook {
+  events: Set<TagHookEvent>;
 }
 
 /**
@@ -139,6 +237,7 @@ export interface HookRegistryOptions {
 export class HookRegistry {
   private hooks: RegisteredHook[] = [];
   private attachmentHooks: RegisteredAttachmentHook[] = [];
+  private tagHooks: RegisteredTagHook[] = [];
   private semaphore: Semaphore;
   private inFlight = new Set<Promise<void>>();
   private logger: { error: (...args: unknown[]) => void };
@@ -150,7 +249,15 @@ export class HookRegistry {
     this.logger = opts.logger ?? console;
   }
 
-  /** Register a hook. Returns an unregister function. */
+  /**
+   * Register a note-mutation hook. Returns an unregister function.
+   *
+   * The default event set is `["created", "updated"]` — explicit
+   * `event: "deleted"` (or include it in the array) is required to
+   * subscribe to deletions. This keeps existing hooks that pre-date the
+   * `"deleted"` event from suddenly receiving a payload shape
+   * (`DeletedNoteRef`) they weren't typed for.
+   */
   onNote(hook: NoteHook): () => void {
     const events = new Set<HookEvent>(
       Array.isArray(hook.event)
@@ -167,7 +274,13 @@ export class HookRegistry {
     };
   }
 
-  /** Register an attachment-mutation hook. Returns an unregister function. */
+  /**
+   * Register an attachment-mutation hook. Returns an unregister function.
+   *
+   * The default event set is `["created"]` only (matches the historical
+   * shape pre-deletion-events). Subscribe to `"deleted"` explicitly when
+   * the handler needs to react to attachment removal.
+   */
   onAttachment(hook: AttachmentHook): () => void {
     const events = new Set<AttachmentHookEvent>(
       Array.isArray(hook.event)
@@ -184,15 +297,38 @@ export class HookRegistry {
     };
   }
 
+  /**
+   * Register a tag-mutation hook. Returns an unregister function. Default
+   * event set is both `"upserted"` and `"deleted"` — symmetric with the
+   * sole consumer's needs (the git-mirror reacts to either to refresh its
+   * schema sidecars).
+   */
+  onTag(hook: TagHook): () => void {
+    const events = new Set<TagHookEvent>(
+      Array.isArray(hook.event)
+        ? hook.event
+        : hook.event
+          ? [hook.event]
+          : (["upserted", "deleted"] as TagHookEvent[]),
+    );
+    const entry: RegisteredTagHook = { ...hook, events };
+    this.tagHooks.push(entry);
+    return () => {
+      const idx = this.tagHooks.indexOf(entry);
+      if (idx >= 0) this.tagHooks.splice(idx, 1);
+    };
+  }
+
   /** Remove all registered hooks. Mostly for tests. */
   clear(): void {
     this.hooks = [];
     this.attachmentHooks = [];
+    this.tagHooks = [];
   }
 
-  /** Count of currently registered hooks (notes + attachments). */
+  /** Count of currently registered hooks (notes + attachments + tags). */
   get size(): number {
-    return this.hooks.length + this.attachmentHooks.length;
+    return this.hooks.length + this.attachmentHooks.length + this.tagHooks.length;
   }
 
   /** Count of currently in-flight handler executions. */
@@ -201,13 +337,19 @@ export class HookRegistry {
   }
 
   /**
-   * Dispatch a mutation event. Matches hooks, schedules their handlers
-   * onto a microtask, and returns immediately. The caller is never
-   * blocked on handler execution.
+   * Dispatch a note-mutation event. Matches hooks, schedules their
+   * handlers onto a microtask, and returns immediately. The caller is
+   * never blocked on handler execution.
    *
    * Must only be called after the triggering SQLite write has committed.
+   *
+   * For `"deleted"` the `note` argument is a `DeletedNoteRef` ({ id,
+   * path }) — the row is gone, so the runtime can't re-read it before
+   * dispatching to handlers. For `"created"` / `"updated"` the full
+   * `Note` is expected; `runHandler` will re-read from the store for
+   * non-deleted events to pick up the latest committed state.
    */
-  dispatch(event: HookEvent, note: Note, store: Store): void {
+  dispatch(event: HookEvent, note: NoteHookPayload, store: Store): void {
     if (this.hooks.length === 0) return;
 
     // Snapshot matches synchronously so subsequent hook registration
@@ -241,13 +383,12 @@ export class HookRegistry {
 
   /**
    * Dispatch an attachment-mutation event. Same post-commit/microtask
-   * contract as `dispatch()` for notes — callers are never blocked on
-   * handler execution, and the triggering SQLite write must already be
-   * committed.
+   * contract as `dispatch()` for notes. For `"deleted"` the payload is
+   * a `DeletedAttachmentRef`; for `"created"` it's the full `Attachment`.
    */
   dispatchAttachment(
     event: AttachmentHookEvent,
-    attachment: Attachment,
+    attachment: AttachmentHookPayload,
     store: Store,
   ): void {
     if (this.attachmentHooks.length === 0) return;
@@ -277,19 +418,61 @@ export class HookRegistry {
     });
   }
 
+  /**
+   * Dispatch a tag-mutation event. Same post-commit / microtask contract
+   * as the note + attachment dispatchers. `tag` is the bare tag name; the
+   * git-mirror handler matches on it to identify which `.parachute/schemas/<tag>.yaml`
+   * sidecar to rewrite or remove.
+   */
+  dispatchTag(event: TagHookEvent, tag: string, store: Store): void {
+    if (this.tagHooks.length === 0) return;
+
+    const matches: RegisteredTagHook[] = [];
+    for (const hook of this.tagHooks) {
+      if (!hook.events.has(event)) continue;
+      try {
+        if (hook.when && !hook.when(tag)) continue;
+      } catch (err) {
+        this.logger.error(
+          `[hooks] predicate threw for ${hook.name ?? "anonymous"} on tag ${tag}:`,
+          err,
+        );
+        continue;
+      }
+      matches.push(hook);
+    }
+    if (matches.length === 0) return;
+
+    queueMicrotask(() => {
+      for (const hook of matches) {
+        const task = this.runTagHandler(hook, event, tag, store);
+        this.inFlight.add(task);
+        task.finally(() => this.inFlight.delete(task));
+      }
+    });
+  }
+
   private async runHandler(
     hook: RegisteredHook,
     event: HookEvent,
-    note: Note,
+    note: NoteHookPayload,
     store: Store,
   ): Promise<void> {
     const release = await this.semaphore.acquire();
     try {
-      // Re-read the note so the handler sees the latest state (another
-      // handler may have written back in between). If the note was
-      // deleted, silently drop.
-      const fresh = (await store.getNote(note.id)) ?? note;
-      await hook.handler(fresh, store, event);
+      // For non-deleted events, re-read the note so the handler sees the
+      // latest committed state (another handler may have written back
+      // between dispatch and this acquisition). For "deleted" events the
+      // row is gone — pass the DeletedNoteRef payload straight through.
+      let payload: NoteHookPayload = note;
+      if (event !== "deleted") {
+        const fresh = await store.getNote(note.id);
+        if (fresh) payload = fresh;
+        // If the note was deleted between dispatch and re-read, fall
+        // back to the dispatch-time payload — same shape as before; the
+        // handler can sense the disappearance via its own predicate.
+      }
+      await hook.handler(payload, store, event);
     } catch (err) {
       this.logger.error(
         `[hooks] handler ${hook.name ?? "anonymous"} threw on ${event} ${note.id}:`,
@@ -303,19 +486,41 @@ export class HookRegistry {
   private async runAttachmentHandler(
     hook: RegisteredAttachmentHook,
     event: AttachmentHookEvent,
-    attachment: Attachment,
+    attachment: AttachmentHookPayload,
     store: Store,
   ): Promise<void> {
     const release = await this.semaphore.acquire();
     try {
-      // Re-read the attachment so the handler sees the latest metadata
-      // (another handler may have written back in between). If the
-      // attachment was deleted, silently drop.
-      const fresh = (await store.getAttachment(attachment.id)) ?? attachment;
-      await hook.handler(fresh, store, event);
+      // Symmetric with runHandler: re-read for non-deleted events,
+      // pass straight through on delete.
+      let payload: AttachmentHookPayload = attachment;
+      if (event !== "deleted") {
+        const fresh = await store.getAttachment(attachment.id);
+        if (fresh) payload = fresh;
+      }
+      await hook.handler(payload, store, event);
     } catch (err) {
       this.logger.error(
         `[hooks] attachment handler ${hook.name ?? "anonymous"} threw on ${event} ${attachment.id}:`,
+        err,
+      );
+    } finally {
+      release();
+    }
+  }
+
+  private async runTagHandler(
+    hook: RegisteredTagHook,
+    event: TagHookEvent,
+    tag: string,
+    store: Store,
+  ): Promise<void> {
+    const release = await this.semaphore.acquire();
+    try {
+      await hook.handler(tag, store, event);
+    } catch (err) {
+      this.logger.error(
+        `[hooks] tag handler ${hook.name ?? "anonymous"} threw on ${event} ${tag}:`,
         err,
       );
     } finally {

--- a/core/src/portable-md.test.ts
+++ b/core/src/portable-md.test.ts
@@ -33,6 +33,7 @@ import {
   parseFrontmatter,
   portableExportFilePath,
   probeCaseSensitive,
+  pruneOrphans,
   SIDECAR_DIR,
   NOTES_META_DIR,
   supportsInlineFrontmatter,
@@ -1797,5 +1798,166 @@ describe("case-collision detection (vault#327)", async () => {
     });
     expect(stats.notes).toBe(2);
     expect(stats.disambiguated_paths).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneOrphans (vault#XXX — event-driven mirror delete propagation)
+// ---------------------------------------------------------------------------
+
+describe("pruneOrphans", async () => {
+  let tmpBase: string;
+  beforeEach(() => {
+    tmpBase = join(tmpdir(), `parachute-prune-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(tmpBase, { recursive: true });
+  });
+
+  it("no-op on non-existent directory", () => {
+    const stats = pruneOrphans({
+      outDir: join(tmpBase, "doesnt-exist"),
+      validNoteIds: new Set(),
+      validTagNames: new Set(),
+      validAttachmentIds: new Set(),
+    });
+    expect(stats.notes_removed).toBe(0);
+    expect(stats.unparseable_files).toHaveLength(0);
+  });
+
+  it("removes orphaned note .md file", async () => {
+    const outDir = join(tmpBase, "orphan-note");
+    // First do a real export so the structure is realistic.
+    const db = new Database(":memory:");
+    const store = new SqliteStore(db);
+    await store.createNote("alive", { id: "01HFAA", path: "alive" });
+    await store.createNote("doomed", { id: "01HFBB", path: "doomed" });
+    await exportVaultToDir(store, { outDir, vaultName: "t", exportedAt: "2026-01-01T00:00:00.000Z" });
+    expect(existsSync(join(outDir, "alive.md"))).toBe(true);
+    expect(existsSync(join(outDir, "doomed.md"))).toBe(true);
+
+    // Now prune with only "alive" in the valid set.
+    const stats = pruneOrphans({
+      outDir,
+      validNoteIds: new Set(["01HFAA"]),
+      validTagNames: new Set(),
+      validAttachmentIds: new Set(),
+    });
+    expect(stats.notes_removed).toBe(1);
+    expect(existsSync(join(outDir, "alive.md"))).toBe(true);
+    expect(existsSync(join(outDir, "doomed.md"))).toBe(false);
+  });
+
+  it("removes orphaned schema sidecar", async () => {
+    const outDir = join(tmpBase, "orphan-schema");
+    const db = new Database(":memory:");
+    const store = new SqliteStore(db);
+    await store.upsertTagRecord("alive-tag", { description: "stays" });
+    await store.upsertTagRecord("doomed-tag", { description: "goes" });
+    await exportVaultToDir(store, { outDir, vaultName: "t", exportedAt: "2026-01-01T00:00:00.000Z" });
+    const schemasDir = join(outDir, SIDECAR_DIR, "schemas");
+    expect(existsSync(join(schemasDir, "alive-tag.yaml"))).toBe(true);
+    expect(existsSync(join(schemasDir, "doomed-tag.yaml"))).toBe(true);
+
+    const stats = pruneOrphans({
+      outDir,
+      validNoteIds: new Set(),
+      validTagNames: new Set(["alive-tag"]),
+      validAttachmentIds: new Set(),
+    });
+    expect(stats.schemas_removed).toBe(1);
+    expect(existsSync(join(schemasDir, "alive-tag.yaml"))).toBe(true);
+    expect(existsSync(join(schemasDir, "doomed-tag.yaml"))).toBe(false);
+  });
+
+  it("removes orphaned attachment directories", async () => {
+    const outDir = join(tmpBase, "orphan-att");
+    // Build the export structure by hand (attachment binaries need
+    // assetsDir wiring; cheaper to just create the dirs).
+    const attachmentsDir = join(outDir, SIDECAR_DIR, "attachments");
+    mkdirSync(attachmentsDir, { recursive: true });
+    mkdirSync(join(attachmentsDir, "att-alive"), { recursive: true });
+    writeFileSync(join(attachmentsDir, "att-alive", "voice.m4a"), "");
+    mkdirSync(join(attachmentsDir, "att-doomed"), { recursive: true });
+    writeFileSync(join(attachmentsDir, "att-doomed", "voice.m4a"), "");
+    // Need .parachute/vault.yaml so the structure is recognized (cheap to fake)
+    writeFileSync(join(outDir, SIDECAR_DIR, "vault.yaml"), "name: t\n");
+
+    const stats = pruneOrphans({
+      outDir,
+      validNoteIds: new Set(),
+      validTagNames: new Set(),
+      validAttachmentIds: new Set(["att-alive"]),
+    });
+    expect(stats.attachment_dirs_removed).toBe(1);
+    expect(existsSync(join(attachmentsDir, "att-alive"))).toBe(true);
+    expect(existsSync(join(attachmentsDir, "att-doomed"))).toBe(false);
+  });
+
+  it("skips unparseable .md files without crashing", async () => {
+    const outDir = join(tmpBase, "unparseable");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "no-frontmatter.md"), "just content, no frontmatter\n");
+    writeFileSync(join(outDir, "garbage.md"), "---\nnot-real-yaml\n");
+    const stats = pruneOrphans({
+      outDir,
+      validNoteIds: new Set(),
+      validTagNames: new Set(),
+      validAttachmentIds: new Set(),
+    });
+    // Both files lacked an `id`, so we record them but don't remove.
+    expect(stats.notes_removed).toBe(0);
+    expect(stats.unparseable_files.length).toBeGreaterThanOrEqual(2);
+    expect(existsSync(join(outDir, "no-frontmatter.md"))).toBe(true);
+    expect(existsSync(join(outDir, "garbage.md"))).toBe(true);
+  });
+
+  it("preserves all files when everything is in the valid sets", async () => {
+    const outDir = join(tmpBase, "happy-path");
+    const db = new Database(":memory:");
+    const store = new SqliteStore(db);
+    const a = await store.createNote("a", { path: "a" });
+    const b = await store.createNote("b", { path: "b" });
+    await store.upsertTagRecord("tag1", { description: "x" });
+    await exportVaultToDir(store, { outDir, vaultName: "t", exportedAt: "2026-01-01T00:00:00.000Z" });
+    const stats = pruneOrphans({
+      outDir,
+      validNoteIds: new Set([a.id, b.id]),
+      validTagNames: new Set(["tag1"]),
+      validAttachmentIds: new Set(),
+    });
+    expect(stats.notes_removed).toBe(0);
+    expect(stats.schemas_removed).toBe(0);
+    expect(stats.attachment_dirs_removed).toBe(0);
+    expect(existsSync(join(outDir, "a.md"))).toBe(true);
+    expect(existsSync(join(outDir, "b.md"))).toBe(true);
+  });
+
+  it("removes orphan note + corresponding notes-meta sidecar for csv/yaml notes", async () => {
+    // For non-frontmatter extensions, the sidecar lives at
+    // .parachute/notes-meta/<id>.yaml. Pruning the note should remove
+    // both files.
+    const outDir = join(tmpBase, "orphan-csv");
+    const db = new Database(":memory:");
+    const store = new SqliteStore(db);
+    await store.createNote("col1,col2\n1,2\n", {
+      id: "01CSV-DEL",
+      path: "data/table",
+      extension: "csv",
+    });
+    await exportVaultToDir(store, { outDir, vaultName: "t", exportedAt: "2026-01-01T00:00:00.000Z" });
+    const contentFile = join(outDir, "data", "table.csv");
+    const sidecarFile = join(outDir, SIDECAR_DIR, "notes-meta", "01CSV-DEL.yaml");
+    expect(existsSync(contentFile)).toBe(true);
+    expect(existsSync(sidecarFile)).toBe(true);
+
+    const stats = pruneOrphans({
+      outDir,
+      validNoteIds: new Set(), // doom it
+      validTagNames: new Set(),
+      validAttachmentIds: new Set(),
+    });
+    expect(stats.notes_removed).toBe(1);
+    expect(stats.sidecars_removed).toBeGreaterThanOrEqual(1);
+    expect(existsSync(contentFile)).toBe(false);
+    expect(existsSync(sidecarFile)).toBe(false);
   });
 });

--- a/core/src/portable-md.test.ts
+++ b/core/src/portable-md.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, existsSync, statSync } from "fs";
+import { mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync, existsSync, statSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -1802,7 +1802,7 @@ describe("case-collision detection (vault#327)", async () => {
 });
 
 // ---------------------------------------------------------------------------
-// pruneOrphans (vault#XXX — event-driven mirror delete propagation)
+// pruneOrphans (vault#382 — event-driven mirror delete propagation)
 // ---------------------------------------------------------------------------
 
 describe("pruneOrphans", async () => {
@@ -1959,5 +1959,94 @@ describe("pruneOrphans", async () => {
     expect(stats.sidecars_removed).toBeGreaterThanOrEqual(1);
     expect(existsSync(contentFile)).toBe(false);
     expect(existsSync(sidecarFile)).toBe(false);
+  });
+
+  // Reviewer-flagged regression on vault#382 Critical #2 — pruneOrphans
+  // walks via statSync (follows symlinks); without the safeRm guard a
+  // symlink inside the mirror pointing OUTSIDE outDir would resurface
+  // its target's files as orphans and rmSync would happily delete them
+  // off-tree. The guard resolves each candidate and refuses anything
+  // not under outDir; refusals get recorded in `unparseable_files` so
+  // an operator can see what was skipped.
+  it("refuses to delete files reached via a symlink pointing outside outDir", async () => {
+    const outDir = join(tmpBase, "symlink-attack");
+    const outside = join(tmpBase, "outside");
+    mkdirSync(outside, { recursive: true });
+    mkdirSync(outDir, { recursive: true });
+    // A real, sensitive file in `outside/` we don't want pruneOrphans
+    // to touch under any circumstance.
+    const externalFile = join(outside, "do-not-touch.md");
+    writeFileSync(externalFile, "---\nid: 01EXTERNAL\n---\nimportant\n");
+    // A symlink inside outDir pointing at outside/ — walkContentFiles
+    // would normally surface outside/do-not-touch.md as a candidate.
+    try {
+      symlinkSync(outside, join(outDir, "via-link"));
+    } catch {
+      // Some CI sandboxes refuse symlink creation. Skip the test in
+      // that case rather than fail spuriously.
+      return;
+    }
+
+    const stats = pruneOrphans({
+      outDir,
+      validNoteIds: new Set(), // doom every id we see
+      validTagNames: new Set(),
+      validAttachmentIds: new Set(),
+    });
+
+    // Critical assertion: the external file MUST survive.
+    expect(existsSync(externalFile)).toBe(true);
+    // And the refusal MUST be recorded so the operator sees it.
+    expect(
+      stats.unparseable_files.some(
+        (u) => u.path.includes("via-link") || u.reason.includes("outside"),
+      ),
+    ).toBe(true);
+  });
+
+  // Reviewer-flagged regression on vault#382 Critical #1 — pruneOrphans
+  // builds `validTagNames` from ALL tag-table rows in mirror-deps.ts.
+  // After `deleteTagSchema(t)` the schema fields are cleared but the
+  // tag row persists with the bare name, so the sidecar lingers
+  // forever. The fix routes validTagNames through `hasSchemaContent`
+  // before passing into pruneOrphans, and exports the predicate so
+  // mirror-deps can reuse the single source of truth.
+  it("considers a schema-content-free tag the same as a deleted tag for sidecar pruning", async () => {
+    const outDir = join(tmpBase, "stale-schema");
+    const db = new Database(":memory:");
+    const store = new SqliteStore(db);
+    await store.upsertTagRecord("bare", {}); // bare-name only
+    await store.upsertTagRecord("with-schema", { description: "real" });
+    await exportVaultToDir(store, {
+      outDir,
+      vaultName: "t",
+      exportedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const schemasDir = join(outDir, SIDECAR_DIR, "schemas");
+    // The bare tag SHOULDN'T have a sidecar; the schema-bearing one
+    // SHOULD. This confirms the export-writer's contract before the
+    // prune step.
+    expect(existsSync(join(schemasDir, "bare.yaml"))).toBe(false);
+    expect(existsSync(join(schemasDir, "with-schema.yaml"))).toBe(true);
+
+    // Now seed a stale sidecar for `bare` (simulating "the operator
+    // previously had a schema for `bare`, then cleared it via
+    // `deleteTagSchema`"). pruneOrphans should remove this iff the
+    // caller correctly filtered validTagNames by hasSchemaContent.
+    writeFileSync(join(schemasDir, "bare.yaml"), 'name: "bare"\ndescription: "stale"\n');
+    expect(existsSync(join(schemasDir, "bare.yaml"))).toBe(true);
+
+    // Filtered set — only `with-schema` has hasSchemaContent === true.
+    const validTagNames = new Set(["with-schema"]);
+    const stats = pruneOrphans({
+      outDir,
+      validNoteIds: new Set(),
+      validTagNames,
+      validAttachmentIds: new Set(),
+    });
+
+    expect(stats.schemas_removed).toBe(1);
+    expect(existsSync(join(schemasDir, "bare.yaml"))).toBe(false);
+    expect(existsSync(join(schemasDir, "with-schema.yaml"))).toBe(true);
   });
 });

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -1001,6 +1001,336 @@ export async function exportVaultToDir(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Orphan sweep — for git-mirror's delete propagation
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a `pruneOrphans` pass.
+ */
+export interface PruneOrphansStats {
+  /** Note content files removed (frontmatter id not in `validNoteIds`). */
+  notes_removed: number;
+  /** Sidecar metadata files removed (under `.parachute/notes-meta/`). */
+  sidecars_removed: number;
+  /** Schema sidecars removed (under `.parachute/schemas/`). */
+  schemas_removed: number;
+  /** Attachment directories removed (under `.parachute/attachments/`). */
+  attachment_dirs_removed: number;
+  /**
+   * Files we couldn't parse / classify. Surfaced for operator audit;
+   * the sweep doesn't touch them. Empty when everything classified
+   * cleanly.
+   */
+  unparseable_files: Array<{ path: string; reason: string }>;
+}
+
+/**
+ * Options for the orphan-sweep pass. Run periodically (the mirror manager
+ * arms a safety-net poll, default 1h) and after operator-visible deletions
+ * (the mirror manager's targeted-deletion fast path also calls this for the
+ * touched-set).
+ *
+ * The sweep is the bookkeeping cousin of the event-driven fast path: events
+ * cover the common case (a single note deletion fires "deleted" → mirror
+ * removes that file); the sweep covers anything the fast path missed
+ * (direct SQL writes, app crashes between dispatch and handler, restart
+ * gaps).
+ */
+export interface PruneOrphansOptions {
+  /** Directory to sweep — same shape as an `exportVaultToDir` outDir. */
+  outDir: string;
+  /** Note IDs that should be kept (everything else under the export gets removed). */
+  validNoteIds: Set<string>;
+  /** Tag names that should be kept (other schema sidecars under `.parachute/schemas/` get removed). */
+  validTagNames: Set<string>;
+  /** Attachment IDs that should be kept (other dirs under `.parachute/attachments/` get removed). */
+  validAttachmentIds: Set<string>;
+  /**
+   * Override `extension`-based content-file extension recognition. The
+   * default treats `.md` and `.mdx` as having inline frontmatter (with
+   * `id:` reachable via the file head); everything else needs a sidecar
+   * lookup to know what id owns it.
+   */
+  supportsInlineFrontmatter?: (ext: string) => boolean;
+}
+
+/**
+ * Sweep the export directory for files belonging to notes / tags /
+ * attachments that no longer exist in the vault. Removes them so the
+ * mirror's `git diff` reflects what vault actually has.
+ *
+ * Strategy:
+ *   1. Walk content files. For each `.md` / `.mdx`, parse the frontmatter
+ *      `id` and compare against `validNoteIds`. Mismatch → remove the
+ *      file. Files we can't parse are recorded in `unparseable_files`
+ *      and left alone (best-effort, no destructive guesses).
+ *   2. For non-inline-frontmatter extensions (`.csv`, `.yaml`, etc.),
+ *      check the matching `.parachute/notes-meta/<id>.yaml` sidecar — the
+ *      sidecar carries the canonical `id` + `path` + `extension` triple.
+ *      An orphaned sidecar (no matching content file) is also removed,
+ *      and an orphaned content file (no matching sidecar) without a
+ *      parseable frontmatter is left as unparseable.
+ *   3. Walk `.parachute/schemas/`. Each file is `<tag>.yaml` (after
+ *      filename sanitization). Parse the `name:` field; compare against
+ *      `validTagNames`. Mismatch → remove.
+ *   4. Walk `.parachute/attachments/`. Each subdir name IS the
+ *      attachment id (per `exportVaultToDir`'s layout). Compare against
+ *      `validAttachmentIds`. Mismatch → recursive remove.
+ *
+ * Returns counts so callers can log + decide whether to commit.
+ *
+ * Safe to call on a directory that's never been exported to (returns
+ * zero counts; doesn't create anything).
+ */
+export function pruneOrphans(opts: PruneOrphansOptions): PruneOrphansStats {
+  const stats: PruneOrphansStats = {
+    notes_removed: 0,
+    sidecars_removed: 0,
+    schemas_removed: 0,
+    attachment_dirs_removed: 0,
+    unparseable_files: [],
+  };
+
+  const outDir = opts.outDir;
+  if (!existsSync(outDir)) return stats;
+
+  const supportsInline = opts.supportsInlineFrontmatter ?? supportsInlineFrontmatter;
+  const sidecarRoot = join(outDir, SIDECAR_DIR);
+  const notesMetaRoot = join(sidecarRoot, NOTES_META_DIR);
+  const schemasRoot = join(sidecarRoot, "schemas");
+  const attachmentsRoot = join(sidecarRoot, "attachments");
+
+  // ---- 1 + 2. Notes + sidecars ----
+  //
+  // First pass: build the sidecar id → { path, extension } map so we can
+  // resolve non-inline-frontmatter content files via their sidecar.
+  // Sidecars whose claimed (path, extension) doesn't map to an existing
+  // content file are tracked as "orphaned sidecar" candidates.
+  const sidecarById = new Map<string, { path: string | null; extension: string | null }>();
+  const sidecarFilesById = new Map<string, string>(); // id → absolute filepath
+  if (existsSync(notesMetaRoot)) {
+    try {
+      for (const entry of readdirSync(notesMetaRoot)) {
+        if (!entry.endsWith(".yaml")) continue;
+        const id = entry.slice(0, -5);
+        const full = join(notesMetaRoot, entry);
+        sidecarFilesById.set(id, full);
+        try {
+          const text = readFileSync(full, "utf-8");
+          const { frontmatter } = parseFrontmatter(`---\n${text}---\n`);
+          sidecarById.set(id, {
+            path: typeof frontmatter.path === "string" ? (frontmatter.path as string) : null,
+            extension: typeof frontmatter.extension === "string" ? (frontmatter.extension as string) : null,
+          });
+        } catch (err) {
+          stats.unparseable_files.push({
+            path: full,
+            reason: `failed to parse sidecar: ${(err as Error).message ?? err}`,
+          });
+        }
+      }
+    } catch (err) {
+      // Notes-meta dir read-error is non-fatal — record + carry on.
+      stats.unparseable_files.push({
+        path: notesMetaRoot,
+        reason: `notes-meta walk failed: ${(err as Error).message ?? err}`,
+      });
+    }
+  }
+
+  // Now walk content files (everything outside the .parachute sidecar).
+  const contentFiles = walkContentFiles(outDir);
+  // Track which sidecars matched a content file so we can also remove
+  // orphaned sidecars (sidecar present but content file gone).
+  const pairedSidecarIds = new Set<string>();
+  for (const filepath of contentFiles) {
+    const ext = extname(filepath).slice(1).toLowerCase();
+    if (supportsInline(ext)) {
+      // Parse frontmatter, read id.
+      try {
+        const raw = readFileSync(filepath, "utf-8");
+        const { frontmatter } = parseFrontmatter(raw);
+        const id = typeof frontmatter.id === "string" ? (frontmatter.id as string) : null;
+        if (!id) {
+          stats.unparseable_files.push({
+            path: filepath,
+            reason: "no `id` in frontmatter",
+          });
+          continue;
+        }
+        if (!opts.validNoteIds.has(id)) {
+          try {
+            rmSync(filepath, { force: true });
+            stats.notes_removed++;
+          } catch (err) {
+            stats.unparseable_files.push({
+              path: filepath,
+              reason: `unlink failed: ${(err as Error).message ?? err}`,
+            });
+          }
+        }
+      } catch (err) {
+        stats.unparseable_files.push({
+          path: filepath,
+          reason: `read failed: ${(err as Error).message ?? err}`,
+        });
+      }
+    } else {
+      // Sidecar-required extension. Find the matching sidecar by
+      // (path, extension) — sidecars are keyed by id, so we sweep the
+      // sidecarById map.
+      const relPath = relative(outDir, filepath).replace(/\\/g, "/");
+      // Strip extension to get the canonical path stored in the sidecar
+      // (vault paths don't carry extensions).
+      const pathNoExt = relPath.slice(0, -(ext.length + 1));
+      let foundId: string | null = null;
+      for (const [id, info] of sidecarById.entries()) {
+        if (
+          info.path === pathNoExt &&
+          (info.extension ?? "md").toLowerCase() === ext
+        ) {
+          foundId = id;
+          break;
+        }
+      }
+      if (!foundId) {
+        // Content file with no sidecar — can't tell which note owns it.
+        // Conservative: leave alone, record as unparseable.
+        stats.unparseable_files.push({
+          path: filepath,
+          reason: "no sidecar metadata could be matched by (path, extension)",
+        });
+        continue;
+      }
+      pairedSidecarIds.add(foundId);
+      if (!opts.validNoteIds.has(foundId)) {
+        // Note is orphaned — remove both content and sidecar.
+        try {
+          rmSync(filepath, { force: true });
+          stats.notes_removed++;
+        } catch (err) {
+          stats.unparseable_files.push({
+            path: filepath,
+            reason: `unlink failed: ${(err as Error).message ?? err}`,
+          });
+        }
+        const sidecarPath = sidecarFilesById.get(foundId);
+        if (sidecarPath) {
+          try {
+            rmSync(sidecarPath, { force: true });
+            stats.sidecars_removed++;
+          } catch (err) {
+            stats.unparseable_files.push({
+              path: sidecarPath,
+              reason: `unlink failed: ${(err as Error).message ?? err}`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Sweep up orphaned sidecars (sidecar exists but no content file
+  // matched OR sidecar's id isn't in validNoteIds).
+  for (const [id, sidecarPath] of sidecarFilesById.entries()) {
+    if (opts.validNoteIds.has(id) && pairedSidecarIds.has(id)) continue;
+    if (opts.validNoteIds.has(id) && !pairedSidecarIds.has(id)) {
+      // Sidecar refers to a valid note but the content file is gone —
+      // that's an inconsistency, not an orphan. Leave the sidecar so
+      // the next export can rewrite the content file alongside it.
+      continue;
+    }
+    try {
+      rmSync(sidecarPath, { force: true });
+      stats.sidecars_removed++;
+    } catch (err) {
+      stats.unparseable_files.push({
+        path: sidecarPath,
+        reason: `unlink failed: ${(err as Error).message ?? err}`,
+      });
+    }
+  }
+
+  // ---- 3. Schema sidecars ----
+  if (existsSync(schemasRoot)) {
+    try {
+      for (const entry of readdirSync(schemasRoot)) {
+        if (!entry.endsWith(".yaml")) continue;
+        const full = join(schemasRoot, entry);
+        try {
+          const text = readFileSync(full, "utf-8");
+          const { frontmatter } = parseFrontmatter(`---\n${text}---\n`);
+          const name = typeof frontmatter.name === "string" ? (frontmatter.name as string) : null;
+          if (!name) {
+            // Fall back to filename — sanitizeTagFilename replaces `/`
+            // with `__`, so reverse for the lookup.
+            const fromFilename = entry.slice(0, -5).replace(/__/g, "/");
+            if (!opts.validTagNames.has(fromFilename)) {
+              rmSync(full, { force: true });
+              stats.schemas_removed++;
+            }
+            continue;
+          }
+          if (!opts.validTagNames.has(name)) {
+            rmSync(full, { force: true });
+            stats.schemas_removed++;
+          }
+        } catch (err) {
+          stats.unparseable_files.push({
+            path: full,
+            reason: `schema sweep failed: ${(err as Error).message ?? err}`,
+          });
+        }
+      }
+    } catch (err) {
+      stats.unparseable_files.push({
+        path: schemasRoot,
+        reason: `schemas walk failed: ${(err as Error).message ?? err}`,
+      });
+    }
+  }
+
+  // ---- 4. Attachment directories ----
+  if (existsSync(attachmentsRoot)) {
+    try {
+      for (const entry of readdirSync(attachmentsRoot)) {
+        const full = join(attachmentsRoot, entry);
+        let stat;
+        try {
+          stat = statSync(full);
+        } catch (err) {
+          stats.unparseable_files.push({
+            path: full,
+            reason: `stat failed: ${(err as Error).message ?? err}`,
+          });
+          continue;
+        }
+        if (!stat.isDirectory()) continue;
+        // The directory name IS the attachment id (per the export layout).
+        if (!opts.validAttachmentIds.has(entry)) {
+          try {
+            rmSync(full, { recursive: true, force: true });
+            stats.attachment_dirs_removed++;
+          } catch (err) {
+            stats.unparseable_files.push({
+              path: full,
+              reason: `attachment dir remove failed: ${(err as Error).message ?? err}`,
+            });
+          }
+        }
+      }
+    } catch (err) {
+      stats.unparseable_files.push({
+        path: attachmentsRoot,
+        reason: `attachments walk failed: ${(err as Error).message ?? err}`,
+      });
+    }
+  }
+
+  return stats;
+}
+
 function hasSchemaContent(tag: TagRecord): boolean {
   if (tag.description !== undefined && tag.description.length > 0) return true;
   if (tag.fields && Object.keys(tag.fields).length > 0) return true;

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -72,7 +72,7 @@
  * See vault#308.
  */
 
-import { readdirSync, readFileSync, statSync, mkdirSync, writeFileSync, copyFileSync, existsSync, rmSync } from "fs";
+import { readdirSync, readFileSync, realpathSync, statSync, mkdirSync, writeFileSync, copyFileSync, existsSync, rmSync } from "fs";
 import { basename, join, relative, extname, dirname, resolve as resolvePath, sep as pathSep } from "path";
 import type { Store, Note, Link, Attachment } from "./types.js";
 import type { TagRecord } from "./tag-schemas.js";
@@ -1101,6 +1101,55 @@ export function pruneOrphans(opts: PruneOrphansOptions): PruneOrphansStats {
   const schemasRoot = join(sidecarRoot, "schemas");
   const attachmentsRoot = join(sidecarRoot, "attachments");
 
+  // Path-traversal guard. `walkContentFiles` uses `statSync` which
+  // follows symlinks — a symlink inside the mirror pointing OUTSIDE
+  // `outDir` would resurface its target's files in the prune sweep,
+  // and a bare `rmSync(filepath)` would delete them off-tree. Every
+  // deletion in this function routes through `safeRm`, which calls
+  // `realpathSync` (resolves through symlinks, unlike syntactic-only
+  // `path.resolve`) and refuses to delete anything that isn't `outDir`
+  // or beneath it after symlink resolution. Refusals get recorded in
+  // `unparseable_files` so an operator can see what was skipped.
+  // Reviewer-flagged on vault#382 (Critical #2).
+  const outDirReal = realpathSync(outDir);
+  const safeRm = (
+    candidate: string,
+    onSuccess: () => void,
+    options: { recursive?: boolean } = {},
+  ): void => {
+    let real: string;
+    try {
+      real = realpathSync(candidate);
+    } catch (err) {
+      // realpathSync throws if the path doesn't exist or is unreadable.
+      // Don't delete what we can't fully resolve.
+      stats.unparseable_files.push({
+        path: candidate,
+        reason: `realpath failed: ${(err as Error).message ?? err}`,
+      });
+      return;
+    }
+    if (!isWithinDir(real, outDirReal)) {
+      stats.unparseable_files.push({
+        path: candidate,
+        reason: "real path resolved outside mirror outDir — refusing to delete (symlink?)",
+      });
+      return;
+    }
+    try {
+      // Delete via the resolved real path; never via the unresolved
+      // candidate (which could route through a symlink we already
+      // determined would escape).
+      rmSync(real, { force: true, recursive: options.recursive ?? false });
+      onSuccess();
+    } catch (err) {
+      stats.unparseable_files.push({
+        path: candidate,
+        reason: `unlink failed: ${(err as Error).message ?? err}`,
+      });
+    }
+  };
+
   // ---- 1 + 2. Notes + sidecars ----
   //
   // First pass: build the sidecar id → { path, extension } map so we can
@@ -1160,15 +1209,9 @@ export function pruneOrphans(opts: PruneOrphansOptions): PruneOrphansStats {
           continue;
         }
         if (!opts.validNoteIds.has(id)) {
-          try {
-            rmSync(filepath, { force: true });
+          safeRm(filepath, () => {
             stats.notes_removed++;
-          } catch (err) {
-            stats.unparseable_files.push({
-              path: filepath,
-              reason: `unlink failed: ${(err as Error).message ?? err}`,
-            });
-          }
+          });
         }
       } catch (err) {
         stats.unparseable_files.push({
@@ -1206,26 +1249,14 @@ export function pruneOrphans(opts: PruneOrphansOptions): PruneOrphansStats {
       pairedSidecarIds.add(foundId);
       if (!opts.validNoteIds.has(foundId)) {
         // Note is orphaned — remove both content and sidecar.
-        try {
-          rmSync(filepath, { force: true });
+        safeRm(filepath, () => {
           stats.notes_removed++;
-        } catch (err) {
-          stats.unparseable_files.push({
-            path: filepath,
-            reason: `unlink failed: ${(err as Error).message ?? err}`,
-          });
-        }
+        });
         const sidecarPath = sidecarFilesById.get(foundId);
         if (sidecarPath) {
-          try {
-            rmSync(sidecarPath, { force: true });
+          safeRm(sidecarPath, () => {
             stats.sidecars_removed++;
-          } catch (err) {
-            stats.unparseable_files.push({
-              path: sidecarPath,
-              reason: `unlink failed: ${(err as Error).message ?? err}`,
-            });
-          }
+          });
         }
       }
     }
@@ -1241,15 +1272,9 @@ export function pruneOrphans(opts: PruneOrphansOptions): PruneOrphansStats {
       // the next export can rewrite the content file alongside it.
       continue;
     }
-    try {
-      rmSync(sidecarPath, { force: true });
+    safeRm(sidecarPath, () => {
       stats.sidecars_removed++;
-    } catch (err) {
-      stats.unparseable_files.push({
-        path: sidecarPath,
-        reason: `unlink failed: ${(err as Error).message ?? err}`,
-      });
-    }
+    });
   }
 
   // ---- 3. Schema sidecars ----
@@ -1267,14 +1292,16 @@ export function pruneOrphans(opts: PruneOrphansOptions): PruneOrphansStats {
             // with `__`, so reverse for the lookup.
             const fromFilename = entry.slice(0, -5).replace(/__/g, "/");
             if (!opts.validTagNames.has(fromFilename)) {
-              rmSync(full, { force: true });
-              stats.schemas_removed++;
+              safeRm(full, () => {
+                stats.schemas_removed++;
+              });
             }
             continue;
           }
           if (!opts.validTagNames.has(name)) {
-            rmSync(full, { force: true });
-            stats.schemas_removed++;
+            safeRm(full, () => {
+              stats.schemas_removed++;
+            });
           }
         } catch (err) {
           stats.unparseable_files.push({
@@ -1309,15 +1336,13 @@ export function pruneOrphans(opts: PruneOrphansOptions): PruneOrphansStats {
         if (!stat.isDirectory()) continue;
         // The directory name IS the attachment id (per the export layout).
         if (!opts.validAttachmentIds.has(entry)) {
-          try {
-            rmSync(full, { recursive: true, force: true });
-            stats.attachment_dirs_removed++;
-          } catch (err) {
-            stats.unparseable_files.push({
-              path: full,
-              reason: `attachment dir remove failed: ${(err as Error).message ?? err}`,
-            });
-          }
+          safeRm(
+            full,
+            () => {
+              stats.attachment_dirs_removed++;
+            },
+            { recursive: true },
+          );
         }
       }
     } catch (err) {
@@ -1331,7 +1356,20 @@ export function pruneOrphans(opts: PruneOrphansOptions): PruneOrphansStats {
   return stats;
 }
 
-function hasSchemaContent(tag: TagRecord): boolean {
+/**
+ * True iff the tag carries content the export writer will emit as a
+ * schema sidecar (`.parachute/schemas/<tag>.yaml`). Bare-name tags
+ * (the `tags` table has a row but description/fields/relationships/
+ * parents are all empty) get no sidecar — and crucially, after
+ * `deleteTagSchema` clears those fields the row persists with the
+ * bare name. Callers building the `validTagNames` set for
+ * `pruneOrphans` MUST filter through this predicate, otherwise the
+ * stale sidecar lingers indefinitely.
+ *
+ * Reviewer-flagged on vault#382: without this filter, a cleared
+ * schema's sidecar never gets pruned.
+ */
+export function hasSchemaContent(tag: TagRecord): boolean {
   if (tag.description !== undefined && tag.description.length > 0) return true;
   if (tag.fields && Object.keys(tag.fields).length > 0) return true;
   if (tag.relationships && Object.keys(tag.relationships).length > 0) return true;

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -217,10 +217,23 @@ export class BunSqliteStore implements Store {
   }
 
   async deleteNote(id: string): Promise<void> {
-    // Read before delete so we can invalidate config caches on the way out.
+    // Read before delete so we can invalidate config caches on the way out
+    // AND so the post-delete hook dispatch carries the minimum payload
+    // ({ id, path }). The full note can't be reconstructed post-delete —
+    // by design, hooks subscribing to "deleted" receive a DeletedNoteRef,
+    // not a Note.
     const existing = noteOps.getNote(this.db, id);
     noteOps.deleteNote(this.db, id);
     if (existing?.path) this.invalidateConfigCachesForPath(existing.path);
+    // Dispatch even when `existing` was null — the caller asked for a
+    // deletion, and downstream consumers (e.g. the mirror) reconcile via
+    // id. Path is undefined in that case; the mirror sweep will catch
+    // any orphans missed by the targeted-removal fast path.
+    this.hooks.dispatch(
+      "deleted",
+      { id, ...(existing?.path ? { path: existing.path } : {}) },
+      this,
+    );
   }
 
   async queryNotes(opts: QueryOpts): Promise<Note[]> {
@@ -340,6 +353,10 @@ export class BunSqliteStore implements Store {
     // and may have declared `fields` powering schema validation.
     this._tagHierarchy = null;
     this._schemaConfig = null;
+    // Fire "deleted" only when SOMETHING happened (the underlying
+    // deleteTag returns `deleted: false` when the tag didn't exist).
+    // The git-mirror reacts to this by sweeping the schema sidecar.
+    if (result.deleted) this.hooks.dispatchTag("deleted", name, this);
     return result;
   }
 
@@ -352,6 +369,16 @@ export class BunSqliteStore implements Store {
     // the schema-config by parent_names + fields content.
     this._tagHierarchy = null;
     this._schemaConfig = null;
+    // Rename = delete-then-upsert from the perspective of any consumer
+    // that keys schema artifacts on the tag name (e.g. the git-mirror's
+    // `.parachute/schemas/<tag>.yaml` sidecar file). Fire both events
+    // so the consumer drops the old artifact and writes the new one.
+    // Only dispatch when the rename actually happened — error returns
+    // ({ error: ... }) shouldn't notify subscribers about phantom moves.
+    if ("renamed" in result) {
+      this.hooks.dispatchTag("deleted", oldName, this);
+      this.hooks.dispatchTag("upserted", newName, this);
+    }
     return result;
   }
 
@@ -365,6 +392,15 @@ export class BunSqliteStore implements Store {
     // bust the schema cache — `fields` declarations follow tag identity.
     this._tagHierarchy = null;
     this._schemaConfig = null;
+    // Each merged source vanishes from the tag set; the target's
+    // schema may have absorbed fields/relationships from the sources.
+    // Fire "deleted" for each source and "upserted" for the target so
+    // the mirror sweeps the source sidecars and rewrites the target.
+    for (const source of sources) {
+      if (source === target) continue;
+      this.hooks.dispatchTag("deleted", source, this);
+    }
+    this.hooks.dispatchTag("upserted", target, this);
     return result;
   }
 
@@ -440,12 +476,26 @@ export class BunSqliteStore implements Store {
     // `fields` drives validation — bust the schema cache so the next
     // create/update sees the new declarations.
     this._schemaConfig = null;
+    // The tag schema sidecar in the mirror needs to track this. Fire
+    // "upserted" regardless of whether the row was created or modified
+    // — the mirror writes the sidecar fresh either way.
+    this.hooks.dispatchTag("upserted", tag, this);
     return result;
   }
 
   async deleteTagSchema(tag: string) {
     const result = tagSchemaOps.deleteTagSchema(this.db, tag);
-    if (result) this._schemaConfig = null;
+    if (result) {
+      this._schemaConfig = null;
+      // Schema-only delete: the tag may still exist as a name in the
+      // hierarchy, but the sidecar lost its content. Mirror reacts by
+      // sweeping the sidecar file. (If the underlying row was reduced
+      // to a bare name with no schema content, hasSchemaContent() in
+      // exportVaultToDir already wouldn't have written it on the next
+      // export pass — the targeted delete is the fast path; the sweep
+      // is the safety net.)
+      this.hooks.dispatchTag("deleted", tag, this);
+    }
     return result;
   }
 
@@ -494,6 +544,11 @@ export class BunSqliteStore implements Store {
       this._tagHierarchy = null;
       this._schemaConfig = null;
     }
+    // Tag-mutation event for the git-mirror and any other downstream
+    // consumer. Fire "upserted" on every successful tag-record write —
+    // schema/relationship/parent-name mutations all alter the sidecar
+    // contents the mirror persists.
+    this.hooks.dispatchTag("upserted", tag, this);
     return result;
   }
 
@@ -599,6 +654,17 @@ export class BunSqliteStore implements Store {
     const other = this.db.prepare(
       "SELECT 1 FROM attachments WHERE path = ? LIMIT 1",
     ).get(row.path);
+
+    // Post-delete event for downstream consumers (e.g. the git-mirror's
+    // sweep of `.parachute/attachments/<id>/...`). Payload is the
+    // DeletedAttachmentRef — the row is gone, so we pass only id /
+    // note_id / path.
+    this.hooks.dispatchAttachment(
+      "deleted",
+      { id: attachmentId, noteId, path: row.path },
+      this,
+    );
+
     return { deleted: true, path: row.path, orphaned: !other };
   }
 

--- a/src/mirror-config.test.ts
+++ b/src/mirror-config.test.ts
@@ -12,6 +12,9 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  DEFAULT_SAFETY_NET_SECONDS,
+  MAX_SAFETY_NET_SECONDS,
+  MIN_SAFETY_NET_SECONDS,
   defaultMirrorConfig,
   parseMirrorConfig,
   resolveMirrorPath,
@@ -40,11 +43,14 @@ describe("defaultMirrorConfig", () => {
     expect(d.enabled).toBe(false);
     expect(d.location).toBe("internal");
     expect(d.external_path).toBeNull();
-    expect(d.watch).toBe(false);
+    // Post event-driven shift: sync_mode replaces watch. "events" is the
+    // new default — when an operator flips enabled on, hooks subscribe
+    // automatically.
+    expect(d.sync_mode).toBe("events");
     expect(d.auto_commit).toBe(true);
     expect(d.auto_push).toBe(false);
     expect(d.commit_template).toContain("{{date}}");
-    expect(d.interval_seconds).toBe(5);
+    expect(d.safety_net_seconds).toBe(DEFAULT_SAFETY_NET_SECONDS);
   });
 });
 
@@ -58,39 +64,66 @@ describe("parseMirrorConfig", () => {
     expect(parseMirrorConfig("")).toBeUndefined();
   });
 
-  test("parses a fully-specified mirror block", () => {
+  test("parses a fully-specified mirror block (post-event-driven shape)", () => {
     const yaml = [
       "port: 1940",
       "mirror:",
       "  enabled: true",
       "  location: external",
       "  external_path: /home/aaron/mirrors/gitcoin",
-      "  watch: true",
+      "  sync_mode: events",
       "  auto_commit: true",
       "  auto_push: true",
       '  commit_template: "vault: {{notes_changed}} note{{plural}}"',
-      "  interval_seconds: 10",
+      "  safety_net_seconds: 3600",
     ].join("\n");
     const m = parseMirrorConfig(yaml);
     expect(m).toEqual({
       enabled: true,
       location: "external",
       external_path: "/home/aaron/mirrors/gitcoin",
-      watch: true,
+      sync_mode: "events",
       auto_commit: true,
       auto_push: true,
       commit_template: "vault: {{notes_changed}} note{{plural}}",
-      interval_seconds: 10,
+      safety_net_seconds: 3600,
     });
   });
 
   test("partial mirror block fills missing fields from defaults", () => {
-    const yaml = "mirror:\n  enabled: true\n  watch: true\n";
+    const yaml = "mirror:\n  enabled: true\n  sync_mode: manual\n";
     const m = parseMirrorConfig(yaml)!;
     expect(m.enabled).toBe(true);
-    expect(m.watch).toBe(true);
+    expect(m.sync_mode).toBe("manual");
     expect(m.location).toBe("internal");
     expect(m.auto_commit).toBe(true);
+  });
+
+  test("legacy `watch: true` translates to sync_mode: events", () => {
+    const m = parseMirrorConfig("mirror:\n  enabled: true\n  watch: true\n")!;
+    expect(m.sync_mode).toBe("events");
+  });
+
+  test("legacy `watch: false` translates to sync_mode: manual", () => {
+    const m = parseMirrorConfig("mirror:\n  enabled: true\n  watch: false\n")!;
+    expect(m.sync_mode).toBe("manual");
+  });
+
+  test("explicit sync_mode wins over legacy watch", () => {
+    const yaml = "mirror:\n  enabled: true\n  watch: true\n  sync_mode: manual\n";
+    const m = parseMirrorConfig(yaml)!;
+    expect(m.sync_mode).toBe("manual");
+  });
+
+  test("legacy `interval_seconds: 5` clamps up to MIN_SAFETY_NET_SECONDS", () => {
+    const m = parseMirrorConfig("mirror:\n  enabled: true\n  interval_seconds: 5\n")!;
+    expect(m.safety_net_seconds).toBe(MIN_SAFETY_NET_SECONDS);
+  });
+
+  test("explicit safety_net_seconds wins over legacy interval_seconds", () => {
+    const yaml = "mirror:\n  enabled: true\n  interval_seconds: 5\n  safety_net_seconds: 1800\n";
+    const m = parseMirrorConfig(yaml)!;
+    expect(m.safety_net_seconds).toBe(1800);
   });
 
   test("external_path: null is interpreted as null", () => {
@@ -120,11 +153,11 @@ describe("serializeMirrorConfig", () => {
       enabled: true,
       location: "external" as const,
       external_path: "/home/aaron/team-brain",
-      watch: true,
+      sync_mode: "events" as const,
       auto_commit: true,
       auto_push: false,
       commit_template: "export: {{date}} ({{notes_changed}} note{{plural}})",
-      interval_seconds: 5,
+      safety_net_seconds: 3600,
     };
     const yaml = serializeMirrorConfig(original).join("\n") + "\n";
     const parsed = parseMirrorConfig(yaml);
@@ -251,10 +284,88 @@ describe("validateMirrorConfigShape", () => {
     if (!r.ok) expect(r.field).toBe("enabled");
   });
 
-  test("rejects non-integer interval_seconds", () => {
-    const r = validateMirrorConfigShape({ interval_seconds: 0.5 });
+  test("rejects non-integer safety_net_seconds", () => {
+    const r = validateMirrorConfigShape({ safety_net_seconds: 0.5 });
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.field).toBe("interval_seconds");
+    if (!r.ok) expect(r.field).toBe("safety_net_seconds");
+  });
+
+  test("rejects safety_net_seconds below MIN", () => {
+    const r = validateMirrorConfigShape({ safety_net_seconds: MIN_SAFETY_NET_SECONDS - 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.field).toBe("safety_net_seconds");
+  });
+
+  test("rejects safety_net_seconds above MAX", () => {
+    const r = validateMirrorConfigShape({ safety_net_seconds: MAX_SAFETY_NET_SECONDS + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.field).toBe("safety_net_seconds");
+  });
+
+  test("legacy interval_seconds field clamps + migrates to safety_net_seconds", () => {
+    // Hand-edited config supplies the old field; we still accept it but
+    // route it through the safety-net clamp range.
+    const r = validateMirrorConfigShape({ interval_seconds: 5 });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.safety_net_seconds).toBe(MIN_SAFETY_NET_SECONDS);
+  });
+
+  test("rejects unknown sync_mode", () => {
+    const r = validateMirrorConfigShape({ sync_mode: "interval" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.field).toBe("sync_mode");
+  });
+
+  test("accepts sync_mode events / manual", () => {
+    expect((validateMirrorConfigShape({ sync_mode: "events" }) as { config: { sync_mode: string } }).config.sync_mode).toBe("events");
+    expect((validateMirrorConfigShape({ sync_mode: "manual" }) as { config: { sync_mode: string } }).config.sync_mode).toBe("manual");
+  });
+
+  test("legacy watch: true translates to sync_mode: events", () => {
+    const r = validateMirrorConfigShape({ watch: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.sync_mode).toBe("events");
+  });
+
+  test("legacy watch: false translates to sync_mode: manual", () => {
+    const r = validateMirrorConfigShape({ watch: false });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.sync_mode).toBe("manual");
+  });
+
+  test("rejects auto_push + internal location (validation rather than silent-fail)", () => {
+    // Pre-event-driven shape silently let push fail at runtime for
+    // internal mirrors. Now we reject the combination at config time so
+    // the operator sees the issue immediately.
+    const r = validateMirrorConfigShape({
+      enabled: true,
+      location: "internal",
+      auto_push: true,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.field).toBe("auto_push");
+  });
+
+  test("auto_push + external location is fine", () => {
+    const r = validateMirrorConfigShape({
+      enabled: true,
+      location: "external",
+      external_path: "/tmp/foo",
+      auto_push: true,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  test("auto_push + disabled never errors", () => {
+    // Cross-field rule gates on `enabled`. A disabled config with stale
+    // auto_push: true + internal is the upgrade-path shape; operators
+    // shouldn't have to clear the field to disable.
+    const r = validateMirrorConfigShape({
+      enabled: false,
+      location: "internal",
+      auto_push: true,
+    });
+    expect(r.ok).toBe(true);
   });
 
   test("rejects empty commit_template", () => {

--- a/src/mirror-config.ts
+++ b/src/mirror-config.ts
@@ -38,6 +38,32 @@ import { DEFAULT_COMMIT_TEMPLATE, isGitRepo } from "./export-watch.ts";
 export type MirrorLocation = "internal" | "external";
 
 /**
+ * How the mirror stays current with vault state.
+ *
+ *   - `events` → in-process hooks fire on every note/tag/attachment
+ *     mutation; the manager debounces them (~500ms) into a single export
+ *     pass. A background safety-net poll (default 1h) catches anything
+ *     missed (direct SQL writes, dropped hook dispatches, restart gaps).
+ *     This is the default for new configs and the post-vault#XXX shape.
+ *   - `manual` → no event subscriptions, no polling. The operator runs
+ *     "Run export now" (admin SPA button or POST `/.parachute/mirror/run-now`)
+ *     or `parachute-vault export` from the CLI on their own cadence.
+ *
+ * The pre-vault#XXX `interval_seconds`-driven watch loop has retired —
+ * existing configs migrate to `events` (when `watch: true`) or `manual`
+ * (when `watch: false`). The legacy field still parses, repurposed as
+ * `safety_net_seconds` when explicit.
+ */
+export type MirrorSyncMode = "events" | "manual";
+
+/** Default safety-net poll interval in seconds (1 hour). */
+export const DEFAULT_SAFETY_NET_SECONDS = 3600;
+/** Minimum safety-net poll interval. Anything tighter would defeat the point of "safety net" — that's what the event path is for. */
+export const MIN_SAFETY_NET_SECONDS = 60;
+/** Maximum safety-net poll interval (24 hours). */
+export const MAX_SAFETY_NET_SECONDS = 86400;
+
+/**
  * The persistent mirror configuration block. Lives under the `mirror:` key
  * in the global config.yaml (one mirror per vault server today — multi-vault
  * mirroring is a future ripple, see open question 2 in the design doc).
@@ -46,32 +72,44 @@ export type MirrorLocation = "internal" | "external";
  *   - `enabled` — master switch. When false (the default for upgrading
  *     vaults), no mirror behavior runs at all. The other fields are
  *     preserved so the operator can flip enabled back on without losing
- *     their location/path/watch settings.
+ *     their location/path/sync_mode settings.
  *   - `location` — "internal" or "external". Drives `resolveMirrorPath`.
  *   - `external_path` — required when location=external. Operator-picked
  *     absolute path. Must exist + be a git repo when first validated.
- *   - `watch` — when true, the manager runs the export-watch loop in the
- *     vault server process. When false, the mirror gets a one-shot export
- *     on boot/config-change only; subsequent updates need an explicit
- *     manual export.
+ *   - `sync_mode` — "events" (subscribe to in-process hooks; debounce ~500ms;
+ *     safety-net poll on top) or "manual" (no auto-fire; operator triggers
+ *     manually). Default "events".
  *   - `auto_commit` — after each export pass, `git add -A && git commit`.
  *     Reuses the existing `runGitCommitCycle` from vault#346.
  *   - `auto_push` — after commit, `git push`. Failures non-fatal.
  *   - `commit_template` — passed verbatim to `renderCommitMessage`. Same
  *     variable set as the CLI: `{{date}}`, `{{notes_changed}}`,
  *     `{{plural}}`, `{{first_note_title}}`, `{{vault_name}}`.
- *   - `interval_seconds` — watch-loop poll interval. Default 5, matching
- *     the CLI flag's default.
+ *   - `safety_net_seconds` — `sync_mode: events` runs an hourly background
+ *     sweep on top of the event-driven path. This field controls the
+ *     interval (default 3600). Clamped to `[MIN_SAFETY_NET_SECONDS,
+ *     MAX_SAFETY_NET_SECONDS]` at validation time.
+ *
+ * Legacy / migration:
+ *   - `watch` (boolean) — pre-vault#XXX field. `true` → `sync_mode: events`,
+ *     `false` → `sync_mode: manual`. Parsed for back-compat; the canonical
+ *     form on the wire is `sync_mode`.
+ *   - `interval_seconds` (positive integer) — pre-vault#XXX watch-loop
+ *     poll interval. Reinterpreted as `safety_net_seconds` when no
+ *     explicit `safety_net_seconds` is present AND the value lies in the
+ *     valid range. Out-of-range / missing → default 3600. The field is
+ *     no longer surfaced in the UI; the SPA stops emitting it but the
+ *     parser keeps accepting it for hand-edited configs.
  */
 export interface MirrorConfig {
   enabled: boolean;
   location: MirrorLocation;
   external_path: string | null;
-  watch: boolean;
+  sync_mode: MirrorSyncMode;
   auto_commit: boolean;
   auto_push: boolean;
   commit_template: string;
-  interval_seconds: number;
+  safety_net_seconds: number;
 }
 
 /**
@@ -85,11 +123,11 @@ export function defaultMirrorConfig(): MirrorConfig {
     enabled: false,
     location: "internal",
     external_path: null,
-    watch: false,
+    sync_mode: "events",
     auto_commit: true,
     auto_push: false,
     commit_template: DEFAULT_COMMIT_TEMPLATE,
-    interval_seconds: 5,
+    safety_net_seconds: DEFAULT_SAFETY_NET_SECONDS,
   };
 }
 
@@ -129,6 +167,13 @@ export function parseMirrorConfig(yaml: string): MirrorConfig | undefined {
   const lines = yaml.slice(startIdx).split("\n");
 
   const config = defaultMirrorConfig();
+  // Track legacy field state for migration: if `sync_mode` is absent and
+  // `watch` is set, derive sync_mode from watch. If `safety_net_seconds`
+  // is absent and `interval_seconds` is set (legacy field), repurpose it.
+  let sawSyncMode = false;
+  let sawSafetyNet = false;
+  let legacyWatch: boolean | null = null;
+  let legacyInterval: number | null = null;
 
   for (const line of lines) {
     // Stop at the next top-level key.
@@ -140,7 +185,7 @@ export function parseMirrorConfig(yaml: string): MirrorConfig | undefined {
     const boolField = (
       name: keyof Pick<
         MirrorConfig,
-        "enabled" | "watch" | "auto_commit" | "auto_push"
+        "enabled" | "auto_commit" | "auto_push"
       >,
     ): boolean => {
       const m = trimmed.match(new RegExp(`^${name}:\\s*(true|false)\\s*$`));
@@ -151,9 +196,21 @@ export function parseMirrorConfig(yaml: string): MirrorConfig | undefined {
       return false;
     };
     if (boolField("enabled")) continue;
-    if (boolField("watch")) continue;
     if (boolField("auto_commit")) continue;
     if (boolField("auto_push")) continue;
+
+    const watchMatch = trimmed.match(/^watch:\s*(true|false)\s*$/);
+    if (watchMatch) {
+      legacyWatch = watchMatch[1] === "true";
+      continue;
+    }
+
+    const syncModeMatch = trimmed.match(/^sync_mode:\s*(events|manual)\s*$/);
+    if (syncModeMatch) {
+      config.sync_mode = syncModeMatch[1] as MirrorSyncMode;
+      sawSyncMode = true;
+      continue;
+    }
 
     const locationMatch = trimmed.match(/^location:\s*(internal|external)\s*$/);
     if (locationMatch) {
@@ -181,15 +238,45 @@ export function parseMirrorConfig(yaml: string): MirrorConfig | undefined {
       continue;
     }
 
+    const safetyNetMatch = trimmed.match(/^safety_net_seconds:\s*(\d+)\s*$/);
+    if (safetyNetMatch) {
+      const n = parseInt(safetyNetMatch[1]!, 10);
+      if (Number.isFinite(n) && n > 0) {
+        config.safety_net_seconds = clampSafetyNet(n);
+        sawSafetyNet = true;
+      }
+      continue;
+    }
+
     const intervalMatch = trimmed.match(/^interval_seconds:\s*(\d+)\s*$/);
     if (intervalMatch) {
       const n = parseInt(intervalMatch[1]!, 10);
-      if (Number.isFinite(n) && n > 0) config.interval_seconds = n;
+      if (Number.isFinite(n) && n > 0) legacyInterval = n;
       continue;
     }
   }
 
+  // Migration: explicit `sync_mode` wins; otherwise derive from `watch`.
+  // A config that carries neither falls through to defaults (events).
+  if (!sawSyncMode && legacyWatch !== null) {
+    config.sync_mode = legacyWatch ? "events" : "manual";
+  }
+  // Migration: explicit `safety_net_seconds` wins; otherwise upgrade
+  // `interval_seconds` (legacy short-cadence values like 5 get clamped
+  // up to MIN_SAFETY_NET_SECONDS — the safety-net path doesn't want
+  // 5-second polls). Out-of-range values fall through to the default.
+  if (!sawSafetyNet && legacyInterval !== null) {
+    config.safety_net_seconds = clampSafetyNet(legacyInterval);
+  }
+
   return config;
+}
+
+/** Clamp safety_net_seconds to the valid range. */
+function clampSafetyNet(n: number): number {
+  if (n < MIN_SAFETY_NET_SECONDS) return MIN_SAFETY_NET_SECONDS;
+  if (n > MAX_SAFETY_NET_SECONDS) return MAX_SAFETY_NET_SECONDS;
+  return n;
 }
 
 /**
@@ -215,12 +302,12 @@ export function serializeMirrorConfig(config: MirrorConfig): string[] {
       `  external_path: ${needsQuote ? `"${config.external_path}"` : config.external_path}`,
     );
   }
-  lines.push(`  watch: ${config.watch}`);
+  lines.push(`  sync_mode: ${config.sync_mode}`);
   lines.push(`  auto_commit: ${config.auto_commit}`);
   lines.push(`  auto_push: ${config.auto_push}`);
   // Templates contain `{{ }}` and frequently `:` — always quote.
   lines.push(`  commit_template: "${config.commit_template.replace(/"/g, '\\"')}"`);
-  lines.push(`  interval_seconds: ${config.interval_seconds}`);
+  lines.push(`  safety_net_seconds: ${config.safety_net_seconds}`);
   return lines;
 }
 
@@ -334,11 +421,24 @@ export function validateMirrorConfigShape(
     }
   }
 
+  // Legacy back-compat: `watch: boolean` translates to sync_mode.
+  // `sync_mode` takes priority if both are present.
   if ("watch" in blob) {
     if (typeof blob.watch !== "boolean") {
-      return { ok: false, field: "watch", error: "`watch` must be boolean." };
+      return { ok: false, error: "`watch` must be boolean." };
     }
-    out.watch = blob.watch;
+    out.sync_mode = blob.watch ? "events" : "manual";
+  }
+
+  if ("sync_mode" in blob) {
+    if (blob.sync_mode !== "events" && blob.sync_mode !== "manual") {
+      return {
+        ok: false,
+        field: "sync_mode",
+        error: '`sync_mode` must be "events" or "manual".',
+      };
+    }
+    out.sync_mode = blob.sync_mode;
   }
 
   if ("auto_commit" in blob) {
@@ -382,7 +482,33 @@ export function validateMirrorConfigShape(
     out.commit_template = blob.commit_template;
   }
 
-  if ("interval_seconds" in blob) {
+  if ("safety_net_seconds" in blob) {
+    if (
+      typeof blob.safety_net_seconds !== "number" ||
+      !Number.isFinite(blob.safety_net_seconds) ||
+      blob.safety_net_seconds <= 0 ||
+      !Number.isInteger(blob.safety_net_seconds)
+    ) {
+      return {
+        ok: false,
+        field: "safety_net_seconds",
+        error: "`safety_net_seconds` must be a positive integer.",
+      };
+    }
+    if (
+      blob.safety_net_seconds < MIN_SAFETY_NET_SECONDS ||
+      blob.safety_net_seconds > MAX_SAFETY_NET_SECONDS
+    ) {
+      return {
+        ok: false,
+        field: "safety_net_seconds",
+        error: `\`safety_net_seconds\` must be between ${MIN_SAFETY_NET_SECONDS} and ${MAX_SAFETY_NET_SECONDS}.`,
+      };
+    }
+    out.safety_net_seconds = blob.safety_net_seconds;
+  } else if ("interval_seconds" in blob) {
+    // Legacy field still accepted for hand-edited configs. Migrate by
+    // clamping into the safety-net range.
     if (
       typeof blob.interval_seconds !== "number" ||
       !Number.isFinite(blob.interval_seconds) ||
@@ -391,11 +517,15 @@ export function validateMirrorConfigShape(
     ) {
       return {
         ok: false,
-        field: "interval_seconds",
         error: "`interval_seconds` must be a positive integer.",
       };
     }
-    out.interval_seconds = blob.interval_seconds;
+    const clamped = blob.interval_seconds < MIN_SAFETY_NET_SECONDS
+      ? MIN_SAFETY_NET_SECONDS
+      : blob.interval_seconds > MAX_SAFETY_NET_SECONDS
+        ? MAX_SAFETY_NET_SECONDS
+        : blob.interval_seconds;
+    out.safety_net_seconds = clamped;
   }
 
   // Cross-field rule: external requires external_path — but ONLY when
@@ -411,6 +541,23 @@ export function validateMirrorConfigShape(
       field: "external_path",
       error:
         '`external_path` is required when `location` is "external" and `enabled` is true. Provide an absolute path to an existing git repository.',
+    };
+  }
+
+  // Cross-field rule: auto_push only makes sense for external mirrors —
+  // internal mirrors live under vault's data dir with no configured
+  // remote. Silent-fail on push was the pre-event-driven behavior; the
+  // backend now rejects the combination so the operator sees the issue
+  // at config time. The UI hides the auto_push checkbox when location
+  // is internal (vault#380's reviewer-flagged nit), so this only fires
+  // when an operator either edits config.yaml by hand or POSTs a bare
+  // JSON body with mismatched fields.
+  if (out.enabled && out.auto_push && out.location === "internal") {
+    return {
+      ok: false,
+      field: "auto_push",
+      error:
+        "`auto_push: true` requires `location: external` (internal mirrors live under the vault data directory and have no configured remote). Switch the location, or set auto_push to false.",
     };
   }
 

--- a/src/mirror-config.ts
+++ b/src/mirror-config.ts
@@ -44,12 +44,12 @@ export type MirrorLocation = "internal" | "external";
  *     mutation; the manager debounces them (~500ms) into a single export
  *     pass. A background safety-net poll (default 1h) catches anything
  *     missed (direct SQL writes, dropped hook dispatches, restart gaps).
- *     This is the default for new configs and the post-vault#XXX shape.
+ *     This is the default for new configs and the post-vault#382 shape.
  *   - `manual` → no event subscriptions, no polling. The operator runs
  *     "Run export now" (admin SPA button or POST `/.parachute/mirror/run-now`)
  *     or `parachute-vault export` from the CLI on their own cadence.
  *
- * The pre-vault#XXX `interval_seconds`-driven watch loop has retired —
+ * The pre-vault#382 `interval_seconds`-driven watch loop has retired —
  * existing configs migrate to `events` (when `watch: true`) or `manual`
  * (when `watch: false`). The legacy field still parses, repurposed as
  * `safety_net_seconds` when explicit.
@@ -91,10 +91,10 @@ export const MAX_SAFETY_NET_SECONDS = 86400;
  *     MAX_SAFETY_NET_SECONDS]` at validation time.
  *
  * Legacy / migration:
- *   - `watch` (boolean) — pre-vault#XXX field. `true` → `sync_mode: events`,
+ *   - `watch` (boolean) — pre-vault#382 field. `true` → `sync_mode: events`,
  *     `false` → `sync_mode: manual`. Parsed for back-compat; the canonical
  *     form on the wire is `sync_mode`.
- *   - `interval_seconds` (positive integer) — pre-vault#XXX watch-loop
+ *   - `interval_seconds` (positive integer) — pre-vault#382 watch-loop
  *     poll interval. Reinterpreted as `safety_net_seconds` when no
  *     explicit `safety_net_seconds` is present AND the value lies in the
  *     valid range. Out-of-range / missing → default 3600. The field is

--- a/src/mirror-deps.ts
+++ b/src/mirror-deps.ts
@@ -7,7 +7,7 @@
  * vault-store + portable-md.
  */
 
-import { exportVaultToDir, pruneOrphans } from "../core/src/portable-md.ts";
+import { exportVaultToDir, hasSchemaContent, pruneOrphans } from "../core/src/portable-md.ts";
 
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { readGlobalConfig, writeGlobalConfig, readVaultConfig } from "./config.ts";
@@ -49,13 +49,16 @@ export function buildMirrorDeps(vaultName: string): MirrorDeps {
       // walk per dimension; cheap on typical vaults.
       const allNotes = await store.queryNotes({ limit: 1_000_000, sort: "asc" });
       const validNoteIds = new Set(allNotes.map((n) => n.id));
-      // Tag names with schema content drive the schema sidecars. We
-      // include ALL tag names (not just schema-bearing) — the prune
-      // sweep removes a sidecar only when the tag is gone, and a tag
-      // whose schema content was wiped but name persists still has a
-      // sidecar slot the next export will rewrite from scratch.
+      // Tag names with schema content drive the schema sidecars. Filter
+      // through `hasSchemaContent` — a tag whose schema content was wiped
+      // via `deleteTagSchema` keeps its tags-table row (bare name), so a
+      // map-by-name set would leave the stale sidecar in the mirror
+      // indefinitely. Only schema-bearing tags belong in this set.
+      // Reviewer-flagged on vault#382 (Critical #1).
       const tagRecords = await store.listTagRecords();
-      const validTagNames = new Set(tagRecords.map((t) => t.tag));
+      const validTagNames = new Set(
+        tagRecords.filter((t) => hasSchemaContent(t)).map((t) => t.tag),
+      );
       // Attachment IDs across all notes (the prune sweep keys on id).
       const validAttachmentIds = new Set<string>();
       for (const note of allNotes) {

--- a/src/mirror-deps.ts
+++ b/src/mirror-deps.ts
@@ -7,8 +7,9 @@
  * vault-store + portable-md.
  */
 
-import { exportVaultToDir } from "../core/src/portable-md.ts";
+import { exportVaultToDir, pruneOrphans } from "../core/src/portable-md.ts";
 
+import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { readGlobalConfig, writeGlobalConfig, readVaultConfig } from "./config.ts";
 import { defaultMirrorConfig, type MirrorConfig } from "./mirror-config.ts";
 import type { MirrorDeps } from "./mirror-manager.ts";
@@ -42,6 +43,38 @@ export function buildMirrorDeps(vaultName: string): MirrorDeps {
       });
       return { notes: stats.notes };
     },
+    runPrune: async ({ outDir }) => {
+      const store = getVaultStore(vaultName);
+      // Build the valid-id sets the prune sweep needs. Single-query
+      // walk per dimension; cheap on typical vaults.
+      const allNotes = await store.queryNotes({ limit: 1_000_000, sort: "asc" });
+      const validNoteIds = new Set(allNotes.map((n) => n.id));
+      // Tag names with schema content drive the schema sidecars. We
+      // include ALL tag names (not just schema-bearing) — the prune
+      // sweep removes a sidecar only when the tag is gone, and a tag
+      // whose schema content was wiped but name persists still has a
+      // sidecar slot the next export will rewrite from scratch.
+      const tagRecords = await store.listTagRecords();
+      const validTagNames = new Set(tagRecords.map((t) => t.tag));
+      // Attachment IDs across all notes (the prune sweep keys on id).
+      const validAttachmentIds = new Set<string>();
+      for (const note of allNotes) {
+        const atts = await store.getAttachments(note.id);
+        for (const a of atts) validAttachmentIds.add(a.id);
+      }
+      const stats = pruneOrphans({
+        outDir,
+        validNoteIds,
+        validTagNames,
+        validAttachmentIds,
+      });
+      return {
+        notes_removed: stats.notes_removed,
+        sidecars_removed: stats.sidecars_removed,
+        schemas_removed: stats.schemas_removed,
+        attachment_dirs_removed: stats.attachment_dirs_removed,
+      };
+    },
     firstChangedNoteTitle: async (cursor) => {
       if (!cursor) return "";
       try {
@@ -62,6 +95,11 @@ export function buildMirrorDeps(vaultName: string): MirrorDeps {
       global.mirror = config;
       writeGlobalConfig(global);
     },
+    // Share the process-wide hook registry so mirror's subscriptions land
+    // on the same event bus that `BunSqliteStore` dispatches on. This is
+    // load-bearing for the event-driven path; without it, the manager
+    // falls back to safety-net polling only.
+    hooks: defaultHookRegistry,
   };
 }
 

--- a/src/mirror-manager.test.ts
+++ b/src/mirror-manager.test.ts
@@ -21,6 +21,7 @@ import {
   type MirrorDeps,
 } from "./mirror-manager.ts";
 import { defaultMirrorConfig, type MirrorConfig } from "./mirror-config.ts";
+import { HookRegistry } from "../core/src/hooks.ts";
 
 // Snapshot HOME + PARACHUTE_HOME at module load; restore after every test
 // so the `process.env.HOME = ...` rewrite in `makeFakeDeps` doesn't leak
@@ -82,8 +83,18 @@ function makeFakeDeps(opts: {
   initialConfig?: MirrorConfig | undefined;
   /** Optional override for runExport — return note count per call. */
   runExport?: (call: { outDir: string; sinceCursor?: string }) => Promise<{ notes: number }>;
+  /** Optional override for runPrune. */
+  runPrune?: (call: { outDir: string }) => Promise<{
+    notes_removed: number;
+    sidecars_removed: number;
+    schemas_removed: number;
+    attachment_dirs_removed: number;
+  }>;
+  /** Hook registry for the event-driven path. Tests that exercise hooks pass one. */
+  hooks?: HookRegistry;
 }): MirrorDeps & {
   exportCalls: Array<{ outDir: string; sinceCursor: string | undefined }>;
+  pruneCalls: Array<{ outDir: string }>;
   storedConfig: MirrorConfig | undefined;
 } {
   process.env.PARACHUTE_HOME = opts.parachuteHome;
@@ -92,9 +103,11 @@ function makeFakeDeps(opts: {
   const state: {
     config: MirrorConfig | undefined;
     exportCalls: Array<{ outDir: string; sinceCursor: string | undefined }>;
+    pruneCalls: Array<{ outDir: string }>;
   } = {
     config: opts.initialConfig,
     exportCalls: [],
+    pruneCalls: [],
   };
 
   const base: MirrorDeps = {
@@ -107,11 +120,17 @@ function makeFakeDeps(opts: {
       if (opts.runExport) return opts.runExport(call);
       return { notes: 1 };
     },
+    runPrune: async (call: { outDir: string }) => {
+      state.pruneCalls.push({ outDir: call.outDir });
+      if (opts.runPrune) return opts.runPrune(call);
+      return { notes_removed: 0, sidecars_removed: 0, schemas_removed: 0, attachment_dirs_removed: 0 };
+    },
     firstChangedNoteTitle: async () => "Inbox/fake",
     readMirrorConfig: () => state.config,
     writeMirrorConfig: (c: MirrorConfig) => {
       state.config = c;
     },
+    hooks: opts.hooks,
   };
   // Defining the test-visible getters via defineProperty so the getter
   // bodies run on every access — otherwise an Object.assign snapshots
@@ -120,12 +139,17 @@ function makeFakeDeps(opts: {
     get: () => state.exportCalls,
     enumerable: true,
   });
+  Object.defineProperty(base, "pruneCalls", {
+    get: () => state.pruneCalls,
+    enumerable: true,
+  });
   Object.defineProperty(base, "storedConfig", {
     get: () => state.config,
     enumerable: true,
   });
   return base as MirrorDeps & {
     exportCalls: Array<{ outDir: string; sinceCursor: string | undefined }>;
+    pruneCalls: Array<{ outDir: string }>;
     storedConfig: MirrorConfig | undefined;
   };
 }
@@ -240,7 +264,7 @@ describe("MirrorManager.start — lifecycle matrix", () => {
         ...defaultMirrorConfig(),
         enabled: true,
         location: "internal",
-        watch: false,
+        sync_mode: "manual",
         auto_commit: false, // skip commit cycle for this unit
       },
     });
@@ -268,9 +292,9 @@ describe("MirrorManager.start — lifecycle matrix", () => {
         ...defaultMirrorConfig(),
         enabled: true,
         location: "internal",
-        watch: true,
+        sync_mode: "events",
         auto_commit: false,
-        interval_seconds: 1,
+        safety_net_seconds: 60,
       },
     });
     const mgr = new MirrorManager(deps);
@@ -296,9 +320,9 @@ describe("MirrorManager.start — lifecycle matrix", () => {
         enabled: true,
         location: "external",
         external_path: external,
-        watch: true,
+        sync_mode: "events",
         auto_commit: false,
-        interval_seconds: 1,
+        safety_net_seconds: 60,
       },
     });
     const mgr = new MirrorManager(deps);
@@ -322,7 +346,7 @@ describe("MirrorManager.start — lifecycle matrix", () => {
         enabled: true,
         location: "external",
         external_path: "/definitely/not/a/path/here",
-        watch: true,
+        sync_mode: "events",
       },
     });
     const mgr = new MirrorManager(deps);
@@ -365,7 +389,7 @@ describe("MirrorManager.start — lifecycle matrix", () => {
         ...defaultMirrorConfig(),
         enabled: true,
         location: "internal",
-        watch: false,
+        sync_mode: "manual",
       },
     });
     const mgr = new MirrorManager(deps);
@@ -391,7 +415,7 @@ describe("MirrorManager.start — lifecycle matrix", () => {
         ...defaultMirrorConfig(),
         enabled: true,
         location: "internal",
-        watch: false,
+        sync_mode: "manual",
         auto_commit: false,
       },
     });
@@ -423,9 +447,9 @@ describe("MirrorManager.stop / reload", () => {
         ...defaultMirrorConfig(),
         enabled: true,
         location: "internal",
-        watch: true,
+        sync_mode: "events",
         auto_commit: false,
-        interval_seconds: 1,
+        safety_net_seconds: 60,
       },
     });
     const mgr = new MirrorManager(deps);
@@ -477,7 +501,7 @@ describe("MirrorManager.stop / reload", () => {
         ...defaultMirrorConfig(),
         enabled: true,
         location: "internal",
-        watch: false,
+        sync_mode: "manual",
         auto_commit: false,
       },
     });
@@ -520,7 +544,7 @@ describe("MirrorManager.runNow", () => {
         ...defaultMirrorConfig(),
         enabled: true,
         location: "internal",
-        watch: false,
+        sync_mode: "manual",
         auto_commit: false,
       },
     });
@@ -545,6 +569,289 @@ describe("MirrorManager.runNow", () => {
     await mgr.start();
     await mgr.runNow();
     expect(deps.exportCalls).toHaveLength(0);
+    await mgr.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event-driven path (vault#XXX) — hook subscriptions, debounce, safety net
+// ---------------------------------------------------------------------------
+
+describe("MirrorManager — event-driven (sync_mode: events)", () => {
+  let home: string;
+  let hooks: HookRegistry;
+  afterEach(async () => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  /** Helper — build a manager pre-wired with hooks + events sync_mode. */
+  async function makeEventDrivenManager(homeArg: string): Promise<{
+    mgr: MirrorManager;
+    hooks: HookRegistry;
+    deps: ReturnType<typeof makeFakeDeps>;
+  }> {
+    fs.mkdirSync(path.join(homeArg, "vault", "data", "default"), { recursive: true });
+    const h = new HookRegistry({ concurrency: 4, logger: { error: () => {} } });
+    const deps = makeFakeDeps({
+      parachuteHome: homeArg,
+      initialConfig: {
+        ...defaultMirrorConfig(),
+        enabled: true,
+        location: "internal",
+        sync_mode: "events",
+        auto_commit: false,
+      },
+      hooks: h,
+    });
+    const mgr = new MirrorManager(deps);
+    await mgr.start();
+    return { mgr, hooks: h, deps };
+  }
+
+  test("start() subscribes to hooks (3 subscriptions: notes, tags, attachments)", async () => {
+    home = tmp("mgr-ev-sub-");
+    const { mgr } = await makeEventDrivenManager(home);
+    expect((mgr as unknown as { _subscriptionCount: () => number })._subscriptionCount()).toBe(3);
+    await mgr.stop();
+  });
+
+  test("start() does not subscribe when sync_mode: manual", async () => {
+    home = tmp("mgr-ev-manual-");
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+    hooks = new HookRegistry({ concurrency: 4, logger: { error: () => {} } });
+    const deps = makeFakeDeps({
+      parachuteHome: home,
+      initialConfig: {
+        ...defaultMirrorConfig(),
+        enabled: true,
+        location: "internal",
+        sync_mode: "manual",
+        auto_commit: false,
+      },
+      hooks,
+    });
+    const mgr = new MirrorManager(deps);
+    await mgr.start();
+    expect((mgr as unknown as { _subscriptionCount: () => number })._subscriptionCount()).toBe(0);
+    await mgr.stop();
+  });
+
+  test("one note-mutation event → debounced flush → one extra export", async () => {
+    home = tmp("mgr-ev-debounce-");
+    const { mgr, deps } = await makeEventDrivenManager(home);
+    expect(deps.exportCalls).toHaveLength(1); // initial export
+
+    // Fire a synthetic event via the hook registry. Use a fake store —
+    // the mirror's handler ignores the payload, just marks dirty.
+    const fakeStore = {} as never;
+    hooks = (mgr as unknown as { deps: MirrorDeps }).deps.hooks!;
+    hooks.dispatch("created", { id: "n1", content: "hi", createdAt: new Date().toISOString() } as never, fakeStore);
+    // Let the dispatch microtask + handler run.
+    await Promise.resolve();
+    await Promise.resolve();
+    await hooks.drain();
+    // The debounce timer is armed; force it for the test.
+    await (mgr as unknown as { _flushDebounceForTest: () => Promise<void> })._flushDebounceForTest();
+
+    expect(deps.exportCalls).toHaveLength(2);
+    // The non-initial export carries the cursor from the initial pass.
+    expect(deps.exportCalls[1]!.sinceCursor).toBeDefined();
+    // Prune was called (event-driven flush always prunes).
+    expect(deps.pruneCalls.length).toBeGreaterThanOrEqual(2);
+    await mgr.stop();
+  });
+
+  test("burst of events → debounce collapses into one export", async () => {
+    home = tmp("mgr-ev-burst-");
+    const { mgr, deps } = await makeEventDrivenManager(home);
+    expect(deps.exportCalls).toHaveLength(1);
+    const initialPruneCount = deps.pruneCalls.length;
+
+    const fakeStore = {} as never;
+    hooks = (mgr as unknown as { deps: MirrorDeps }).deps.hooks!;
+    for (let i = 0; i < 10; i++) {
+      hooks.dispatch("updated", { id: `n${i}`, content: "v", createdAt: new Date().toISOString() } as never, fakeStore);
+    }
+    await Promise.resolve();
+    await Promise.resolve();
+    await hooks.drain();
+    await (mgr as unknown as { _flushDebounceForTest: () => Promise<void> })._flushDebounceForTest();
+
+    // All 10 events collapsed into ONE additional export.
+    expect(deps.exportCalls).toHaveLength(2);
+    expect(deps.pruneCalls.length - initialPruneCount).toBe(1);
+    await mgr.stop();
+  });
+
+  test("event during in-flight export → second flush queued", async () => {
+    home = tmp("mgr-ev-during-flight-");
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+    const h = new HookRegistry({ concurrency: 4, logger: { error: () => {} } });
+
+    // Build runExport that holds open for the first event-driven flush
+    // so we can dispatch a second event mid-flight.
+    let releaseFirstFlush: (() => void) | null = null;
+    let exportCallCount = 0;
+    const deps = makeFakeDeps({
+      parachuteHome: home,
+      initialConfig: {
+        ...defaultMirrorConfig(),
+        enabled: true,
+        location: "internal",
+        sync_mode: "events",
+        auto_commit: false,
+      },
+      hooks: h,
+      runExport: async (_call) => {
+        exportCallCount++;
+        // Only the FIRST event-driven flush blocks (call #2; #1 is initial).
+        if (exportCallCount === 2) {
+          await new Promise<void>((resolve) => {
+            releaseFirstFlush = resolve;
+          });
+        }
+        return { notes: 1 };
+      },
+    });
+    const mgr = new MirrorManager(deps);
+    await mgr.start();
+    expect(exportCallCount).toBe(1);
+
+    const fakeStore = {} as never;
+    h.dispatch("created", { id: "first", content: "x", createdAt: new Date().toISOString() } as never, fakeStore);
+    await Promise.resolve();
+    await Promise.resolve();
+    await h.drain();
+    // Kick off the debounce flush — it'll block on the gate.
+    const flushPromise = (mgr as unknown as { _flushDebounceForTest: () => Promise<void> })._flushDebounceForTest();
+    // Give it a tick to enter runExport.
+    await new Promise((r) => setTimeout(r, 25));
+    expect(exportCallCount).toBe(2);
+
+    // While that one is in flight, dispatch a second event.
+    h.dispatch("updated", { id: "second", content: "y", createdAt: new Date().toISOString() } as never, fakeStore);
+    await Promise.resolve();
+    await Promise.resolve();
+    await h.drain();
+    // Release the first flush — dirtyDuringFlush should re-arm the debounce.
+    releaseFirstFlush!();
+    await flushPromise;
+    // Force the queued debounce too.
+    await (mgr as unknown as { _flushDebounceForTest: () => Promise<void> })._flushDebounceForTest();
+
+    expect(exportCallCount).toBe(3);
+    await mgr.stop();
+  });
+
+  test("stop() unsubscribes hooks + cancels debounce timer", async () => {
+    home = tmp("mgr-ev-stop-");
+    const { mgr, deps } = await makeEventDrivenManager(home);
+    const exportCountBeforeStop = deps.exportCalls.length;
+
+    await mgr.stop();
+    expect((mgr as unknown as { _subscriptionCount: () => number })._subscriptionCount()).toBe(0);
+
+    // Subsequent events should produce no further exports.
+    const h = (mgr as unknown as { deps: MirrorDeps }).deps.hooks!;
+    const fakeStore = {} as never;
+    h.dispatch("created", { id: "ghost", content: "z", createdAt: new Date().toISOString() } as never, fakeStore);
+    await Promise.resolve();
+    await h.drain();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(deps.exportCalls.length).toBe(exportCountBeforeStop);
+  });
+
+  test("manual mode → no subscriptions, only runNow triggers export", async () => {
+    home = tmp("mgr-ev-manual-only-");
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+    const h = new HookRegistry({ concurrency: 4, logger: { error: () => {} } });
+    const deps = makeFakeDeps({
+      parachuteHome: home,
+      initialConfig: {
+        ...defaultMirrorConfig(),
+        enabled: true,
+        location: "internal",
+        sync_mode: "manual",
+        auto_commit: false,
+      },
+      hooks: h,
+    });
+    const mgr = new MirrorManager(deps);
+    await mgr.start();
+    expect(deps.exportCalls).toHaveLength(1); // initial
+
+    // Events fired now should NOT trigger flushes (no subscriptions).
+    h.dispatch("created", { id: "n1", content: "x", createdAt: new Date().toISOString() } as never, {} as never);
+    await Promise.resolve();
+    await h.drain();
+    expect(deps.exportCalls).toHaveLength(1);
+
+    // runNow still fires.
+    await mgr.runNow();
+    expect(deps.exportCalls).toHaveLength(2);
+    await mgr.stop();
+  });
+
+  test("reload() from events → manual tears down subscriptions", async () => {
+    home = tmp("mgr-ev-swap-mode-");
+    const { mgr, hooks: h } = await makeEventDrivenManager(home);
+    expect((mgr as unknown as { _subscriptionCount: () => number })._subscriptionCount()).toBe(3);
+
+    await mgr.reload({
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "internal",
+      sync_mode: "manual",
+      auto_commit: false,
+    });
+    expect((mgr as unknown as { _subscriptionCount: () => number })._subscriptionCount()).toBe(0);
+
+    // Confirm a dispatched event in the new mode is a no-op.
+    h.dispatch("created", { id: "n1", content: "x", createdAt: new Date().toISOString() } as never, {} as never);
+    await Promise.resolve();
+    await h.drain();
+    // No additional export beyond the reload's initial pass.
+    await mgr.stop();
+  });
+
+  test("missing hooks dep → falls back to safety-net only (logs warning, doesn't crash)", async () => {
+    home = tmp("mgr-ev-no-hooks-");
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+    // No `hooks` field on deps → manager should still start cleanly.
+    const deps = makeFakeDeps({
+      parachuteHome: home,
+      initialConfig: {
+        ...defaultMirrorConfig(),
+        enabled: true,
+        location: "internal",
+        sync_mode: "events",
+        auto_commit: false,
+      },
+      // Intentionally omit `hooks`.
+    });
+    const mgr = new MirrorManager(deps);
+    const status = await mgr.start();
+    expect(status.enabled).toBe(true);
+    expect(status.watch_running).toBe(true);
+    expect((mgr as unknown as { _subscriptionCount: () => number })._subscriptionCount()).toBe(0);
+    await mgr.stop();
+  });
+
+  test("prune is invoked on initial export AND on event-driven flushes", async () => {
+    home = tmp("mgr-ev-prune-");
+    const { mgr, deps } = await makeEventDrivenManager(home);
+    // Initial export should have called prune.
+    expect(deps.pruneCalls.length).toBeGreaterThanOrEqual(1);
+
+    const fakeStore = {} as never;
+    hooks = (mgr as unknown as { deps: MirrorDeps }).deps.hooks!;
+    hooks.dispatch("deleted", { id: "gone", path: "old/note" } as never, fakeStore);
+    await Promise.resolve();
+    await Promise.resolve();
+    await hooks.drain();
+    const pruneBefore = deps.pruneCalls.length;
+    await (mgr as unknown as { _flushDebounceForTest: () => Promise<void> })._flushDebounceForTest();
+    expect(deps.pruneCalls.length).toBe(pruneBefore + 1);
     await mgr.stop();
   });
 });

--- a/src/mirror-manager.test.ts
+++ b/src/mirror-manager.test.ts
@@ -574,7 +574,7 @@ describe("MirrorManager.runNow", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Event-driven path (vault#XXX) — hook subscriptions, debounce, safety net
+// Event-driven path (vault#382) — hook subscriptions, debounce, safety net
 // ---------------------------------------------------------------------------
 
 describe("MirrorManager — event-driven (sync_mode: events)", () => {

--- a/src/mirror-manager.ts
+++ b/src/mirror-manager.ts
@@ -1,20 +1,30 @@
 /**
- * Mirror lifecycle manager — boot-time bootstrap + in-process watch loop.
+ * Mirror lifecycle manager — boot-time bootstrap + event-driven exports.
  *
  * This is the persistent counterpart to vault#346's CLI watch+commit mode.
+ * Post-event-driven shift (vault#XXX, this PR), the manager replaces the
+ * original `setInterval` polling loop with in-process hook subscriptions.
+ * Every note / tag / attachment mutation fires an event; the manager
+ * debounces them (~500ms) into a single export pass. A background
+ * safety-net poll runs once per `safety_net_seconds` (default 1h) to
+ * catch anything the event path missed — direct SQL writes, dropped
+ * hook dispatches, restart gaps.
+ *
  * Responsibilities:
  *
  *   - On vault server boot: read mirror config, resolve mirror path,
  *     bootstrap (mkdir + git init + initial commit) when internal + new,
  *     trigger an initial export to bring the mirror to current state,
- *     and — if `watch: true` — start an in-process polling loop.
+ *     and — if `sync_mode: events` — subscribe to hooks + arm the
+ *     safety-net poll.
  *
  *   - On config change (via `PUT /admin/mirror` or operator-triggered
- *     reload): stop the current watch loop cleanly, re-resolve, restart
- *     with the new shape.
+ *     reload): tear down all subscriptions + timers, re-resolve,
+ *     restart with the new shape.
  *
- *   - On vault server shutdown: drain in-flight export + cancel the
- *     interval timer cleanly.
+ *   - On vault server shutdown: unsubscribe, cancel any pending
+ *     debounce timer, cancel safety-net poll, let an in-flight export
+ *     finish via the soft settle window.
  *
  * Singleton per-process: one `MirrorManager` instance backs the vault
  * server's lifecycle. Tests instantiate `MirrorManager` directly with
@@ -27,11 +37,28 @@
  * `PARACHUTE_VAULT_NAME` / `default_vault`; the mirror config follows
  * suit. Multi-vault mirror routing is a future ripple (open question 2
  * in the design doc).
+ *
+ * ## Race-condition contract
+ *
+ * - **Burst collapse** — two events within DEBOUNCE_MS produce one
+ *   export pass. The first event arms the timer; subsequent events
+ *   re-arm it.
+ * - **Event during in-flight export** — flag `dirtyDuringFlush`; after
+ *   the in-flight pass completes, run another. No second concurrent
+ *   pass; no missed events.
+ * - **Stop() during in-flight** — like the legacy soft-settle window,
+ *   give the export ~250ms to finish before returning. Subscriptions
+ *   come down BEFORE the settle wait so no further events queue.
+ * - **Safety net during event-driven path** — the poll's tick first
+ *   checks the dirty bit. If clear, it runs a full sweep anyway (catches
+ *   missed events). If set, it skips — the debounce timer's already
+ *   coming.
  */
 
 import { existsSync, mkdirSync, readdirSync, statSync } from "fs";
 
 import {
+  DEFAULT_SAFETY_NET_SECONDS,
   defaultMirrorConfig,
   resolveMirrorPath,
   type MirrorConfig,
@@ -43,6 +70,15 @@ import {
   runGitCommitCycle,
 } from "./export-watch.ts";
 import { vaultDir } from "./config.ts";
+import type { HookRegistry } from "../core/src/hooks.ts";
+
+/**
+ * Debounce window between an event arrival and the export pass it
+ * triggers. 500ms is the sweet spot: long enough to collapse a burst
+ * (typing in a frontend, a batch import) into one export, short enough
+ * that the mirror feels live during normal editing.
+ */
+const DEBOUNCE_MS = 500;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -56,11 +92,18 @@ import { vaultDir } from "./config.ts";
 export interface MirrorStatus {
   /** True iff `mirror.enabled` is true AND bootstrap succeeded. */
   enabled: boolean;
-  /** True iff a watch interval timer is currently armed. */
+  /**
+   * True iff hook subscriptions are currently active.
+   *
+   * Pre-event-driven this was named after the polling loop; we retain
+   * the name for SPA-shape stability — the SPA's "Watch loop" label
+   * now reflects "events subscribed + safety-net armed". The semantics
+   * shifted, not the API.
+   */
   watch_running: boolean;
   /** Resolved mirror path on disk, or null if disabled / unresolved. */
   mirror_path: string | null;
-  /** ISO timestamp of the most recent export pass (initial or watch). */
+  /** ISO timestamp of the most recent export pass (initial or event-driven or safety-net). */
   last_export_at: string | null;
   /** Notes touched by the most recent export pass. */
   last_export_notes_count: number | null;
@@ -89,6 +132,18 @@ export interface MirrorDeps {
     sinceCursor?: string;
   }) => Promise<{ notes: number }>;
   /**
+   * Run an orphan-prune sweep against the mirror dir. Returns counts so
+   * the manager can log + surface them in status. Optional — when
+   * undefined, the manager skips the prune step (test seam; production
+   * always wires it through `mirror-deps.ts`).
+   */
+  runPrune?: (opts: { outDir: string }) => Promise<{
+    notes_removed: number;
+    sidecars_removed: number;
+    schemas_removed: number;
+    attachment_dirs_removed: number;
+  }>;
+  /**
    * Resolve the first-changed-note title since `cursor`, for the
    * `{{first_note_title}}` commit-template variable. Best-effort — empty
    * string when nothing matches.
@@ -101,6 +156,14 @@ export interface MirrorDeps {
    * via the standard writer — used by `PUT /admin/mirror`.
    */
   writeMirrorConfig: (config: MirrorConfig) => void;
+  /**
+   * Shared in-process hook registry. The manager calls `.onNote()` /
+   * `.onTag()` / `.onAttachment()` on this registry to drive
+   * event-driven exports. Optional — when undefined the manager runs
+   * with only the safety-net poll (back-compat shape for tests that
+   * predate the event-driven path).
+   */
+  hooks?: HookRegistry;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,17 +286,18 @@ export async function bootstrapInternalMirror(
 
 /**
  * Singleton lifecycle controller. Holds the active mirror config, the
- * resolved path, the watch timer (when running), and the rolling status.
+ * resolved path, hook subscriptions (when sync_mode=events), the
+ * safety-net poll timer, the debounce timer, and the rolling status.
  *
  * State transitions:
  *
- *   constructed → start() → [enabled? bootstrap+initial-export+watch?]
+ *   constructed → start() → [enabled? bootstrap + initial-export +
+ *                            subscribe-to-hooks + arm-safety-net?]
  *     ↓                              ↓
- *     stop()                       reload() — stop current loop, re-evaluate
+ *     stop()                       reload() — tear down everything, re-evaluate
  *
- * Re-entrancy: the watch tick uses a `inFlight` guard like the CLI mode so
- * back-to-back ticks (e.g. when an export takes longer than the interval)
- * don't pile up.
+ * Re-entrancy: in-flight + dirtyDuringFlush guards collapse concurrent
+ * triggers into one pass + one follow-up (never two parallel exports).
  */
 export class MirrorManager {
   private deps: MirrorDeps;
@@ -246,9 +310,17 @@ export class MirrorManager {
     last_commit_sha: null,
     last_error: null,
   };
-  private timer: ReturnType<typeof setInterval> | null = null;
+  /** Safety-net poll timer (interval). Null while not armed. */
+  private safetyNetTimer: ReturnType<typeof setInterval> | null = null;
+  /** Debounce timer (single-shot setTimeout). Null when no events pending. */
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Unsubscribe handles returned by `hooks.on*()`. */
+  private unsubscribes: Array<() => void> = [];
   private stopping = false;
+  /** A flush is currently running. Other triggers should not start a new one. */
   private inFlight = false;
+  /** Set when an event/safety-net tick arrives during an in-flight flush. */
+  private dirtyDuringFlush = false;
   /** Most recent export cursor — passed as `--since` to the next pass. */
   private cursor: string | undefined = undefined;
   private currentConfig: MirrorConfig = defaultMirrorConfig();
@@ -354,29 +426,33 @@ export class MirrorManager {
 
     // Initial export — full pass (no cursor) so the mirror starts
     // byte-equivalent to current vault state, regardless of when the
-    // previous mirror was last refreshed.
+    // previous mirror was last refreshed. Also prunes orphans because
+    // the initial pass writes the entire vault; anything left over
+    // from a prior mirror run that doesn't match a current note is by
+    // definition orphaned.
     try {
-      await this.runOneCycle({ isInitial: true });
+      await this.runOneCycle({ isInitial: true, prune: true });
     } catch (err) {
       const msg = (err as Error).message ?? String(err);
       this.status.last_error = `initial export failed: ${msg}`;
       console.warn(`[mirror] ${this.status.last_error}`);
       // Don't disable the manager — operator may want to retry without
-      // restarting the server. Keep status.enabled true so the watch
-      // loop attempts again if armed; the next successful pass clears
-      // last_error.
+      // restarting the server. Keep status.enabled true so the safety-
+      // net loop attempts again if armed; the next successful pass
+      // clears last_error.
     }
 
-    if (config.watch) {
-      this.armWatchTimer();
+    if (config.sync_mode === "events") {
+      this.subscribeToHooks();
+      this.armSafetyNetTimer();
       this.status.watch_running = true;
       console.log(
-        `[mirror] enabled (location: ${config.location}, watch: true) — initial export complete, watch loop running every ${config.interval_seconds}s`,
+        `[mirror] enabled (location: ${config.location}, sync_mode: events) — initial export complete, hooks subscribed, safety-net every ${config.safety_net_seconds}s`,
       );
     } else {
       this.status.watch_running = false;
       console.log(
-        `[mirror] enabled (location: ${config.location}, watch: false) — initial export complete, manual mode`,
+        `[mirror] enabled (location: ${config.location}, sync_mode: manual) — initial export complete, manual mode`,
       );
     }
 
@@ -384,21 +460,43 @@ export class MirrorManager {
   }
 
   /**
-   * Stop the watch loop cleanly. Awaits the in-flight cycle (if any) up to
-   * a soft timeout — don't hang shutdown forever, but give a running
-   * export a chance to finish + write a coherent commit.
+   * Stop the mirror lifecycle cleanly:
+   *   - Unsubscribe from hooks first so no new events queue.
+   *   - Cancel debounce + safety-net timers.
+   *   - Await the in-flight cycle (if any) up to a soft timeout.
    *
    * `preserveStatus: true` is the start()-internal path that keeps the
    * status fields around for the about-to-restart pass; default false
-   * blanks them.
+   * blanks the `watch_running` indicator.
    */
   async stop(opts: { preserveStatus?: boolean } = {}): Promise<void> {
     this.stopping = true;
-    if (this.timer) {
-      clearInterval(this.timer);
-      this.timer = null;
+
+    // Unsubscribe BEFORE waiting for in-flight — additional events
+    // arriving after we start the settle wait would re-arm the debounce
+    // timer and stretch the wait indefinitely.
+    for (const off of this.unsubscribes) {
+      try {
+        off();
+      } catch (err) {
+        // Unsubscribe should never throw; defensive log only.
+        console.warn(`[mirror] unsubscribe threw: ${(err as Error).message ?? err}`);
+      }
     }
-    // Brief settle window — match the CLI watch-loop convention.
+    this.unsubscribes = [];
+
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.safetyNetTimer) {
+      clearInterval(this.safetyNetTimer);
+      this.safetyNetTimer = null;
+    }
+
+    // Brief settle window — give an in-flight export ~250ms to complete
+    // + write a coherent commit. Don't hang shutdown indefinitely; the
+    // export's status will surface a half-finished state on next start.
     const settleMs = 250;
     const start = Date.now();
     while (this.inFlight && Date.now() - start < settleMs) {
@@ -408,6 +506,9 @@ export class MirrorManager {
       this.status.watch_running = false;
     }
     this.stopping = false;
+    // Discard any dirty bit from events that arrived during shutdown —
+    // they'll be picked up on the next start()'s initial export anyway.
+    this.dirtyDuringFlush = false;
   }
 
   /**
@@ -425,26 +526,178 @@ export class MirrorManager {
 
   /**
    * Force a one-shot export cycle right now. Useful for "force re-export"
-   * buttons (future hub UI) + tests that want a deterministic cycle
-   * without waiting on the timer.
+   * buttons (admin SPA) + tests that want a deterministic cycle without
+   * waiting on the debounce or safety-net timer.
+   *
+   * Always runs with prune=true: a manual trigger is an explicit "make
+   * the mirror match vault state right now" request; orphan sweeps are
+   * cheap on typical vaults and the operator probably wanted that
+   * effect anyway.
    */
   async runNow(): Promise<MirrorStatus> {
     if (!this.status.enabled) {
       return this.getStatus();
     }
-    await this.runOneCycle({ isInitial: false });
+    await this.runOneCycle({ isInitial: false, prune: true });
     return this.getStatus();
   }
 
   // Visible-for-test: number of `start()` calls so far.
   _startCount(): number { return this.startCount; }
 
+  // ---------------------------------------------------------------------
+  // Event-driven path
+  // ---------------------------------------------------------------------
+
   /**
-   * Stage → export → commit pipeline for a single cycle. Updates status
-   * fields with the outcome. Errors logged + reflected in `last_error`
-   * but never rethrown out of the watch loop (the loop would die).
+   * Subscribe to note / tag / attachment hooks. Each event arms the
+   * debounce timer (or marks the dirty bit if a flush is already
+   * running). Stop() will call the unsubscribe handles in `unsubscribes`.
+   *
+   * Subscribes to every mutation event the mirror cares about:
+   *   - notes: created, updated, deleted
+   *   - tags: upserted, deleted
+   *   - attachments: created, deleted
    */
-  private async runOneCycle(opts: { isInitial: boolean }): Promise<void> {
+  private subscribeToHooks(): void {
+    const hooks = this.deps.hooks;
+    if (!hooks) {
+      // No hook registry wired — fall back to safety-net only. Logged
+      // once at start; tests that exercise this path inspect status,
+      // not logs.
+      console.warn(
+        `[mirror] sync_mode: events requested but no HookRegistry wired in deps — running with safety-net poll only`,
+      );
+      return;
+    }
+
+    const onMutation = () => {
+      // Cheap pulse — flag dirty + arm the debounce.
+      if (this.inFlight) {
+        this.dirtyDuringFlush = true;
+        return;
+      }
+      this.armDebounce();
+    };
+
+    this.unsubscribes.push(
+      hooks.onNote({
+        name: "mirror-note-mutation",
+        event: ["created", "updated", "deleted"],
+        handler: onMutation,
+      }),
+    );
+    this.unsubscribes.push(
+      hooks.onTag({
+        name: "mirror-tag-mutation",
+        event: ["upserted", "deleted"],
+        handler: onMutation,
+      }),
+    );
+    this.unsubscribes.push(
+      hooks.onAttachment({
+        name: "mirror-attachment-mutation",
+        event: ["created", "deleted"],
+        handler: onMutation,
+      }),
+    );
+  }
+
+  /**
+   * Arm or re-arm the debounce timer. Subsequent calls within
+   * DEBOUNCE_MS reset the timer (classic debounce). When the timer
+   * fires, run an export pass; if events arrived during the export,
+   * run again.
+   */
+  private armDebounce(): void {
+    if (this.stopping) return;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      void this.runFlush({ prune: false });
+    }, DEBOUNCE_MS);
+    this.debounceTimer.unref?.();
+  }
+
+  /**
+   * Run a single flush — guards against concurrent runs, follows up
+   * with another pass if events arrived mid-flight. The event-driven
+   * fast path uses prune=false (rely on the targeted "deleted" events
+   * for delete propagation; the safety-net + manual-run paths sweep).
+   *
+   * In practice deletions DO need pruning even on the fast path —
+   * `exportVaultToDir` only writes existing notes; the file the
+   * deletion event refers to has to be removed somewhere. The current
+   * implementation runs a full prune sweep on every flush so deletes
+   * propagate within the debounce window. (If profiling shows this is
+   * expensive for very large vaults, a targeted-deletion queue could
+   * replace the sweep on the fast path — recorded as a possible
+   * future optimization in the design doc.)
+   */
+  private async runFlush(opts: { prune: boolean }): Promise<void> {
+    if (this.stopping) return;
+    if (this.inFlight) {
+      // Shouldn't happen given the dirty-bit guards in armDebounce +
+      // safetyNet; defensive only.
+      this.dirtyDuringFlush = true;
+      return;
+    }
+    this.inFlight = true;
+    try {
+      // Event-driven flushes prune-on-flush so deletions actually
+      // propagate. Cost: O(mirror size) per flush — fine for typical
+      // vaults. See doc above on the targeted-queue optimization.
+      await this.runOneCycle({ isInitial: false, prune: true });
+    } catch (err) {
+      const msg = (err as Error).message ?? String(err);
+      this.status.last_error = `event-driven flush failed: ${msg}`;
+      console.warn(`[mirror] ${this.status.last_error}`);
+    } finally {
+      this.inFlight = false;
+    }
+
+    // If events arrived during the flush, run again (one follow-up,
+    // not a loop — armDebounce re-engages if events keep coming).
+    if (this.dirtyDuringFlush && !this.stopping) {
+      this.dirtyDuringFlush = false;
+      this.armDebounce();
+    }
+  }
+
+  /**
+   * Arm the safety-net poll. Runs once per `safety_net_seconds`. When
+   * it fires:
+   *   - If a flush is already pending (debounce armed) or in-flight,
+   *     skip (the event path will catch it).
+   *   - Otherwise, run a full prune+export sweep so anything missed by
+   *     the events (direct SQL writes, dropped dispatches, restart
+   *     gaps) lands in the mirror.
+   */
+  private armSafetyNetTimer(): void {
+    if (this.safetyNetTimer) return;
+    const intervalMs = (
+      this.currentConfig.safety_net_seconds || DEFAULT_SAFETY_NET_SECONDS
+    ) * 1000;
+    this.safetyNetTimer = setInterval(async () => {
+      if (this.stopping) return;
+      if (this.debounceTimer || this.inFlight) {
+        // Event path's already handling things; this poll is a no-op.
+        return;
+      }
+      await this.runFlush({ prune: true });
+    }, intervalMs);
+    this.safetyNetTimer.unref?.();
+  }
+
+  /**
+   * Stage → export → prune (optional) → commit pipeline for a single
+   * cycle. Updates status fields with the outcome. Errors logged +
+   * reflected in `last_error` but never rethrown out of the event
+   * dispatcher (would kill the loop).
+   */
+  private async runOneCycle(opts: { isInitial: boolean; prune: boolean }): Promise<void> {
     const nextCursor = new Date().toISOString();
     const path = this.status.mirror_path!;
     const sinceCursor = opts.isInitial ? undefined : this.cursor;
@@ -459,6 +712,34 @@ export class MirrorManager {
       return;
     }
 
+    // Orphan sweep — removes files in the mirror that don't correspond
+    // to a current vault note/tag/attachment. Counts surface in logs;
+    // the count of removed files is folded into the commit's
+    // `notes_changed` so the commit message reflects the delete too.
+    let prunedNotes = 0;
+    if (opts.prune && this.deps.runPrune) {
+      try {
+        const pruneStats = await this.deps.runPrune({ outDir: path });
+        prunedNotes = pruneStats.notes_removed + pruneStats.sidecars_removed;
+        const removedTotal =
+          pruneStats.notes_removed +
+          pruneStats.sidecars_removed +
+          pruneStats.schemas_removed +
+          pruneStats.attachment_dirs_removed;
+        if (removedTotal > 0) {
+          console.log(
+            `[mirror] prune: removed ${pruneStats.notes_removed} note(s), ${pruneStats.sidecars_removed} sidecar(s), ${pruneStats.schemas_removed} schema(s), ${pruneStats.attachment_dirs_removed} attachment dir(s)`,
+          );
+        }
+      } catch (err) {
+        // Prune failure is non-fatal — the export already wrote the
+        // current state; the next sweep retries.
+        console.warn(
+          `[mirror] prune failed (non-fatal): ${(err as Error).message ?? err}`,
+        );
+      }
+    }
+
     this.cursor = nextCursor;
     this.status.last_export_at = nextCursor;
     this.status.last_export_notes_count = stats.notes;
@@ -471,11 +752,23 @@ export class MirrorManager {
       return;
     }
 
+    // Commit when EITHER notes changed OR orphans were pruned. The
+    // commit message's `notes_changed` reflects the union — operators
+    // reading a "deleted 3 notes" diff in their mirror should see that
+    // count in the commit. (Pre-event-driven this was strictly
+    // notes-from-export; orphan deletes weren't tracked.)
+    const totalChanged = stats.notes + prunedNotes;
+    if (totalChanged === 0) {
+      // Nothing to commit; runGitCommitCycle would no-op anyway, but
+      // skipping early avoids the firstNoteTitle DB lookup.
+      return;
+    }
+
     const firstNoteTitle = await this.deps.firstChangedNoteTitle(sinceCursor);
     const commitResult = await runGitCommitCycle({
       repoDir: path,
       template: this.currentConfig.commit_template,
-      notesChanged: stats.notes,
+      notesChanged: totalChanged,
       vaultName: this.deps.vaultName,
       firstNoteTitle,
       push: this.currentConfig.auto_push,
@@ -492,30 +785,25 @@ export class MirrorManager {
     }
   }
 
+  // ---------------------------------------------------------------------
+  // Test seams
+  // ---------------------------------------------------------------------
+
   /**
-   * Arm the watch interval. Tick is in-flight-guarded so a slow export
-   * doesn't pile up parallel runs.
+   * Force the debounce timer to fire immediately (cancel + run flush).
+   * Used by mirror-manager.test.ts to avoid sleeping through 500ms in
+   * every event-driven test case. Not exposed via the public API.
    */
-  private armWatchTimer(): void {
-    if (this.timer) return;
-    const intervalMs = this.currentConfig.interval_seconds * 1000;
-    this.timer = setInterval(async () => {
-      if (this.stopping || this.inFlight) return;
-      this.inFlight = true;
-      try {
-        await this.runOneCycle({ isInitial: false });
-      } catch (err) {
-        // Defensive — runOneCycle already swallows export errors, but
-        // commit/git errors might bubble. Never kill the loop.
-        const msg = (err as Error).message ?? String(err);
-        this.status.last_error = `watch tick failed: ${msg}`;
-        console.warn(`[mirror] ${this.status.last_error}`);
-      } finally {
-        this.inFlight = false;
-      }
-    }, intervalMs);
-    // Don't keep the server process alive purely on the timer; vault
-    // already has the HTTP server + various intervals doing that.
-    this.timer.unref?.();
+  async _flushDebounceForTest(): Promise<void> {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    await this.runFlush({ prune: false });
+  }
+
+  /** Test seam: snapshot of the unsubscribe-handle count. */
+  _subscriptionCount(): number {
+    return this.unsubscribes.length;
   }
 }

--- a/src/mirror-manager.ts
+++ b/src/mirror-manager.ts
@@ -2,7 +2,7 @@
  * Mirror lifecycle manager — boot-time bootstrap + event-driven exports.
  *
  * This is the persistent counterpart to vault#346's CLI watch+commit mode.
- * Post-event-driven shift (vault#XXX, this PR), the manager replaces the
+ * Post-event-driven shift (vault#382, this PR), the manager replaces the
  * original `setInterval` polling loop with in-process hook subscriptions.
  * Every note / tag / attachment mutation fires an event; the manager
  * debounces them (~500ms) into a single export pass. A background

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -298,18 +298,18 @@ describe("handleMirrorPut", () => {
     await manager.stop();
   });
 
-  test("PUT restarts watch loop with new interval", async () => {
+  test("PUT restarts event-driven mirror lifecycle", async () => {
     home = tmp("mirror-put-restart-");
     const { manager } = makeManager(home);
-    // Enable with watch.
+    // Enable with events sync_mode.
     const req1 = new Request("http://x/admin/mirror", {
       method: "PUT",
       body: JSON.stringify({
         enabled: true,
         location: "internal",
-        watch: true,
+        sync_mode: "events",
         auto_commit: false,
-        interval_seconds: 1,
+        safety_net_seconds: 60,
       }),
     });
     const res1 = await handleMirrorPut(req1, manager);
@@ -356,16 +356,16 @@ describe("handleMirrorPut", () => {
       put({
         enabled: true,
         location: "internal",
-        watch: true,
+        sync_mode: "events",
         auto_commit: false,
-        interval_seconds: 1,
+        safety_net_seconds: 60,
       }),
       put({
         enabled: true,
         location: "internal",
-        watch: true,
+        sync_mode: "events",
         auto_commit: false,
-        interval_seconds: 2,
+        safety_net_seconds: 120,
       }),
     ]);
     expect(res1.status).toBe(200);
@@ -378,7 +378,7 @@ describe("handleMirrorPut", () => {
     const status = manager.getStatus();
     expect(status.enabled).toBe(true);
     expect(status.watch_running).toBe(true);
-    expect(manager.getConfig().interval_seconds).toBe(2);
+    expect(manager.getConfig().safety_net_seconds).toBe(120);
     await manager.stop();
   });
 });

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -59,9 +59,12 @@ export function handleMirrorGet(manager: MirrorManager): Response {
  * lifecycle.
  *
  * Request shape: same JSON as the MirrorConfig type — { enabled,
- * location, external_path, watch, auto_commit, auto_push,
- * commit_template, interval_seconds }. All fields optional; missing
- * fields fall back to defaults.
+ * location, external_path, sync_mode, auto_commit, auto_push,
+ * commit_template, safety_net_seconds }. All fields optional; missing
+ * fields fall back to defaults. Legacy `watch: boolean` and
+ * `interval_seconds: number` are also accepted (back-compat with
+ * hand-edited configs); they translate to `sync_mode` / `safety_net_seconds`
+ * via `validateMirrorConfigShape`.
  *
  * Validation surface:
  *   - JSON shape: location ∈ {internal, external}, types match, etc.

--- a/src/server.ts
+++ b/src/server.ts
@@ -315,18 +315,31 @@ const server = Bun.serve({
 console.log(`Parachute Vault server listening on http://${hostname}:${server.port}`);
 
 // Graceful shutdown — best-effort drain of in-flight note-mutation hooks.
+//
+// Order matters under the event-driven mirror shape (vault#XXX):
+//   1. MirrorManager.stop() runs FIRST so it can unsubscribe from hooks
+//      cleanly + cancel its debounce timer. Otherwise the registry drain
+//      below would wait on the manager's hook handler that just queued
+//      itself after a final mutation.
+//   2. Then drain hooks + stop the transcription worker in parallel —
+//      neither depends on the other.
+//
+// The whole thing races a 5s timeout so a stuck handler doesn't hang
+// shutdown indefinitely.
 async function shutdown(signal: string): Promise<void> {
   console.log(`\n[${signal}] shutting down; in-flight hooks: ${defaultHookRegistry.inFlightCount}`);
   try {
     await Promise.race([
-      Promise.all([
-        defaultHookRegistry.drain(),
-        transcriptionWorker?.stop() ?? Promise.resolve(),
-        // Mirror manager: cancel the watch interval + let any in-flight
-        // export cycle settle. `stop` already has its own brief timeout
-        // (250ms) so this doesn't block the larger shutdown race.
-        mirrorManager?.stop() ?? Promise.resolve(),
-      ]),
+      (async () => {
+        // Mirror stop first — unsubscribes + cancels its debounce. Its
+        // internal soft-settle timeout (250ms) bounds the wait.
+        await (mirrorManager?.stop() ?? Promise.resolve());
+        // Then drain hooks + stop the transcription worker in parallel.
+        await Promise.all([
+          defaultHookRegistry.drain(),
+          transcriptionWorker?.stop() ?? Promise.resolve(),
+        ]);
+      })(),
       new Promise<void>((resolve) => setTimeout(resolve, 5000)),
     ]);
   } catch (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -316,7 +316,7 @@ console.log(`Parachute Vault server listening on http://${hostname}:${server.por
 
 // Graceful shutdown — best-effort drain of in-flight note-mutation hooks.
 //
-// Order matters under the event-driven mirror shape (vault#XXX):
+// Order matters under the event-driven mirror shape (vault#382):
 //   1. MirrorManager.stop() runs FIRST so it can unsubscribe from hooks
 //      cleanly + cancel its debounce timer. Otherwise the registry drain
 //      below would wait on the manager's hook handler that just queued

--- a/src/transcription-worker.ts
+++ b/src/transcription-worker.ts
@@ -554,10 +554,15 @@ export function registerTranscriptionHook(
   return registry.onAttachment({
     name: "transcription-kickoff",
     event: "created",
-    when: (att) =>
-      (att.metadata as { transcribe_status?: string } | undefined)
-        ?.transcribe_status === "pending",
-    handler: async (attachment, store) => {
+    when: (att) => {
+      // Only "created" payloads reach this predicate (we don't subscribe
+      // to "deleted"), so `metadata` is populated. The union widening
+      // post-deletion-events just means we narrow here defensively.
+      const meta = (att as Attachment).metadata as { transcribe_status?: string } | undefined;
+      return meta?.transcribe_status === "pending";
+    },
+    handler: async (payload, store) => {
+      const attachment = payload as Attachment;
       const vault = resolveVault(store);
       if (!vault) {
         logger.error(

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -29,7 +29,7 @@ import { join, normalize } from "path";
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from "fs";
 import crypto from "node:crypto";
 import type { Note, Store, Attachment } from "../core/src/types.ts";
-import type { HookRegistry, HookEvent } from "../core/src/hooks.ts";
+import type { HookRegistry, HookEvent, NoteHookPayload } from "../core/src/hooks.ts";
 import type { TriggerConfig, TriggerWhen } from "./config.ts";
 import { getVaultNameForStore } from "./vault-store.ts";
 import { assetsDir } from "./routes.ts";
@@ -56,6 +56,10 @@ export function buildPredicate(when: TriggerWhen, triggerName: string): (note: N
   const pendingKey = `${triggerName}_pending_at`;
   const renderedKey = `${triggerName}_rendered_at`;
 
+  // Hook dispatcher passes `NoteHookPayload` (Note | DeletedNoteRef). All
+  // triggers default to events `["created", "updated"]` so deleted shapes
+  // never reach this predicate, but we still type the parameter as Note
+  // — narrowing here keeps the rest of the predicate body unchanged.
   return (note: Note) => {
     const meta = note.metadata as Record<string, unknown> | undefined;
 
@@ -310,8 +314,17 @@ export function registerTriggers(
     const unregister = hooks.onNote({
       name: trigger.name,
       event: events,
-      when: predicate,
-      handler: async (note: Note, store: Store, hookEvent?: HookEvent) => {
+      when: (payload: NoteHookPayload) => {
+        // Triggers don't subscribe to "deleted"; if the union ever
+        // widens via config, the predicate sees a partial shape that
+        // simply doesn't match anything tag/metadata-based and returns
+        // false. Safe by construction.
+        return predicate(payload as Note);
+      },
+      handler: async (payload: NoteHookPayload, store: Store, hookEvent?: HookEvent) => {
+        // Same shape contract as the predicate — triggers don't
+        // subscribe to deleted events, so narrow back to Note.
+        const note = payload as Note;
         const existingMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
 
         // Handler-side re-check (same race-window protection as the old hooks)

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -110,7 +110,7 @@ export type MirrorLocation = "internal" | "external";
  * fires no automatic exports — the operator triggers via the "Run
  * export now" button or `parachute-vault export` from the CLI.
  *
- * Pre-vault#XXX `watch: boolean` migrated as: true → "events", false →
+ * Pre-vault#382 `watch: boolean` migrated as: true → "events", false →
  * "manual". The backend's validator still accepts `watch` as a back-
  * compat alias.
  */

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -103,22 +103,42 @@ export async function getVaultDetail(name: string): Promise<VaultDetailResult> {
 
 export type MirrorLocation = "internal" | "external";
 
+/**
+ * Event-driven mode subscribes to in-process hooks (note / tag /
+ * attachment mutations) and debounces them into a single export pass;
+ * a background safety-net poll catches anything missed. Manual mode
+ * fires no automatic exports — the operator triggers via the "Run
+ * export now" button or `parachute-vault export` from the CLI.
+ *
+ * Pre-vault#XXX `watch: boolean` migrated as: true → "events", false →
+ * "manual". The backend's validator still accepts `watch` as a back-
+ * compat alias.
+ */
+export type MirrorSyncMode = "events" | "manual";
+
 export interface MirrorConfig {
   enabled: boolean;
   /** "internal" → hidden under vault data dir; "external" → operator-picked path. */
   location: MirrorLocation;
   /** Required when location=external + enabled. Must exist + be a git repo. */
   external_path: string | null;
-  /** When true, the manager runs the watch loop in-process. */
-  watch: boolean;
+  /**
+   * `events` (default) → hooks drive exports; mirror stays current as you
+   * write. `manual` → no auto-fire; operator runs exports explicitly.
+   */
+  sync_mode: MirrorSyncMode;
   /** Per-pass `git add -A && git commit` if true. */
   auto_commit: boolean;
   /** Per-commit `git push` if true. Failures non-fatal. */
   auto_push: boolean;
   /** Verbatim template; reuses the CLI's variable set (`{{date}}` etc.). */
   commit_template: string;
-  /** Watch-loop poll interval in seconds. */
-  interval_seconds: number;
+  /**
+   * Background safety-net poll interval in seconds (only matters when
+   * `sync_mode: events`). Default 3600. Clamped to a sane range
+   * server-side; the SPA doesn't surface this directly today.
+   */
+  safety_net_seconds: number;
 }
 
 export interface MirrorStatus {

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -31,7 +31,7 @@ function mount(): void {
   );
 }
 
-// Fallback bootstrap path (closes vault#XXX / hub-side discovery-tile bug):
+// Fallback bootstrap path (closes vault#382 / hub-side discovery-tile bug):
 // when the operator clicked the **discovery-page** vault tile (hub.ts
 // renders one per vault via `uiUrl: "/admin/"`), the browser landed here
 // without a `#token=...` fragment — the discovery tile is a plain anchor,

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -39,12 +39,12 @@ const snapshotFixture = (
     enabled: false,
     location: "internal",
     external_path: null,
-    watch: false,
+    sync_mode: "events",
     auto_commit: true,
     auto_push: false,
     commit_template:
       "export: {{date}} ({{notes_changed}} note{{plural}})",
-    interval_seconds: 5,
+    safety_net_seconds: 3600,
     // override any config-typed fields if passed
     ...Object.fromEntries(
       Object.entries(over).filter(([k]) =>
@@ -52,11 +52,11 @@ const snapshotFixture = (
           "enabled",
           "location",
           "external_path",
-          "watch",
+          "sync_mode",
           "auto_commit",
           "auto_push",
           "commit_template",
-          "interval_seconds",
+          "safety_net_seconds",
         ].includes(k),
       ),
     ),
@@ -114,7 +114,7 @@ describe("VaultMirror — admin scope", () => {
       snapshotFixture({
         enabled: true,
         location: "internal",
-        watch: true,
+        sync_mode: "events",
         watch_running: true,
         mirror_path: "/tmp/vault/mirror",
         last_export_at: "2026-05-27T10:00:00.000Z",
@@ -159,7 +159,7 @@ describe("VaultMirror — admin scope", () => {
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
     );
 
-    // Apply "History" preset → enabled, internal, watch on, interval 5
+    // Apply "History" preset → enabled, internal, sync_mode events
     await user.click(
       screen.getByRole("button", { name: /Apply History preset/i }),
     );
@@ -167,15 +167,48 @@ describe("VaultMirror — admin scope", () => {
     const enableCheckbox = screen.getByLabelText(/Enable mirror/i) as HTMLInputElement;
     expect(enableCheckbox.checked).toBe(true);
 
-    // Schedule resolves to "Live (every 5s)" for interval=5 + watch=true
-    const scheduleSelect = screen.getByLabelText(/Schedule/i) as HTMLSelectElement;
-    expect(scheduleSelect.value).toBe("live");
+    // Sync mode resolves to "events" (the new default for hook-driven exports)
+    const syncModeSelect = screen.getByLabelText(/Sync mode/i) as HTMLSelectElement;
+    expect(syncModeSelect.value).toBe("events");
 
     // Internal radio selected
     const internalRadio = screen.getByLabelText(
       /Internal/i,
     ) as HTMLInputElement;
     expect(internalRadio.checked).toBe(true);
+  });
+
+  it("Manual Export preset switches to sync_mode: manual", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Apply Manual Export preset/i }),
+    );
+
+    const syncModeSelect = screen.getByLabelText(/Sync mode/i) as HTMLSelectElement;
+    expect(syncModeSelect.value).toBe("manual");
+    expect(
+      screen.getByText(/No auto-fire. Exports only run when you click/i),
+    ).toBeInTheDocument();
+  });
+
+  it("sync_mode events shows the safety-net hint", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture({ enabled: true, sync_mode: "events" }));
+    renderRoute();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/Every change to a note, tag, or attachment triggers an export within/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/safety check runs hourly/i)).toBeInTheDocument();
   });
 
   it("clicking Live Mirror preset switches to external location + reveals path field", async () => {
@@ -238,7 +271,7 @@ describe("VaultMirror — admin scope", () => {
   it("Save button calls PUT with the current config", async () => {
     vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
     vi.mocked(api.putMirror).mockResolvedValue(
-      snapshotFixture({ enabled: true, location: "internal", watch: true }),
+      snapshotFixture({ enabled: true, location: "internal", sync_mode: "events" }),
     );
 
     renderRoute();

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -16,7 +16,7 @@
  * The detailed fields below the presets let custom shapes through
  * without bypassing the form's validation.
  *
- * Post-event-driven shift (vault#XXX): the granular schedule picker
+ * Post-event-driven shift (vault#382): the granular schedule picker
  * (Live/Minute/10min/Hourly/Daily/Manual) has been replaced by a binary
  * sync-mode picker — "On change" (events) and "Manual only" (no
  * auto-fire). The export is event-driven now; time-based cadence is the

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -16,12 +16,12 @@
  * The detailed fields below the presets let custom shapes through
  * without bypassing the form's validation.
  *
- * Schedule preset → `interval_seconds` mapping: friendly labels (Live /
- * Every minute / Hourly / Daily / Manual only) on the picker, the
- * backend's existing integer-seconds field on the wire. "Manual only"
- * is the special case that sets `watch: false` — every other choice
- * implies `watch: true` since the value's meaningless when the watch
- * loop isn't running.
+ * Post-event-driven shift (vault#XXX): the granular schedule picker
+ * (Live/Minute/10min/Hourly/Daily/Manual) has been replaced by a binary
+ * sync-mode picker — "On change" (events) and "Manual only" (no
+ * auto-fire). The export is event-driven now; time-based cadence is the
+ * exclusive territory of the operator's own cron (or the admin SPA's
+ * "Run export now" button).
  */
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
@@ -43,54 +43,24 @@ type LoadState =
   | { kind: "error"; message: string };
 
 /**
- * Schedule presets — friendly labels operators recognize, mapped to the
- * backend's `interval_seconds` integer. "Manual only" is the odd one
- * out: it sets `watch: false` instead of choosing an interval, because
- * the interval value is meaningless when the watch loop isn't armed.
+ * Sync-mode picker options. "On change" subscribes to in-process hooks
+ * (note / tag / attachment mutations) and debounces them into a single
+ * export pass; the mirror stays fresh as the operator writes. "Manual
+ * only" disables both events and the safety-net poll; only the "Run
+ * export now" button (or `parachute-vault export` from the CLI) fires
+ * an export.
+ *
+ * No schedule picker — the granular Live/Minute/Hourly options the
+ * pre-event-driven UI offered have retired. Events are the live path;
+ * cron is the cadence path; the operator chooses whichever fits.
  */
-const SCHEDULE_OPTIONS: ReadonlyArray<{
-  value: string;
+const SYNC_MODE_OPTIONS: ReadonlyArray<{
+  value: "events" | "manual";
   label: string;
-  interval?: number;
-  watch: boolean;
 }> = [
-  { value: "live", label: "Live (every 5s)", interval: 5, watch: true },
-  { value: "minute", label: "Every minute", interval: 60, watch: true },
-  { value: "10min", label: "Every 10 minutes", interval: 600, watch: true },
-  { value: "hourly", label: "Hourly", interval: 3600, watch: true },
-  { value: "daily", label: "Daily", interval: 86400, watch: true },
-  { value: "manual", label: "Manual only", watch: false },
+  { value: "events", label: "On change (default)" },
+  { value: "manual", label: "Manual only" },
 ];
-
-/**
- * Map the persisted `(watch, interval_seconds)` pair back to the picker
- * value. Non-exact intervals (operator hand-edited config.yaml to 17s,
- * say) fall through to "live" as the closest aligned default; the
- * underlying `interval_seconds` field is still preserved on the config
- * blob until the operator picks a different option and saves.
- */
-function inferScheduleValue(config: MirrorConfig): string {
-  if (!config.watch) return "manual";
-  const match = SCHEDULE_OPTIONS.find(
-    (opt) => opt.watch && opt.interval === config.interval_seconds,
-  );
-  return match?.value ?? "live";
-}
-
-/**
- * Apply a schedule choice to a config blob. "manual" flips watch off;
- * everything else sets watch=true + the named interval.
- */
-function applySchedule(config: MirrorConfig, value: string): MirrorConfig {
-  const opt = SCHEDULE_OPTIONS.find((o) => o.value === value);
-  if (!opt) return config;
-  if (!opt.watch) return { ...config, watch: false };
-  return {
-    ...config,
-    watch: true,
-    interval_seconds: opt.interval ?? config.interval_seconds,
-  };
-}
 
 /**
  * Preset definitions — the three shapes the design doc names. Each is a
@@ -112,41 +82,39 @@ const PRESETS: ReadonlyArray<Preset> = [
     id: "history",
     label: "History",
     subtext:
-      "Local audit trail. Hidden under vault data. Always-on watch.",
+      "Local audit trail. Hidden under vault data. Events-driven.",
     apply: (current) => ({
       ...current,
       enabled: true,
       location: "internal",
-      watch: true,
+      sync_mode: "events",
       auto_commit: true,
       auto_push: false,
-      interval_seconds: 5,
     }),
   },
   {
     id: "live",
     label: "Live Mirror",
     subtext:
-      "Visible folder. Open in Obsidian, push to GitHub.",
+      "Visible folder. Open in Obsidian, push to GitHub. Events-driven.",
     apply: (current) => ({
       ...current,
       enabled: true,
       location: "external",
-      watch: true,
+      sync_mode: "events",
       auto_commit: true,
       // Don't force-flip auto_push — operator may not have credentials yet.
-      interval_seconds: 5,
     }),
   },
   {
     id: "manual",
     label: "Manual Export",
-    subtext: "Snapshot on demand.",
+    subtext: "Snapshot on demand. No auto-fire.",
     apply: (current) => ({
       ...current,
       enabled: true,
       location: "external",
-      watch: false,
+      sync_mode: "manual",
       auto_commit: true,
       auto_push: false,
     }),
@@ -387,7 +355,6 @@ function ConfigForm({
   onSaved: (snap: MirrorSnapshot) => void;
 }) {
   const [config, setConfig] = useState<MirrorConfig>(initial);
-  const [schedule, setSchedule] = useState<string>(inferScheduleValue(initial));
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [saving, setSaving] = useState(false);
   // Field-level error gets rendered next to that field; the bare
@@ -401,18 +368,15 @@ function ConfigForm({
   // freeze on the first-rendered snapshot and ignore subsequent reloads.
   useEffect(() => {
     setConfig(initial);
-    setSchedule(inferScheduleValue(initial));
   }, [initial]);
 
   const onApplyPreset = (preset: Preset) => {
     const next = preset.apply(config);
     setConfig(next);
-    setSchedule(inferScheduleValue(next));
   };
 
-  const onChangeSchedule = (value: string) => {
-    setSchedule(value);
-    setConfig((prev) => applySchedule(prev, value));
+  const onChangeSyncMode = (value: "events" | "manual") => {
+    setConfig((prev) => ({ ...prev, sync_mode: value }));
   };
 
   const onSubmit = async (e: React.FormEvent) => {
@@ -439,7 +403,9 @@ function ConfigForm({
         const lower = msg.toLowerCase();
         if (lower.includes("external_path")) setErrorField("external_path");
         else if (lower.includes("commit_template")) setErrorField("commit_template");
-        else if (lower.includes("interval_seconds")) setErrorField("interval_seconds");
+        else if (lower.includes("safety_net_seconds")) setErrorField("safety_net_seconds");
+        else if (lower.includes("sync_mode")) setErrorField("sync_mode");
+        else if (lower.includes("auto_push")) setErrorField("auto_push");
         else if (lower.includes("location")) setErrorField("location");
         else setErrorField(null);
       } else {
@@ -554,23 +520,23 @@ function ConfigForm({
       ) : null}
 
       <div className="form-row">
-        <label htmlFor="schedule-select">Schedule</label>
+        <label htmlFor="sync-mode-select">Sync mode</label>
         <select
-          id="schedule-select"
-          value={schedule}
+          id="sync-mode-select"
+          value={config.sync_mode}
           disabled={readOnly}
-          onChange={(e) => onChangeSchedule(e.target.value)}
+          onChange={(e) => onChangeSyncMode(e.target.value as "events" | "manual")}
         >
-          {SCHEDULE_OPTIONS.map((opt) => (
+          {SYNC_MODE_OPTIONS.map((opt) => (
             <option key={opt.value} value={opt.value}>
               {opt.label}
             </option>
           ))}
         </select>
         <p className="dim" style={{ margin: "0.35rem 0 0" }}>
-          {schedule === "manual"
-            ? "Watch loop disabled — exports only fire when you click \"Run export now\"."
-            : "Watch loop runs in-process and triggers an export pass at the chosen interval."}
+          {config.sync_mode === "manual"
+            ? "No auto-fire. Exports only run when you click \"Run export now\" (or run `parachute-vault export` from the CLI)."
+            : "Every change to a note, tag, or attachment triggers an export within ~500ms. A background safety check runs hourly to catch anything missed."}
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Replaces the mirror's polling loop (`setInterval` every N seconds) with an event-driven shape that subscribes to in-process hooks for note / tag / attachment mutations, debounces them (~500ms), and flushes a single export pass. A background safety-net poll (default 1h) catches anything the event path missed.

Also closes the **pre-existing deletion gap** — `store.deleteNote()` had no event surface, so deleted notes stayed forever in the mirror. New events (`note:deleted`, `tag:deleted`, `tag:upserted`, `attachment:deleted`) feed an orphan-prune sweep on every flush.

Owner directive (Aaron 2026-05-27): "I want better auto push and better event driven... Do not be lazy." This PR is the **event-driven** half; the auto-push half is a sibling PR.

## What changed

**Cut 1 — `core/src/hooks.ts`**
- `HookEvent` adds `"deleted"`. Default `onNote` event set stays `["created", "updated"]` (back-compat — handlers pre-this-PR don't suddenly see the narrower `DeletedNoteRef` shape).
- `AttachmentHookEvent` adds `"deleted"`. Default stays `["created"]`.
- New `TagHook` + `TagHookEvent` (`"upserted" | "deleted"`) via `onTag()` / `dispatchTag()`.
- `DeletedNoteRef` / `DeletedAttachmentRef` types — minimal id/path payloads for the post-delete shape.

**Cut 2 — `core/src/store.ts`**
- `deleteNote` dispatches `"deleted"`. `deleteTag` / `deleteTagSchema` / `upsertTagSchema` / `upsertTagRecord` / `renameTag` / `mergeTags` dispatch tag events. `deleteAttachment` dispatches an attachment `"deleted"` event.

**Cut 3 — `src/mirror-manager.ts`**
- `setInterval` replaced with hook subscriptions (`subscribeToHooks`) + debounce (`armDebounce`) + safety-net poll (`armSafetyNetTimer`).
- Race-condition contract: burst collapse, event-during-in-flight via `dirtyDuringFlush`, stop-during-flush unsubscribes BEFORE settling, safety-net no-ops when event path's already pending.

**Cut 4 — `core/src/portable-md.ts`**
- New `pruneOrphans({ outDir, validNoteIds, validTagNames, validAttachmentIds })` sweep. Removes orphaned `.md`/`.mdx` notes (frontmatter id check), `notes-meta/<id>.yaml` sidecars (for non-frontmatter extensions), `.parachute/schemas/<tag>.yaml`, and `.parachute/attachments/<id>/` dirs. Unparseable files recorded + left alone.

**Cut 5 — config + UI**
- `MirrorConfig`: `sync_mode: "events" | "manual"` (default `"events"`) + `safety_net_seconds: number` (default 3600, clamped 60–86400) replace `watch` + `interval_seconds`. Parser still accepts the legacy fields for back-compat.
- Cross-field validation: `auto_push: true` + `location: internal` is now rejected at config time (was silent-fail before).
- SPA: granular Live/Minute/Hourly/Daily schedule picker replaced with binary "On change" / "Manual only".

**Cut 6 — boot order**
- `server.ts` shutdown now runs `mirrorManager.stop()` BEFORE `defaultHookRegistry.drain()` so the manager unsubscribes cleanly before the drain awaits its own handlers.

**Cuts 7+8 — tests + pre-existing fixes**
- New tests: 15 hook events, 7 pruneOrphans, 10 event-driven manager, 14 mirror-config (including 3 cross-field). All bun:test + vitest gates green.
- The `auto_push + internal` silent-fail bug is closed; the `runNow` cursor-advance hint stays (documented behavior, not a regression).

## Test plan

- [x] `bun test ./src/ ./core/src/` — **1732 pass, 0 fail** (was 1700 pre-PR; +32 net new tests)
- [x] `bun run typecheck` (server) — clean
- [x] `cd web/ui && bunx vitest run` — **82 pass, 0 fail** (was 75 pre-PR; +7 net new SPA tests)
- [x] `cd web/ui && bun run typecheck` — clean
- [x] `cd web/ui && bun run build` — clean (verify-base passes)
- [x] **Sandboxed E2E (real vault server in `PARACHUTE_HOME=/tmp/vault-event-test-$$`):**
  - Create note via REST → mirror file appears at `<mirror>/event-test-note.md` within 2s
  - Delete note via REST → mirror file removed within 2s
  - Create tag with schema → `.parachute/schemas/<tag>.yaml` appears
  - Delete tag → schema sidecar removed

## Migration story

Existing operator configs:
- `mirror.watch: true` → translates to `sync_mode: events`
- `mirror.watch: false` → translates to `sync_mode: manual`
- `mirror.interval_seconds: N` → repurposed as `safety_net_seconds` (clamped to `[60, 86400]`)

No operator action required. The SPA's PUT writes the new canonical fields on next save.

## Pre-existing issues flagged

- `runNow()` advances the export cursor even when `auto_commit: false`. Documented as a hint in the SPA; left unchanged.
- The portable-md export's in-memory bulk load (`queryNotes({ limit: 1_000_000 })`) is a documented ceiling — not a regression, but worth watching for >100k-note vaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)