### PR TITLE
chore(release): 0.4.9-rc.5 — event-driven mirror exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.4",
+  "version": "0.4.9-rc.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump. Picks up #382:
- Mirror manager rewritten to event-driven (HookRegistry subscriptions + 500ms debounce); polling demoted to ~hourly safety net
- New "deleted" events on notes/tags/attachments; deletions propagate to mirror
- pruneOrphans handles orphaned mirror files (with realpathSync containment guard against symlink-to-outside attacks — flagged + fixed in review)
- Stale schema sidecar fix (deleteTagSchema-then-prune now correctly removes the sidecar instead of keeping it indefinitely)
- Schema reframe: sync_mode + safety_net_seconds replace watch + interval_seconds (back-compat parse retained)
- SPA: "On change" / "Manual only" picker replaces granular cadence

## Test plan

- [x] `bun test ./core ./src ./package` — 1734 pass / 0 fail
- [x] `cd web/ui && bunx vitest run` — 82 pass / 0 fail
- [x] Both typechecks clean
- [x] Sandboxed E2E: note + tag create/delete propagated to mirror within 2s
- [ ] After merge: tag `v0.4.9-rc.5` + push → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)