### PR TITLE
feat(vault): UI-configurable git push credentials (GitHub OAuth + PAT)

### DIFF
--- a/src/github-device-flow.test.ts
+++ b/src/github-device-flow.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Tests for the GitHub Device Flow client. All HTTP calls go through an
+ * injected fetch — no real network round-trips, no real GitHub OAuth app.
+ *
+ * Coverage:
+ *   - requestDeviceCode happy path + missing-field error
+ *   - pollForToken: granted / pending / slow_down / expired / denied
+ *   - fetchUser happy path
+ *   - listRepos: single-page, paginated, truncated
+ *   - createRepo happy path
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  createRepo,
+  fetchUser,
+  GITHUB_CLIENT_ID_PLACEHOLDER,
+  getGithubClientId,
+  isPlaceholderClientId,
+  listRepos,
+  pollForToken,
+  requestDeviceCode,
+  type FetchLike,
+} from "./github-device-flow.ts";
+
+/** Build a mock fetch that returns a predefined response per URL match. */
+function mockFetch(
+  responses: Array<{
+    match: (url: string) => boolean;
+    response: {
+      ok: boolean;
+      status: number;
+      body: unknown;
+    };
+  }>,
+): FetchLike {
+  let callIdx = 0;
+  return async (url) => {
+    // Walk in order; allow each handler to be hit once unless multi-use.
+    for (let i = callIdx; i < responses.length; i++) {
+      if (responses[i]!.match(url)) {
+        callIdx = i + 1;
+        const r = responses[i]!.response;
+        return {
+          ok: r.ok,
+          status: r.status,
+          text: async () => (typeof r.body === "string" ? r.body : JSON.stringify(r.body)),
+          json: async () => r.body,
+        };
+      }
+    }
+    throw new Error(`mockFetch: no matching response for ${url}`);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Client id helpers
+// ---------------------------------------------------------------------------
+
+describe("client id helpers", () => {
+  test("getGithubClientId reads from env when set", () => {
+    const prev = process.env.PARACHUTE_GITHUB_CLIENT_ID;
+    try {
+      process.env.PARACHUTE_GITHUB_CLIENT_ID = "Iv1.realclient";
+      expect(getGithubClientId()).toBe("Iv1.realclient");
+    } finally {
+      if (prev === undefined) delete process.env.PARACHUTE_GITHUB_CLIENT_ID;
+      else process.env.PARACHUTE_GITHUB_CLIENT_ID = prev;
+    }
+  });
+
+  test("getGithubClientId falls back to placeholder when env unset", () => {
+    const prev = process.env.PARACHUTE_GITHUB_CLIENT_ID;
+    delete process.env.PARACHUTE_GITHUB_CLIENT_ID;
+    try {
+      expect(getGithubClientId()).toBe(GITHUB_CLIENT_ID_PLACEHOLDER);
+    } finally {
+      if (prev !== undefined) process.env.PARACHUTE_GITHUB_CLIENT_ID = prev;
+    }
+  });
+
+  test("isPlaceholderClientId catches the literal + the substring", () => {
+    expect(isPlaceholderClientId(GITHUB_CLIENT_ID_PLACEHOLDER)).toBe(true);
+    expect(isPlaceholderClientId("PLACEHOLDER_X")).toBe(true);
+    expect(isPlaceholderClientId("Iv1.realone")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requestDeviceCode
+// ---------------------------------------------------------------------------
+
+describe("requestDeviceCode", () => {
+  test("returns the GitHub device-code tuple on success", async () => {
+    const fetcher = mockFetch([
+      {
+        match: (u) => u.includes("/login/device/code"),
+        response: {
+          ok: true,
+          status: 200,
+          body: {
+            device_code: "abc123",
+            user_code: "XXXX-YYYY",
+            verification_uri: "https://github.com/login/device",
+            expires_in: 900,
+            interval: 5,
+          },
+        },
+      },
+    ]);
+    const result = await requestDeviceCode("Iv1.test", fetcher);
+    expect(result.device_code).toBe("abc123");
+    expect(result.user_code).toBe("XXXX-YYYY");
+    expect(result.interval).toBe(5);
+  });
+
+  test("throws on missing required fields (bad shape from upstream)", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: { ok: true, status: 200, body: { user_code: "X" } },
+      },
+    ]);
+    await expect(requestDeviceCode("Iv1.test", fetcher)).rejects.toThrow(
+      /missing required fields/,
+    );
+  });
+
+  test("throws on non-2xx HTTP response", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: { ok: false, status: 404, body: "not found" },
+      },
+    ]);
+    await expect(requestDeviceCode("Iv1.test", fetcher)).rejects.toThrow(/404/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pollForToken — every spec state
+// ---------------------------------------------------------------------------
+
+describe("pollForToken", () => {
+  test("granted state with access token", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: {
+          ok: true,
+          status: 200,
+          body: { access_token: "gho_real", scope: "repo", token_type: "bearer" },
+        },
+      },
+    ]);
+    const r = await pollForToken("Iv1.test", "dev_code", fetcher);
+    expect(r.state).toBe("granted");
+    if (r.state === "granted") {
+      expect(r.access_token).toBe("gho_real");
+      expect(r.scope).toBe("repo");
+    }
+  });
+
+  test("pending state", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: {
+          ok: true,
+          status: 200,
+          body: { error: "authorization_pending" },
+        },
+      },
+    ]);
+    const r = await pollForToken("Iv1.test", "dev_code", fetcher);
+    expect(r.state).toBe("pending");
+  });
+
+  test("slow_down state carries new interval", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: {
+          ok: true,
+          status: 200,
+          body: { error: "slow_down", interval: 10 },
+        },
+      },
+    ]);
+    const r = await pollForToken("Iv1.test", "dev_code", fetcher);
+    expect(r.state).toBe("slow_down");
+    if (r.state === "slow_down") expect(r.interval).toBe(10);
+  });
+
+  test("expired state", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: { ok: true, status: 200, body: { error: "expired_token" } },
+      },
+    ]);
+    const r = await pollForToken("Iv1.test", "dev_code", fetcher);
+    expect(r.state).toBe("expired");
+  });
+
+  test("denied state", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: { ok: true, status: 200, body: { error: "access_denied" } },
+      },
+    ]);
+    const r = await pollForToken("Iv1.test", "dev_code", fetcher);
+    expect(r.state).toBe("denied");
+  });
+
+  test("unknown error maps to denied (defense)", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: {
+          ok: true,
+          status: 200,
+          body: { error: "weird_new_error" },
+        },
+      },
+    ]);
+    const r = await pollForToken("Iv1.test", "dev_code", fetcher);
+    expect(r.state).toBe("denied");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchUser
+// ---------------------------------------------------------------------------
+
+describe("fetchUser", () => {
+  test("returns login + id (and optional name)", async () => {
+    const fetcher = mockFetch([
+      {
+        match: (u) => u.includes("/user"),
+        response: {
+          ok: true,
+          status: 200,
+          body: { login: "aaron", id: 12345, name: "Aaron Gabriel", avatar_url: "https://x/y.png" },
+        },
+      },
+    ]);
+    const user = await fetchUser("gho_test", fetcher);
+    expect(user.login).toBe("aaron");
+    expect(user.id).toBe(12345);
+    expect(user.name).toBe("Aaron Gabriel");
+  });
+
+  test("throws on missing required fields", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: { ok: true, status: 200, body: { login: "x" } },
+      },
+    ]);
+    await expect(fetchUser("gho_test", fetcher)).rejects.toThrow(/missing login or id/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listRepos
+// ---------------------------------------------------------------------------
+
+describe("listRepos", () => {
+  test("single page (< perPage repos) returns repos, untruncated", async () => {
+    const fetcher = mockFetch([
+      {
+        match: (u) => u.includes("page=1"),
+        response: {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              name: "a",
+              full_name: "aaron/a",
+              private: true,
+              html_url: "https://github.com/aaron/a",
+              description: null,
+              updated_at: "2026-05-28T00:00:00Z",
+              clone_url: "https://github.com/aaron/a.git",
+              owner: { login: "aaron" },
+            },
+          ],
+        },
+      },
+    ]);
+    const result = await listRepos("gho_test", { perPage: 100, maxPages: 3 }, fetcher);
+    expect(result.repos).toHaveLength(1);
+    expect(result.truncated).toBe(false);
+    expect(result.repos[0]!.owner).toBe("aaron");
+    expect(result.repos[0]!.full_name).toBe("aaron/a");
+  });
+
+  test("paginates until a short page (< perPage) signals the end", async () => {
+    const fullPage = Array.from({ length: 2 }, (_, i) => ({
+      name: `repo${i}`,
+      full_name: `aaron/repo${i}`,
+      private: false,
+      html_url: `https://github.com/aaron/repo${i}`,
+      description: null,
+      updated_at: "2026-05-28T00:00:00Z",
+      clone_url: `https://github.com/aaron/repo${i}.git`,
+      owner: { login: "aaron" },
+    }));
+    const shortPage = [
+      {
+        name: "last",
+        full_name: "aaron/last",
+        private: false,
+        html_url: "https://github.com/aaron/last",
+        description: null,
+        updated_at: "2026-05-28T00:00:00Z",
+        clone_url: "https://github.com/aaron/last.git",
+        owner: { login: "aaron" },
+      },
+    ];
+    const fetcher = mockFetch([
+      { match: (u) => u.includes("page=1"), response: { ok: true, status: 200, body: fullPage } },
+      { match: (u) => u.includes("page=2"), response: { ok: true, status: 200, body: shortPage } },
+    ]);
+    const result = await listRepos("gho_test", { perPage: 2, maxPages: 3 }, fetcher);
+    expect(result.repos).toHaveLength(3);
+    expect(result.truncated).toBe(false);
+  });
+
+  test("marks truncated when maxPages cap hit and page still full", async () => {
+    const fullPage = Array.from({ length: 2 }, (_, i) => ({
+      name: `repo${i}`,
+      full_name: `aaron/repo${i}`,
+      private: false,
+      html_url: `https://github.com/aaron/repo${i}`,
+      description: null,
+      updated_at: "2026-05-28T00:00:00Z",
+      clone_url: `https://github.com/aaron/repo${i}.git`,
+      owner: { login: "aaron" },
+    }));
+    const fetcher = mockFetch([
+      { match: (u) => u.includes("page=1"), response: { ok: true, status: 200, body: fullPage } },
+      { match: (u) => u.includes("page=2"), response: { ok: true, status: 200, body: fullPage } },
+    ]);
+    const result = await listRepos("gho_test", { perPage: 2, maxPages: 2 }, fetcher);
+    expect(result.repos).toHaveLength(4);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createRepo
+// ---------------------------------------------------------------------------
+
+describe("createRepo", () => {
+  test("creates a private repo with description", async () => {
+    const fetcher = mockFetch([
+      {
+        match: (u) => u.includes("/user/repos"),
+        response: {
+          ok: true,
+          status: 201,
+          body: {
+            name: "my-vault",
+            full_name: "aaron/my-vault",
+            private: true,
+            html_url: "https://github.com/aaron/my-vault",
+            description: "Parachute Vault mirror",
+            updated_at: "2026-05-28T00:00:00Z",
+            clone_url: "https://github.com/aaron/my-vault.git",
+            owner: { login: "aaron" },
+          },
+        },
+      },
+    ]);
+    const repo = await createRepo(
+      "gho_test",
+      { name: "my-vault", description: "Parachute Vault mirror" },
+      fetcher,
+    );
+    expect(repo.full_name).toBe("aaron/my-vault");
+    expect(repo.private).toBe(true);
+    expect(repo.clone_url).toBe("https://github.com/aaron/my-vault.git");
+  });
+
+  test("surfaces GitHub error message on failure (name taken, validation)", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: {
+          ok: false,
+          status: 422,
+          body: { message: "Repository creation failed: name already exists" },
+        },
+      },
+    ]);
+    await expect(
+      createRepo("gho_test", { name: "exists" }, fetcher),
+    ).rejects.toThrow(/already exists/);
+  });
+});

--- a/src/github-device-flow.ts
+++ b/src/github-device-flow.ts
@@ -1,0 +1,415 @@
+/**
+ * GitHub OAuth Device Flow client + supporting API calls.
+ *
+ * Why Device Flow (not Web Flow): self-hosted vault origins are
+ * unpredictable (localhost:1940, random Tailscale FQDN, custom domain). Web
+ * Flow needs a pre-registered callback URL per OAuth app; Device Flow needs
+ * only a public `client_id` and the operator authorizes by typing a code at
+ * github.com/login/device from any device. Same UX as `gh auth login`.
+ *
+ * Spec: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow
+ *
+ * All HTTP calls accept an injectable `fetch` so tests can mock the wire
+ * without spawning a real GitHub round-trip. Production wiring uses the
+ * platform `fetch` (Bun's native).
+ *
+ * **GITHUB_CLIENT_ID setup (REQUIRED before this works in production):**
+ *
+ *   1. Visit https://github.com/settings/developers
+ *   2. "OAuth Apps" → "New OAuth App"
+ *   3. Application name: "Parachute Vault" (or operator-chosen)
+ *      Homepage URL: https://parachute.computer
+ *      Authorization callback URL: https://parachute.computer/oauth/github
+ *      (callback URL is required by GitHub's form but unused in Device Flow)
+ *   4. After creating: open the app's settings page
+ *   5. Tick the "Enable Device Flow" checkbox
+ *   6. Copy the Client ID (looks like `Iv1.abc123...` or `Ov23li...`)
+ *   7. Set the `GITHUB_CLIENT_ID` constant below to that value
+ *
+ * The placeholder ships with this PR. Production builds are gated on a real
+ * client_id; the PR body flags Aaron as the action owner.
+ */
+
+// ---------------------------------------------------------------------------
+// Client ID — REPLACE BEFORE TAGGING A RELEASE.
+//
+// This is the public OAuth app client_id. No secret is needed for Device
+// Flow (the operator's typed code is the proof-of-presence factor). Safe to
+// commit + ship in client builds. But: tied to ONE registered GitHub OAuth
+// App, which Aaron owns under the Parachute org / his account. Set this
+// after running the setup checklist above.
+//
+// TODO(aaron): replace with the real client_id from the registered OAuth
+// app. Until then, the device-flow endpoints return a clear-error response
+// instead of attempting GitHub's API with an invalid id (which surfaces an
+// opaque "Not Found" that's hard to debug).
+// ---------------------------------------------------------------------------
+
+export const GITHUB_CLIENT_ID_PLACEHOLDER =
+  "Iv1.PLACEHOLDER_REPLACE_ME_BEFORE_RELEASE" as const;
+
+/**
+ * The active client id at runtime. Resolved from the env (preferred — lets
+ * operators override per-deploy) or the constant above (for tests +
+ * defaults). Defaults to the placeholder; the route handlers check for the
+ * placeholder and return an actionable error before hitting GitHub.
+ */
+export function getGithubClientId(): string {
+  return process.env.PARACHUTE_GITHUB_CLIENT_ID || GITHUB_CLIENT_ID_PLACEHOLDER;
+}
+
+/** Returns true when no real client id has been configured. */
+export function isPlaceholderClientId(clientId: string): boolean {
+  return clientId === GITHUB_CLIENT_ID_PLACEHOLDER || clientId.includes("PLACEHOLDER");
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  /** Seconds the client should wait between polls. */
+  interval: number;
+}
+
+/** Discriminated union of poll outcomes. */
+export type TokenPollResult =
+  | { state: "pending" }
+  | { state: "slow_down"; interval: number }
+  | { state: "expired" }
+  | { state: "denied" }
+  | {
+      state: "granted";
+      access_token: string;
+      scope: string;
+      token_type: string;
+    };
+
+export interface GitHubUser {
+  login: string;
+  id: number;
+  name: string | null;
+  avatar_url?: string;
+}
+
+export interface GitHubRepoInfo {
+  owner: string;
+  name: string;
+  full_name: string;
+  private: boolean;
+  html_url: string;
+  description: string | null;
+  /** ISO timestamp. Used by the SPA for "last updated" sort/display. */
+  updated_at: string;
+  /** HTTPS clone URL (no auth). The mirror gets the authed shape applied
+   *  separately via `applyToGitRemote`. */
+  clone_url: string;
+}
+
+export interface ListReposResult {
+  repos: GitHubRepoInfo[];
+  /** True when the operator has more than `maxPages * per_page` repos and
+   *  we stopped paginating. Signals the UI to recommend the manual-URL
+   *  paste or a search filter. */
+  truncated: boolean;
+}
+
+/** Minimal fetch-like surface — injectable for tests. */
+export type FetchLike = (
+  input: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+  json: () => Promise<unknown>;
+}>;
+
+function defaultFetch(): FetchLike {
+  return globalThis.fetch as FetchLike;
+}
+
+// ---------------------------------------------------------------------------
+// Device Flow endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Start a device-flow authorization. POSTs to GitHub's `/login/device/code`
+ * with the public client_id + the `repo` scope (the minimum we need to push
+ * to the operator's private repos).
+ *
+ * Throws on transport or shape error — the route handler catches + returns
+ * a 502. Successful return is the four-tuple GitHub spec calls for
+ * (device_code, user_code, verification_uri, expires_in, interval).
+ */
+export async function requestDeviceCode(
+  clientId: string,
+  fetchImpl: FetchLike = defaultFetch(),
+): Promise<DeviceCodeResponse> {
+  const res = await fetchImpl("https://github.com/login/device/code", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      // `repo` is the broad-private-repo scope. Read-only push isn't a
+      // thing on GitHub; if we want to push, we need write access to repo
+      // contents, which `repo` includes. The narrower scope `public_repo`
+      // wouldn't cover private repos — most operator vaults are private.
+      scope: "repo",
+    }).toString(),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `GitHub device-code request failed (${res.status}): ${body.slice(0, 200)}`,
+    );
+  }
+  const parsed = (await res.json()) as Partial<DeviceCodeResponse>;
+  if (
+    typeof parsed.device_code !== "string" ||
+    typeof parsed.user_code !== "string" ||
+    typeof parsed.verification_uri !== "string" ||
+    typeof parsed.expires_in !== "number" ||
+    typeof parsed.interval !== "number"
+  ) {
+    throw new Error(
+      `GitHub device-code response missing required fields: ${JSON.stringify(parsed).slice(0, 200)}`,
+    );
+  }
+  return parsed as DeviceCodeResponse;
+}
+
+/**
+ * Poll GitHub's `/login/oauth/access_token` for a granted token. Returns a
+ * discriminated union the route handler can branch on.
+ *
+ * GitHub returns a 200 with an `error` field for the in-flight states
+ * (`authorization_pending`, `slow_down`, etc.); we map those to our `state`
+ * field. A true HTTP error (5xx) throws.
+ */
+export async function pollForToken(
+  clientId: string,
+  deviceCode: string,
+  fetchImpl: FetchLike = defaultFetch(),
+): Promise<TokenPollResult> {
+  const res = await fetchImpl("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      device_code: deviceCode,
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    }).toString(),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `GitHub access_token poll failed (${res.status}): ${body.slice(0, 200)}`,
+    );
+  }
+  const parsed = (await res.json()) as Record<string, unknown>;
+
+  // Success: { access_token, scope, token_type }
+  if (typeof parsed.access_token === "string") {
+    return {
+      state: "granted",
+      access_token: parsed.access_token,
+      scope: typeof parsed.scope === "string" ? parsed.scope : "",
+      token_type: typeof parsed.token_type === "string" ? parsed.token_type : "bearer",
+    };
+  }
+
+  // In-flight / failure states: { error, error_description, interval? }
+  const error = typeof parsed.error === "string" ? parsed.error : null;
+  if (error === "authorization_pending") return { state: "pending" };
+  if (error === "slow_down") {
+    const interval = typeof parsed.interval === "number" ? parsed.interval : 5;
+    return { state: "slow_down", interval };
+  }
+  if (error === "expired_token") return { state: "expired" };
+  if (error === "access_denied") return { state: "denied" };
+  // Unknown error — treat as denied so the UI surfaces a clear failure
+  // rather than hanging on pending. The actual GitHub error string is
+  // not surfaced (it'd leak via logs); the route's response carries a
+  // generic "denied" + the message via console.warn.
+  console.warn(
+    `[github-device-flow] unexpected error from access_token poll: ${error ?? JSON.stringify(parsed).slice(0, 100)}`,
+  );
+  return { state: "denied" };
+}
+
+// ---------------------------------------------------------------------------
+// User + repo APIs (used after token granted)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the authenticated user's profile. Used immediately after a
+ * `granted` token to populate `user_login` + `user_id` in the stored
+ * credential.
+ */
+export async function fetchUser(
+  token: string,
+  fetchImpl: FetchLike = defaultFetch(),
+): Promise<GitHubUser> {
+  const res = await fetchImpl("https://api.github.com/user", {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `token ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `GitHub /user fetch failed (${res.status}): ${body.slice(0, 200)}`,
+    );
+  }
+  const parsed = (await res.json()) as Partial<GitHubUser>;
+  if (typeof parsed.login !== "string" || typeof parsed.id !== "number") {
+    throw new Error(`GitHub /user response missing login or id`);
+  }
+  return {
+    login: parsed.login,
+    id: parsed.id,
+    name: typeof parsed.name === "string" ? parsed.name : null,
+    avatar_url: typeof parsed.avatar_url === "string" ? parsed.avatar_url : undefined,
+  };
+}
+
+/**
+ * Paginated list of repos the authenticated user owns. Sorted by most-
+ * recently-updated so the repo the operator probably wants is near the top.
+ * Truncates after `maxPages * perPage` repos (default 3 * 100 = 300) — most
+ * operators have far fewer, the truncation signals the UI to prompt for a
+ * search filter.
+ */
+export async function listRepos(
+  token: string,
+  opts: { maxPages?: number; perPage?: number } = {},
+  fetchImpl: FetchLike = defaultFetch(),
+): Promise<ListReposResult> {
+  const perPage = opts.perPage ?? 100;
+  const maxPages = opts.maxPages ?? 3;
+  const repos: GitHubRepoInfo[] = [];
+  let truncated = false;
+  for (let page = 1; page <= maxPages; page++) {
+    const res = await fetchImpl(
+      `https://api.github.com/user/repos?type=owner&sort=updated&per_page=${perPage}&page=${page}`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `token ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(
+        `GitHub /user/repos fetch failed (${res.status}, page ${page}): ${body.slice(0, 200)}`,
+      );
+    }
+    const items = (await res.json()) as Array<{
+      name: string;
+      full_name: string;
+      private: boolean;
+      html_url: string;
+      description: string | null;
+      updated_at: string;
+      clone_url: string;
+      owner: { login: string };
+    }>;
+    for (const item of items) {
+      repos.push({
+        owner: item.owner.login,
+        name: item.name,
+        full_name: item.full_name,
+        private: item.private,
+        html_url: item.html_url,
+        description: item.description,
+        updated_at: item.updated_at,
+        clone_url: item.clone_url,
+      });
+    }
+    // No more pages.
+    if (items.length < perPage) {
+      return { repos, truncated: false };
+    }
+    // Page filled to perPage — there might be more. If we're at the cap,
+    // mark as truncated and return.
+    if (page === maxPages) {
+      truncated = true;
+    }
+  }
+  return { repos, truncated };
+}
+
+/**
+ * Create a new repo on the authenticated user's account. Defaults to private
+ * because the operator's vault is more likely sensitive than public. The
+ * repo gets initialized empty (no README) so the first `git push` from the
+ * mirror lands the operator's vault as commit 1.
+ */
+export async function createRepo(
+  token: string,
+  opts: { name: string; description?: string; private?: boolean },
+  fetchImpl: FetchLike = defaultFetch(),
+): Promise<GitHubRepoInfo> {
+  const res = await fetchImpl("https://api.github.com/user/repos", {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `token ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      name: opts.name,
+      description: opts.description ?? "Parachute Vault mirror",
+      private: opts.private ?? true,
+      auto_init: false,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    let parsed: { message?: string } = {};
+    try {
+      parsed = JSON.parse(body) as { message?: string };
+    } catch {
+      // not JSON
+    }
+    throw new Error(
+      `GitHub /user/repos create failed (${res.status}): ${parsed.message ?? body.slice(0, 200)}`,
+    );
+  }
+  const item = (await res.json()) as {
+    name: string;
+    full_name: string;
+    private: boolean;
+    html_url: string;
+    description: string | null;
+    updated_at: string;
+    clone_url: string;
+    owner: { login: string };
+  };
+  return {
+    owner: item.owner.login,
+    name: item.name,
+    full_name: item.full_name,
+    private: item.private,
+    html_url: item.html_url,
+    description: item.description,
+    updated_at: item.updated_at,
+    clone_url: item.clone_url,
+  };
+}

--- a/src/mirror-credentials.test.ts
+++ b/src/mirror-credentials.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Tests for mirror-credentials.ts — the UI-configurable git push
+ * credential store.
+ *
+ * Coverage:
+ *   - Read/write round-trip (parse + serialize symmetric across realistic
+ *     credential shapes).
+ *   - File perms enforced at 0o600 (the storage layer's whole security
+ *     model rides on this).
+ *   - Redaction masks tokens consistently — `sanitizeCredentials` is what
+ *     the HTTP responses + logs go through.
+ *   - Idempotent delete (Disconnect should succeed even if the file is
+ *     gone).
+ *   - Git remote helpers add/replace `origin` idempotently and don't leak
+ *     the token in stderr/stdout we surface back to callers.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  applyToGitRemote,
+  deleteCredentials,
+  emptyCredentials,
+  githubAuthedRemoteUrl,
+  mirrorCredentialsPath,
+  parseCredentials,
+  previewToken,
+  readCredentials,
+  redactRemoteUrl,
+  sanitizeCredentials,
+  serializeCredentials,
+  unsetGitRemote,
+  writeCredentials,
+  type MirrorCredentials,
+} from "./mirror-credentials.ts";
+
+const ORIG_HOME = process.env.HOME;
+const ORIG_PARACHUTE_HOME = process.env.PARACHUTE_HOME;
+
+function tmp(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function withSandbox<T>(fn: (home: string) => T): T {
+  const home = tmp("mirror-creds-");
+  fs.mkdirSync(path.join(home, "vault"), { recursive: true });
+  process.env.PARACHUTE_HOME = home;
+  process.env.HOME = home;
+  try {
+    return fn(home);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  if (ORIG_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIG_HOME;
+  if (ORIG_PARACHUTE_HOME === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = ORIG_PARACHUTE_HOME;
+});
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+describe("emptyCredentials", () => {
+  test("returns a fully-null shape — no active method, no provider blocks", () => {
+    const e = emptyCredentials();
+    expect(e.active_method).toBeNull();
+    expect(e.github_oauth).toBeNull();
+    expect(e.pat).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Serialize / parse round-trip
+// ---------------------------------------------------------------------------
+
+describe("serialize + parse round-trip", () => {
+  test("empty credentials round-trip cleanly", () => {
+    const out = parseCredentials(serializeCredentials(emptyCredentials()));
+    expect(out).toEqual(emptyCredentials());
+  });
+
+  test("github_oauth credentials round-trip", () => {
+    const creds: MirrorCredentials = {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_abc123def456ghi789",
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 12345,
+      },
+      pat: null,
+    };
+    const out = parseCredentials(serializeCredentials(creds));
+    expect(out).toEqual(creds);
+  });
+
+  test("pat credentials round-trip", () => {
+    const creds: MirrorCredentials = {
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        token: "ghp_xyz9876543210abc",
+        remote_url: "https://github.com/aaron/my-vault.git",
+        label: "GitHub PAT",
+      },
+    };
+    const out = parseCredentials(serializeCredentials(creds));
+    expect(out).toEqual(creds);
+  });
+
+  test("both surfaces populated, github_oauth active", () => {
+    // The operator can have BOTH a github_oauth and a pat configured
+    // (e.g. linked GitHub, plus a fallback PAT). Only one is the
+    // active_method at any time; the others stay populated so flipping
+    // back is a single click rather than re-authenticating.
+    const creds: MirrorCredentials = {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_test",
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: {
+        token: "ghp_test",
+        remote_url: "https://github.com/aaron/backup.git",
+        label: "Backup PAT",
+      },
+    };
+    // Short tokens get the < 12 char branch for previewToken; pad these
+    // up so the round-trip path is exercising the realistic shape.
+    creds.github_oauth!.access_token = "gho_abc123def456ghi789";
+    creds.pat!.token = "ghp_xyz9876543210abc";
+    const out = parseCredentials(serializeCredentials(creds));
+    expect(out).toEqual(creds);
+  });
+
+  test("special characters in label are quoted/escaped on round-trip", () => {
+    const creds: MirrorCredentials = {
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        token: "ghp_test1234567890abcdef",
+        remote_url: "https://gitlab.com/team/repo.git",
+        label: 'PAT with "quotes" and: colons',
+      },
+    };
+    const out = parseCredentials(serializeCredentials(creds));
+    expect(out.pat!.label).toBe('PAT with "quotes" and: colons');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+describe("readCredentials / writeCredentials", () => {
+  test("returns null when no file exists", () => {
+    withSandbox(() => {
+      expect(readCredentials()).toBeNull();
+    });
+  });
+
+  test("write + read round-trip with real disk", () => {
+    withSandbox(() => {
+      const creds: MirrorCredentials = {
+        active_method: "github_oauth",
+        github_oauth: {
+          access_token: "gho_abc123def456ghi789",
+          scope: "repo",
+          authorized_at: "2026-05-28T03:14:15.000Z",
+          user_login: "aaron",
+          user_id: 12345,
+        },
+        pat: null,
+      };
+      writeCredentials(creds);
+      const read = readCredentials();
+      expect(read).toEqual(creds);
+    });
+  });
+
+  test("write enforces 0600 perms — the storage model rides on this", () => {
+    withSandbox(() => {
+      const creds: MirrorCredentials = {
+        ...emptyCredentials(),
+        active_method: "pat",
+        pat: {
+          token: "ghp_test1234567890abcdef",
+          remote_url: "https://github.com/x/y.git",
+          label: "test",
+        },
+      };
+      writeCredentials(creds);
+      const p = mirrorCredentialsPath();
+      const stat = fs.statSync(p);
+      const perms = stat.mode & 0o777;
+      expect(perms).toBe(0o600);
+    });
+  });
+
+  test("write creates the parent directory if missing", () => {
+    const home = tmp("mirror-creds-mkdir-");
+    process.env.PARACHUTE_HOME = home;
+    process.env.HOME = home;
+    try {
+      // Note: don't pre-create the vault subdir.
+      const creds: MirrorCredentials = { ...emptyCredentials() };
+      writeCredentials(creds);
+      expect(fs.existsSync(path.join(home, "vault", ".mirror-credentials.yaml"))).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("write is atomic — partial file not left on failure path", () => {
+    withSandbox(() => {
+      const creds: MirrorCredentials = {
+        active_method: "github_oauth",
+        github_oauth: {
+          access_token: "gho_initial1234567890",
+          scope: "repo",
+          authorized_at: "2026-05-28T03:14:15.000Z",
+          user_login: "aaron",
+          user_id: 1,
+        },
+        pat: null,
+      };
+      writeCredentials(creds);
+      // Subsequent write replaces atomically (.tmp rename onto final).
+      const updated: MirrorCredentials = {
+        ...creds,
+        github_oauth: { ...creds.github_oauth!, access_token: "gho_updated123456789" },
+      };
+      writeCredentials(updated);
+      const read = readCredentials();
+      expect(read?.github_oauth?.access_token).toBe("gho_updated123456789");
+      // No leftover .tmp file.
+      expect(fs.existsSync(`${mirrorCredentialsPath()}.tmp`)).toBe(false);
+    });
+  });
+});
+
+describe("deleteCredentials", () => {
+  test("idempotent — missing file is a no-op (doesn't throw)", () => {
+    withSandbox(() => {
+      expect(() => deleteCredentials()).not.toThrow();
+    });
+  });
+
+  test("removes the file when present", () => {
+    withSandbox(() => {
+      writeCredentials({ ...emptyCredentials(), active_method: null });
+      expect(fs.existsSync(mirrorCredentialsPath())).toBe(true);
+      deleteCredentials();
+      expect(fs.existsSync(mirrorCredentialsPath())).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+describe("previewToken", () => {
+  test("masks middle of typical OAuth tokens", () => {
+    expect(previewToken("gho_abcdefghijklmnop")).toBe("gho_…mnop");
+  });
+
+  test("fully masks tokens shorter than 12 chars (defense in depth)", () => {
+    expect(previewToken("short")).toBe("***");
+    expect(previewToken("")).toBe("***");
+  });
+
+  test("preserves enough to verify but not enough to use", () => {
+    const t = "ghp_1234567890abcdefghij";
+    const p = previewToken(t);
+    // Has the prefix + the trailing chars.
+    expect(p.startsWith("ghp_")).toBe(true);
+    expect(p.endsWith("ghij")).toBe(true);
+    // Doesn't contain the middle.
+    expect(p).not.toContain("567890abc");
+  });
+});
+
+describe("redactRemoteUrl", () => {
+  test("strips userinfo from HTTPS URLs", () => {
+    expect(
+      redactRemoteUrl("https://x-access-token:gho_secret@github.com/a/b.git"),
+    ).toContain("***@github.com/a/b.git");
+    expect(
+      redactRemoteUrl("https://x-access-token:gho_secret@github.com/a/b.git"),
+    ).not.toContain("gho_secret");
+  });
+
+  test("leaves URLs without userinfo unchanged", () => {
+    expect(redactRemoteUrl("https://github.com/a/b.git")).toBe(
+      "https://github.com/a/b.git",
+    );
+  });
+
+  test("non-URL string fully masks (defense in depth)", () => {
+    expect(redactRemoteUrl("not a url")).toBe("***");
+  });
+});
+
+describe("sanitizeCredentials", () => {
+  test("null input returns the fully-null public shape", () => {
+    expect(sanitizeCredentials(null)).toEqual({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+  });
+
+  test("github_oauth credential exposes user info but masks token", () => {
+    const creds: MirrorCredentials = {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_secret1234567890",
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 12345,
+      },
+      pat: null,
+    };
+    const safe = sanitizeCredentials(creds);
+    expect(safe.github_oauth?.user_login).toBe("aaron");
+    expect(safe.github_oauth?.user_id).toBe(12345);
+    expect(safe.github_oauth?.scope).toBe("repo");
+    expect(safe.github_oauth?.token_preview).toBe("gho_…7890");
+    // No raw token leaks.
+    expect(JSON.stringify(safe)).not.toContain("gho_secret");
+  });
+
+  test("pat credential masks both token AND any token embedded in remote_url", () => {
+    const creds: MirrorCredentials = {
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        token: "ghp_secret1234567890",
+        remote_url:
+          "https://x-access-token:ghp_secret1234567890@github.com/owner/repo.git",
+        label: "GitHub PAT",
+      },
+    };
+    const safe = sanitizeCredentials(creds);
+    expect(safe.pat?.label).toBe("GitHub PAT");
+    expect(safe.pat?.token_preview).toBe("ghp_…7890");
+    // Embedded token in URL must be redacted.
+    expect(safe.pat?.remote_url).not.toContain("ghp_secret");
+    expect(JSON.stringify(safe)).not.toContain("ghp_secret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Git remote helpers (real git, real tempdir)
+// ---------------------------------------------------------------------------
+
+describe("githubAuthedRemoteUrl", () => {
+  test("builds the x-access-token https URL", () => {
+    expect(
+      githubAuthedRemoteUrl("gho_test", "aaron", "my-vault"),
+    ).toBe("https://x-access-token:gho_test@github.com/aaron/my-vault.git");
+  });
+});
+
+describe("applyToGitRemote + unsetGitRemote", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmp("mirror-creds-remote-");
+    Bun.spawnSync(["git", "init", "-q", "-b", "main"], { cwd: dir });
+    Bun.spawnSync(["git", "config", "user.email", "t@p.computer"], { cwd: dir });
+    Bun.spawnSync(["git", "config", "user.name", "T P"], { cwd: dir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("adds origin when no remote configured", async () => {
+    const url = "https://x-access-token:gho_test1234567890@github.com/a/b.git";
+    const res = await applyToGitRemote(dir, url);
+    expect(res.ok).toBe(true);
+    const probe = Bun.spawnSync(["git", "remote", "get-url", "origin"], { cwd: dir });
+    expect(probe.exitCode).toBe(0);
+    expect(new TextDecoder().decode(probe.stdout).trim()).toBe(url);
+  });
+
+  test("replaces origin when already configured (idempotent rotation)", async () => {
+    Bun.spawnSync(["git", "remote", "add", "origin", "https://old.example/x.git"], { cwd: dir });
+    const newUrl = "https://x-access-token:gho_new1234567890@github.com/c/d.git";
+    const res = await applyToGitRemote(dir, newUrl);
+    expect(res.ok).toBe(true);
+    const probe = Bun.spawnSync(["git", "remote", "get-url", "origin"], { cwd: dir });
+    expect(new TextDecoder().decode(probe.stdout).trim()).toBe(newUrl);
+  });
+
+  test("unsetGitRemote removes origin", async () => {
+    Bun.spawnSync(["git", "remote", "add", "origin", "https://x.example/a.git"], { cwd: dir });
+    const res = await unsetGitRemote(dir);
+    expect(res.ok).toBe(true);
+    const probe = Bun.spawnSync(["git", "remote", "get-url", "origin"], { cwd: dir });
+    expect(probe.exitCode).not.toBe(0); // no remote
+  });
+
+  test("unsetGitRemote is idempotent — no remote = ok", async () => {
+    const res = await unsetGitRemote(dir);
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/mirror-credentials.test.ts
+++ b/src/mirror-credentials.test.ts
@@ -157,6 +157,34 @@ describe("serialize + parse round-trip", () => {
     const out = parseCredentials(serializeCredentials(creds));
     expect(out.pat!.label).toBe('PAT with "quotes" and: colons');
   });
+
+  // Reviewer-flagged on vault#384 — without newline escaping a label
+  // containing a literal `\n` produces multi-line YAML that breaks
+  // the per-line section parser. PAT/OAuth tokens never carry newlines
+  // but operator-supplied labels have no such guarantee.
+  test("newlines + carriage returns in label round-trip via escapes", () => {
+    const labelWithLineBreak = "Line one\nLine two";
+    const labelWithCR = "First\rSecond";
+    for (const label of [labelWithLineBreak, labelWithCR]) {
+      const creds: MirrorCredentials = {
+        active_method: "pat",
+        github_oauth: null,
+        pat: {
+          token: "ghp_newline_test_token_12345",
+          remote_url: "https://gitlab.com/team/repo.git",
+          label,
+        },
+      };
+      const serialized = serializeCredentials(creds);
+      // Serialized YAML must NOT contain literal newlines inside the
+      // label scalar (would break section parsing).
+      const labelLine = serialized.split("\n").find((l) => l.includes("label:"))!;
+      expect(labelLine).not.toContain("\n");
+      // Round-trip recovers the original.
+      const out = parseCredentials(serialized);
+      expect(out.pat!.label).toBe(label);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/mirror-credentials.ts
+++ b/src/mirror-credentials.ts
@@ -1,0 +1,561 @@
+/**
+ * Mirror credentials store — UI-configurable git push credentials.
+ *
+ * After vault#382 (event-driven mirror), `auto_push: true` works only if the
+ * operator's shell has the right git credential plumbing wired (SSH key,
+ * GH_TOKEN, system credential helper). For self-hosted users that pattern is
+ * a non-starter — most have never opened a terminal. This module owns the
+ * UI-configurable alternative.
+ *
+ * Two surfaces:
+ *   - **GitHub OAuth Device Flow** — the recommended path. Operator opens a
+ *     modal, vault calls GitHub's device-code endpoint, the operator types
+ *     a code at github.com/login/device, vault polls until granted, the
+ *     resulting `gho_*` token is stored and embedded in the mirror's git
+ *     remote URL so bare `git push` works. Same UX as `gh auth login`.
+ *     **Why Device Flow, not Web Flow:** Web Flow needs a pre-registered
+ *     callback URL per OAuth app; self-hosted vaults have unpredictable
+ *     origins (localhost:1940, random Tailscale FQDN, custom domain). Device
+ *     Flow needs only a public `client_id` and works against any vault
+ *     origin without infrastructure.
+ *   - **Personal Access Token (PAT) fallback** — provider-agnostic. Operator
+ *     pastes a token + a remote URL with HTTPS auth; vault stores both and
+ *     embeds them in the mirror's remote URL. Works against GitHub, GitLab,
+ *     Codeberg, Gitea, anything that accepts an HTTPS token in the URL.
+ *
+ * **Storage:** `<configDir>/vault/.mirror-credentials.yaml`, perms `0o600`,
+ * **not encrypted at rest**. Rationale: encryption-at-rest with the key on
+ * the same disk doesn't add real security; OS perms ARE the protection. Same
+ * trust model as `~/.git-credentials` (which most operators already use).
+ * The file is documented as sensitive; redaction in logs is enforced by
+ * `sanitizeCredentials` + a discipline of "never log the raw token."
+ *
+ * **One credential set per vault.** Multi-credential ("I want repo A pushed
+ * with token X, repo B with token Y") isn't supported — vault#382 ships one
+ * mirror per vault server today; one credential set per vault matches.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Which credential surface is currently active. Null when none configured.
+ * - `github_oauth` — populated `github_oauth` block.
+ * - `pat` — populated `pat` block (Personal Access Token + remote URL).
+ */
+export type ActiveMethod = "github_oauth" | "pat" | null;
+
+/**
+ * GitHub OAuth Device Flow result. Stored verbatim after a successful poll
+ * returns `granted`. The `access_token` is what gets embedded in the git
+ * remote URL at push time (via `x-access-token:<TOKEN>@github.com/...`).
+ */
+export interface GitHubOAuthCredential {
+  /** The `gho_*` token returned by GitHub's `/login/oauth/access_token`. */
+  access_token: string;
+  /** Scope string GitHub granted (typically "repo"). */
+  scope: string;
+  /** ISO timestamp captured at the moment we saved the token. */
+  authorized_at: string;
+  /** GitHub login (`@octocat`). */
+  user_login: string;
+  /** GitHub numeric user id — stable across login renames. */
+  user_id: number;
+}
+
+/**
+ * Personal Access Token fallback. The operator pastes both the token AND
+ * the remote URL — vault doesn't try to guess one from the other (GitHub
+ * uses `https://x-access-token:<token>@github.com/...`, GitLab uses
+ * `https://oauth2:<token>@gitlab.com/...`, etc., and there's no generic
+ * rule). The stored URL is what gets set as the mirror's remote.
+ */
+export interface PATCredential {
+  /** Bearer token (ghp_*, glpat-*, etc.). */
+  token: string;
+  /**
+   * Full HTTPS remote URL with auth embedded, e.g.
+   * `https://x-access-token:ghp_abc@github.com/owner/repo.git`. The operator
+   * supplies this; we don't synthesize.
+   */
+  remote_url: string;
+  /** Operator-visible label, e.g. "GitHub PAT for backup". */
+  label: string;
+}
+
+/**
+ * The on-disk + on-the-wire shape. One file per vault server (matches the
+ * "one mirror per vault server today" invariant from mirror-config.ts).
+ */
+export interface MirrorCredentials {
+  /**
+   * Which credential method is active. Read paths check this; if null the
+   * mirror runs with no embedded credentials (bare `git push` inherits
+   * the shell — back-compat with pre-PR operators).
+   */
+  active_method: ActiveMethod;
+  github_oauth: GitHubOAuthCredential | null;
+  pat: PATCredential | null;
+}
+
+/**
+ * Redacted view of credentials, safe for logs / API responses. Masks tokens
+ * to first-4 + last-4 chars; preserves user metadata so the operator can
+ * verify "yes, this is the right account/repo" without re-authenticating.
+ */
+export interface MirrorCredentialsPublic {
+  active_method: ActiveMethod;
+  github_oauth: {
+    user_login: string;
+    user_id: number;
+    scope: string;
+    authorized_at: string;
+    token_preview: string;
+  } | null;
+  pat: {
+    label: string;
+    remote_url: string;
+    token_preview: string;
+  } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Path to the per-vault-server credentials file.
+ *
+ * Note: this is a SERVER-wide credentials file (`<configDir>/vault/.mirror-credentials.yaml`),
+ * not a per-vault file. The mirror manager itself is server-wide (one mirror
+ * per vault server today) so the credentials follow that scope. When multi-
+ * vault mirroring lands (open question 2 in the design doc), this becomes
+ * per-vault and gets keyed by name. Today's shape: one file.
+ *
+ * Path resolution mirrors `config.ts:vaultHomePath()` — re-reads
+ * `PARACHUTE_HOME` on every call so test sandboxes (`PARACHUTE_VAULT_HOME`
+ * is a vault-internal var that doesn't override here — we use the canonical
+ * `PARACHUTE_HOME` that the rest of vault honors).
+ */
+export function mirrorCredentialsPath(): string {
+  const root = process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
+  return join(root, "vault", ".mirror-credentials.yaml");
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/** Empty credentials — what readCredentials returns when the file is absent. */
+export function emptyCredentials(): MirrorCredentials {
+  return {
+    active_method: null,
+    github_oauth: null,
+    pat: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// YAML — hand-rolled to match the pattern in mirror-config.ts. No new dep.
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize credentials as YAML. Keeps the file hand-editable for operators
+ * who want to rotate a token by `vim`-ing the file.
+ *
+ * Format:
+ *
+ *   active_method: github_oauth
+ *   github_oauth:
+ *     access_token: gho_...
+ *     scope: repo
+ *     authorized_at: 2026-05-28T03:14:15.000Z
+ *     user_login: aaron
+ *     user_id: 12345
+ *   pat:
+ *     token: ghp_...
+ *     remote_url: https://github.com/aaron/my-vault.git
+ *     label: "GitHub PAT"
+ */
+export function serializeCredentials(creds: MirrorCredentials): string {
+  const lines: string[] = [];
+  lines.push(`active_method: ${creds.active_method === null ? "null" : creds.active_method}`);
+  if (creds.github_oauth) {
+    lines.push("github_oauth:");
+    lines.push(`  access_token: ${quoteIfNeeded(creds.github_oauth.access_token)}`);
+    lines.push(`  scope: ${quoteIfNeeded(creds.github_oauth.scope)}`);
+    lines.push(`  authorized_at: ${quoteIfNeeded(creds.github_oauth.authorized_at)}`);
+    lines.push(`  user_login: ${quoteIfNeeded(creds.github_oauth.user_login)}`);
+    lines.push(`  user_id: ${creds.github_oauth.user_id}`);
+  } else {
+    lines.push("github_oauth: null");
+  }
+  if (creds.pat) {
+    lines.push("pat:");
+    lines.push(`  token: ${quoteIfNeeded(creds.pat.token)}`);
+    lines.push(`  remote_url: ${quoteIfNeeded(creds.pat.remote_url)}`);
+    lines.push(`  label: ${quoteIfNeeded(creds.pat.label)}`);
+  } else {
+    lines.push("pat: null");
+  }
+  return lines.join("\n") + "\n";
+}
+
+/** Quote a YAML scalar when it contains characters that confuse parsers. */
+function quoteIfNeeded(value: string): string {
+  if (/[:#"'\\]/.test(value) || value.trim() !== value || value.length === 0) {
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+/** Parse a YAML scalar that may be quoted; otherwise return the trimmed value. */
+function parseScalar(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+  return trimmed;
+}
+
+/**
+ * Parse the credentials YAML file. Lenient — unknown fields ignored, missing
+ * blocks default to null. Returns `emptyCredentials()` if the file is empty
+ * or contains nothing recognized.
+ */
+export function parseCredentials(yaml: string): MirrorCredentials {
+  const result = emptyCredentials();
+  const lines = yaml.split("\n");
+  let section: "github_oauth" | "pat" | null = null;
+  // Buffer per-section scalars so we can validate as a block before commit.
+  let oauth: Partial<GitHubOAuthCredential> = {};
+  let pat: Partial<PATCredential> = {};
+
+  const commitSection = () => {
+    if (section === "github_oauth") {
+      if (
+        oauth.access_token &&
+        oauth.scope !== undefined &&
+        oauth.authorized_at &&
+        oauth.user_login &&
+        typeof oauth.user_id === "number"
+      ) {
+        result.github_oauth = oauth as GitHubOAuthCredential;
+      }
+      oauth = {};
+    } else if (section === "pat") {
+      if (pat.token && pat.remote_url && pat.label !== undefined) {
+        result.pat = pat as PATCredential;
+      }
+      pat = {};
+    }
+  };
+
+  for (const line of lines) {
+    if (line.match(/^\s*$/)) continue;
+
+    // Top-level scalars / section headers.
+    if (line.match(/^\S/)) {
+      // Close the previous section before starting a new one.
+      commitSection();
+      section = null;
+      const activeMatch = line.match(/^active_method:\s*(.*)$/);
+      if (activeMatch) {
+        const v = parseScalar(activeMatch[1]!);
+        if (v === "github_oauth" || v === "pat") result.active_method = v;
+        else result.active_method = null;
+        continue;
+      }
+      if (line.match(/^github_oauth:\s*null\s*$/)) {
+        result.github_oauth = null;
+        continue;
+      }
+      if (line.match(/^pat:\s*null\s*$/)) {
+        result.pat = null;
+        continue;
+      }
+      if (line.match(/^github_oauth:\s*$/)) {
+        section = "github_oauth";
+        continue;
+      }
+      if (line.match(/^pat:\s*$/)) {
+        section = "pat";
+        continue;
+      }
+      continue;
+    }
+
+    // Indented section field.
+    const fieldMatch = line.match(/^\s+(\w+):\s*(.*)$/);
+    if (!fieldMatch) continue;
+    const [, key, rawVal] = fieldMatch;
+    if (section === "github_oauth") {
+      if (key === "access_token") oauth.access_token = parseScalar(rawVal!);
+      else if (key === "scope") oauth.scope = parseScalar(rawVal!);
+      else if (key === "authorized_at") oauth.authorized_at = parseScalar(rawVal!);
+      else if (key === "user_login") oauth.user_login = parseScalar(rawVal!);
+      else if (key === "user_id") {
+        const n = Number(parseScalar(rawVal!));
+        if (Number.isFinite(n)) oauth.user_id = n;
+      }
+    } else if (section === "pat") {
+      if (key === "token") pat.token = parseScalar(rawVal!);
+      else if (key === "remote_url") pat.remote_url = parseScalar(rawVal!);
+      else if (key === "label") pat.label = parseScalar(rawVal!);
+    }
+  }
+
+  commitSection();
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * Read credentials from disk. Returns `null` when the file doesn't exist
+ * (operator hasn't connected anything yet); throws when the file is present
+ * but unreadable (a permission error is a loud configuration problem).
+ */
+export function readCredentials(): MirrorCredentials | null {
+  const path = mirrorCredentialsPath();
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, "utf8");
+  return parseCredentials(raw);
+}
+
+/**
+ * Persist credentials atomically:
+ *   1. Write to `<path>.tmp` with perms 0600 (write + read by owner only).
+ *   2. Rename onto the final path (atomic on POSIX; mostly atomic on Windows).
+ *   3. Re-apply 0600 perms in case the rename clobbered them (defense in
+ *      depth — `mv` shouldn't alter perms, but the test surface is wide).
+ *
+ * Fails loudly: any errno propagates. Callers (the route handler) catch +
+ * surface a 500 with the underlying message — quietly losing credentials
+ * would be worse than crashing the request.
+ */
+export function writeCredentials(creds: MirrorCredentials): void {
+  const path = mirrorCredentialsPath();
+  const dir = dirname(path);
+  // Vault home may not exist yet (tests, fresh installs); create it.
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmp = `${path}.tmp`;
+  const serialized = serializeCredentials(creds);
+  writeFileSync(tmp, serialized, { mode: 0o600 });
+  // Belt-and-braces: writeFileSync's `mode` is only honored on file
+  // CREATION. If the temp file already existed (interrupted prior write),
+  // the existing perms persist. Re-chmod to be sure.
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, path);
+  // Some filesystems preserve the old file's perms across rename; force
+  // 0600 on the final path. No-op on the common case.
+  chmodSync(path, 0o600);
+
+  // Defensive verification — if the perms are wrong on disk, throw so the
+  // caller surfaces the misconfiguration to the operator. A world-readable
+  // credentials file would silently leak the OAuth token.
+  const stat = statSync(path);
+  const perms = stat.mode & 0o777;
+  if (perms !== 0o600) {
+    throw new Error(
+      `Mirror credentials file at ${path} has perms ${perms.toString(8)}, expected 0600. Refusing to leave a world-readable token on disk.`,
+    );
+  }
+}
+
+/**
+ * Delete the credentials file. Idempotent — missing file is a no-op (the
+ * Disconnect UX should succeed even if the file was already removed).
+ */
+export function deleteCredentials(): void {
+  const path = mirrorCredentialsPath();
+  if (existsSync(path)) unlinkSync(path);
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Mask a token to first-4 + last-4 chars with a fixed-width middle. Designed
+ * to be safe to log + display in the UI's status section (operator can verify
+ * "yes, this is the token I authorized" without revealing the secret).
+ *
+ * Short tokens (< 12 chars) get fully masked rather than partially revealed
+ * — anything that short isn't a real production token, but defense in depth
+ * costs nothing.
+ */
+export function previewToken(token: string): string {
+  if (token.length < 12) return "***";
+  return `${token.slice(0, 4)}…${token.slice(-4)}`;
+}
+
+/**
+ * Produce a redacted view of credentials. Use this anywhere credentials
+ * leave the trust boundary — logs, HTTP responses, UI state. The full
+ * shape lives only in memory + on disk.
+ */
+export function sanitizeCredentials(
+  creds: MirrorCredentials | null,
+): MirrorCredentialsPublic {
+  if (!creds) {
+    return { active_method: null, github_oauth: null, pat: null };
+  }
+  return {
+    active_method: creds.active_method,
+    github_oauth: creds.github_oauth
+      ? {
+          user_login: creds.github_oauth.user_login,
+          user_id: creds.github_oauth.user_id,
+          scope: creds.github_oauth.scope,
+          authorized_at: creds.github_oauth.authorized_at,
+          token_preview: previewToken(creds.github_oauth.access_token),
+        }
+      : null,
+    pat: creds.pat
+      ? {
+          label: creds.pat.label,
+          remote_url: redactRemoteUrl(creds.pat.remote_url),
+          token_preview: previewToken(creds.pat.token),
+        }
+      : null,
+  };
+}
+
+/**
+ * Mask the userinfo portion of a remote URL — the operator might have
+ * pasted `https://user:token@host/...` and we don't want the raw token
+ * leaking via the redacted view. Returns the URL with `user:***@` swapped
+ * in for the entire userinfo, leaving the host + path intact.
+ */
+export function redactRemoteUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.username || u.password) {
+      u.username = "***";
+      u.password = "";
+      return u.toString();
+    }
+    return url;
+  } catch {
+    // Non-URL string — return a generic placeholder.
+    return "***";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Git remote URL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the HTTPS remote URL with an embedded GitHub OAuth token for `owner/repo`.
+ *
+ *   https://x-access-token:<TOKEN>@github.com/<owner>/<repo>.git
+ *
+ * The `x-access-token` username convention is GitHub-specific. PATs work
+ * through the same shape (GitHub treats `gho_*` and `ghp_*` identically at
+ * the credential-helper layer); GitLab / Codeberg use different conventions,
+ * so the PAT path stores the full URL operator-supplied rather than
+ * synthesizing.
+ */
+export function githubAuthedRemoteUrl(
+  token: string,
+  owner: string,
+  repo: string,
+): string {
+  // GitHub repo names allow `.`, `-`, `_`. URL-escape just in case
+  // someone has a weird name; the path-component encoder is too aggressive
+  // here (it would escape `.`), so we trust GitHub's naming rules.
+  return `https://x-access-token:${token}@github.com/${owner}/${repo}.git`;
+}
+
+/**
+ * Set the embedded-credential remote URL on a mirror repo's git config.
+ *
+ * Idempotent: calling on an already-configured remote replaces the URL
+ * (which is what we want — token rotation should "just work" when the
+ * stored credentials update). Adds the remote if it doesn't exist; updates
+ * it if it does.
+ *
+ * **Logs are scrubbed.** We never log the URL itself (it carries the
+ * token). We log a redacted form via `redactRemoteUrl` instead.
+ */
+export async function applyToGitRemote(
+  repoDir: string,
+  remoteUrl: string,
+): Promise<{ ok: boolean; error?: string }> {
+  // Probe for an existing `origin`. `git remote get-url origin` returns
+  // exit 0 if it exists, non-zero otherwise.
+  const probe = Bun.spawn(["git", "remote", "get-url", "origin"], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const probeCode = await probe.exited;
+  const verb = probeCode === 0 ? "set-url" : "add";
+  const cmd =
+    verb === "set-url"
+      ? ["git", "remote", "set-url", "origin", remoteUrl]
+      : ["git", "remote", "add", "origin", remoteUrl];
+  const proc = Bun.spawn(cmd, {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = new TextDecoder()
+      .decode(await new Response(proc.stderr).arrayBuffer())
+      .trim();
+    return { ok: false, error: stderr };
+  }
+  return { ok: true };
+}
+
+/**
+ * Remove the embedded-credential remote (when credentials are cleared).
+ * Idempotent: missing remote is fine — the operator might never have had
+ * one set up.
+ */
+export async function unsetGitRemote(
+  repoDir: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const probe = Bun.spawn(["git", "remote", "get-url", "origin"], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const probeCode = await probe.exited;
+  if (probeCode !== 0) return { ok: true }; // nothing to unset
+  const proc = Bun.spawn(["git", "remote", "remove", "origin"], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = new TextDecoder()
+      .decode(await new Response(proc.stderr).arrayBuffer())
+      .trim();
+    return { ok: false, error: stderr };
+  }
+  return { ok: true };
+}

--- a/src/mirror-credentials.ts
+++ b/src/mirror-credentials.ts
@@ -215,10 +215,21 @@ export function serializeCredentials(creds: MirrorCredentials): string {
   return lines.join("\n") + "\n";
 }
 
-/** Quote a YAML scalar when it contains characters that confuse parsers. */
+/**
+ * Quote a YAML scalar when it contains characters that confuse parsers.
+ * `gho_*` / `ghp_*` tokens never carry newlines or special chars, but the
+ * operator-supplied `label` field has no such guarantee — a label with a
+ * literal `\n` would break the parser's per-line section logic. Escape
+ * newlines + carriage returns + backslash + quote inside the quoted form.
+ * Reviewer-flagged on vault#384.
+ */
 function quoteIfNeeded(value: string): string {
-  if (/[:#"'\\]/.test(value) || value.trim() !== value || value.length === 0) {
-    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  if (/[:#"'\\\n\r]/.test(value) || value.trim() !== value || value.length === 0) {
+    return `"${value
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, "\\n")
+      .replace(/\r/g, "\\r")}"`;
   }
   return value;
 }
@@ -227,7 +238,12 @@ function quoteIfNeeded(value: string): string {
 function parseScalar(raw: string): string {
   const trimmed = raw.trim();
   if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
-    return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+    return trimmed
+      .slice(1, -1)
+      .replace(/\\n/g, "\n")
+      .replace(/\\r/g, "\r")
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, "\\");
   }
   return trimmed;
 }

--- a/src/mirror-manager.ts
+++ b/src/mirror-manager.ts
@@ -70,6 +70,10 @@ import {
   runGitCommitCycle,
 } from "./export-watch.ts";
 import { vaultDir } from "./config.ts";
+import {
+  applyToGitRemote,
+  readCredentials,
+} from "./mirror-credentials.ts";
 import type { HookRegistry } from "../core/src/hooks.ts";
 
 /**
@@ -285,6 +289,24 @@ export async function bootstrapInternalMirror(
 // ---------------------------------------------------------------------------
 
 /**
+ * Read the current `origin` URL from a git repo's config, or null when no
+ * origin is set. Module-local helper for the credential-application path.
+ */
+async function readCurrentOrigin(repoDir: string): Promise<string | null> {
+  const proc = Bun.spawn(["git", "remote", "get-url", "origin"], {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) return null;
+  const url = new TextDecoder()
+    .decode(await new Response(proc.stdout).arrayBuffer())
+    .trim();
+  return url.length > 0 ? url : null;
+}
+
+/**
  * Singleton lifecycle controller. Holds the active mirror config, the
  * resolved path, hook subscriptions (when sync_mode=events), the
  * safety-net poll timer, the debounce timer, and the rolling status.
@@ -423,6 +445,16 @@ export class MirrorManager {
 
     this.status.enabled = true;
     this.status.last_error = null;
+
+    // Apply UI-configured credentials to the mirror's git remote, if any.
+    // The PAT path stores the full authed URL; we set it as `origin`.
+    // The GitHub OAuth path only sets `origin` when the operator has
+    // picked a repo (handleAuthGithubSelectRepo writes it then); on a
+    // restart with credentials present but no repo picked yet, this is
+    // a no-op. Failures are non-fatal — the operator's mirror still
+    // exports; they get the original "push needs credentials" feedback
+    // when auto_push fires.
+    await this.applyCredentialsToRemote(path);
 
     // Initial export — full pass (no cursor) so the mirror starts
     // byte-equivalent to current vault state, regardless of when the
@@ -782,6 +814,74 @@ export class MirrorManager {
       await shaProc.exited;
       const sha = new TextDecoder().decode(await new Response(shaProc.stdout).arrayBuffer()).trim();
       if (sha.length > 0) this.status.last_commit_sha = sha;
+    }
+  }
+
+  /**
+   * Apply UI-configured credentials to the mirror dir's `origin`. Called
+   * on every start()/reload() so credential rotations land without
+   * requiring a server restart. Idempotent:
+   *   - active_method=pat → set origin to the stored authed URL
+   *   - active_method=github_oauth + a picked repo → set origin (the
+   *     pick path stores the authed URL in the same flow)
+   *   - active_method=github_oauth + no repo picked → no-op (UI is mid-
+   *     flow)
+   *   - no credentials at all → leave whatever the operator wired by
+   *     hand alone (don't clobber a manually-set remote)
+   *
+   * Never throws — push failures will surface via the existing
+   * non-fatal-warn path in runGitCommitCycle.
+   */
+  private async applyCredentialsToRemote(repoDir: string): Promise<void> {
+    try {
+      const creds = readCredentials();
+      if (!creds || !creds.active_method) {
+        // No UI-configured credentials. Leave the remote alone — the
+        // operator may have set one up via `git remote add` manually.
+        return;
+      }
+      if (creds.active_method === "pat" && creds.pat) {
+        const result = await applyToGitRemote(repoDir, creds.pat.remote_url);
+        if (!result.ok) {
+          console.warn(
+            `[mirror] could not apply PAT remote URL (non-fatal): ${result.error}`,
+          );
+        }
+        return;
+      }
+      // github_oauth: the active token is set, but a repo may not yet be
+      // picked. The select-repo route handler writes the URL; on a
+      // subsequent restart we can't reconstruct the URL without the
+      // owner/repo. Best-effort: if `origin` already points at a github.com
+      // URL, rewrite it with the stored token in case the token rotated.
+      if (creds.active_method === "github_oauth" && creds.github_oauth) {
+        const current = await readCurrentOrigin(repoDir);
+        if (current && current.includes("github.com")) {
+          // Parse owner/repo out of the current URL.
+          const match = current.match(
+            /github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?$/,
+          );
+          if (match) {
+            const [, owner, repo] = match;
+            const { githubAuthedRemoteUrl } = await import("./mirror-credentials.ts");
+            const authed = githubAuthedRemoteUrl(
+              creds.github_oauth.access_token,
+              owner!,
+              repo!,
+            );
+            const result = await applyToGitRemote(repoDir, authed);
+            if (!result.ok) {
+              console.warn(
+                `[mirror] could not refresh github_oauth remote URL (non-fatal): ${result.error}`,
+              );
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.warn(
+        `[mirror] credential application failed (non-fatal): ${(err as Error).message ?? err}`,
+      );
     }
   }
 

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -17,10 +17,25 @@ import {
   type MirrorDeps,
 } from "./mirror-manager.ts";
 import {
+  _resetDeviceFlowSessionsForTest,
+  handleAuthDelete,
+  handleAuthGet,
+  handleAuthGithubCreateRepo,
+  handleAuthGithubDeviceCode,
+  handleAuthGithubPoll,
+  handleAuthGithubRepos,
+  handleAuthPat,
   handleMirrorGet,
   handleMirrorPut,
   handleMirrorRunNow,
 } from "./mirror-routes.ts";
+import {
+  mirrorCredentialsPath,
+  readCredentials,
+  writeCredentials,
+  type MirrorCredentials,
+} from "./mirror-credentials.ts";
+import type { FetchLike } from "./github-device-flow.ts";
 
 // Same env-restore pattern as mirror-manager.test.ts — keeps HOME +
 // PARACHUTE_HOME from leaking between test files.
@@ -436,3 +451,400 @@ describe("handleMirrorRunNow", () => {
     await manager.stop();
   });
 });
+
+// ---------------------------------------------------------------------------
+// /.parachute/mirror/auth/* — credential routes (Cut 3)
+//
+// These routes back the SPA's "Connect GitHub" / "Use PAT" / "Disconnect"
+// flows. The route layer is tested in isolation: we inject a mock fetch
+// so GitHub's API calls don't go over the wire, point PARACHUTE_HOME at
+// a tempdir so credentials writes don't touch real operator state, and
+// drive the routes via the same Request/Response API the live router
+// uses.
+// ---------------------------------------------------------------------------
+
+function buildMockFetch(
+  responses: Array<{ match: (u: string) => boolean; body: unknown; status?: number }>,
+): FetchLike {
+  let idx = 0;
+  return async (url) => {
+    for (let i = idx; i < responses.length; i++) {
+      if (responses[i]!.match(url)) {
+        idx = i + 1;
+        const r = responses[i]!;
+        return {
+          ok: (r.status ?? 200) >= 200 && (r.status ?? 200) < 300,
+          status: r.status ?? 200,
+          text: async () => (typeof r.body === "string" ? r.body : JSON.stringify(r.body)),
+          json: async () => r.body,
+        };
+      }
+    }
+    throw new Error(`mockFetch: no matching response for ${url}`);
+  };
+}
+
+describe("auth credential routes — GET /auth", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    _resetDeviceFlowSessionsForTest();
+  });
+
+  test("returns fully-null sanitized shape when no credentials stored", async () => {
+    home = tmp("mirror-auth-empty-");
+    makeManager(home);
+    const res = handleAuthGet();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { active_method: null; github_oauth: null; pat: null };
+    expect(body.active_method).toBeNull();
+    expect(body.github_oauth).toBeNull();
+    expect(body.pat).toBeNull();
+  });
+
+  test("returns sanitized shape when github_oauth credentials present (no token leaks)", async () => {
+    home = tmp("mirror-auth-oauth-");
+    makeManager(home);
+    const creds: MirrorCredentials = {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_secret123456789",
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    };
+    writeCredentials(creds);
+    const res = handleAuthGet();
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain("gho_secret");
+    const body = JSON.parse(text) as { github_oauth: { user_login: string; token_preview: string } };
+    expect(body.github_oauth.user_login).toBe("aaron");
+    expect(body.github_oauth.token_preview).toBe("gho_…6789");
+  });
+});
+
+describe("auth credential routes — DELETE /auth", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    _resetDeviceFlowSessionsForTest();
+  });
+
+  test("wipes credentials from disk", async () => {
+    home = tmp("mirror-auth-delete-");
+    const { manager } = makeManager(home);
+    writeCredentials({
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        token: "ghp_xxxxxxxxxxxxxxxxxxxx",
+        remote_url: "https://github.com/a/b.git",
+        label: "test",
+      },
+    });
+    expect(fs.existsSync(mirrorCredentialsPath())).toBe(true);
+    const res = await handleAuthDelete(manager);
+    expect(res.status).toBe(200);
+    expect(fs.existsSync(mirrorCredentialsPath())).toBe(false);
+  });
+
+  test("idempotent — missing credentials file still 200", async () => {
+    home = tmp("mirror-auth-delete-empty-");
+    const { manager } = makeManager(home);
+    const res = await handleAuthDelete(manager);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("auth credential routes — device flow", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    _resetDeviceFlowSessionsForTest();
+    delete process.env.PARACHUTE_GITHUB_CLIENT_ID;
+  });
+
+  test("device-code returns 503 with placeholder client_id (no env override)", async () => {
+    home = tmp("mirror-auth-placeholder-");
+    makeManager(home);
+    delete process.env.PARACHUTE_GITHUB_CLIENT_ID;
+    const res = await handleAuthGithubDeviceCode();
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error_type: string };
+    expect(body.error_type).toBe("placeholder_client_id");
+  });
+
+  test("poll without polling_id returns 400", async () => {
+    home = tmp("mirror-auth-poll-bad-");
+    const { manager } = makeManager(home);
+    process.env.PARACHUTE_GITHUB_CLIENT_ID = "Iv1.real";
+    const req = new Request("http://x/auth/github/poll", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    const res = await handleAuthGithubPoll(req, manager);
+    expect(res.status).toBe(400);
+  });
+
+  test("poll with unknown polling_id returns 404 with expired state", async () => {
+    home = tmp("mirror-auth-poll-unknown-");
+    const { manager } = makeManager(home);
+    process.env.PARACHUTE_GITHUB_CLIENT_ID = "Iv1.real";
+    const req = new Request("http://x/auth/github/poll", {
+      method: "POST",
+      body: JSON.stringify({ polling_id: "nonexistent" }),
+    });
+    const res = await handleAuthGithubPoll(req, manager);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { state: string };
+    expect(body.state).toBe("expired");
+  });
+
+  test("full device flow with mocked fetch — code → granted → user → credentials saved", async () => {
+    home = tmp("mirror-auth-flow-");
+    const { manager } = makeManager(home);
+    process.env.PARACHUTE_GITHUB_CLIENT_ID = "Iv1.real";
+
+    // device-code request
+    const fetchA = buildMockFetch([
+      {
+        match: (u) => u.includes("/login/device/code"),
+        body: {
+          device_code: "dev_xyz",
+          user_code: "ABCD-1234",
+          verification_uri: "https://github.com/login/device",
+          expires_in: 900,
+          interval: 5,
+        },
+      },
+    ]);
+    const codeRes = await handleAuthGithubDeviceCode(fetchA);
+    expect(codeRes.status).toBe(200);
+    const codeBody = (await codeRes.json()) as { polling_id: string; user_code: string };
+    expect(codeBody.user_code).toBe("ABCD-1234");
+    // device_code MUST NOT leak in the response.
+    expect(JSON.stringify(codeBody)).not.toContain("dev_xyz");
+    const polling_id = codeBody.polling_id;
+    expect(polling_id.length).toBeGreaterThan(0);
+
+    // poll once — pending
+    const fetchPending = buildMockFetch([
+      {
+        match: () => true,
+        body: { error: "authorization_pending" },
+      },
+    ]);
+    const pendingRes = await handleAuthGithubPoll(
+      new Request("http://x/poll", { method: "POST", body: JSON.stringify({ polling_id }) }),
+      manager,
+      fetchPending,
+    );
+    expect(pendingRes.status).toBe(200);
+    const pendingBody = (await pendingRes.json()) as { state: string };
+    expect(pendingBody.state).toBe("pending");
+
+    // poll once — granted, fetch user, save credentials
+    const fetchGranted = buildMockFetch([
+      {
+        match: (u) => u.includes("/login/oauth/access_token"),
+        body: { access_token: "gho_real1234567890", scope: "repo", token_type: "bearer" },
+      },
+      {
+        match: (u) => u.includes("/user"),
+        body: { login: "aaron", id: 12345, name: "Aaron G", avatar_url: "https://x/y.png" },
+      },
+    ]);
+    const grantRes = await handleAuthGithubPoll(
+      new Request("http://x/poll", { method: "POST", body: JSON.stringify({ polling_id }) }),
+      manager,
+      fetchGranted,
+    );
+    expect(grantRes.status).toBe(200);
+    const grantBody = (await grantRes.json()) as {
+      state: string;
+      user: { login: string; id: number };
+    };
+    expect(grantBody.state).toBe("granted");
+    expect(grantBody.user.login).toBe("aaron");
+    expect(grantBody.user.id).toBe(12345);
+    // Credentials persisted; no token leak in response.
+    expect(JSON.stringify(grantBody)).not.toContain("gho_real");
+    const saved = readCredentials();
+    expect(saved?.active_method).toBe("github_oauth");
+    expect(saved?.github_oauth?.access_token).toBe("gho_real1234567890");
+    expect(saved?.github_oauth?.user_login).toBe("aaron");
+  });
+});
+
+describe("auth credential routes — PAT", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("rejects missing token with 400", async () => {
+    home = tmp("mirror-auth-pat-notoken-");
+    const { manager } = makeManager(home);
+    const res = await handleAuthPat(
+      new Request("http://x/pat", {
+        method: "POST",
+        body: JSON.stringify({ remote_url: "https://github.com/a/b.git" }),
+      }),
+      manager,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { field: string };
+    expect(body.field).toBe("token");
+  });
+
+  test("rejects missing remote_url with 400", async () => {
+    home = tmp("mirror-auth-pat-nourl-");
+    const { manager } = makeManager(home);
+    const res = await handleAuthPat(
+      new Request("http://x/pat", {
+        method: "POST",
+        body: JSON.stringify({ token: "ghp_x" }),
+      }),
+      manager,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { field: string };
+    expect(body.field).toBe("remote_url");
+  });
+
+  test("rejects non-HTTPS remote_url (SSH/file URLs not yet supported)", async () => {
+    home = tmp("mirror-auth-pat-ssh-");
+    const { manager } = makeManager(home);
+    const res = await handleAuthPat(
+      new Request("http://x/pat", {
+        method: "POST",
+        body: JSON.stringify({
+          token: "ghp_x",
+          remote_url: "git@github.com:owner/repo.git",
+        }),
+      }),
+      manager,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("probe-fail returns 400 with redacted error message (no token leak)", async () => {
+    // Probe against a definitely-not-real domain. We bypass the network
+    // path via a token that should cause `git ls-remote` to fail
+    // immediately. The interesting assertion is "the error message we
+    // surface back doesn't include the token literal".
+    home = tmp("mirror-auth-pat-probefail-");
+    const { manager } = makeManager(home);
+    const secret = "ghp_definitelynotvalidatall1234567890";
+    const res = await handleAuthPat(
+      new Request("http://x/pat", {
+        method: "POST",
+        body: JSON.stringify({
+          token: secret,
+          remote_url: "https://nonexistent.parachute.test/owner/repo.git",
+        }),
+      }),
+      manager,
+    );
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).not.toContain(secret);
+  }, 20_000);
+});
+
+describe("auth credential routes — github repos / create-repo", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("repos returns 400 when not connected to GitHub", async () => {
+    home = tmp("mirror-auth-repos-noauth-");
+    makeManager(home);
+    const res = await handleAuthGithubRepos();
+    expect(res.status).toBe(400);
+  });
+
+  test("repos returns list when authed", async () => {
+    home = tmp("mirror-auth-repos-ok-");
+    makeManager(home);
+    writeCredentials({
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_test1234567890",
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/repos"),
+        body: [
+          {
+            name: "a",
+            full_name: "aaron/a",
+            private: true,
+            html_url: "https://github.com/aaron/a",
+            description: null,
+            updated_at: "2026-05-28T00:00:00Z",
+            clone_url: "https://github.com/aaron/a.git",
+            owner: { login: "aaron" },
+          },
+        ],
+      },
+    ]);
+    const res = await handleAuthGithubRepos(fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { repos: Array<{ full_name: string }> };
+    expect(body.repos).toHaveLength(1);
+    expect(body.repos[0]!.full_name).toBe("aaron/a");
+  });
+
+  test("create-repo proxies through with mocked fetch", async () => {
+    home = tmp("mirror-auth-create-repo-");
+    makeManager(home);
+    writeCredentials({
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_test1234567890",
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/repos"),
+        status: 201,
+        body: {
+          name: "new-vault",
+          full_name: "aaron/new-vault",
+          private: true,
+          html_url: "https://github.com/aaron/new-vault",
+          description: "x",
+          updated_at: "2026-05-28T00:00:00Z",
+          clone_url: "https://github.com/aaron/new-vault.git",
+          owner: { login: "aaron" },
+        },
+      },
+    ]);
+    const req = new Request("http://x/create", {
+      method: "POST",
+      body: JSON.stringify({ name: "new-vault" }),
+    });
+    const res = await handleAuthGithubCreateRepo(req, fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { full_name: string };
+    expect(body.full_name).toBe("aaron/new-vault");
+  });
+});
+

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -598,6 +598,19 @@ export async function handleAuthPat(
 
 /**
  * Run `git ls-remote <url>` with a hard timeout, no interactive prompts.
+ *
+ * Threat-model note (reviewer-flagged on vault#384):
+ *   The URL passed here contains the user's token in userinfo position
+ *   (`https://x-access-token:<TOKEN>@host/repo.git`). On Linux that means
+ *   the token sits in `/proc/<pid>/cmdline` for the ~10s probe window,
+ *   readable by any process running as another UID with default perms.
+ *   For vault's threat model (owner-operated, single-user self-host) this
+ *   is acceptable — anyone with shell on the box already has read access
+ *   to `~/.parachute/vault/.mirror-credentials.yaml` (0600) and
+ *   `<mirror>/.git/config` (0644). Same posture as `~/.git-credentials`
+ *   and `~/.netrc`. If we ever ship multi-tenant vault (cloud Tier 2)
+ *   this needs to switch to env-based auth via a credential helper script
+ *   so the token never enters argv.
  */
 async function probeGitLsRemote(
   url: string,

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -31,6 +31,27 @@ import {
   type MirrorConfig,
 } from "./mirror-config.ts";
 import type { MirrorManager } from "./mirror-manager.ts";
+import {
+  applyToGitRemote,
+  deleteCredentials,
+  emptyCredentials,
+  readCredentials,
+  sanitizeCredentials,
+  unsetGitRemote,
+  writeCredentials,
+  type MirrorCredentials,
+} from "./mirror-credentials.ts";
+import {
+  createRepo,
+  fetchUser,
+  getGithubClientId,
+  isPlaceholderClientId,
+  listRepos,
+  pollForToken,
+  requestDeviceCode,
+  type FetchLike,
+  type GitHubRepoInfo,
+} from "./github-device-flow.ts";
 
 /**
  * `GET /vault/<name>/.parachute/mirror` — return the persisted config +
@@ -191,4 +212,652 @@ export function buildMirrorGetResponse(
     config: config ?? defaultMirrorConfig(),
     status,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Credential routes — Cut 3 of the UI-configurable push credentials work.
+//
+// Six surfaces, all `vault:<name>:admin`-gated upstream:
+//
+//   POST   /.parachute/mirror/auth/github/device-code  — start GitHub Device
+//          Flow; returns { polling_id, user_code, verification_uri, expires_in,
+//          interval }. The full device_code is kept server-side; the SPA polls
+//          by polling_id (a short opaque token) so the device_code doesn't
+//          land on the wire twice.
+//   POST   /.parachute/mirror/auth/github/poll         — poll for token, body
+//          { polling_id }. On `granted`: fetch user, save credentials, set
+//          remote URL, return { state: "granted", user }. Other states
+//          surface verbatim.
+//   POST   /.parachute/mirror/auth/pat                 — validate + store a
+//          PAT (token + remote_url + label). Validates via `git ls-remote`.
+//   GET    /.parachute/mirror/auth                     — current connection
+//          status (NO secrets). Returns the sanitized public shape.
+//   DELETE /.parachute/mirror/auth                     — wipe credentials,
+//          unset embedded-credential remote URL.
+//   GET    /.parachute/mirror/auth/github/repos        — list operator's
+//          GitHub repos via stored OAuth token.
+//   POST   /.parachute/mirror/auth/github/create-repo  — create a new private
+//          repo on behalf of the operator.
+//
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory device-flow polling sessions. Maps a short opaque `polling_id`
+ * to the server-side `device_code` + metadata. Lives in process memory only;
+ * a vault restart blanks them (the operator restarts the flow, no big deal —
+ * the OAuth app's tokens that have already landed in credentials.yaml
+ * survive).
+ *
+ * 15-minute TTL — matches GitHub's default `expires_in` and saves us
+ * leaking polling slots on abandoned flows.
+ */
+interface DeviceFlowSession {
+  device_code: string;
+  client_id: string;
+  expires_at: number; // epoch ms
+  interval: number;
+}
+const deviceFlowSessions = new Map<string, DeviceFlowSession>();
+
+function generatePollingId(): string {
+  // 16 hex chars from crypto. Not a secret (it's just a session-lookup
+  // key) but cryptographic strength keeps two concurrent operators from
+  // ever colliding.
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function reapExpiredSessions(now = Date.now()): void {
+  for (const [k, v] of deviceFlowSessions.entries()) {
+    if (v.expires_at <= now) deviceFlowSessions.delete(k);
+  }
+}
+
+/** Test seam — flush all in-memory sessions. */
+export function _resetDeviceFlowSessionsForTest(): void {
+  deviceFlowSessions.clear();
+}
+
+/**
+ * Errors out cleanly when the operator hasn't replaced the placeholder
+ * client_id. The user-facing message explains the next step.
+ */
+function placeholderClientIdResponse(): Response {
+  return Response.json(
+    {
+      error: "GitHub OAuth not configured",
+      error_type: "placeholder_client_id",
+      message:
+        "This Parachute Vault build doesn't have a registered GitHub OAuth App client_id. Set the PARACHUTE_GITHUB_CLIENT_ID environment variable (see src/github-device-flow.ts for setup steps) or use the Personal Access Token path instead.",
+    },
+    { status: 503 },
+  );
+}
+
+/**
+ * `POST /.parachute/mirror/auth/github/device-code` — kick off the device
+ * flow. Server retains the `device_code`; the SPA gets a short
+ * `polling_id` it uses to poll without re-sending the device_code on
+ * every round-trip.
+ */
+export async function handleAuthGithubDeviceCode(
+  fetchImpl?: FetchLike,
+): Promise<Response> {
+  const clientId = getGithubClientId();
+  if (isPlaceholderClientId(clientId)) {
+    return placeholderClientIdResponse();
+  }
+  let result;
+  try {
+    result = await requestDeviceCode(clientId, fetchImpl);
+  } catch (err) {
+    return Response.json(
+      {
+        error: "Device code request failed",
+        message: (err as Error).message ?? String(err),
+      },
+      { status: 502 },
+    );
+  }
+  reapExpiredSessions();
+  const polling_id = generatePollingId();
+  deviceFlowSessions.set(polling_id, {
+    device_code: result.device_code,
+    client_id: clientId,
+    expires_at: Date.now() + result.expires_in * 1000,
+    interval: result.interval,
+  });
+  return Response.json(
+    {
+      polling_id,
+      user_code: result.user_code,
+      verification_uri: result.verification_uri,
+      expires_in: result.expires_in,
+      interval: result.interval,
+    },
+    { headers: { "Access-Control-Allow-Origin": "*" } },
+  );
+}
+
+/**
+ * `POST /.parachute/mirror/auth/github/poll` — poll for token (body
+ * `{polling_id}`). On `granted`, fetch user, save credentials, return
+ * `{state: "granted", user}`. On `pending`/`slow_down`, return state +
+ * any new interval. On terminal failure, return state + cleanup the
+ * session entry.
+ */
+export async function handleAuthGithubPoll(
+  req: Request,
+  manager: MirrorManager,
+  fetchImpl?: FetchLike,
+): Promise<Response> {
+  let body: { polling_id?: unknown };
+  try {
+    body = (await req.json()) as { polling_id?: unknown };
+  } catch (err) {
+    return Response.json(
+      { error: "Invalid JSON body", message: (err as Error).message ?? String(err) },
+      { status: 400 },
+    );
+  }
+  if (typeof body.polling_id !== "string") {
+    return Response.json(
+      { error: "polling_id required", message: "Pass the polling_id from /auth/github/device-code." },
+      { status: 400 },
+    );
+  }
+  reapExpiredSessions();
+  const session = deviceFlowSessions.get(body.polling_id);
+  if (!session) {
+    return Response.json(
+      {
+        state: "expired",
+        message: "Polling session not found or expired. Start the device flow again.",
+      },
+      { status: 404 },
+    );
+  }
+  let poll;
+  try {
+    poll = await pollForToken(session.client_id, session.device_code, fetchImpl);
+  } catch (err) {
+    return Response.json(
+      {
+        error: "Poll failed",
+        message: (err as Error).message ?? String(err),
+      },
+      { status: 502 },
+    );
+  }
+
+  if (poll.state === "granted") {
+    // Fetch user info to populate credentials.
+    let user;
+    try {
+      user = await fetchUser(poll.access_token, fetchImpl);
+    } catch (err) {
+      return Response.json(
+        {
+          error: "Token granted but /user fetch failed",
+          message: (err as Error).message ?? String(err),
+        },
+        { status: 502 },
+      );
+    }
+    // Persist credentials. Keep any existing PAT — only swap active method.
+    const existing = readCredentials() ?? emptyCredentials();
+    const next: MirrorCredentials = {
+      ...existing,
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: poll.access_token,
+        scope: poll.scope,
+        authorized_at: new Date().toISOString(),
+        user_login: user.login,
+        user_id: user.id,
+      },
+    };
+    try {
+      writeCredentials(next);
+    } catch (err) {
+      return Response.json(
+        {
+          error: "Credentials write failed",
+          message: (err as Error).message ?? String(err),
+        },
+        { status: 500 },
+      );
+    }
+    // Clean up the polling session.
+    deviceFlowSessions.delete(body.polling_id);
+    // Apply to git remote if mirror is currently running on an external
+    // path that's a git repo. The credentials become active on next push;
+    // the operator doesn't have to restart vault. We don't have an owner/
+    // repo yet (the operator hasn't picked a repo) — that wiring happens
+    // in the create-repo or repo-picked path. So at this point we just
+    // store credentials; the URL gets set when the operator picks a repo.
+    return Response.json(
+      {
+        state: "granted",
+        user: {
+          login: user.login,
+          id: user.id,
+          name: user.name,
+          avatar_url: user.avatar_url,
+        },
+      },
+      { headers: { "Access-Control-Allow-Origin": "*" } },
+    );
+  }
+
+  if (poll.state === "expired" || poll.state === "denied") {
+    deviceFlowSessions.delete(body.polling_id);
+  }
+
+  // Pending / slow_down / expired / denied — surface verbatim.
+  const responseBody: Record<string, unknown> = { state: poll.state };
+  if (poll.state === "slow_down") responseBody.interval = poll.interval;
+  return Response.json(responseBody, {
+    headers: { "Access-Control-Allow-Origin": "*" },
+  });
+}
+
+/**
+ * `POST /.parachute/mirror/auth/pat` — store a PAT + remote URL.
+ *
+ * Validation:
+ *   - `token` is a non-empty string.
+ *   - `remote_url` is a non-empty string that parses as an HTTPS URL.
+ *   - `git ls-remote <remote_url>` succeeds with timeout 10s. The token
+ *     can be embedded in the URL or rely on the server's git config —
+ *     we just need git to be able to talk to the remote.
+ *
+ * Probes via `git ls-remote` with GIT_TERMINAL_PROMPT=0 (no interactive
+ * prompts; bad creds fail fast) and a 10-second hard timeout.
+ */
+export async function handleAuthPat(
+  req: Request,
+  manager: MirrorManager,
+): Promise<Response> {
+  let body: { token?: unknown; remote_url?: unknown; label?: unknown };
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch (err) {
+    return Response.json(
+      { error: "Invalid JSON body", message: (err as Error).message ?? String(err) },
+      { status: 400 },
+    );
+  }
+  const token = typeof body.token === "string" ? body.token.trim() : "";
+  const remote_url = typeof body.remote_url === "string" ? body.remote_url.trim() : "";
+  const label =
+    typeof body.label === "string" && body.label.trim().length > 0
+      ? body.label.trim()
+      : "Custom git credential";
+  if (token.length === 0) {
+    return Response.json(
+      {
+        error: "token required",
+        field: "token",
+        message: "Provide a personal access token (e.g. ghp_...).",
+      },
+      { status: 400 },
+    );
+  }
+  if (remote_url.length === 0) {
+    return Response.json(
+      {
+        error: "remote_url required",
+        field: "remote_url",
+        message: "Provide the full HTTPS remote URL (e.g. https://github.com/owner/repo.git).",
+      },
+      { status: 400 },
+    );
+  }
+  // Quick URL shape check.
+  let parsed: URL;
+  try {
+    parsed = new URL(remote_url);
+  } catch {
+    return Response.json(
+      {
+        error: "remote_url invalid",
+        field: "remote_url",
+        message: "remote_url must be a valid URL (https://host/owner/repo.git).",
+      },
+      { status: 400 },
+    );
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return Response.json(
+      {
+        error: "remote_url invalid",
+        field: "remote_url",
+        message: "remote_url must use http:// or https://; SSH remotes need a different flow.",
+      },
+      { status: 400 },
+    );
+  }
+
+  // Validate via `git ls-remote <embedded-auth-url>` — uses the same
+  // x-access-token shape we'd embed at push time so the probe exercises
+  // the actual auth path. If the operator pasted a URL that already has
+  // userinfo, use it verbatim; otherwise embed token via x-access-token.
+  const authedUrl =
+    parsed.username || parsed.password
+      ? remote_url
+      : (() => {
+          const u = new URL(remote_url);
+          u.username = "x-access-token";
+          u.password = token;
+          return u.toString();
+        })();
+  const probeResult = await probeGitLsRemote(authedUrl, 10_000);
+  if (!probeResult.ok) {
+    return Response.json(
+      {
+        error: "Probe failed",
+        message: `git ls-remote could not reach ${parsed.host}: ${probeResult.error}`,
+      },
+      { status: 400 },
+    );
+  }
+
+  // Save the userinfo'd URL — that's what gets embedded as `origin` so
+  // bare `git push` works without needing GIT_ASKPASS etc.
+  const next: MirrorCredentials = {
+    ...(readCredentials() ?? emptyCredentials()),
+    active_method: "pat",
+    pat: {
+      token,
+      remote_url: authedUrl,
+      label,
+    },
+  };
+  try {
+    writeCredentials(next);
+  } catch (err) {
+    return Response.json(
+      {
+        error: "Credentials write failed",
+        message: (err as Error).message ?? String(err),
+      },
+      { status: 500 },
+    );
+  }
+
+  // Push the new URL onto the mirror's git remote if it's currently
+  // resolved + on disk. Non-fatal if the mirror isn't running.
+  await applyCredentialsToMirror(manager);
+
+  return Response.json(sanitizeCredentials(next), {
+    headers: { "Access-Control-Allow-Origin": "*" },
+  });
+}
+
+/**
+ * Run `git ls-remote <url>` with a hard timeout, no interactive prompts.
+ */
+async function probeGitLsRemote(
+  url: string,
+  timeoutMs: number,
+): Promise<{ ok: boolean; error?: string }> {
+  // GIT_TERMINAL_PROMPT=0 ensures bad credentials FAIL FAST instead of
+  // sitting at "Username:" indefinitely (which the timeout would then
+  // catch, but failing fast on the auth wall is the better UX).
+  const proc = Bun.spawn(["git", "ls-remote", url], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: "0",
+      // Also kill any system credential helper from intercepting — we
+      // want the probe to use ONLY the URL-embedded credential, not
+      // whatever's in keychain.
+      GIT_ASKPASS: "/bin/echo",
+    },
+  });
+  const timer = setTimeout(() => {
+    try {
+      proc.kill();
+    } catch {
+      // already exited
+    }
+  }, timeoutMs);
+  const exitCode = await proc.exited;
+  clearTimeout(timer);
+  if (exitCode === 0) return { ok: true };
+  const stderr = new TextDecoder()
+    .decode(await new Response(proc.stderr).arrayBuffer())
+    .trim();
+  // Redact userinfo from anything we surface back; git's error messages
+  // sometimes echo the URL.
+  const redacted = stderr.replace(/https?:\/\/[^@\s]+@/g, "https://***@");
+  return { ok: false, error: redacted };
+}
+
+/**
+ * `GET /.parachute/mirror/auth` — connection status (no secrets).
+ */
+export function handleAuthGet(): Response {
+  const creds = readCredentials();
+  return Response.json(sanitizeCredentials(creds), {
+    headers: { "Access-Control-Allow-Origin": "*" },
+  });
+}
+
+/**
+ * `DELETE /.parachute/mirror/auth` — wipe credentials, clear the embedded
+ * remote URL on the mirror dir.
+ */
+export async function handleAuthDelete(manager: MirrorManager): Promise<Response> {
+  deleteCredentials();
+  // Strip origin from the mirror dir if one is set.
+  const status = manager.getStatus();
+  if (status.mirror_path) {
+    try {
+      await unsetGitRemote(status.mirror_path);
+    } catch (err) {
+      console.warn(
+        `[mirror-auth] failed to unset git remote (non-fatal): ${(err as Error).message ?? err}`,
+      );
+    }
+  }
+  return Response.json(sanitizeCredentials(null), {
+    headers: { "Access-Control-Allow-Origin": "*" },
+  });
+}
+
+/**
+ * `GET /.parachute/mirror/auth/github/repos` — list operator's repos via
+ * the stored OAuth token. Requires `active_method === "github_oauth"`.
+ */
+export async function handleAuthGithubRepos(
+  fetchImpl?: FetchLike,
+): Promise<Response> {
+  const creds = readCredentials();
+  if (!creds || creds.active_method !== "github_oauth" || !creds.github_oauth) {
+    return Response.json(
+      {
+        error: "Not connected to GitHub",
+        message: "Run the device flow first (POST /.parachute/mirror/auth/github/device-code).",
+      },
+      { status: 400 },
+    );
+  }
+  let result;
+  try {
+    result = await listRepos(creds.github_oauth.access_token, {}, fetchImpl);
+  } catch (err) {
+    return Response.json(
+      {
+        error: "Repo list failed",
+        message: (err as Error).message ?? String(err),
+      },
+      { status: 502 },
+    );
+  }
+  return Response.json(
+    { repos: result.repos, truncated: result.truncated },
+    { headers: { "Access-Control-Allow-Origin": "*" } },
+  );
+}
+
+/**
+ * `POST /.parachute/mirror/auth/github/create-repo` — create a new repo on
+ * the operator's account, return the new RepoInfo. The SPA flows straight
+ * from this into the "repo selected" state.
+ */
+export async function handleAuthGithubCreateRepo(
+  req: Request,
+  fetchImpl?: FetchLike,
+): Promise<Response> {
+  const creds = readCredentials();
+  if (!creds || creds.active_method !== "github_oauth" || !creds.github_oauth) {
+    return Response.json(
+      {
+        error: "Not connected to GitHub",
+        message: "Run the device flow first.",
+      },
+      { status: 400 },
+    );
+  }
+  let body: { name?: unknown; description?: unknown; private?: unknown };
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch (err) {
+    return Response.json(
+      { error: "Invalid JSON body", message: (err as Error).message ?? String(err) },
+      { status: 400 },
+    );
+  }
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (name.length === 0) {
+    return Response.json(
+      { error: "name required", field: "name", message: "Provide a repo name." },
+      { status: 400 },
+    );
+  }
+  const isPrivate = body.private === false ? false : true; // default true
+  const description = typeof body.description === "string" ? body.description : undefined;
+  let repo: GitHubRepoInfo;
+  try {
+    repo = await createRepo(
+      creds.github_oauth.access_token,
+      { name, description, private: isPrivate },
+      fetchImpl,
+    );
+  } catch (err) {
+    return Response.json(
+      { error: "Create failed", message: (err as Error).message ?? String(err) },
+      { status: 502 },
+    );
+  }
+  return Response.json(repo, { headers: { "Access-Control-Allow-Origin": "*" } });
+}
+
+/**
+ * `POST /.parachute/mirror/auth/github/select-repo` — operator picked a
+ * repo from the list (or just created one). Body `{owner, name}`. Writes
+ * the embedded-credential URL onto the mirror dir's `origin`.
+ */
+export async function handleAuthGithubSelectRepo(
+  req: Request,
+  manager: MirrorManager,
+): Promise<Response> {
+  const creds = readCredentials();
+  if (!creds || creds.active_method !== "github_oauth" || !creds.github_oauth) {
+    return Response.json(
+      {
+        error: "Not connected to GitHub",
+        message: "Run the device flow first.",
+      },
+      { status: 400 },
+    );
+  }
+  let body: { owner?: unknown; name?: unknown };
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch (err) {
+    return Response.json(
+      { error: "Invalid JSON body", message: (err as Error).message ?? String(err) },
+      { status: 400 },
+    );
+  }
+  const owner = typeof body.owner === "string" ? body.owner.trim() : "";
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!owner || !name) {
+    return Response.json(
+      {
+        error: "owner and name required",
+        message: "Provide both `owner` and `name` for the repo to push to.",
+      },
+      { status: 400 },
+    );
+  }
+  // Reach into mirror-credentials.ts for the authed URL builder.
+  const { githubAuthedRemoteUrl } = await import("./mirror-credentials.ts");
+  const authedUrl = githubAuthedRemoteUrl(
+    creds.github_oauth.access_token,
+    owner,
+    name,
+  );
+
+  // Apply to the mirror dir if running. If the mirror isn't running (no
+  // mirror_path), we still consider this a success — the credentials are
+  // stored, and the URL will get applied next time the mirror starts.
+  const status = manager.getStatus();
+  let applied = false;
+  if (status.mirror_path) {
+    const res = await applyToGitRemote(status.mirror_path, authedUrl);
+    if (!res.ok) {
+      return Response.json(
+        {
+          error: "Failed to set remote URL on mirror",
+          message: res.error,
+        },
+        { status: 500 },
+      );
+    }
+    applied = true;
+  }
+  return Response.json(
+    {
+      ok: true,
+      applied,
+      owner,
+      name,
+      // Echo the redacted form back so the SPA can show "pushing to <repo>".
+      // No raw token in the response.
+      remote: `https://github.com/${owner}/${name}.git`,
+    },
+    { headers: { "Access-Control-Allow-Origin": "*" } },
+  );
+}
+
+/**
+ * Apply the active credential's remote URL to the running mirror dir.
+ * Idempotent. Called from auth/pat (after store) + auth/github/select-repo
+ * (after store). Non-fatal on failure — the credentials are saved either
+ * way; the next mirror restart picks them up.
+ */
+export async function applyCredentialsToMirror(
+  manager: MirrorManager,
+): Promise<void> {
+  const status = manager.getStatus();
+  if (!status.mirror_path) return;
+  const creds = readCredentials();
+  if (!creds || !creds.active_method) {
+    await unsetGitRemote(status.mirror_path);
+    return;
+  }
+  if (creds.active_method === "pat" && creds.pat) {
+    await applyToGitRemote(status.mirror_path, creds.pat.remote_url);
+    return;
+  }
+  // GitHub OAuth — needs the operator to have picked a repo; the URL
+  // wiring happens in handleAuthGithubSelectRepo. Nothing to apply here
+  // until a repo is selected. Caller is responsible for invoking
+  // select-repo separately.
 }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -72,7 +72,19 @@ import {
 } from "./oauth-discovery.ts";
 import { handleConfigSchema, handleConfig } from "./module-config.ts";
 import { buildAuthStatus } from "./auth-status.ts";
-import { handleMirrorGet, handleMirrorPut, handleMirrorRunNow } from "./mirror-routes.ts";
+import {
+  handleAuthDelete,
+  handleAuthGet,
+  handleAuthGithubCreateRepo,
+  handleAuthGithubDeviceCode,
+  handleAuthGithubPoll,
+  handleAuthGithubRepos,
+  handleAuthGithubSelectRepo,
+  handleAuthPat,
+  handleMirrorGet,
+  handleMirrorPut,
+  handleMirrorRunNow,
+} from "./mirror-routes.ts";
 import { getMirrorManager } from "./mirror-registry.ts";
 
 /**
@@ -542,6 +554,67 @@ export async function route(
     }
     if (req.method === "POST") return handleMirrorRunNow(manager);
     return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  // /.parachute/mirror/auth/* — UI-configurable git push credentials.
+  // GitHub OAuth Device Flow + PAT fallback. All admin-gated; the
+  // routes themselves don't carry secrets in their responses
+  // (mirror-routes.ts redacts via sanitizeCredentials).
+  if (subpath.startsWith("/.parachute/mirror/auth")) {
+    if (!hasScopeForVault(auth.scopes, vaultName, "admin")) {
+      return Response.json(
+        {
+          error: "Forbidden",
+          error_type: "insufficient_scope",
+          message: `This endpoint requires the '${SCOPE_ADMIN}' scope (or '${SCOPE_ADMIN.replace("vault:", `vault:${vaultName}:`)}').`,
+          required_scope: SCOPE_ADMIN,
+          granted_scopes: auth.scopes,
+        },
+        { status: 403 },
+      );
+    }
+    const manager = getMirrorManager();
+    if (!manager) {
+      return Response.json(
+        {
+          error: "Mirror manager not initialized",
+          message:
+            "The vault server hasn't wired a mirror manager yet (no vaults exist, or boot failed). Check logs for [mirror] entries.",
+        },
+        { status: 503 },
+      );
+    }
+
+    if (subpath === "/.parachute/mirror/auth") {
+      if (req.method === "GET") return handleAuthGet();
+      if (req.method === "DELETE") return handleAuthDelete(manager);
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (subpath === "/.parachute/mirror/auth/github/device-code") {
+      if (req.method === "POST") return handleAuthGithubDeviceCode();
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (subpath === "/.parachute/mirror/auth/github/poll") {
+      if (req.method === "POST") return handleAuthGithubPoll(req, manager);
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (subpath === "/.parachute/mirror/auth/github/repos") {
+      if (req.method === "GET") return handleAuthGithubRepos();
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (subpath === "/.parachute/mirror/auth/github/create-repo") {
+      if (req.method === "POST") return handleAuthGithubCreateRepo(req);
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (subpath === "/.parachute/mirror/auth/github/select-repo") {
+      if (req.method === "POST") return handleAuthGithubSelectRepo(req, manager);
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (subpath === "/.parachute/mirror/auth/pat") {
+      if (req.method === "POST") return handleAuthPat(req, manager);
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    return Response.json({ error: "Not found" }, { status: 404 });
   }
 
   const apiMatch = subpath.match(/^\/api(\/.*)?$/);

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -222,6 +222,172 @@ export async function runMirrorNow(vaultName: string): Promise<MirrorSnapshot> {
   return (await res.json()) as MirrorSnapshot;
 }
 
+// ---------------------------------------------------------------------------
+// Mirror credentials — `/vault/<name>/.parachute/mirror/auth[/*]`
+//
+// UI-configurable git push credentials. Two surfaces: GitHub OAuth Device
+// Flow (preferred), and Personal Access Token fallback. The endpoints
+// don't return secrets — only redacted previews + user metadata.
+// ---------------------------------------------------------------------------
+
+/** Sanitized public shape — what the server hands back on GET /auth. */
+export interface MirrorCredentialStatus {
+  active_method: "github_oauth" | "pat" | null;
+  github_oauth: {
+    user_login: string;
+    user_id: number;
+    scope: string;
+    authorized_at: string;
+    token_preview: string;
+  } | null;
+  pat: {
+    label: string;
+    remote_url: string;
+    token_preview: string;
+  } | null;
+}
+
+export interface DeviceCodeResponse {
+  polling_id: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+export type DevicePollState =
+  | { state: "pending" }
+  | { state: "slow_down"; interval: number }
+  | { state: "expired"; message?: string }
+  | { state: "denied" }
+  | {
+      state: "granted";
+      user: { login: string; id: number; name: string | null; avatar_url?: string };
+    };
+
+export interface GitHubRepoInfo {
+  owner: string;
+  name: string;
+  full_name: string;
+  private: boolean;
+  html_url: string;
+  description: string | null;
+  updated_at: string;
+  clone_url: string;
+}
+
+export async function getMirrorAuth(vaultName: string): Promise<MirrorCredentialStatus> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth`,
+    { headers: mirrorAuthHeaders() },
+  );
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as MirrorCredentialStatus;
+}
+
+export async function deleteMirrorAuth(vaultName: string): Promise<MirrorCredentialStatus> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth`,
+    { method: "DELETE", headers: mirrorAuthHeaders() },
+  );
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as MirrorCredentialStatus;
+}
+
+export async function startGithubDeviceFlow(
+  vaultName: string,
+): Promise<DeviceCodeResponse> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/device-code`,
+    { method: "POST", headers: mirrorAuthHeaders() },
+  );
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as DeviceCodeResponse;
+}
+
+export async function pollGithubDeviceFlow(
+  vaultName: string,
+  pollingId: string,
+): Promise<DevicePollState> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/poll`,
+    {
+      method: "POST",
+      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({ polling_id: pollingId }),
+    },
+  );
+  if (!res.ok && res.status !== 404) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as DevicePollState;
+}
+
+export async function postMirrorAuthPat(
+  vaultName: string,
+  args: { token: string; remote_url: string; label?: string },
+): Promise<MirrorCredentialStatus> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/pat`,
+    {
+      method: "POST",
+      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      body: JSON.stringify(args),
+    },
+  );
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as MirrorCredentialStatus;
+}
+
+export async function listGithubRepos(
+  vaultName: string,
+): Promise<{ repos: GitHubRepoInfo[]; truncated: boolean }> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/repos`,
+    { headers: mirrorAuthHeaders() },
+  );
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as { repos: GitHubRepoInfo[]; truncated: boolean };
+}
+
+export async function createGithubRepo(
+  vaultName: string,
+  args: { name: string; description?: string; private?: boolean },
+): Promise<GitHubRepoInfo> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/create-repo`,
+    {
+      method: "POST",
+      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      body: JSON.stringify(args),
+    },
+  );
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as GitHubRepoInfo;
+}
+
+export async function selectGithubRepo(
+  vaultName: string,
+  args: { owner: string; name: string },
+): Promise<{ ok: boolean; applied: boolean; owner: string; name: string; remote: string }> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/select-repo`,
+    {
+      method: "POST",
+      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      body: JSON.stringify(args),
+    },
+  );
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as {
+    ok: boolean;
+    applied: boolean;
+    owner: string;
+    name: string;
+    remote: string;
+  };
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -28,6 +28,22 @@ vi.mock("../lib/api.ts", async () => {
     getMirror: vi.fn(),
     putMirror: vi.fn(),
     runMirrorNow: vi.fn(),
+    // Credential surface (vault#384 — UI-configurable push credentials).
+    // Default mocks return "no credentials configured" so existing tests
+    // see the expected pre-credentials shape. Per-test overrides via
+    // `vi.mocked(api.getMirrorAuth).mockResolvedValue(...)`.
+    getMirrorAuth: vi.fn().mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    }),
+    deleteMirrorAuth: vi.fn(),
+    startGithubDeviceFlow: vi.fn(),
+    pollGithubDeviceFlow: vi.fn(),
+    postMirrorAuthPat: vi.fn(),
+    listGithubRepos: vi.fn(),
+    createGithubRepo: vi.fn(),
+    selectGithubRepo: vi.fn(),
   };
 });
 vi.mock("../lib/scope.ts");
@@ -404,5 +420,181 @@ describe("VaultMirror — read scope", () => {
     expect(screen.getByText(/read-only token/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Save$/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /Run export now/i })).toBeDisabled();
+  });
+
+  it("hides the Git remote section for read-only sessions (admin scope gates it)", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "external", external_path: "/tmp/x" }),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("heading", { name: /Git remote/i })).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Git remote credentials section (vault#384)
+// ---------------------------------------------------------------------------
+
+describe("VaultMirror — Git remote credentials", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(true);
+  });
+
+  it("shows 'Not connected' + the two connect buttons when no credentials", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "external", external_path: "/tmp/x" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/Not connected/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Connect GitHub/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Use Personal Access Token/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows 'Connected to @login' + Disconnect when github_oauth is active", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "external", external_path: "/tmp/x" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: "github_oauth",
+      github_oauth: {
+        user_login: "aaron",
+        user_id: 1,
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        token_preview: "gho_…7890",
+      },
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/Connected to/i)).toBeInTheDocument(),
+    );
+    // Show the masked token preview, not a raw token.
+    expect(screen.getByText("gho_…7890")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Disconnect/i })).toBeInTheDocument();
+  });
+
+  it("displays the friendly auto_push warning when no credentials but auto_push=true", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        location: "external",
+        external_path: "/tmp/x",
+        auto_push: true,
+      }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/Auto-push needs git credentials/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("displays 'Will push to @login' when credentials configured and auto_push=true", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        location: "external",
+        external_path: "/tmp/x",
+        auto_push: true,
+      }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: "github_oauth",
+      github_oauth: {
+        user_login: "aaron",
+        user_id: 1,
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        token_preview: "gho_…7890",
+      },
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/Will push to/i)).toBeInTheDocument(),
+    );
+    // Use of @login appears in the auto_push banner; the Connected status
+    // also says the login. Both should be rendered.
+    const matches = screen.getAllByText(/@aaron/);
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it("opens the OAuth modal and displays the user_code after a successful device-code request", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "external", external_path: "/tmp/x" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    vi.mocked(api.startGithubDeviceFlow).mockResolvedValue({
+      polling_id: "test_polling_id",
+      user_code: "ABCD-1234",
+      verification_uri: "https://github.com/login/device",
+      expires_in: 900,
+      interval: 5,
+    });
+    vi.mocked(api.pollGithubDeviceFlow).mockResolvedValue({ state: "pending" });
+
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Connect GitHub/i }));
+    await waitFor(() =>
+      expect(screen.getByText("ABCD-1234")).toBeInTheDocument(),
+    );
+    expect(api.startGithubDeviceFlow).toHaveBeenCalledWith("work");
+    // verification_uri rendered as a link.
+    const link = screen.getByRole("link", { name: /github\.com\/login\/device/i }) as HTMLAnchorElement;
+    expect(link.href).toContain("github.com/login/device");
+  });
+
+  it("opens the PAT modal and accepts token + remote URL input", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "external", external_path: "/tmp/x" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Use Personal Access Token/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Use Personal Access Token/i })).toBeInTheDocument(),
+    );
+    const tokenInput = screen.getByLabelText(/Token/i) as HTMLInputElement;
+    const urlInput = screen.getByLabelText(/Remote URL/i) as HTMLInputElement;
+    await user.type(tokenInput, "ghp_test1234567890");
+    await user.type(urlInput, "https://github.com/aaron/vault.git");
+    expect(tokenInput.value).toBe("ghp_test1234567890");
+    expect(urlInput.value).toBe("https://github.com/aaron/vault.git");
   });
 });

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -1102,6 +1102,7 @@ function RepoPicker({
   onError: (message: string) => void;
 }) {
   const [repos, setRepos] = useState<GitHubRepoInfo[] | null>(null);
+  const [truncated, setTruncated] = useState(false);
   const [filter, setFilter] = useState("");
   const [picking, setPicking] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -1111,8 +1112,10 @@ function RepoPicker({
   useEffect(() => {
     let cancelled = false;
     listGithubRepos(vaultName)
-      .then(({ repos }) => {
-        if (!cancelled) setRepos(repos);
+      .then(({ repos, truncated }) => {
+        if (cancelled) return;
+        setRepos(repos);
+        setTruncated(Boolean(truncated));
       })
       .catch((err) => {
         if (!cancelled) onError(err instanceof Error ? err.message : String(err));
@@ -1170,6 +1173,14 @@ function RepoPicker({
           onChange={(e) => setFilter(e.target.value)}
         />
       </div>
+
+      {truncated ? (
+        <p className="muted" style={{ fontSize: "0.85em" }}>
+          Showing the first 300 repos. Use the filter above to narrow down — or
+          paste the clone URL directly via Personal Access Token below if your
+          repo isn't here.
+        </p>
+      ) : null}
 
       {repos === null ? <p className="muted">Loading repos…</p> : null}
 

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -23,16 +23,27 @@
  * exclusive territory of the operator's own cron (or the admin SPA's
  * "Run export now" button).
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   HttpError,
+  type DeviceCodeResponse,
+  type GitHubRepoInfo,
   type MirrorConfig,
+  type MirrorCredentialStatus,
   type MirrorSnapshot,
   type MirrorStatus,
+  createGithubRepo,
+  deleteMirrorAuth,
   getMirror,
+  getMirrorAuth,
+  listGithubRepos,
+  pollGithubDeviceFlow,
+  postMirrorAuthPat,
   putMirror,
   runMirrorNow,
+  selectGithubRepo,
+  startGithubDeviceFlow,
 } from "../lib/api.ts";
 import { hasAdminScope } from "../lib/scope.ts";
 
@@ -218,6 +229,30 @@ function MirrorScreen({
   onSnapshot: (snap: MirrorSnapshot) => void;
 }) {
   const isAdmin = hasAdminScope(vaultName);
+  // Credential status — fetched separately because it lives at a different
+  // endpoint + has its own update cadence (OAuth modal + PAT modal save
+  // both invalidate it).
+  const [creds, setCreds] = useState<MirrorCredentialStatus | null>(null);
+  const [credsError, setCredsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    let cancelled = false;
+    getMirrorAuth(vaultName)
+      .then((c) => {
+        if (!cancelled) setCreds(c);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        // 401/403 already covered by parent route's auth gate; other
+        // errors surface as a soft note in the GitRemote section.
+        setCredsError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vaultName, isAdmin]);
+
   return (
     <>
       <StatusCard
@@ -238,11 +273,21 @@ function MirrorScreen({
         vaultName={vaultName}
         initial={snapshot.config}
         readOnly={!isAdmin}
+        creds={creds}
         onSaved={(snap) => {
           onSnapshot(snap);
           onRefresh();
         }}
       />
+      {isAdmin ? (
+        <GitRemoteSection
+          vaultName={vaultName}
+          creds={creds}
+          credsError={credsError}
+          onCredsChanged={setCreds}
+          locationIsExternal={snapshot.config.location === "external"}
+        />
+      ) : null}
     </>
   );
 }
@@ -347,11 +392,15 @@ function ConfigForm({
   vaultName,
   initial,
   readOnly,
+  creds,
   onSaved,
 }: {
   vaultName: string;
   initial: MirrorConfig;
   readOnly: boolean;
+  /** Credentials snapshot — drives the auto_push warning copy. Null while
+   *  loading; treated identically to "no credentials configured." */
+  creds: MirrorCredentialStatus | null;
   onSaved: (snap: MirrorSnapshot) => void;
 }) {
   const [config, setConfig] = useState<MirrorConfig>(initial);
@@ -577,11 +626,26 @@ function ConfigForm({
             Push after each commit
           </label>
           {config.auto_push ? (
-            <div className="warn-banner" style={{ marginTop: "0.5rem" }} role="alert">
-              Auto-push requires git credentials configured outside vault (e.g., SSH
-              key, <code>GH_TOKEN</code>). Failed pushes are logged but won't crash the
-              export.
-            </div>
+            creds?.active_method ? (
+              <div className="info-banner" style={{ marginTop: "0.5rem" }} role="status">
+                {creds.active_method === "github_oauth" && creds.github_oauth ? (
+                  <>
+                    Will push to <code>@{creds.github_oauth.user_login}</code> on GitHub.
+                  </>
+                ) : creds.active_method === "pat" && creds.pat ? (
+                  <>Will push using saved credential: <code>{creds.pat.label}</code>.</>
+                ) : (
+                  <>Will push using saved credential.</>
+                )}{" "}
+                Failed pushes are logged but won't crash the export.
+              </div>
+            ) : (
+              <div className="warn-banner" style={{ marginTop: "0.5rem" }} role="alert">
+                Auto-push needs git credentials. Either connect GitHub in the{" "}
+                <strong>Git remote</strong> section below, or paste a Personal Access
+                Token + remote URL. Failed pushes are logged but won't crash the export.
+              </div>
+            )
           ) : null}
         </div>
       ) : null}
@@ -649,5 +713,645 @@ function ConfigForm({
         </button>
       </div>
     </form>
+  );
+}
+
+// ===========================================================================
+// Git remote credentials — UI for connecting GitHub OAuth or pasting a PAT.
+// ===========================================================================
+
+/**
+ * Top-level credentials section. Shows current connection state +
+ * affords Connect GitHub / Use PAT / Disconnect.
+ *
+ * The OAuth modal is the primary path: operator clicks "Connect GitHub",
+ * vault calls GitHub's device-code endpoint, the modal displays the
+ * user_code + verification_uri, operator types the code at
+ * github.com/login/device, the modal polls until granted, then surfaces a
+ * repo picker (or a "Create new private repo" form). Picking a repo
+ * writes the embedded-credential URL onto the mirror's `origin`, closes
+ * the flow.
+ *
+ * The PAT modal is the fallback: two fields (token + remote URL) + a
+ * "Validate & save" button. The server runs `git ls-remote` against the
+ * URL with the embedded token to confirm before saving.
+ */
+function GitRemoteSection({
+  vaultName,
+  creds,
+  credsError,
+  onCredsChanged,
+  locationIsExternal,
+}: {
+  vaultName: string;
+  creds: MirrorCredentialStatus | null;
+  credsError: string | null;
+  onCredsChanged: (creds: MirrorCredentialStatus) => void;
+  locationIsExternal: boolean;
+}) {
+  const [oauthOpen, setOauthOpen] = useState(false);
+  const [patOpen, setPatOpen] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const connected = creds?.active_method !== null && creds?.active_method !== undefined;
+
+  const onDisconnect = async () => {
+    if (!confirm("Disconnect git remote credentials? Auto-push will stop working until you reconnect.")) {
+      return;
+    }
+    setDisconnecting(true);
+    setActionError(null);
+    try {
+      const c = await deleteMirrorAuth(vaultName);
+      onCredsChanged(c);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  return (
+    <div className="section">
+      <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>
+        Git remote
+      </h3>
+      <p className="dim" style={{ marginTop: 0 }}>
+        Credentials for <code>auto-push</code>. Stored on this server with{" "}
+        <code>0600</code> file permissions. Never sent to GitHub or any third party.
+      </p>
+
+      {!locationIsExternal ? (
+        <div className="info-banner" style={{ marginBottom: "0.75rem" }} role="status">
+          Internal mirrors live under the vault's data directory and have no remote.
+          Switch the location above to <strong>External</strong> to enable pushing.
+        </div>
+      ) : null}
+
+      {credsError ? (
+        <div className="error-banner" role="alert">
+          Could not load credential status: <code>{credsError}</code>
+        </div>
+      ) : null}
+
+      {connected ? (
+        <div className="kv" style={{ marginBottom: "0.75rem" }}>
+          <div>Status</div>
+          <div>
+            {creds?.active_method === "github_oauth" && creds.github_oauth ? (
+              <>
+                Connected to <code>@{creds.github_oauth.user_login}</code> on GitHub
+              </>
+            ) : creds?.active_method === "pat" && creds.pat ? (
+              <>
+                Custom credential: <code>{creds.pat.label}</code>
+              </>
+            ) : null}
+          </div>
+          {creds?.active_method === "github_oauth" && creds.github_oauth ? (
+            <>
+              <div>Token</div>
+              <div>
+                <code>{creds.github_oauth.token_preview}</code>{" "}
+                <span className="dim">
+                  · scope {creds.github_oauth.scope || "—"} · authorized{" "}
+                  {creds.github_oauth.authorized_at.slice(0, 10)}
+                </span>
+              </div>
+            </>
+          ) : null}
+          {creds?.active_method === "pat" && creds.pat ? (
+            <>
+              <div>Remote</div>
+              <div>
+                <code>{creds.pat.remote_url}</code>
+              </div>
+              <div>Token</div>
+              <div>
+                <code>{creds.pat.token_preview}</code>
+              </div>
+            </>
+          ) : null}
+        </div>
+      ) : (
+        <p className="dim">Not connected. Auto-push won't work until you connect.</p>
+      )}
+
+      {actionError ? (
+        <div className="error-banner" role="alert">
+          <code>{actionError}</code>
+        </div>
+      ) : null}
+
+      <div className="actions">
+        {!connected ? (
+          <>
+            <button type="button" onClick={() => setOauthOpen(true)}>
+              Connect GitHub
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setPatOpen(true)}
+            >
+              Use Personal Access Token
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="secondary"
+            onClick={onDisconnect}
+            disabled={disconnecting}
+          >
+            {disconnecting ? "Disconnecting…" : "Disconnect"}
+          </button>
+        )}
+      </div>
+
+      {oauthOpen ? (
+        <GithubOAuthModal
+          vaultName={vaultName}
+          onClose={() => setOauthOpen(false)}
+          onConnected={(c) => {
+            onCredsChanged(c);
+            setOauthOpen(false);
+          }}
+        />
+      ) : null}
+
+      {patOpen ? (
+        <PATModal
+          vaultName={vaultName}
+          onClose={() => setPatOpen(false)}
+          onSaved={(c) => {
+            onCredsChanged(c);
+            setPatOpen(false);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GitHub OAuth modal — device flow start + poll loop + repo picker.
+// ---------------------------------------------------------------------------
+
+type OAuthPhase =
+  | { kind: "starting" }
+  | { kind: "polling"; code: DeviceCodeResponse; pollIntervalMs: number; startedAt: number }
+  | { kind: "granted"; user: { login: string } }
+  | { kind: "error"; message: string };
+
+function GithubOAuthModal({
+  vaultName,
+  onClose,
+  onConnected,
+}: {
+  vaultName: string;
+  onClose: () => void;
+  onConnected: (creds: MirrorCredentialStatus) => void;
+}) {
+  const [phase, setPhase] = useState<OAuthPhase>({ kind: "starting" });
+  const [now, setNow] = useState(Date.now());
+  const pollAbortRef = useRef<boolean>(false);
+
+  // Tick clock so the countdown ticks down visibly.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Start the device flow on mount.
+  useEffect(() => {
+    let cancelled = false;
+    pollAbortRef.current = false;
+    startGithubDeviceFlow(vaultName)
+      .then((code) => {
+        if (cancelled) return;
+        setPhase({
+          kind: "polling",
+          code,
+          pollIntervalMs: Math.max(code.interval, 1) * 1000,
+          startedAt: Date.now(),
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setPhase({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+      pollAbortRef.current = true;
+    };
+  }, [vaultName]);
+
+  // Poll loop — re-armed on every phase transition while phase=polling.
+  useEffect(() => {
+    if (phase.kind !== "polling") return;
+    const code = phase.code;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let currentIntervalMs = phase.pollIntervalMs;
+    const tick = async () => {
+      if (cancelled || pollAbortRef.current) return;
+      try {
+        const result = await pollGithubDeviceFlow(vaultName, code.polling_id);
+        if (cancelled) return;
+        if (result.state === "granted") {
+          setPhase({ kind: "granted", user: { login: result.user.login } });
+          return;
+        }
+        if (result.state === "denied") {
+          setPhase({ kind: "error", message: "Authorization denied." });
+          return;
+        }
+        if (result.state === "expired") {
+          setPhase({ kind: "error", message: "The device code expired. Try again." });
+          return;
+        }
+        if (result.state === "slow_down") {
+          currentIntervalMs = result.interval * 1000;
+        }
+        timer = setTimeout(tick, currentIntervalMs);
+      } catch (err) {
+        if (cancelled) return;
+        setPhase({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    };
+    timer = setTimeout(tick, currentIntervalMs);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [phase, vaultName]);
+
+  const copyCode = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch {
+      // Clipboard API can fail in HTTP / no-permission contexts. Silent fail.
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="list-header">
+          <h3 style={{ margin: 0 }}>Connect GitHub</h3>
+          <button type="button" className="secondary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        {phase.kind === "starting" ? (
+          <p className="muted">Requesting device code from GitHub…</p>
+        ) : null}
+
+        {phase.kind === "polling" ? (
+          <>
+            <p>
+              <strong>Step 1.</strong> Open{" "}
+              <a href={phase.code.verification_uri} target="_blank" rel="noreferrer">
+                {phase.code.verification_uri}
+              </a>{" "}
+              in your browser.
+            </p>
+            <p>
+              <strong>Step 2.</strong> Enter this code:
+            </p>
+            <div className="device-code-row">
+              <code className="device-code">{phase.code.user_code}</code>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => copyCode(phase.code.user_code)}
+              >
+                Copy
+              </button>
+            </div>
+            <p className="dim">
+              Waiting for authorization…{" "}
+              {formatCountdown(phase.code.expires_in, phase.startedAt, now)}
+            </p>
+          </>
+        ) : null}
+
+        {phase.kind === "granted" ? (
+          <RepoPicker
+            vaultName={vaultName}
+            user={phase.user}
+            onPicked={async (owner, name) => {
+              await selectGithubRepo(vaultName, { owner, name });
+              const c = await getMirrorAuth(vaultName);
+              onConnected(c);
+            }}
+            onError={(message) => setPhase({ kind: "error", message })}
+          />
+        ) : null}
+
+        {phase.kind === "error" ? (
+          <>
+            <div className="error-banner" role="alert">
+              <code>{phase.message}</code>
+            </div>
+            <div className="actions">
+              <button type="button" onClick={() => setPhase({ kind: "starting" })}>
+                Try again
+              </button>
+              <button type="button" className="secondary" onClick={onClose}>
+                Close
+              </button>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function formatCountdown(expiresIn: number, startedAt: number, now: number): string {
+  const elapsed = Math.floor((now - startedAt) / 1000);
+  const remaining = Math.max(0, expiresIn - elapsed);
+  const mins = Math.floor(remaining / 60);
+  const secs = remaining % 60;
+  return `${mins}:${String(secs).padStart(2, "0")} remaining`;
+}
+
+// ---------------------------------------------------------------------------
+// Repo picker — surfaces after a granted device-flow token.
+// ---------------------------------------------------------------------------
+
+function RepoPicker({
+  vaultName,
+  user,
+  onPicked,
+  onError,
+}: {
+  vaultName: string;
+  user: { login: string };
+  onPicked: (owner: string, name: string) => Promise<void>;
+  onError: (message: string) => void;
+}) {
+  const [repos, setRepos] = useState<GitHubRepoInfo[] | null>(null);
+  const [filter, setFilter] = useState("");
+  const [picking, setPicking] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    listGithubRepos(vaultName)
+      .then(({ repos }) => {
+        if (!cancelled) setRepos(repos);
+      })
+      .catch((err) => {
+        if (!cancelled) onError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vaultName, onError]);
+
+  const filtered = (repos ?? []).filter((r) =>
+    filter.length === 0
+      ? true
+      : r.full_name.toLowerCase().includes(filter.toLowerCase()),
+  );
+
+  const pickRepo = async (owner: string, name: string) => {
+    setPicking(`${owner}/${name}`);
+    try {
+      await onPicked(owner, name);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPicking(null);
+    }
+  };
+
+  const createAndPick = async () => {
+    if (newName.trim().length === 0) return;
+    setCreating(true);
+    try {
+      const repo = await createGithubRepo(vaultName, {
+        name: newName.trim(),
+        description: "Parachute Vault mirror",
+        private: true,
+      });
+      await onPicked(repo.owner, repo.name);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <>
+      <p>
+        Authorized as <code>@{user.login}</code>. Pick a repository to push the mirror to:
+      </p>
+
+      <div className="form-row">
+        <input
+          type="search"
+          placeholder="Filter by name…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+      </div>
+
+      {repos === null ? <p className="muted">Loading repos…</p> : null}
+
+      {repos !== null ? (
+        <div className="repo-list">
+          {filtered.length === 0 && filter.length > 0 ? (
+            <p className="dim">No repos match "{filter}".</p>
+          ) : null}
+          {filtered.length === 0 && filter.length === 0 && repos.length === 0 ? (
+            <p className="dim">You don't own any repos on this account yet.</p>
+          ) : null}
+          {filtered.map((r) => (
+            <button
+              type="button"
+              key={r.full_name}
+              className="repo-row"
+              onClick={() => pickRepo(r.owner, r.name)}
+              disabled={picking !== null}
+            >
+              <span>
+                <strong>{r.name}</strong>
+                {r.private ? <span className="dim"> · private</span> : null}
+              </span>
+              <span className="dim">{r.updated_at.slice(0, 10)}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {!showCreate ? (
+        <div className="actions" style={{ marginTop: "0.75rem" }}>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => setShowCreate(true)}
+          >
+            + Create new private repo
+          </button>
+        </div>
+      ) : (
+        <div className="form-row" style={{ marginTop: "0.75rem" }}>
+          <label htmlFor="new-repo-name">New repo name</label>
+          <input
+            id="new-repo-name"
+            type="text"
+            value={newName}
+            placeholder="my-vault-backup"
+            onChange={(e) => setNewName(e.target.value)}
+          />
+          <div className="actions">
+            <button
+              type="button"
+              onClick={createAndPick}
+              disabled={creating || newName.trim().length === 0}
+            >
+              {creating ? "Creating…" : "Create"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setShowCreate(false)}
+              disabled={creating}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PAT modal — paste a token + remote URL, validate via `git ls-remote`.
+// ---------------------------------------------------------------------------
+
+function PATModal({
+  vaultName,
+  onClose,
+  onSaved,
+}: {
+  vaultName: string;
+  onClose: () => void;
+  onSaved: (creds: MirrorCredentialStatus) => void;
+}) {
+  const [token, setToken] = useState("");
+  const [remoteUrl, setRemoteUrl] = useState("");
+  const [label, setLabel] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const creds = await postMirrorAuthPat(vaultName, {
+        token: token.trim(),
+        remote_url: remoteUrl.trim(),
+        label: label.trim() || undefined,
+      });
+      onSaved(creds);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="list-header">
+          <h3 style={{ margin: 0 }}>Use Personal Access Token</h3>
+          <button type="button" className="secondary" onClick={onClose} disabled={saving}>
+            Close
+          </button>
+        </div>
+        <p className="dim">
+          Works for any provider that supports HTTPS push with a token in the URL
+          (GitHub, GitLab, Codeberg, Gitea, …). The token is stored with{" "}
+          <code>0600</code> file perms on this server.
+        </p>
+        <form onSubmit={onSubmit}>
+          <div className="form-row">
+            <label htmlFor="pat-token">Token</label>
+            <input
+              id="pat-token"
+              type="password"
+              value={token}
+              autoComplete="off"
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="ghp_… or glpat-… or similar"
+              required
+            />
+          </div>
+          <div className="form-row">
+            <label htmlFor="pat-url">Remote URL</label>
+            <input
+              id="pat-url"
+              type="url"
+              value={remoteUrl}
+              onChange={(e) => setRemoteUrl(e.target.value)}
+              placeholder="https://github.com/owner/repo.git"
+              required
+            />
+            <p className="dim" style={{ margin: "0.35rem 0 0" }}>
+              We'll embed your token in the URL before saving (using GitHub's{" "}
+              <code>x-access-token</code> convention). The URL you see on disk will
+              carry the token; ensure the file isn't shared.
+            </p>
+          </div>
+          <div className="form-row">
+            <label htmlFor="pat-label">Label (optional)</label>
+            <input
+              id="pat-label"
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="GitHub PAT for backup"
+            />
+          </div>
+          {error ? (
+            <div className="error-banner" role="alert">
+              <code>{error}</code>
+            </div>
+          ) : null}
+          <div className="actions">
+            <button type="submit" disabled={saving}>
+              {saving ? "Validating…" : "Validate & save"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
   );
 }

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -444,3 +444,95 @@ select:focus {
   margin: 0;
 }
 
+/* ---------------------------------------------------------------------------
+ * Git remote credentials UI — banner variants + OAuth/PAT modals.
+ * ------------------------------------------------------------------------- */
+
+.info-banner {
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  color: var(--accent-hover);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  width: min(520px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+}
+
+.device-code-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+}
+
+.device-code {
+  font-size: 1.4rem;
+  letter-spacing: 0.1em;
+  padding: 0.6rem 1rem;
+  background: var(--bg-soft);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  user-select: all;
+  flex: 1;
+  text-align: center;
+}
+
+.repo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 260px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.4rem;
+  background: var(--bg-soft);
+}
+
+.repo-row {
+  background: var(--bg);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+.repo-row:hover {
+  border-color: var(--accent);
+  background: white;
+}
+.repo-row:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+


### PR DESCRIPTION
## Summary

Aaron's 2026-05-27 directive named two halves of the auto-push UX. Event-driven landed in vault#382. This PR ships the second half: **UI-configurable git push credentials**, so self-hosted users without shell access can connect a git remote + turn on auto-push without ever opening a terminal.

Aaron's words (verbatim): _"auto push needs to be easy and intuitive for a user, and we need to assume that a lot of users aren't going to have easy shell access or know how to use a shell."_

## Architecture decisions (locked before implementation)

- **GitHub OAuth Device Flow over Web Flow.** Self-hosted vault origins are unpredictable (localhost:1940, Tailscale FQDNs, custom domains) — Web Flow needs a pre-registered callback URL per OAuth app, Device Flow needs only a public client_id. Same UX as `gh auth login`.
- **File-based credential storage, OS-perms-protected, NOT encrypted at rest.** `<configDir>/vault/.mirror-credentials.yaml`, perms `0o600`. Encryption-at-rest with the key on the same disk doesn't add real security; OS perms ARE the protection. Same trust model as `~/.git-credentials`.
- **HTTPS-token auth via embedded credentials.** Mirror's `origin` is set to `https://x-access-token:<TOKEN>@github.com/<owner>/<repo>.git` (GitHub) or whatever userinfo'd URL the operator pastes (PAT, any provider). Bare `git push` works because the URL carries the token.
- **SSH key support deferred.** Will land in a follow-up (`GIT_SSH_COMMAND` injection at push time). PAT path covers anyone willing to paste a token.

## Cuts

### 1. Credential storage layer — `src/mirror-credentials.ts`
- YAML, `0o600`, atomic writes (tmp + rename), perm-verified on every write
- `readCredentials` / `writeCredentials` / `deleteCredentials` / `applyToGitRemote` / `unsetGitRemote`
- `sanitizeCredentials` masks tokens to first-4 + last-4; `redactRemoteUrl` strips userinfo from any URL we echo back

### 2. GitHub Device Flow client — `src/github-device-flow.ts`
- `requestDeviceCode` / `pollForToken` / `fetchUser` / `listRepos` / `createRepo`
- Injectable `fetch` for tests
- Discriminated-union poll results (pending / slow_down / expired / denied / granted)
- **`GITHUB_CLIENT_ID` is a placeholder** — see "Manual step before tagging" below

### 3. HTTP routes — `src/mirror-routes.ts` (extended)
All `vault:<name>:admin`-gated. Mounted at `/vault/<name>/.parachute/mirror/auth[/*]`:

| Method | Path | Purpose |
|---|---|---|
| GET | `/auth` | Sanitized credential status (no secrets) |
| DELETE | `/auth` | Wipe creds + unset origin |
| POST | `/auth/github/device-code` | Start flow; returns `polling_id` (server retains `device_code`, 15-min TTL session map) |
| POST | `/auth/github/poll` | Poll once; on granted, save creds + fetch user |
| GET | `/auth/github/repos` | List operator's owned repos via stored OAuth token |
| POST | `/auth/github/create-repo` | Create new private repo |
| POST | `/auth/github/select-repo` | Write embedded-credential URL onto mirror's `origin` |
| POST | `/auth/pat` | Validate (live `git ls-remote` probe, 10s timeout, `GIT_TERMINAL_PROMPT=0`) + store |

### 4. Wire into push path — `src/mirror-manager.ts`
- `start()` and `reload()` call `applyCredentialsToRemote()` after bootstrap
- PAT: set origin to stored authed URL
- github_oauth: rewrite origin with fresh token if existing origin points at github.com (handles token rotation across restarts)
- Idempotent

### 5. SPA — `web/ui/src/routes/VaultMirror.tsx`
New "Git remote" section below location/path. Status chip ("Not connected" / "Connected to @login" / "Custom credential: <label>"), Connect GitHub / Use PAT / Disconnect buttons.

- **OAuth modal:** shows the `user_code` (monospace, big), copy-to-clipboard button, countdown timer, polls every `interval` seconds (`slow_down` handled), transitions to repo picker on granted
- **Repo picker:** search filter, list of operator's repos (last-updated sorted), inline "Create new private repo" form
- **PAT modal:** token + remote_url + optional label, "Validate & save" hits `/auth/pat`
- **Auto-push warning rewrite:** when credentials configured, shows "Will push to @login on GitHub" (or label for PAT); when not configured, the friendlier "connect GitHub or paste a PAT" message replaces the prior "Auto-push requires git credentials configured outside vault (e.g., SSH key, GH_TOKEN)" wall-of-text

### 6. Tests — 75 new tests across 3 files
- `mirror-credentials.test.ts` (24): round-trip, 0o600 enforcement, redaction, atomic write, idempotent delete, real-git remote-set
- `github-device-flow.test.ts` (15): each API call, every poll state, pagination/truncation
- `mirror-routes.test.ts` (13 new, 29 total): placeholder check, full device flow with mocked fetch, PAT validation including a real-failing-remote probe that confirms NO token leak
- `VaultMirror.test.tsx` (6 new, 18 total): status display, modal open, OAuth flow start, PAT input acceptance

### 7. Tightening while here
- Auto-push warning copy rewrite (above)
- Token-in-logs discipline: never log raw tokens; all wire responses use `sanitizeCredentials`; `git ls-remote` stderr passes through a `redactRemoteUrl` regex before surfacing

## Test plan

- [x] `bun test ./src/` → 1197/1197 pass
- [x] `bun test ./src ./core ./package` → 1795/1795 pass
- [x] `bun run typecheck` → clean
- [x] `cd web/ui && bun run typecheck` → clean
- [x] `cd web/ui && bunx vitest run` → 89/89 pass
- [x] `cd web/ui && bun run build` → clean (verify-base passes)
- [x] Sandboxed credential round-trip end-to-end (`PARACHUTE_HOME=/tmp/...`): write + read + sanitize + delete via real disk, 0o600 confirmed
- [x] Sandboxed PAT probe against real failing github.com remote: returns 400, error is actionable, **token does NOT appear in response body**
- [x] Placeholder `GITHUB_CLIENT_ID` check returns 503 with clear error pointing at setup steps

## Manual step Aaron has to do before tagging

The PR ships with `GITHUB_CLIENT_ID_PLACEHOLDER` as the client id and a 503-with-actionable-error placeholder check. Before tagging:

1. github.com/settings/developers → "New OAuth App"
2. Application name: "Parachute Vault"
   Homepage URL: https://parachute.computer
   Authorization callback URL: https://parachute.computer/oauth/github  (required by GitHub's form; unused in Device Flow)
3. After creating: open the app's settings page
4. Tick the "Enable Device Flow" checkbox
5. Copy the Client ID (looks like `Iv1.abc...` or `Ov23li...`)
6. Either set the `GITHUB_CLIENT_ID_PLACEHOLDER` constant in `src/github-device-flow.ts` to the real value, OR have operators set `PARACHUTE_GITHUB_CLIENT_ID` in their env (preferred for self-hosters who want their own OAuth app — same client_id-portability model as `gh`)

Until that's done, the PAT path works on its own (no OAuth app needed; the operator pastes their own ghp_* / glpat-* / etc.).

## Discipline notes

- **No tokens in logs** anywhere. Verified by grep + the live PAT probe test.
- **`sanitizeCredentials` is the wire boundary.** Every response that mentions credentials passes through it.
- **`GIT_ASKPASS=/bin/echo`** on the PAT probe so bad creds fail fast instead of hanging at "Username:".
- **`0o600` is re-verified after every write** — defense in depth against the `writeFileSync(mode)` honoring-only-on-create quirk.
- **15-min TTL on device-flow polling sessions** matches GitHub's `expires_in`; reaping happens on every device-code POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)