### PR TITLE
chore(release): 0.4.9-rc.6 — UI-configurable git push credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.5",
+  "version": "0.4.9-rc.6",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump. Picks up #384:
- GitHub Device Flow + PAT credential paths for vault's mirror auto-push
- Admin SPA wires `auto_push: true` end-to-end without shell access
- Credential storage at `~/.parachute/vault/.mirror-credentials.yaml` (0o600)
- 75 new tests; both typechecks clean

## Pre-release action for Aaron

The OAuth path needs a GitHub OAuth app registered + Client ID wired before it's functional. See the PR body on #384 for the setup checklist; PAT path works standalone in the meantime.

## Test plan

- [x] `bun test ./core ./src ./package` — 1796 pass / 0 fail
- [x] `cd web/ui && bunx vitest run` — 89 pass / 0 fail
- [x] Both typechecks clean
- [ ] After merge: tag `v0.4.9-rc.6` + push → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)