### PR TITLE
ux(mirror): lead with PAT (universal) + History preset (managed default)

### DIFF
--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -225,9 +225,11 @@ export async function runMirrorNow(vaultName: string): Promise<MirrorSnapshot> {
 // ---------------------------------------------------------------------------
 // Mirror credentials — `/vault/<name>/.parachute/mirror/auth[/*]`
 //
-// UI-configurable git push credentials. Two surfaces: GitHub OAuth Device
-// Flow (preferred), and Personal Access Token fallback. The endpoints
-// don't return secrets — only redacted previews + user metadata.
+// UI-configurable git push credentials. Two surfaces: Personal Access
+// Token (universal — works against any HTTPS+token git host) and GitHub
+// OAuth Device Flow (one-click shortcut for GitHub users, same
+// end-state as a hand-pasted PAT). The endpoints don't return secrets
+// — only redacted previews + user metadata.
 // ---------------------------------------------------------------------------
 
 /** Sanitized public shape — what the server hands back on GET /auth. */

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -465,6 +465,31 @@ describe("VaultMirror — Git remote credentials", () => {
     ).toBeInTheDocument();
   });
 
+  // Reviewer-flagged on vault#388 — substring-matchy existence checks
+  // above don't pin the primary/secondary distinction. Per Aaron's
+  // 2026-05-28 direction, PAT is the primary action (works against any
+  // HTTPS+token git host); GitHub Device Flow is the GitHub-specific
+  // one-click shortcut and gets the .secondary class. A future
+  // refactor that flips them back would now fail this assertion.
+  it("renders PAT as primary action and GitHub as secondary shortcut", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "external", external_path: "/tmp/x" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+    );
+    const patBtn = screen.getByRole("button", { name: /Use Personal Access Token/i });
+    const ghBtn = screen.getByRole("button", { name: /Connect GitHub/i });
+    expect(patBtn.className).not.toContain("secondary");
+    expect(ghBtn.className).toContain("secondary");
+  });
+
   it("shows 'Connected to @login' + Disconnect when github_oauth is active", async () => {
     vi.mocked(api.getMirror).mockResolvedValue(
       snapshotFixture({ enabled: true, location: "external", external_path: "/tmp/x" }),

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -491,6 +491,13 @@ function ConfigForm({
 
       <div className="form-row">
         <label>Presets</label>
+        <p className="dim" style={{ marginTop: 0, marginBottom: "0.5rem", fontSize: "0.9em" }}>
+          <strong>History</strong> is the easiest start — vault manages the
+          mirror folder under its own data dir, no path to pick, no remote
+          to configure. <strong>Live Mirror</strong> + <strong>Manual
+          Export</strong> are for operators who want to point at a visible
+          folder (Obsidian, GitHub).
+        </p>
         <div className="preset-grid">
           {PRESETS.map((preset) => (
             <button
@@ -722,9 +729,16 @@ function ConfigForm({
 
 /**
  * Top-level credentials section. Shows current connection state +
- * affords Connect GitHub / Use PAT / Disconnect.
+ * affords Use PAT / Connect GitHub / Disconnect.
  *
- * The OAuth modal is the primary path: operator clicks "Connect GitHub",
+ * PAT is the primary path because it works against any HTTPS+token git
+ * host (GitHub, GitLab, Gitea, Bitbucket, self-hosted). The GitHub
+ * Device Flow is presented as a one-click shortcut for GitHub users —
+ * same end-state (a token wired into the mirror's remote URL), just
+ * one fewer step. Aaron called this framing 2026-05-28: leading with
+ * "Connect GitHub" implies Parachute is GitHub-only, which it isn't.
+ *
+ * The OAuth modal works like this: operator clicks "Connect GitHub",
  * vault calls GitHub's device-code endpoint, the modal displays the
  * user_code + verification_uri, operator types the code at
  * github.com/login/device, the modal polls until granted, then surfaces a
@@ -835,7 +849,12 @@ function GitRemoteSection({
           ) : null}
         </div>
       ) : (
-        <p className="dim">Not connected. Auto-push won't work until you connect.</p>
+        <p className="dim">
+          Not connected. Auto-push won't work until you connect. Personal
+          Access Token is the universal path (works with GitHub, GitLab,
+          Gitea, Bitbucket, anything that takes an HTTPS token); the GitHub
+          shortcut just saves a step for GitHub users.
+        </p>
       )}
 
       {actionError ? (
@@ -847,15 +866,23 @@ function GitRemoteSection({
       <div className="actions">
         {!connected ? (
           <>
-            <button type="button" onClick={() => setOauthOpen(true)}>
-              Connect GitHub
+            {/*
+              PAT is the primary action — works against any HTTPS+token git
+              host (GitHub, GitLab, Gitea, Bitbucket, self-hosted). The
+              GitHub Device Flow is a convenience shortcut: same result as
+              generating a PAT manually, just one fewer step for GitHub
+              users. Don't lead with the GitHub-specific path; it'd
+              suggest Parachute is GitHub-only.
+            */}
+            <button type="button" onClick={() => setPatOpen(true)}>
+              Use Personal Access Token
             </button>
             <button
               type="button"
               className="secondary"
-              onClick={() => setPatOpen(true)}
+              onClick={() => setOauthOpen(true)}
             >
-              Use Personal Access Token
+              Connect GitHub (one-click for GitHub users)
             </button>
           </>
         ) : (


### PR DESCRIPTION
## Summary

UX rebalance per Aaron's direction 2026-05-28: lead with the universal credential path (PAT — works for GitHub, GitLab, Gitea, Bitbucket, self-hosted) and surface the History preset as the natural default for operators who don't navigate a filesystem (Render-based installs especially).

No backend changes. Two surface tweaks in \`web/ui/src/routes/VaultMirror.tsx\`:

1. **Credential buttons reordered.** "Use Personal Access Token" is the primary action; "Connect GitHub" becomes a secondary one-click shortcut clearly labeled as such.
2. **Preset explainer.** Short paragraph above the preset cards calls out History as the easiest start (vault-managed path, no remote setup), with Live Mirror + Manual Export framed as opt-in for operators who want a visible folder.

The 21 existing VaultMirror tests pass unchanged (button-name regexes are substring matches, so the expanded GitHub label still resolves).

## Test plan

- [x] \`cd web/ui && bunx vitest run\` — 89/89
- [x] Both typechecks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)