### PR TITLE
chore(release): 0.4.9-rc.7 — PAT-first mirror UX rebalance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.6",
+  "version": "0.4.9-rc.7",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump only. Picks up #388 (UI rebalance: PAT primary, GitHub OAuth secondary shortcut, History preset called out as default for Render / non-shell operators) per Aaron's 2026-05-28 direction.

## Test plan

- [x] vitest 90 pass / 0 fail
- [x] bun test 1796 pass / 0 fail
- [x] Both typechecks clean
- [ ] After merge: tag `v0.4.9-rc.7` + push → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)