### PR TITLE
feat(vault): import vault from a git repo (sibling to mirror export)

### DIFF
--- a/src/mirror-import.test.ts
+++ b/src/mirror-import.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Tests for the clone-and-import worker (vault#391).
+ *
+ * Mocks the git binary via the `spawn` injection point so we don't
+ * actually clone anything in tests — instead we pre-populate the tempdir
+ * the fake "clone" claims to have written, or have the fake return a
+ * non-zero exit code to exercise the failure paths.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SqliteStore } from "../core/src/store.ts";
+import { exportVaultToDir } from "../core/src/portable-md.ts";
+import {
+  CloneFailedError,
+  ImportConflictError,
+  NotAVaultExportError,
+  _isImportInFlight,
+  _resetImportInFlightForTest,
+  authedCloneUrl,
+  cloneAndImport,
+  type GitSpawn,
+} from "./mirror-import.ts";
+import {
+  emptyCredentials,
+  mirrorCredentialsPath,
+  writeCredentials,
+  type MirrorCredentials,
+} from "./mirror-credentials.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmp(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/**
+ * Build a real portable-md export on disk + return its path. Used by tests
+ * that need a valid clone-target so the import succeeds.
+ */
+async function buildExportFixture(opts?: { extraNotes?: number }): Promise<string> {
+  const extraNotes = opts?.extraNotes ?? 0;
+  const store = new SqliteStore(new Database(":memory:"));
+  await store.createNote("alpha body", { id: "n-alpha", path: "alpha", tags: ["t1"] });
+  await store.createNote("beta body", { id: "n-beta", path: "beta" });
+  for (let i = 0; i < extraNotes; i++) {
+    await store.createNote(`extra ${i}`, { id: `n-extra-${i}`, path: `extra-${i}` });
+  }
+  const exportDir = tmp("import-fixture-export-");
+  await exportVaultToDir(store, {
+    outDir: exportDir,
+    vaultName: "source",
+    exportedAt: "2026-05-28T00:00:00.000Z",
+  });
+  return exportDir;
+}
+
+/**
+ * Build a fake spawn that copies a pre-baked fixture into the tempdir
+ * the importer expects. Mimics what `git clone <url> <tempDir>` would do
+ * on success: populate the tempDir with the fixture's contents.
+ */
+function spawnCloneSuccess(fixtureDir: string): GitSpawn {
+  return async (argv) => {
+    // argv = ["git", "clone", "--depth", "1", <url>, <destDir>]
+    expect(argv[0]).toBe("git");
+    expect(argv[1]).toBe("clone");
+    const destDir = argv[argv.length - 1]!;
+    // Copy fixture into the destination. The destination already exists
+    // (mkdtempSync created it), so use cpSync's `recursive` mode.
+    cpSync(fixtureDir, destDir, { recursive: true });
+    return { exitCode: 0, stderr: "", timedOut: false };
+  };
+}
+
+const spawnCloneFailure = (stderr: string): GitSpawn =>
+  async () => ({ exitCode: 128, stderr, timedOut: false });
+
+const spawnCloneTimeout: GitSpawn = async () => ({
+  exitCode: -1,
+  stderr: "",
+  timedOut: true,
+});
+
+const ORIG_HOME = process.env.HOME;
+const ORIG_PARACHUTE_HOME = process.env.PARACHUTE_HOME;
+
+afterEach(() => {
+  _resetImportInFlightForTest();
+  if (ORIG_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIG_HOME;
+  if (ORIG_PARACHUTE_HOME === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = ORIG_PARACHUTE_HOME;
+});
+
+// ---------------------------------------------------------------------------
+// authedCloneUrl
+// ---------------------------------------------------------------------------
+
+describe("authedCloneUrl", () => {
+  test("returns null for unparseable URL", () => {
+    expect(authedCloneUrl("not-a-url", { kind: "none" })).toBeNull();
+  });
+
+  test("passes ssh URLs verbatim (no userinfo to embed)", () => {
+    // `git@github.com:owner/repo.git` parses to a URL with protocol `git:`,
+    // not http/https — our helper returns it verbatim.
+    const r = authedCloneUrl("git://github.com/owner/repo.git", { kind: "pat", token: "ghp_x" });
+    expect(r).not.toBeNull();
+    expect(r!.authedUrl).toBe("git://github.com/owner/repo.git");
+    expect(r!.appliedAuth).toBe("none");
+  });
+
+  test("does not override URL that already carries userinfo", () => {
+    const r = authedCloneUrl("https://user:pass@github.com/owner/repo.git", {
+      kind: "pat",
+      token: "ghp_x",
+    });
+    expect(r).not.toBeNull();
+    expect(r!.authedUrl).toContain("user:pass@");
+    expect(r!.appliedAuth).toBe("none");
+  });
+
+  test("per-call PAT embeds x-access-token user", () => {
+    const r = authedCloneUrl("https://github.com/owner/repo.git", {
+      kind: "pat",
+      token: "ghp_abc123",
+    });
+    expect(r).not.toBeNull();
+    expect(r!.authedUrl).toContain("x-access-token:ghp_abc123@");
+    expect(r!.appliedAuth).toBe("per_call_pat");
+  });
+
+  test("none auth returns verbatim URL", () => {
+    const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "none" });
+    expect(r).not.toBeNull();
+    expect(r!.authedUrl).toBe("https://github.com/owner/repo.git");
+    expect(r!.appliedAuth).toBe("none");
+  });
+
+  describe("credentialsFile path", () => {
+    let home: string;
+    beforeEach(() => {
+      home = tmp("import-creds-");
+      process.env.PARACHUTE_HOME = home;
+      process.env.HOME = home;
+    });
+    afterEach(() => {
+      if (home) rmSync(home, { recursive: true, force: true });
+    });
+
+    test("no credentials file → verbatim URL", () => {
+      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" });
+      expect(r!.appliedAuth).toBe("none");
+    });
+
+    test("stored github_oauth credentials → embed token on github.com", () => {
+      const creds: MirrorCredentials = {
+        ...emptyCredentials(),
+        active_method: "github_oauth",
+        github_oauth: {
+          access_token: "gho_abc",
+          scope: "repo",
+          authorized_at: "2026-05-28T00:00:00.000Z",
+          user_login: "aaron",
+          user_id: 1,
+        },
+      };
+      writeCredentials(creds);
+      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" });
+      expect(r!.authedUrl).toContain("x-access-token:gho_abc@");
+      expect(r!.appliedAuth).toBe("stored_oauth");
+    });
+
+    test("stored github_oauth + non-github host → verbatim (OAuth token is useless off-host)", () => {
+      const creds: MirrorCredentials = {
+        ...emptyCredentials(),
+        active_method: "github_oauth",
+        github_oauth: {
+          access_token: "gho_abc",
+          scope: "repo",
+          authorized_at: "2026-05-28T00:00:00.000Z",
+          user_login: "aaron",
+          user_id: 1,
+        },
+      };
+      writeCredentials(creds);
+      const r = authedCloneUrl("https://gitlab.com/owner/repo.git", { kind: "credentialsFile" });
+      expect(r!.appliedAuth).toBe("none");
+    });
+
+    test("stored PAT + matching host → embed token", () => {
+      const creds: MirrorCredentials = {
+        ...emptyCredentials(),
+        active_method: "pat",
+        pat: {
+          token: "glpat_xyz",
+          remote_url: "https://x-access-token:glpat_xyz@gitlab.com/owner/repo.git",
+          label: "GitLab PAT",
+        },
+      };
+      writeCredentials(creds);
+      const r = authedCloneUrl("https://gitlab.com/owner/repo.git", { kind: "credentialsFile" });
+      expect(r!.authedUrl).toContain("x-access-token:glpat_xyz@");
+      expect(r!.appliedAuth).toBe("stored_pat");
+    });
+
+    test("stored PAT + non-matching host → verbatim", () => {
+      const creds: MirrorCredentials = {
+        ...emptyCredentials(),
+        active_method: "pat",
+        pat: {
+          token: "glpat_xyz",
+          remote_url: "https://x-access-token:glpat_xyz@gitlab.com/owner/repo.git",
+          label: "GitLab PAT",
+        },
+      };
+      writeCredentials(creds);
+      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" });
+      expect(r!.appliedAuth).toBe("none");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cloneAndImport — success path
+// ---------------------------------------------------------------------------
+
+describe("cloneAndImport — success", () => {
+  let fixtureDir: string;
+  let assetsDir: string;
+  let store: SqliteStore;
+
+  beforeEach(async () => {
+    fixtureDir = await buildExportFixture();
+    assetsDir = tmp("import-assets-");
+    store = new SqliteStore(new Database(":memory:"));
+  });
+
+  afterEach(() => {
+    if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+    if (assetsDir) rmSync(assetsDir, { recursive: true, force: true });
+  });
+
+  test("merge mode — imports notes from a fixture export", async () => {
+    const result = await cloneAndImport({
+      vaultName: "default",
+      remoteUrl: "https://github.com/owner/repo.git",
+      auth: { kind: "none" },
+      mode: "merge",
+      store,
+      assetsDir,
+      spawn: spawnCloneSuccess(fixtureDir),
+    });
+    expect(result.notes_imported).toBe(2); // alpha + beta
+    expect(result.notes_deleted).toBeUndefined();
+    expect(result.warnings).toEqual([]);
+
+    const restored = await store.getNote("n-alpha");
+    expect(restored).toBeTruthy();
+    expect(restored!.content.trimEnd()).toBe("alpha body");
+  });
+
+  test("merge mode — preserves existing notes that aren't in the remote", async () => {
+    // Seed a local note that the remote doesn't carry.
+    await store.createNote("local-only", { id: "n-local", path: "local" });
+    const result = await cloneAndImport({
+      vaultName: "default",
+      remoteUrl: "https://github.com/owner/repo.git",
+      auth: { kind: "none" },
+      mode: "merge",
+      store,
+      assetsDir,
+      spawn: spawnCloneSuccess(fixtureDir),
+    });
+    expect(result.notes_imported).toBe(2);
+    expect(result.notes_deleted).toBeUndefined();
+    // Local note survives.
+    const localStill = await store.getNote("n-local");
+    expect(localStill).toBeTruthy();
+  });
+
+  test("replace mode — wipes existing notes, sets notes_deleted", async () => {
+    await store.createNote("local-only", { id: "n-local", path: "local" });
+    const result = await cloneAndImport({
+      vaultName: "default",
+      remoteUrl: "https://github.com/owner/repo.git",
+      auth: { kind: "none" },
+      mode: "replace",
+      store,
+      assetsDir,
+      spawn: spawnCloneSuccess(fixtureDir),
+    });
+    expect(result.notes_imported).toBe(2);
+    expect(result.notes_deleted).toBe(1);
+    // Local note got wiped before the import replayed.
+    const localGone = await store.getNote("n-local");
+    expect(localGone).toBeNull();
+  });
+
+  test("cleans up tempdir on success", async () => {
+    const workDirRoot = tmp("import-workroot-");
+    await cloneAndImport({
+      vaultName: "default",
+      remoteUrl: "https://github.com/owner/repo.git",
+      auth: { kind: "none" },
+      mode: "merge",
+      store,
+      assetsDir,
+      spawn: spawnCloneSuccess(fixtureDir),
+      workDirRoot,
+    });
+    // workDirRoot itself still exists; the parachute-import-<rand> subdir
+    // inside it should be gone.
+    const { readdirSync } = await import("node:fs");
+    const entries = readdirSync(workDirRoot);
+    expect(entries.filter((e) => e.startsWith("parachute-import-"))).toEqual([]);
+    rmSync(workDirRoot, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cloneAndImport — failure paths
+// ---------------------------------------------------------------------------
+
+describe("cloneAndImport — failures", () => {
+  let assetsDir: string;
+  let store: SqliteStore;
+
+  beforeEach(() => {
+    assetsDir = tmp("import-assets-fail-");
+    store = new SqliteStore(new Database(":memory:"));
+  });
+
+  afterEach(() => {
+    if (assetsDir) rmSync(assetsDir, { recursive: true, force: true });
+  });
+
+  test("invalid URL → CloneFailedError before any spawn", async () => {
+    let spawnCalled = false;
+    const fakeSpawn: GitSpawn = async () => {
+      spawnCalled = true;
+      return { exitCode: 0, stderr: "", timedOut: false };
+    };
+    await expect(
+      cloneAndImport({
+        vaultName: "default",
+        remoteUrl: "not-a-url",
+        auth: { kind: "none" },
+        mode: "merge",
+        store,
+        assetsDir,
+        spawn: fakeSpawn,
+      }),
+    ).rejects.toThrow(CloneFailedError);
+    expect(spawnCalled).toBe(false);
+  });
+
+  test("git clone non-zero exit → CloneFailedError with redacted stderr", async () => {
+    await expect(
+      cloneAndImport({
+        vaultName: "default",
+        remoteUrl: "https://github.com/owner/repo.git",
+        auth: { kind: "pat", token: "ghp_secret" },
+        mode: "merge",
+        store,
+        assetsDir,
+        spawn: spawnCloneFailure(
+          "fatal: could not read Password for 'https://x-access-token:ghp_secret@github.com'",
+        ),
+      }),
+    ).rejects.toThrow(/git clone failed/);
+
+    // Re-run to capture the error message; ensure the token is redacted.
+    try {
+      await cloneAndImport({
+        vaultName: "default",
+        remoteUrl: "https://github.com/owner/repo.git",
+        auth: { kind: "pat", token: "ghp_secret" },
+        mode: "merge",
+        store,
+        assetsDir,
+        spawn: spawnCloneFailure(
+          "fatal: could not read Password for 'https://x-access-token:ghp_secret@github.com'",
+        ),
+      });
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).not.toContain("ghp_secret");
+      expect(message).toContain("***@");
+    }
+  });
+
+  test("clone timeout → CloneFailedError mentioning timeout", async () => {
+    await expect(
+      cloneAndImport({
+        vaultName: "default",
+        remoteUrl: "https://github.com/owner/repo.git",
+        auth: { kind: "none" },
+        mode: "merge",
+        store,
+        assetsDir,
+        spawn: spawnCloneTimeout,
+        cloneTimeoutMs: 100,
+      }),
+    ).rejects.toThrow(/timed out/);
+  });
+
+  test("clone target lacks .parachute/vault.yaml → NotAVaultExportError", async () => {
+    const notAnExport = tmp("import-not-export-");
+    writeFileSync(join(notAnExport, "README.md"), "hello");
+    const fakeSpawn: GitSpawn = async (argv) => {
+      const dest = argv[argv.length - 1]!;
+      cpSync(notAnExport, dest, { recursive: true });
+      return { exitCode: 0, stderr: "", timedOut: false };
+    };
+    await expect(
+      cloneAndImport({
+        vaultName: "default",
+        remoteUrl: "https://github.com/owner/repo.git",
+        auth: { kind: "none" },
+        mode: "merge",
+        store,
+        assetsDir,
+        spawn: fakeSpawn,
+      }),
+    ).rejects.toThrow(NotAVaultExportError);
+    rmSync(notAnExport, { recursive: true, force: true });
+  });
+
+  test("concurrent imports against the same vault → ImportConflictError", async () => {
+    // Build a real fixture so the long-running clone has something
+    // valid to find.
+    const fixture = await buildExportFixture();
+
+    // First import — slow spawn (resolves on the next tick), but starts
+    // immediately.
+    let firstSpawnGate: (v?: unknown) => void;
+    const firstSpawn: GitSpawn = async (argv) => {
+      await new Promise((res) => {
+        firstSpawnGate = res;
+      });
+      const dest = argv[argv.length - 1]!;
+      cpSync(fixture, dest, { recursive: true });
+      return { exitCode: 0, stderr: "", timedOut: false };
+    };
+
+    const firstPromise = cloneAndImport({
+      vaultName: "default",
+      remoteUrl: "https://github.com/owner/repo.git",
+      auth: { kind: "none" },
+      mode: "merge",
+      store,
+      assetsDir,
+      spawn: firstSpawn,
+    });
+
+    // Wait a tick so the inFlight set has populated.
+    await new Promise((res) => setTimeout(res, 10));
+    expect(_isImportInFlight("default")).toBe(true);
+
+    // Second import — should immediately reject.
+    await expect(
+      cloneAndImport({
+        vaultName: "default",
+        remoteUrl: "https://github.com/owner/repo.git",
+        auth: { kind: "none" },
+        mode: "merge",
+        store,
+        assetsDir,
+        spawn: spawnCloneSuccess(fixture),
+      }),
+    ).rejects.toThrow(ImportConflictError);
+
+    // Let the first import finish.
+    firstSpawnGate!();
+    await firstPromise;
+    expect(_isImportInFlight("default")).toBe(false);
+
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  test("cleans up tempdir even when import throws", async () => {
+    const workDirRoot = tmp("import-workroot-fail-");
+    const notAnExport = tmp("import-not-export-fail-");
+    writeFileSync(join(notAnExport, "README.md"), "hello");
+    const fakeSpawn: GitSpawn = async (argv) => {
+      const dest = argv[argv.length - 1]!;
+      cpSync(notAnExport, dest, { recursive: true });
+      return { exitCode: 0, stderr: "", timedOut: false };
+    };
+    await expect(
+      cloneAndImport({
+        vaultName: "default",
+        remoteUrl: "https://github.com/owner/repo.git",
+        auth: { kind: "none" },
+        mode: "merge",
+        store,
+        assetsDir,
+        spawn: fakeSpawn,
+        workDirRoot,
+      }),
+    ).rejects.toThrow();
+    const { readdirSync } = await import("node:fs");
+    const entries = readdirSync(workDirRoot);
+    expect(entries.filter((e) => e.startsWith("parachute-import-"))).toEqual([]);
+    rmSync(workDirRoot, { recursive: true, force: true });
+    rmSync(notAnExport, { recursive: true, force: true });
+  });
+});

--- a/src/mirror-import.test.ts
+++ b/src/mirror-import.test.ts
@@ -115,12 +115,39 @@ describe("authedCloneUrl", () => {
     expect(authedCloneUrl("not-a-url", { kind: "none" })).toBeNull();
   });
 
-  test("passes ssh URLs verbatim (no userinfo to embed)", () => {
-    // `git@github.com:owner/repo.git` parses to a URL with protocol `git:`,
-    // not http/https — our helper returns it verbatim.
+  test("passes git:// URLs verbatim (no userinfo to embed)", () => {
+    // `git://github.com/owner/repo.git` parses as a URL with protocol
+    // `git:`, not http/https — our helper returns it verbatim.
     const r = authedCloneUrl("git://github.com/owner/repo.git", { kind: "pat", token: "ghp_x" });
     expect(r).not.toBeNull();
     expect(r!.authedUrl).toBe("git://github.com/owner/repo.git");
+    expect(r!.appliedAuth).toBe("none");
+  });
+
+  // Reviewer-flagged on vault#390 — the original ssh-shorthand assertion
+  // accidentally tested `git://` instead of the `git@host:owner/repo`
+  // shape, leaving the ssh-shorthand regex branch uncovered. SSH
+  // shorthand doesn't parse as `new URL()` (no scheme), so authedCloneUrl
+  // falls through the regex matcher and returns the URL verbatim — there
+  // is no userinfo slot to embed a token into. This test pins that path.
+  test("passes ssh-shorthand URLs verbatim (no scheme, no userinfo slot)", () => {
+    const r = authedCloneUrl("git@github.com:owner/repo.git", {
+      kind: "pat",
+      token: "ghp_should_not_appear",
+    });
+    expect(r).not.toBeNull();
+    expect(r!.authedUrl).toBe("git@github.com:owner/repo.git");
+    expect(r!.authedUrl).not.toContain("ghp_should_not_appear");
+    expect(r!.appliedAuth).toBe("none");
+  });
+
+  test("passes ssh:// URLs verbatim", () => {
+    const r = authedCloneUrl("ssh://git@github.com/owner/repo.git", {
+      kind: "pat",
+      token: "ghp_x",
+    });
+    expect(r).not.toBeNull();
+    expect(r!.authedUrl).toBe("ssh://git@github.com/owner/repo.git");
     expect(r!.appliedAuth).toBe("none");
   });
 

--- a/src/mirror-import.ts
+++ b/src/mirror-import.ts
@@ -49,6 +49,17 @@
  * against the same vault name. The first lays a marker; the second
  * receives the conflict signal so the HTTP handler can return 409.
  *
+ * **SIGTERM tempdir leak (known, acceptable):** if vault gets killed
+ * mid-clone (SIGINT/SIGTERM during the `Bun.spawn` window), the
+ * `parachute-import-<rand>` tempdir is abandoned on disk. Same posture
+ * as `probeGitLsRemote` in mirror-routes.ts — owner can sweep
+ * `/tmp/parachute-import-*` manually if they care. Adding a signal
+ * handler that cleans up only the in-flight import dir(s) is feasible
+ * but a) requires registering on every server boot, b) interacts
+ * weirdly with the existing graceful-shutdown drain path, c) doesn't
+ * close the OOM-killer / power-loss case anyway. Acceptable as-is for
+ * the self-host threat model.
+ *
  * See vault#391 (the import sibling of #384's export work).
  */
 

--- a/src/mirror-import.ts
+++ b/src/mirror-import.ts
@@ -1,0 +1,473 @@
+/**
+ * Clone + import worker — symmetric counterpart to the export path that
+ * vault#382 + vault#384 shipped.
+ *
+ * The "import from a git repo" feature lets an operator on machine B pull a
+ * vault state that machine A has been pushing to a git remote. The flow:
+ *
+ *   1. Operator opens the admin SPA's "Import from git" section.
+ *   2. Picks a remote URL (paste, OAuth repo-picker, or a one-time PAT).
+ *   3. Picks a mode — `merge` (upsert-by-id, preserves notes that aren't
+ *      in the remote) or `replace` (wipe-then-import, the remote becomes
+ *      the new source of truth).
+ *   4. POSTs to `/.parachute/mirror/import`. The handler delegates to
+ *      `cloneAndImport()` below.
+ *
+ * `cloneAndImport()`:
+ *
+ *   - Creates a temp dir (`os.tmpdir() + /parachute-import-<rand>`).
+ *   - Resolves the authed clone URL (stored credentials, supplied per-call
+ *     PAT, or none).
+ *   - Shells `git clone --depth 1 <authedUrl> <tempDir>` with a 60s
+ *     timeout and `GIT_TERMINAL_PROMPT=0` so bad credentials fail fast
+ *     rather than blocking on a stdin prompt.
+ *   - Validates the clone looks like a vault export — `.parachute/vault.yaml`
+ *     must be present. Refuses with a clear error otherwise.
+ *   - On `mode: "replace"`: wipes notes + tags via `store.deleteNote()` /
+ *     `store.deleteTag()` (same shape `importPortableVault` does
+ *     internally when `blowAway: true` — we call the importer with
+ *     `blowAway: true` to inherit that semantics rather than rolling our
+ *     own delete loop).
+ *   - Calls `importPortableVault(store, { inDir, blowAway, assetsDir })`.
+ *   - Returns aggregated stats (notes_imported, tags_imported,
+ *     attachments_imported, notes_deleted, warnings).
+ *   - Always cleans up the temp dir on every code path (try/finally).
+ *
+ * **Threat model — credentials in argv (reviewer-flagged vault#384):**
+ *
+ *   `git clone <https://x-access-token:TOKEN@host/...>` puts the token in
+ *   `/proc/<pid>/cmdline` for the clone window (~few seconds). For vault's
+ *   owner-operated, single-user self-host posture this is acceptable —
+ *   anyone with shell on the box already has read access to
+ *   `~/.parachute/vault/.mirror-credentials.yaml` (0600) and would have
+ *   `~/.git-credentials` for that matter. Same posture as `git ls-remote`
+ *   in mirror-credentials.ts. Multi-tenant cloud (cloud Tier 2) would
+ *   switch this to a credential-helper script so the token never enters
+ *   argv. Today's pattern: documented + scoped to the threat model.
+ *
+ * **Concurrency:** the in-flight set below blocks two concurrent imports
+ * against the same vault name. The first lays a marker; the second
+ * receives the conflict signal so the HTTP handler can return 409.
+ *
+ * See vault#391 (the import sibling of #384's export work).
+ */
+
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  importPortableVault,
+  type ImportStats,
+} from "../core/src/portable-md.ts";
+import type { SqliteStore } from "../core/src/store.ts";
+import { redactRemoteUrl, readCredentials } from "./mirror-credentials.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Auth shape for a clone:
+ *
+ *   - `{ kind: "credentialsFile" }` — use the stored mirror credentials
+ *     (`~/.parachute/vault/.mirror-credentials.yaml`). If none exist the
+ *     clone proceeds unauthed — fine for public repos, will fail for
+ *     private ones with a clear `git`-surfaced error.
+ *   - `{ kind: "pat", token, remoteUrl }` — one-shot. The supplied PAT
+ *     gets embedded in the remote URL via the GitHub `x-access-token`
+ *     convention. Does NOT touch the stored credentials.
+ *   - `{ kind: "none" }` — explicit no-auth (for genuinely public repos).
+ */
+export type ImportAuth =
+  | { kind: "credentialsFile" }
+  | { kind: "pat"; token: string }
+  | { kind: "none" };
+
+/** What the caller passes to `cloneAndImport`. */
+export interface ImportOpts {
+  /** Target vault name (the one currently being imported INTO). */
+  vaultName: string;
+  /** HTTPS or SSH clone URL the operator pasted / picked. */
+  remoteUrl: string;
+  /** How to authenticate the clone. See `ImportAuth`. */
+  auth: ImportAuth;
+  /**
+   * `merge` — upsert-by-id semantics. Existing notes updated, new ones
+   * created, notes that aren't in the remote SURVIVE.
+   * `replace` — wipe-first. The remote becomes the new source of truth;
+   * any local-only notes are deleted.
+   */
+  mode: "merge" | "replace";
+  /** Vault store to write into. */
+  store: SqliteStore;
+  /**
+   * Assets dir (where attachment binaries live for this vault). Wire
+   * via `assetsDir(vaultName)` from `routes.ts`.
+   */
+  assetsDir: string;
+  /** Override the temp dir (test seam). Defaults to `os.tmpdir()`. */
+  workDirRoot?: string;
+  /** Override the spawner (test seam — fake `git`). */
+  spawn?: GitSpawn;
+  /** Override the post-clone import path (test seam — assume cloned dir is a vault export). */
+  importer?: typeof importPortableVault;
+  /** Override the clone timeout (default 60s; test seam to shorten). */
+  cloneTimeoutMs?: number;
+}
+
+/**
+ * Counts + warnings returned to the HTTP caller. `notes_imported` totals
+ * created+updated so the operator sees a single "imported N notes" number
+ * regardless of mode. `notes_deleted` is set only when `mode === "replace"`.
+ */
+export interface ImportResult {
+  notes_imported: number;
+  tags_imported: number;
+  attachments_imported: number;
+  /** Only set when `mode === "replace"`. */
+  notes_deleted?: number;
+  /**
+   * Per-skipped-thing detail (links pointing to notes outside the import
+   * set, attachments missing binaries, sidecars without content files,
+   * etc.). The HTTP handler returns these so the operator can audit.
+   */
+  warnings: string[];
+}
+
+/**
+ * Shape of the spawner we accept. Real impl is `Bun.spawn`. Tests inject
+ * a fake to skip the real git binary.
+ */
+export type GitSpawn = (
+  argv: string[],
+  options: { cwd?: string; timeoutMs: number },
+) => Promise<GitSpawnResult>;
+
+export interface GitSpawnResult {
+  exitCode: number;
+  stderr: string;
+  timedOut: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency guard — refuse 409 if the same vault is already importing.
+// ---------------------------------------------------------------------------
+
+const inFlight = new Set<string>();
+
+/** Throw the conflict signal — handler catches and turns into a 409. */
+export class ImportConflictError extends Error {
+  constructor(vaultName: string) {
+    super(
+      `Import already running for vault "${vaultName}". Wait for it to finish before starting another.`,
+    );
+    this.name = "ImportConflictError";
+  }
+}
+
+/** Throw when the clone target is not a portable-md vault export. */
+export class NotAVaultExportError extends Error {
+  constructor() {
+    super(
+      'This does not look like a Parachute vault export — no `.parachute/vault.yaml` found at the repo root. ' +
+        "Make sure the remote was created by `parachute-vault export` or the mirror's export flow.",
+    );
+    this.name = "NotAVaultExportError";
+  }
+}
+
+/** Throw when the clone itself fails (network, auth, missing repo, etc.). */
+export class CloneFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CloneFailedError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auth URL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the URL we hand to `git clone`. Behavior depends on `auth`:
+ *
+ *   - `pat` → embed `x-access-token:<TOKEN>` userinfo if the URL doesn't
+ *     already carry creds. Sibling of `mirror-credentials.ts`'s
+ *     `applyToGitRemote` approach.
+ *   - `credentialsFile` → if stored creds are GitHub OAuth, embed the
+ *     token. If stored creds are a PAT with a saved URL whose host
+ *     matches, reuse the stored URL. Otherwise pass the URL verbatim.
+ *   - `none` → return the URL verbatim.
+ *
+ * Returns `null` when the URL is unparseable (caller surfaces a 400).
+ */
+export function authedCloneUrl(
+  remoteUrl: string,
+  auth: ImportAuth,
+): { authedUrl: string; appliedAuth: "stored_oauth" | "stored_pat" | "per_call_pat" | "none" } | null {
+  // Local-path / SSH-shorthand pass-through. Git accepts three URL shapes:
+  //   - HTTPS/HTTP — what we embed auth into below.
+  //   - SSH (`git@host:owner/repo`) — relies on ssh-agent, no userinfo
+  //     slot. We pass verbatim.
+  //   - Local path (`/abs/path` or `./rel/path`) or `file://` — used by
+  //     local-disk mirrors + E2E tests. Pass verbatim; no auth to embed.
+  // The naive `new URL(...)` call below would reject all three of these
+  // pre-validation (local paths don't have a scheme), so detect them
+  // first.
+  if (remoteUrl.startsWith("/") || remoteUrl.startsWith("./") || remoteUrl.startsWith("../")) {
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+  if (remoteUrl.startsWith("file://")) {
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+  // SSH shorthand: `git@host:owner/repo.git`. Pattern: `<user>@<host>:<path>`.
+  // Doesn't parse as a URL — detect by the colon-after-host shape.
+  if (/^[A-Za-z0-9_-]+@[A-Za-z0-9.-]+:[^/]/.test(remoteUrl)) {
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(remoteUrl);
+  } catch {
+    return null;
+  }
+  // Only http/https get userinfo treatment. SSH URLs (`ssh://git@host/...`),
+  // git://, etc., parse as URLs but we don't try to embed creds in them.
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+
+  // If the URL already carries userinfo (operator pasted a URL with the
+  // token baked in), trust it and don't override.
+  if (parsed.username || parsed.password) {
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+
+  if (auth.kind === "none") {
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+
+  if (auth.kind === "pat") {
+    const u = new URL(remoteUrl);
+    u.username = "x-access-token";
+    u.password = auth.token;
+    return { authedUrl: u.toString(), appliedAuth: "per_call_pat" };
+  }
+
+  // credentialsFile path — read from disk.
+  const creds = readCredentials();
+  if (!creds || !creds.active_method) {
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+  if (creds.active_method === "github_oauth" && creds.github_oauth) {
+    // Embed the OAuth token if the URL is on github.com.
+    if (parsed.host.toLowerCase() === "github.com") {
+      const u = new URL(remoteUrl);
+      u.username = "x-access-token";
+      u.password = creds.github_oauth.access_token;
+      return { authedUrl: u.toString(), appliedAuth: "stored_oauth" };
+    }
+    // GitHub OAuth token against a non-github host: useless. Fall through.
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+  if (creds.active_method === "pat" && creds.pat) {
+    // If the stored PAT URL host matches the request URL host, the stored
+    // token is the right one. Embed it.
+    let storedHost = "";
+    try {
+      storedHost = new URL(creds.pat.remote_url).host.toLowerCase();
+    } catch {
+      // ignore — fall through to no-auth
+    }
+    if (storedHost && storedHost === parsed.host.toLowerCase()) {
+      const u = new URL(remoteUrl);
+      u.username = "x-access-token";
+      u.password = creds.pat.token;
+      return { authedUrl: u.toString(), appliedAuth: "stored_pat" };
+    }
+    return { authedUrl: remoteUrl, appliedAuth: "none" };
+  }
+  return { authedUrl: remoteUrl, appliedAuth: "none" };
+}
+
+// ---------------------------------------------------------------------------
+// Default git spawner — used in production. Tests inject a fake.
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a git command with a hard timeout + non-interactive env. Returns
+ * exit code + stderr text + timeout flag.
+ */
+export const defaultGitSpawn: GitSpawn = async (argv, options) => {
+  const proc = Bun.spawn(argv, {
+    cwd: options.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: "0",
+      // Kill any system credential helper from intercepting — we want
+      // the clone to use ONLY the URL-embedded credential, not whatever's
+      // in keychain. Same shape as the ls-remote probe.
+      GIT_ASKPASS: "/bin/echo",
+    },
+  });
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    try {
+      proc.kill();
+    } catch {
+      // already exited
+    }
+  }, options.timeoutMs);
+  const exitCode = await proc.exited;
+  clearTimeout(timer);
+  const stderr = new TextDecoder()
+    .decode(await new Response(proc.stderr).arrayBuffer())
+    .trim();
+  return { exitCode, stderr, timedOut };
+};
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Clone a vault export from a git remote and import it into the target
+ * vault. See module-level docstring for the full shape.
+ *
+ * Throws:
+ *   - `ImportConflictError` — another import is already running for this
+ *     vault. Handler returns 409.
+ *   - `CloneFailedError` — git clone exited non-zero (auth wall, network,
+ *     missing repo). Message has the token redacted. Handler returns 502.
+ *   - `NotAVaultExportError` — the clone target lacks `.parachute/vault.yaml`.
+ *     Handler returns 400.
+ *   - Other errors (filesystem, store) propagate; handler returns 500.
+ *
+ * Always cleans up the temp dir.
+ */
+export async function cloneAndImport(opts: ImportOpts): Promise<ImportResult> {
+  if (inFlight.has(opts.vaultName)) {
+    throw new ImportConflictError(opts.vaultName);
+  }
+  inFlight.add(opts.vaultName);
+
+  const spawn = opts.spawn ?? defaultGitSpawn;
+  const importer = opts.importer ?? importPortableVault;
+  const workDirRoot = opts.workDirRoot ?? tmpdir();
+  const cloneTimeoutMs = opts.cloneTimeoutMs ?? 60_000;
+
+  const authResult = authedCloneUrl(opts.remoteUrl, opts.auth);
+  if (!authResult) {
+    inFlight.delete(opts.vaultName);
+    throw new CloneFailedError(
+      `remote_url is not a valid URL: "${redactRemoteUrl(opts.remoteUrl)}"`,
+    );
+  }
+  const { authedUrl } = authResult;
+
+  const tempDir = mkdtempSync(join(workDirRoot, "parachute-import-"));
+  try {
+    const cloneResult = await spawn(
+      ["git", "clone", "--depth", "1", authedUrl, tempDir],
+      { timeoutMs: cloneTimeoutMs },
+    );
+    if (cloneResult.timedOut) {
+      throw new CloneFailedError(
+        `git clone timed out after ${Math.floor(cloneTimeoutMs / 1000)}s. ` +
+          `Check the network connection or try a shallower remote. URL: ${redactRemoteUrl(opts.remoteUrl)}`,
+      );
+    }
+    if (cloneResult.exitCode !== 0) {
+      // Redact any leaked URLs in stderr — git error messages echo them.
+      const redactedStderr = cloneResult.stderr.replace(
+        /https?:\/\/[^@\s]+@/g,
+        "https://***@",
+      );
+      throw new CloneFailedError(
+        `git clone failed for ${redactRemoteUrl(opts.remoteUrl)}: ${redactedStderr}`,
+      );
+    }
+
+    // Validate the clone looks like a vault export.
+    if (!existsSync(join(tempDir, ".parachute", "vault.yaml"))) {
+      throw new NotAVaultExportError();
+    }
+
+    // Delegate to the importer. `blowAway: true` for replace mode triggers
+    // the wipe-then-import path (deletes notes via the public store API
+    // so hooks fire); `false` for merge does upsert-by-id.
+    const stats: ImportStats = await importer(opts.store, {
+      inDir: tempDir,
+      blowAway: opts.mode === "replace",
+      assetsDir: opts.assetsDir,
+    });
+
+    return importResultFromStats(stats, opts.mode);
+  } finally {
+    // Always nuke the temp dir, even on error. The clone might have
+    // partially populated it; force:true skips ENOENT.
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (err) {
+      // Don't mask the original error with a cleanup error — just log.
+      console.warn(
+        `[mirror-import] temp dir cleanup failed (non-fatal): ${(err as Error).message ?? err}`,
+      );
+    }
+    inFlight.delete(opts.vaultName);
+  }
+}
+
+/**
+ * Map the `importPortableVault` stats shape onto the import-API result
+ * shape. Combines created+updated into a single "imported" count (the
+ * operator's mental model is "I imported N notes" not "I created X and
+ * updated Y"); surfaces every skipped link/attachment/sidecar as a
+ * warning string.
+ */
+function importResultFromStats(
+  stats: ImportStats,
+  mode: "merge" | "replace",
+): ImportResult {
+  const warnings: string[] = [];
+  for (const sl of stats.skipped_links) {
+    warnings.push(
+      `Skipped link ${sl.source_id} → ${sl.target_id} (${sl.relationship}): ${sl.reason}`,
+    );
+  }
+  for (const sa of stats.skipped_attachments) {
+    warnings.push(
+      `Skipped attachment ${sa.attachment_id} on note ${sa.note_id}: ${sa.reason}`,
+    );
+  }
+  for (const ss of stats.skipped_sidecars) {
+    warnings.push(
+      `Orphaned sidecar ${ss.sidecar_id} (path=${ss.expected_path ?? "—"}): ${ss.reason}`,
+    );
+  }
+  const result: ImportResult = {
+    notes_imported: stats.notes_created + stats.notes_updated,
+    tags_imported: stats.schemas_restored,
+    attachments_imported: stats.attachments_restored,
+    warnings,
+  };
+  if (mode === "replace") {
+    result.notes_deleted = stats.notes_wiped;
+  }
+  return result;
+}
+
+/** Test seam — surface in-flight state for assertions. */
+export function _isImportInFlight(vaultName: string): boolean {
+  return inFlight.has(vaultName);
+}
+
+/** Test seam — clear the in-flight set. */
+export function _resetImportInFlightForTest(): void {
+  inFlight.clear();
+}

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -26,9 +26,20 @@ import {
   handleAuthGithubRepos,
   handleAuthPat,
   handleMirrorGet,
+  handleMirrorImport,
   handleMirrorPut,
   handleMirrorRunNow,
 } from "./mirror-routes.ts";
+import {
+  _resetImportInFlightForTest,
+  type GitSpawn,
+} from "./mirror-import.ts";
+import { writeVaultConfig } from "./config.ts";
+import { clearVaultStoreCache } from "./vault-store.ts";
+import { exportVaultToDir } from "../core/src/portable-md.ts";
+import { Database } from "bun:sqlite";
+import { SqliteStore } from "../core/src/store.ts";
+import { cpSync, writeFileSync as nodeWriteFileSync } from "node:fs";
 import {
   mirrorCredentialsPath,
   readCredentials,
@@ -845,6 +856,313 @@ describe("auth credential routes — github repos / create-repo", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { full_name: string };
     expect(body.full_name).toBe("aaron/new-vault");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /.parachute/mirror/import — clone-and-import HTTP route (vault#391).
+// ---------------------------------------------------------------------------
+
+/**
+ * Bootstrap a real vault config + db file so getVaultStore('default')
+ * succeeds inside the handler. Returns the home dir for cleanup.
+ */
+async function bootstrapVault(home: string): Promise<void> {
+  process.env.PARACHUTE_HOME = home;
+  process.env.HOME = home;
+  // The minimal layout vault needs to spin up its store: a per-vault
+  // dir at $PARACHUTE_HOME/vault/data/<name> + a `vault.yaml` config.
+  // writeVaultConfig creates these for us.
+  fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+  writeVaultConfig({
+    name: "default",
+    description: "import-test vault",
+    created_at: "2026-05-28T00:00:00.000Z",
+    api_keys: [],
+  });
+  clearVaultStoreCache();
+}
+
+/**
+ * Build a real portable-md vault export, return the path. The clone
+ * spawn-mock copies this into the tempdir to simulate a successful
+ * `git clone`.
+ */
+async function buildExportFixture(): Promise<string> {
+  const fixture = tmp("import-route-fixture-");
+  const exportStore = new SqliteStore(new Database(":memory:"));
+  await exportStore.createNote("alpha body", { id: "n-alpha", path: "alpha", tags: ["t1"] });
+  await exportStore.createNote("beta body", { id: "n-beta", path: "beta" });
+  await exportVaultToDir(exportStore, {
+    outDir: fixture,
+    vaultName: "source",
+    exportedAt: "2026-05-28T00:00:00.000Z",
+  });
+  return fixture;
+}
+
+const spawnCloneSuccess = (fixture: string): GitSpawn => async (argv) => {
+  const destDir = argv[argv.length - 1]!;
+  cpSync(fixture, destDir, { recursive: true });
+  return { exitCode: 0, stderr: "", timedOut: false };
+};
+
+const spawnCloneFail: GitSpawn = async () => ({
+  exitCode: 128,
+  stderr: "fatal: repository not found",
+  timedOut: false,
+});
+
+describe("handleMirrorImport", () => {
+  let home: string;
+  let fixture: string;
+
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    if (fixture) fs.rmSync(fixture, { recursive: true, force: true });
+    _resetImportInFlightForTest();
+    clearVaultStoreCache();
+  });
+
+  test("rejects invalid JSON body with 400", async () => {
+    home = tmp("import-route-badjson-");
+    await bootstrapVault(home);
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: "{not-json",
+    });
+    const res = await handleMirrorImport(req, "default");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error_type: string };
+    expect(body.error_type).toBe("invalid_json");
+  });
+
+  test("rejects missing remote_url with 400", async () => {
+    home = tmp("import-route-no-url-");
+    await bootstrapVault(home);
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({ mode: "merge" }),
+    });
+    const res = await handleMirrorImport(req, "default");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { field: string };
+    expect(body.field).toBe("remote_url");
+  });
+
+  test("rejects invalid mode with 400", async () => {
+    home = tmp("import-route-bad-mode-");
+    await bootstrapVault(home);
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({ remote_url: "https://github.com/a/b.git", mode: "wipe" }),
+    });
+    const res = await handleMirrorImport(req, "default");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { field: string };
+    expect(body.field).toBe("mode");
+  });
+
+  test("rejects per-call PAT without token", async () => {
+    home = tmp("import-route-pat-missing-token-");
+    await bootstrapVault(home);
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/a/b.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "" },
+      }),
+    });
+    const res = await handleMirrorImport(req, "default");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { field: string };
+    expect(body.field).toBe("credentials.token");
+  });
+
+  test("rejects unknown credentials.kind", async () => {
+    home = tmp("import-route-bad-kind-");
+    await bootstrapVault(home);
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/a/b.git",
+        mode: "merge",
+        credentials: { kind: "magic" },
+      }),
+    });
+    const res = await handleMirrorImport(req, "default");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { field: string };
+    expect(body.field).toBe("credentials.kind");
+  });
+
+  test("success path — merge mode imports notes into target vault", async () => {
+    home = tmp("import-route-success-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/a/b.git",
+        mode: "merge",
+        credentials: { kind: "none" },
+      }),
+    });
+    const res = await handleMirrorImport(req, "default", spawnCloneSuccess(fixture));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      notes_imported: number;
+      tags_imported: number;
+      attachments_imported: number;
+      warnings: string[];
+      notes_deleted?: number;
+    };
+    expect(body.notes_imported).toBe(2);
+    expect(body.warnings).toEqual([]);
+    expect(body.notes_deleted).toBeUndefined();
+  });
+
+  test("replace mode sets notes_deleted in response", async () => {
+    home = tmp("import-route-replace-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    // Seed the target vault with a local-only note that gets wiped.
+    const { getVaultStore } = await import("./vault-store.ts");
+    const store = getVaultStore("default");
+    await store.createNote("local", { id: "n-local", path: "local" });
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/a/b.git",
+        mode: "replace",
+        credentials: { kind: "none" },
+      }),
+    });
+    const res = await handleMirrorImport(req, "default", spawnCloneSuccess(fixture));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      notes_imported: number;
+      notes_deleted: number;
+    };
+    expect(body.notes_imported).toBe(2);
+    expect(body.notes_deleted).toBe(1);
+  });
+
+  test("clone failure returns 502 with redacted message", async () => {
+    home = tmp("import-route-clone-fail-");
+    await bootstrapVault(home);
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/a/b.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_secret_xyz" },
+      }),
+    });
+    const res = await handleMirrorImport(req, "default", spawnCloneFail);
+    expect(res.status).toBe(502);
+    const text = await res.text();
+    expect(text).not.toContain("ghp_secret_xyz");
+    const body = JSON.parse(text) as { error_type: string };
+    expect(body.error_type).toBe("clone_failed");
+  });
+
+  test("not-a-vault-export returns 400 with actionable message", async () => {
+    home = tmp("import-route-not-vault-");
+    await bootstrapVault(home);
+    const notAnExport = tmp("import-route-notvault-fixture-");
+    nodeWriteFileSync(path.join(notAnExport, "README.md"), "hello");
+    fixture = notAnExport;
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/a/b.git",
+        mode: "merge",
+        credentials: { kind: "none" },
+      }),
+    });
+    const res = await handleMirrorImport(req, "default", spawnCloneSuccess(notAnExport));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error_type: string; message: string };
+    expect(body.error_type).toBe("not_a_vault_export");
+    expect(body.message).toContain("vault.yaml");
+  });
+
+  test("uses stored credentials when credentials: null (credentialsFile path)", async () => {
+    home = tmp("import-route-stored-creds-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    // Write a stored PAT credential matching github.com.
+    writeCredentials({
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        token: "ghp_stored_token_xyz",
+        remote_url: "https://x-access-token:ghp_stored_token_xyz@github.com/a/b.git",
+        label: "stored",
+      },
+    });
+    // Assert the spawn argv carries the stored token (proves the
+    // credentialsFile path resolved).
+    let observedArgv: string[] | null = null;
+    const fakeSpawn: GitSpawn = async (argv) => {
+      observedArgv = argv;
+      const destDir = argv[argv.length - 1]!;
+      cpSync(fixture, destDir, { recursive: true });
+      return { exitCode: 0, stderr: "", timedOut: false };
+    };
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/a/b.git",
+        mode: "merge",
+        credentials: null,
+      }),
+    });
+    const res = await handleMirrorImport(req, "default", fakeSpawn);
+    expect(res.status).toBe(200);
+    // The clone URL should have the stored token embedded.
+    expect(observedArgv).not.toBeNull();
+    expect(observedArgv!.some((arg) => arg.includes("ghp_stored_token_xyz"))).toBe(true);
+  });
+
+  test("per-call PAT override is used when supplied", async () => {
+    home = tmp("import-route-per-call-pat-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    // Stored credentials should be IGNORED when per-call PAT is supplied.
+    writeCredentials({
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        token: "ghp_stored_xyz",
+        remote_url: "https://x-access-token:ghp_stored_xyz@github.com/a/b.git",
+        label: "stored",
+      },
+    });
+    let observedArgv: string[] | null = null;
+    const fakeSpawn: GitSpawn = async (argv) => {
+      observedArgv = argv;
+      const destDir = argv[argv.length - 1]!;
+      cpSync(fixture, destDir, { recursive: true });
+      return { exitCode: 0, stderr: "", timedOut: false };
+    };
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/a/b.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_per_call_only" },
+      }),
+    });
+    const res = await handleMirrorImport(req, "default", fakeSpawn);
+    expect(res.status).toBe(200);
+    expect(observedArgv).not.toBeNull();
+    const joined = observedArgv!.join(" ");
+    expect(joined).toContain("ghp_per_call_only");
+    expect(joined).not.toContain("ghp_stored_xyz");
   });
 });
 

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -52,6 +52,17 @@ import {
   type FetchLike,
   type GitHubRepoInfo,
 } from "./github-device-flow.ts";
+import {
+  CloneFailedError,
+  ImportConflictError,
+  NotAVaultExportError,
+  cloneAndImport,
+  type GitSpawn,
+  type ImportAuth,
+  type ImportResult,
+} from "./mirror-import.ts";
+import { getVaultStore } from "./vault-store.ts";
+import { assetsDir } from "./routes.ts";
 
 /**
  * `GET /vault/<name>/.parachute/mirror` — return the persisted config +
@@ -873,4 +884,208 @@ export async function applyCredentialsToMirror(
   // wiring happens in handleAuthGithubSelectRepo. Nothing to apply here
   // until a repo is selected. Caller is responsible for invoking
   // select-repo separately.
+}
+
+// ---------------------------------------------------------------------------
+// Import-from-git route — symmetric counterpart to the mirror export work.
+//
+// `POST /vault/<name>/.parachute/mirror/import` — clone a vault export from
+// a git remote and import it into the named vault.
+//
+// Request body:
+//   {
+//     "remote_url": "https://github.com/aaron/my-vault.git",
+//     "mode": "merge" | "replace",
+//     "credentials": null
+//       | { "kind": "pat", "token": "ghp_..." }
+//       | { "kind": "none" }
+//   }
+//
+// `credentials: null` means "use the stored mirror credentials." Passing
+// `{kind: "pat", token}` is the one-shot path — token doesn't get persisted.
+//
+// Response:
+//   200 { notes_imported, tags_imported, attachments_imported,
+//         notes_deleted?, warnings }
+//   400 { error, error_type, message }  — validation / not-a-vault-export
+//   409 { error, error_type, message }  — concurrent import for this vault
+//   502 { error, message }              — clone failed (auth, network, …)
+//
+// Admin-gated upstream in routing.ts.
+// ---------------------------------------------------------------------------
+
+/**
+ * `POST /vault/<name>/.parachute/mirror/import`. See block comment above.
+ *
+ * Synchronous response: imports complete in <30s for typical vaults
+ * (a 1k-note vault clones+imports in well under that bound on Aaron's hardware).
+ * If/when bigger vaults arrive we promote to async polling — for now the
+ * synchronous path keeps the UI flow simple.
+ *
+ * `spawnOverride` is a test seam: lets the test inject a fake git binary.
+ * Production callers omit it; `cloneAndImport` falls back to `defaultGitSpawn`.
+ */
+export async function handleMirrorImport(
+  req: Request,
+  vaultName: string,
+  spawnOverride?: GitSpawn,
+): Promise<Response> {
+  let body: {
+    remote_url?: unknown;
+    mode?: unknown;
+    credentials?: unknown;
+  };
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch (err) {
+    return Response.json(
+      {
+        error: "Invalid JSON body",
+        error_type: "invalid_json",
+        message: (err as Error).message ?? String(err),
+      },
+      { status: 400 },
+    );
+  }
+
+  const remote_url =
+    typeof body.remote_url === "string" ? body.remote_url.trim() : "";
+  if (remote_url.length === 0) {
+    return Response.json(
+      {
+        error: "remote_url required",
+        error_type: "validation",
+        field: "remote_url",
+        message: "Provide an HTTPS or SSH clone URL.",
+      },
+      { status: 400 },
+    );
+  }
+  const mode = body.mode;
+  if (mode !== "merge" && mode !== "replace") {
+    return Response.json(
+      {
+        error: "mode invalid",
+        error_type: "validation",
+        field: "mode",
+        message: 'mode must be "merge" or "replace".',
+      },
+      { status: 400 },
+    );
+  }
+
+  // Resolve auth shape. The wire format mirrors the internal ImportAuth
+  // type, but tightened: only `kind` and `token` cross the wire. `none`
+  // and `null` both fall through to "use stored credentials" because the
+  // common case is "I configured mirror creds; use them" — and the
+  // shorthand keeps the SPA from having to track which kind to send.
+  let auth: ImportAuth;
+  const creds = body.credentials;
+  if (creds === null || creds === undefined) {
+    auth = { kind: "credentialsFile" };
+  } else if (typeof creds === "object") {
+    const credsObj = creds as Record<string, unknown>;
+    if (credsObj.kind === "pat") {
+      const token = typeof credsObj.token === "string" ? credsObj.token.trim() : "";
+      if (token.length === 0) {
+        return Response.json(
+          {
+            error: "credentials.token required",
+            error_type: "validation",
+            field: "credentials.token",
+            message: 'When credentials.kind is "pat", credentials.token must be a non-empty string.',
+          },
+          { status: 400 },
+        );
+      }
+      auth = { kind: "pat", token };
+    } else if (credsObj.kind === "none") {
+      auth = { kind: "none" };
+    } else if (credsObj.kind === "credentialsFile") {
+      auth = { kind: "credentialsFile" };
+    } else {
+      return Response.json(
+        {
+          error: "credentials.kind invalid",
+          error_type: "validation",
+          field: "credentials.kind",
+          message: 'credentials.kind must be "pat", "credentialsFile", or "none". Or pass credentials: null.',
+        },
+        { status: 400 },
+      );
+    }
+  } else {
+    return Response.json(
+      {
+        error: "credentials invalid",
+        error_type: "validation",
+        field: "credentials",
+        message: "credentials must be an object or null.",
+      },
+      { status: 400 },
+    );
+  }
+
+  // Resolve the target vault's store + assets dir. The route is gated on
+  // `vault:<name>:admin`, so we trust vaultName is real by the time we
+  // reach this code path; defensively re-resolve in case the vault was
+  // deleted between auth and now.
+  const store = getVaultStore(vaultName);
+  const assets = assetsDir(vaultName);
+
+  let result: ImportResult;
+  try {
+    result = await cloneAndImport({
+      vaultName,
+      remoteUrl: remote_url,
+      auth,
+      mode,
+      store,
+      assetsDir: assets,
+      spawn: spawnOverride,
+    });
+  } catch (err) {
+    if (err instanceof ImportConflictError) {
+      return Response.json(
+        {
+          error: "Import already running",
+          error_type: "concurrent_import",
+          message: err.message,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof NotAVaultExportError) {
+      return Response.json(
+        {
+          error: "Not a vault export",
+          error_type: "not_a_vault_export",
+          message: err.message,
+        },
+        { status: 400 },
+      );
+    }
+    if (err instanceof CloneFailedError) {
+      return Response.json(
+        {
+          error: "Clone failed",
+          error_type: "clone_failed",
+          message: err.message,
+        },
+        { status: 502 },
+      );
+    }
+    return Response.json(
+      {
+        error: "Import failed",
+        error_type: "internal",
+        message: (err as Error).message ?? String(err),
+      },
+      { status: 500 },
+    );
+  }
+
+  return Response.json(result, {
+    headers: { "Access-Control-Allow-Origin": "*" },
+  });
 }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -82,6 +82,7 @@ import {
   handleAuthGithubSelectRepo,
   handleAuthPat,
   handleMirrorGet,
+  handleMirrorImport,
   handleMirrorPut,
   handleMirrorRunNow,
 } from "./mirror-routes.ts";
@@ -554,6 +555,30 @@ export async function route(
     }
     if (req.method === "POST") return handleMirrorRunNow(manager);
     return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  // /.parachute/mirror/import — clone a vault export from git + import.
+  // Admin-gated. POST-only. Synchronous (imports finish in <30s for
+  // typical vaults). See mirror-routes.ts:handleMirrorImport for the
+  // request/response shape + error map. Symmetric counterpart to the
+  // export-to-git flow vault#382 + vault#384 shipped.
+  if (subpath === "/.parachute/mirror/import") {
+    if (!hasScopeForVault(auth.scopes, vaultName, "admin")) {
+      return Response.json(
+        {
+          error: "Forbidden",
+          error_type: "insufficient_scope",
+          message: `This endpoint requires the '${SCOPE_ADMIN}' scope (or '${SCOPE_ADMIN.replace("vault:", `vault:${vaultName}:`)}').`,
+          required_scope: SCOPE_ADMIN,
+          granted_scopes: auth.scopes,
+        },
+        { status: 403 },
+      );
+    }
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    return handleMirrorImport(req, vaultName);
   }
 
   // /.parachute/mirror/auth/* — UI-configurable git push credentials.

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -390,6 +390,57 @@ export async function selectGithubRepo(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Mirror import — `/vault/<name>/.parachute/mirror/import`
+//
+// Symmetric counterpart to the export-to-git flow. Clones a remote git
+// repo into a tempdir, validates it's a vault export, and imports it
+// into THIS vault. See `src/mirror-import.ts` for the worker.
+// ---------------------------------------------------------------------------
+
+/** How to authenticate the clone. See `src/mirror-import.ts:ImportAuth`. */
+export type MirrorImportCredentials =
+  | null // use stored mirror credentials
+  | { kind: "credentialsFile" } // explicit — same as null
+  | { kind: "pat"; token: string } // one-shot, doesn't touch stored creds
+  | { kind: "none" }; // public repo, no auth
+
+export interface MirrorImportRequest {
+  remote_url: string;
+  mode: "merge" | "replace";
+  credentials: MirrorImportCredentials;
+}
+
+export interface MirrorImportResult {
+  notes_imported: number;
+  tags_imported: number;
+  attachments_imported: number;
+  /** Only set when `mode === "replace"`. */
+  notes_deleted?: number;
+  warnings: string[];
+}
+
+/**
+ * POST a clone-and-import request. Returns the import stats on success.
+ * Throws `HttpError` on validation/clone/conflict failures — caller can
+ * surface the status code-specific message to the user.
+ */
+export async function postMirrorImport(
+  vaultName: string,
+  args: MirrorImportRequest,
+): Promise<MirrorImportResult> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/import`,
+    {
+      method: "POST",
+      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      body: JSON.stringify(args),
+    },
+  );
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as MirrorImportResult;
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -5,7 +5,7 @@
  * `lib/api.ts` is mocked for the wire surface; `lib/scope.ts` is mocked
  * so admin-vs-read gating is controllable per test without crafting JWTs.
  */
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -44,6 +44,8 @@ vi.mock("../lib/api.ts", async () => {
     listGithubRepos: vi.fn(),
     createGithubRepo: vi.fn(),
     selectGithubRepo: vi.fn(),
+    // Import from git (vault#391).
+    postMirrorImport: vi.fn(),
   };
 });
 vi.mock("../lib/scope.ts");
@@ -615,11 +617,201 @@ describe("VaultMirror — Git remote credentials", () => {
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Use Personal Access Token/i })).toBeInTheDocument(),
     );
-    const tokenInput = screen.getByLabelText(/Token/i) as HTMLInputElement;
-    const urlInput = screen.getByLabelText(/Remote URL/i) as HTMLInputElement;
+    // Scope to the PAT modal — vault#391 added an "Import from a git
+    // repo" section below GitRemoteSection which also renders a "Remote
+    // URL" field, so a bare getByLabelText match would be ambiguous.
+    const modal = screen.getByRole("dialog");
+    const tokenInput = within(modal).getByLabelText(/Token/i) as HTMLInputElement;
+    const urlInput = within(modal).getByLabelText(/Remote URL/i) as HTMLInputElement;
     await user.type(tokenInput, "ghp_test1234567890");
     await user.type(urlInput, "https://github.com/aaron/vault.git");
     expect(tokenInput.value).toBe("ghp_test1234567890");
     expect(urlInput.value).toBe("https://github.com/aaron/vault.git");
+  });
+});
+
+// ===========================================================================
+// Import-from-git section (vault#391) — symmetric counterpart to the
+// export flow. Tests the ImportFromGitSection's render, mode toggle,
+// confirm-name gate for Replace, success modal, and error path.
+// ===========================================================================
+
+describe("VaultMirror — Import from git section", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(true);
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: false, location: "internal" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+  });
+
+  it("renders the import section heading + multi-pusher caveat", async () => {
+    renderRoute();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /Import from a git repo/i }),
+      ).toBeInTheDocument(),
+    );
+    // Matches either the <strong> "One vault per remote." or the rest
+    // of the banner body — getAllByText since both render.
+    const matches = screen.getAllByText(/One vault per remote/i);
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it("hides import section for read-only users", async () => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(false);
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Git backup for/i })).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("heading", { name: /Import from a git repo/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("toggling Replace requires typing the vault name to enable Start", async () => {
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
+    );
+
+    const user = userEvent.setup();
+    // Type a URL into the import section's Remote URL field (the one
+    // INSIDE the import section, not the PAT modal which isn't open).
+    const importUrlInput = screen.getByLabelText(/Remote URL/i) as HTMLInputElement;
+    await user.type(importUrlInput, "https://github.com/aaron/vault.git");
+
+    // Switch to Replace mode.
+    await user.click(screen.getByRole("radio", { name: /Replace/i }));
+    expect(screen.getByText(/Replace will delete every note/i)).toBeInTheDocument();
+
+    const startBtn = screen.getByRole("button", { name: /Start import/i });
+    expect(startBtn).toBeDisabled();
+
+    // Wrong confirmation — still disabled.
+    const confirm = screen.getByLabelText(/Type vault name to confirm/i) as HTMLInputElement;
+    await user.type(confirm, "wrong");
+    expect(startBtn).toBeDisabled();
+
+    // Right confirmation — enabled.
+    await user.clear(confirm);
+    await user.type(confirm, "work");
+    expect(startBtn).not.toBeDisabled();
+  });
+
+  it("Start import fires postMirrorImport + shows success summary on resolve", async () => {
+    vi.mocked(api.postMirrorImport).mockResolvedValue({
+      notes_imported: 42,
+      tags_imported: 3,
+      attachments_imported: 5,
+      warnings: [],
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    const importUrlInput = screen.getByLabelText(/Remote URL/i) as HTMLInputElement;
+    await user.type(importUrlInput, "https://github.com/aaron/vault.git");
+    await user.click(screen.getByRole("button", { name: /Start import/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/Import succeeded/i)).toBeInTheDocument(),
+    );
+    expect(api.postMirrorImport).toHaveBeenCalledWith("work", {
+      remote_url: "https://github.com/aaron/vault.git",
+      mode: "merge",
+      credentials: { kind: "none" },
+    });
+    // The success summary mentions the counts.
+    expect(screen.getByText(/Imported 42 notes/i)).toBeInTheDocument();
+    // Auto-wire offer surfaces.
+    expect(screen.getByText(/Set this repo as the active mirror remote/i)).toBeInTheDocument();
+  });
+
+  it("one-time PAT credential is sent on Start", async () => {
+    vi.mocked(api.postMirrorImport).mockResolvedValue({
+      notes_imported: 1,
+      tags_imported: 0,
+      attachments_imported: 0,
+      warnings: [],
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText(/Remote URL/i),
+      "https://github.com/aaron/private.git",
+    );
+    await user.click(screen.getByLabelText(/One-time credential/i));
+    const patField = screen.getByPlaceholderText(/ghp_/) as HTMLInputElement;
+    await user.type(patField, "ghp_oneshot_xyz");
+    await user.click(screen.getByRole("button", { name: /Start import/i }));
+    await waitFor(() =>
+      expect(api.postMirrorImport).toHaveBeenCalledWith("work", {
+        remote_url: "https://github.com/aaron/private.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_oneshot_xyz" },
+      }),
+    );
+  });
+
+  it("uses credentials: null (stored creds) when mirror has saved credentials", async () => {
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        label: "saved",
+        remote_url: "https://github.com/aaron/saved.git",
+        token_preview: "ghp_…1234",
+      },
+    });
+    vi.mocked(api.postMirrorImport).mockResolvedValue({
+      notes_imported: 7,
+      tags_imported: 1,
+      attachments_imported: 0,
+      warnings: [],
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText(/Remote URL/i),
+      "https://github.com/aaron/saved.git",
+    );
+    await user.click(screen.getByRole("button", { name: /Start import/i }));
+    await waitFor(() =>
+      expect(api.postMirrorImport).toHaveBeenCalledWith("work", {
+        remote_url: "https://github.com/aaron/saved.git",
+        mode: "merge",
+        credentials: null,
+      }),
+    );
+  });
+
+  it("surfaces server error message on failure", async () => {
+    vi.mocked(api.postMirrorImport).mockRejectedValue(
+      new api.HttpError(502, "git clone failed for https://***@github.com/missing/repo.git: fatal: not found"),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText(/Remote URL/i),
+      "https://github.com/missing/repo.git",
+    );
+    await user.click(screen.getByRole("button", { name: /Start import/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/git clone failed/i)).toBeInTheDocument(),
+    );
   });
 });

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -31,6 +31,8 @@ import {
   type GitHubRepoInfo,
   type MirrorConfig,
   type MirrorCredentialStatus,
+  type MirrorImportCredentials,
+  type MirrorImportResult,
   type MirrorSnapshot,
   type MirrorStatus,
   createGithubRepo,
@@ -40,6 +42,7 @@ import {
   listGithubRepos,
   pollGithubDeviceFlow,
   postMirrorAuthPat,
+  postMirrorImport,
   putMirror,
   runMirrorNow,
   selectGithubRepo,
@@ -286,6 +289,12 @@ function MirrorScreen({
           credsError={credsError}
           onCredsChanged={setCreds}
           locationIsExternal={snapshot.config.location === "external"}
+        />
+      ) : null}
+      {isAdmin ? (
+        <ImportFromGitSection
+          vaultName={vaultName}
+          creds={creds}
         />
       ) : null}
     </>
@@ -1389,6 +1398,520 @@ function PATModal({
             </button>
           </div>
         </form>
+      </div>
+    </div>
+  );
+}
+
+// ===========================================================================
+// Import-from-git section — pull a vault state from a remote git repo into
+// THIS vault. Symmetric counterpart to the export flow above.
+//
+// Three credential paths:
+//   1. From connected GitHub — only visible when active_method ===
+//      "github_oauth". Opens a repo picker; selected repo's clone URL
+//      becomes the remote.
+//   2. From a remote URL — paste any HTTPS or SSH URL. Uses stored
+//      credentials if available, otherwise warns.
+//   3. One-time with a different credential — toggle reveals a PAT field
+//      for a one-shot import that doesn't touch stored credentials.
+//
+// Two modes:
+//   - Merge (default) — upsert-by-id; preserves notes that aren't in
+//     the remote.
+//   - Replace — wipe-then-import; remote becomes the new source of
+//     truth. Gated behind a typed-name confirm.
+//
+// After success: offer to set the remote as the active mirror remote
+// so future writes push back here (auto-wire offer).
+// ===========================================================================
+
+type ImportMode = "merge" | "replace";
+
+type ImportPhase =
+  | { kind: "idle" }
+  | { kind: "running"; stage: "cloning" | "importing" }
+  | { kind: "success"; result: MirrorImportResult; remoteUrl: string; mode: ImportMode }
+  | { kind: "error"; message: string };
+
+function ImportFromGitSection({
+  vaultName,
+  creds,
+}: {
+  vaultName: string;
+  creds: MirrorCredentialStatus | null;
+}) {
+  const [remoteUrl, setRemoteUrl] = useState("");
+  const [mode, setMode] = useState<ImportMode>("merge");
+  const [usePerCallPat, setUsePerCallPat] = useState(false);
+  const [perCallPat, setPerCallPat] = useState("");
+  const [phase, setPhase] = useState<ImportPhase>({ kind: "idle" });
+  // Typed-name confirmation for replace mode. The operator types the
+  // literal vault name to unlock the Start button.
+  const [confirmText, setConfirmText] = useState("");
+  // Repo picker overlay state.
+  const [showRepoPicker, setShowRepoPicker] = useState(false);
+
+  const hasGithubOauth =
+    creds?.active_method === "github_oauth" && creds.github_oauth !== null;
+  const hasStoredCreds = creds?.active_method !== null && creds?.active_method !== undefined;
+
+  const replaceConfirmed =
+    mode !== "replace" || confirmText.trim() === vaultName;
+
+  const canStart =
+    phase.kind !== "running" &&
+    remoteUrl.trim().length > 0 &&
+    replaceConfirmed &&
+    (!usePerCallPat || perCallPat.trim().length > 0);
+
+  const onStart = async () => {
+    setPhase({ kind: "running", stage: "cloning" });
+    let credentials: MirrorImportCredentials;
+    if (usePerCallPat) {
+      credentials = { kind: "pat", token: perCallPat.trim() };
+    } else if (hasStoredCreds) {
+      credentials = null; // server uses credentialsFile
+    } else {
+      credentials = { kind: "none" };
+    }
+    try {
+      // Stage flip is a UI nicety — the server is synchronous from our POV
+      // so the spinner copy can hint at "importing" partway through.
+      const stageTimer = window.setTimeout(
+        () => setPhase((p) => (p.kind === "running" ? { kind: "running", stage: "importing" } : p)),
+        1500,
+      );
+      const result = await postMirrorImport(vaultName, {
+        remote_url: remoteUrl.trim(),
+        mode,
+        credentials,
+      });
+      window.clearTimeout(stageTimer);
+      setPhase({ kind: "success", result, remoteUrl: remoteUrl.trim(), mode });
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `${err.status === 409 ? "Already running. " : ""}${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setPhase({ kind: "error", message });
+    }
+  };
+
+  const onReset = () => {
+    setPhase({ kind: "idle" });
+    setConfirmText("");
+  };
+
+  return (
+    <div className="section">
+      <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>
+        Import from a git repo
+      </h3>
+      <p className="dim" style={{ marginTop: 0 }}>
+        Pull a vault state from a remote git repo into <strong>this</strong> vault.
+        Use this to load a vault someone has been mirroring, or to sync a vault
+        between machines you control. The remote must be a Parachute vault export
+        (created by <code>parachute-vault export</code> or the mirror's export flow).
+      </p>
+
+      {/*
+        Multi-pusher caveat. Surfaces in both the SPA and the operator
+        doc (parachute.computer/git-backup.njk). Aaron 2026-05-28:
+        "I don't think we need to plan for that too elegantly right
+        now, but it is important to think about." So we warn, we
+        don't detect or block.
+      */}
+      <div className="warn-banner" style={{ marginBottom: "1rem" }} role="note">
+        <strong>One vault per remote.</strong> Multiple vaults pushing to the
+        same git repo isn't a supported shape — the last push wins, and
+        vaults that diverge silently overwrite each other. Today's working
+        pattern is one vault per remote. Active two-way sync is a future
+        direction; for now, do exports from one place and imports as
+        snapshots elsewhere.
+      </div>
+
+      {phase.kind === "success" ? (
+        <ImportSuccessPanel
+          vaultName={vaultName}
+          result={phase.result}
+          remoteUrl={phase.remoteUrl}
+          mode={phase.mode}
+          onReset={onReset}
+        />
+      ) : (
+        <>
+          <div className="form-row">
+            <label htmlFor="import-remote-url">Remote URL</label>
+            <input
+              id="import-remote-url"
+              type="text"
+              value={remoteUrl}
+              placeholder="https://github.com/aaron/my-vault.git"
+              onChange={(e) => setRemoteUrl(e.target.value)}
+              disabled={phase.kind === "running"}
+            />
+            {hasGithubOauth ? (
+              <p className="dim" style={{ margin: "0.35rem 0 0", fontSize: "0.9em" }}>
+                Or{" "}
+                <button
+                  type="button"
+                  onClick={() => setShowRepoPicker(true)}
+                  disabled={phase.kind === "running"}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    color: "var(--accent)",
+                    textDecoration: "underline",
+                    cursor: "pointer",
+                    fontSize: "inherit",
+                  }}
+                >
+                  pick from your GitHub repos
+                </button>
+                .
+              </p>
+            ) : null}
+            {!hasStoredCreds && !usePerCallPat ? (
+              <p className="hint" style={{ marginTop: "0.35rem", fontSize: "0.85em" }}>
+                No saved git credentials. The import will be unauthenticated —
+                works for public repos; private repos will fail with a clear
+                error. Use the one-time credential toggle below if needed.
+              </p>
+            ) : null}
+          </div>
+
+          <div className="form-row">
+            <label>Mode</label>
+            <label className="radio-row">
+              <input
+                type="radio"
+                name="import-mode"
+                value="merge"
+                checked={mode === "merge"}
+                onChange={() => {
+                  setMode("merge");
+                  setConfirmText("");
+                }}
+                disabled={phase.kind === "running"}
+              />
+              <span>
+                <strong>Merge</strong>{" "}
+                <span className="dim">
+                  — upsert by id. Notes in the remote get created/updated; any
+                  notes that exist only locally <strong>survive</strong>.
+                </span>
+              </span>
+            </label>
+            <label className="radio-row">
+              <input
+                type="radio"
+                name="import-mode"
+                value="replace"
+                checked={mode === "replace"}
+                onChange={() => setMode("replace")}
+                disabled={phase.kind === "running"}
+              />
+              <span>
+                <strong>Replace</strong>{" "}
+                <span className="dim">
+                  — wipe this vault first, then import. The remote becomes the
+                  new source of truth. <strong>Destructive.</strong>
+                </span>
+              </span>
+            </label>
+          </div>
+
+          {mode === "replace" ? (
+            <div className="form-row">
+              <div className="error-banner" role="alert" style={{ marginBottom: "0.5rem" }}>
+                <strong>Replace will delete every note in vault "{vaultName}" before
+                importing.</strong> To confirm, type the vault name below:
+              </div>
+              <input
+                id="import-confirm-name"
+                type="text"
+                value={confirmText}
+                placeholder={vaultName}
+                onChange={(e) => setConfirmText(e.target.value)}
+                disabled={phase.kind === "running"}
+                aria-label="Type vault name to confirm"
+              />
+            </div>
+          ) : null}
+
+          <div className="form-row">
+            <label>
+              <input
+                type="checkbox"
+                checked={usePerCallPat}
+                onChange={(e) => setUsePerCallPat(e.target.checked)}
+                disabled={phase.kind === "running"}
+                style={{ width: "auto", marginRight: "0.5rem" }}
+              />
+              One-time credential for this import only
+            </label>
+            <p className="dim" style={{ margin: "0.35rem 0 0", fontSize: "0.85em" }}>
+              Use a different Personal Access Token just for this clone, without
+              changing your saved credentials.
+            </p>
+            {usePerCallPat ? (
+              <input
+                id="import-per-call-pat"
+                type="password"
+                value={perCallPat}
+                placeholder="ghp_… or similar"
+                onChange={(e) => setPerCallPat(e.target.value)}
+                disabled={phase.kind === "running"}
+                autoComplete="off"
+                style={{ marginTop: "0.5rem" }}
+              />
+            ) : null}
+          </div>
+
+          {phase.kind === "error" ? (
+            <div className="error-banner" role="alert">
+              <code>{phase.message}</code>
+            </div>
+          ) : null}
+
+          <div className="actions">
+            <button
+              type="button"
+              onClick={onStart}
+              disabled={!canStart}
+              title={
+                !replaceConfirmed
+                  ? "Type the vault name to confirm Replace."
+                  : remoteUrl.trim().length === 0
+                    ? "Provide a remote URL."
+                    : usePerCallPat && perCallPat.trim().length === 0
+                      ? "Provide a token for one-time credential."
+                      : undefined
+              }
+            >
+              {phase.kind === "running"
+                ? phase.stage === "cloning"
+                  ? "Cloning…"
+                  : "Importing…"
+                : "Start import"}
+            </button>
+          </div>
+        </>
+      )}
+
+      {showRepoPicker ? (
+        <ImportRepoPickerModal
+          vaultName={vaultName}
+          onClose={() => setShowRepoPicker(false)}
+          onPicked={(cloneUrl) => {
+            setRemoteUrl(cloneUrl);
+            setShowRepoPicker(false);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * After-success panel. Shows the import counts + warnings, and offers
+ * to set the imported-from repo as the active mirror remote (auto-wire).
+ *
+ * The auto-wire offer is the symmetric move: if the operator just
+ * imported FROM a repo, they almost certainly want exports going BACK
+ * to the same repo. Yes triggers select-repo (for github-OAuth case)
+ * or guides the operator to the PAT save flow.
+ *
+ * Aaron's directive: "if there are multiple things pushing to the same
+ * git repository … important to think about" — the offer is opt-in
+ * precisely because mindlessly chaining import → push back risks the
+ * multi-pusher footgun. Operator opts in deliberately.
+ */
+function ImportSuccessPanel({
+  vaultName,
+  result,
+  remoteUrl,
+  mode,
+  onReset,
+}: {
+  vaultName: string;
+  result: MirrorImportResult;
+  remoteUrl: string;
+  mode: ImportMode;
+  onReset: () => void;
+}) {
+  const [wireOffered, setWireOffered] = useState(true);
+  return (
+    <>
+      <div className="mint-banner" role="status" style={{ marginBottom: "0.75rem" }}>
+        <strong>Import succeeded.</strong> Imported {result.notes_imported} note
+        {result.notes_imported === 1 ? "" : "s"}, {result.tags_imported} tag schema
+        {result.tags_imported === 1 ? "" : "s"}, {result.attachments_imported}{" "}
+        attachment{result.attachments_imported === 1 ? "" : "s"}
+        {mode === "replace" && result.notes_deleted !== undefined
+          ? `, wiped ${result.notes_deleted} pre-existing note${result.notes_deleted === 1 ? "" : "s"}`
+          : ""}
+        .
+      </div>
+
+      {result.warnings.length > 0 ? (
+        <details style={{ marginBottom: "0.75rem" }}>
+          <summary>
+            {result.warnings.length} warning{result.warnings.length === 1 ? "" : "s"}{" "}
+            (see details)
+          </summary>
+          <ul style={{ marginTop: "0.5rem" }}>
+            {result.warnings.map((w, i) => (
+              <li key={i}>
+                <code style={{ fontSize: "0.85em" }}>{w}</code>
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+
+      {wireOffered ? (
+        <div className="info-banner" style={{ marginBottom: "0.75rem" }} role="status">
+          <p style={{ marginTop: 0 }}>
+            <strong>Set this repo as the active mirror remote?</strong> Future
+            exports from vault <code>{vaultName}</code> would push back to{" "}
+            <code>{remoteUrl}</code>. Skip if you'd rather keep them separate —
+            see the "one vault per remote" note above.
+          </p>
+          <div className="actions">
+            <button
+              type="button"
+              onClick={() => {
+                // We don't auto-wire from here today (the existing
+                // GitRemoteSection above handles credential flow + repo
+                // selection). Closing the offer + scrolling the operator
+                // to the GitRemoteSection is the right next step.
+                setWireOffered(false);
+                document
+                  .querySelector(".section h3")
+                  ?.scrollIntoView({ behavior: "smooth" });
+              }}
+            >
+              Yes — configure mirror push above
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setWireOffered(false)}
+            >
+              No, keep import-only
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="actions">
+        <button type="button" className="secondary" onClick={onReset}>
+          Run another import
+        </button>
+      </div>
+    </>
+  );
+}
+
+/**
+ * Repo picker modal for the import flow. Reuses the existing list-repos
+ * endpoint (the one the export-side picker uses). On pick, populates
+ * the parent's remote URL field with the chosen repo's clone URL.
+ */
+function ImportRepoPickerModal({
+  vaultName,
+  onClose,
+  onPicked,
+}: {
+  vaultName: string;
+  onClose: () => void;
+  onPicked: (cloneUrl: string) => void;
+}) {
+  const [repos, setRepos] = useState<GitHubRepoInfo[] | null>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [filter, setFilter] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listGithubRepos(vaultName)
+      .then(({ repos, truncated }) => {
+        if (cancelled) return;
+        setRepos(repos);
+        setTruncated(Boolean(truncated));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vaultName]);
+
+  const filtered = (repos ?? []).filter((r) =>
+    filter.length === 0
+      ? true
+      : r.full_name.toLowerCase().includes(filter.toLowerCase()),
+  );
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="list-header">
+          <h3 style={{ margin: 0 }}>Pick a repo to import from</h3>
+          <button type="button" className="secondary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        {error ? (
+          <div className="error-banner" role="alert">
+            <code>{error}</code>
+          </div>
+        ) : null}
+        <div className="form-row">
+          <input
+            type="search"
+            placeholder="Filter by name…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+        </div>
+        {truncated ? (
+          <p className="muted" style={{ fontSize: "0.85em" }}>
+            Showing the first 300 repos. Use the filter above to narrow down.
+          </p>
+        ) : null}
+        {repos === null && !error ? <p className="muted">Loading repos…</p> : null}
+        {repos !== null ? (
+          <div className="repo-list">
+            {filtered.length === 0 && filter.length > 0 ? (
+              <p className="dim">No repos match "{filter}".</p>
+            ) : null}
+            {filtered.length === 0 && filter.length === 0 && repos.length === 0 ? (
+              <p className="dim">You don't own any repos on this account.</p>
+            ) : null}
+            {filtered.map((r) => (
+              <button
+                type="button"
+                key={r.full_name}
+                className="repo-row"
+                onClick={() => onPicked(r.clone_url)}
+              >
+                <span>
+                  <strong>{r.name}</strong>
+                  {r.private ? <span className="dim"> · private</span> : null}
+                </span>
+                <span className="dim">{r.updated_at.slice(0, 10)}</span>
+              </button>
+            ))}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -796,7 +796,7 @@ function GitRemoteSection({
   };
 
   return (
-    <div className="section">
+    <div className="section" id="git-remote-section">
       <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>
         Git remote
       </h3>
@@ -1790,10 +1790,14 @@ function ImportSuccessPanel({
                 // GitRemoteSection above handles credential flow + repo
                 // selection). Closing the offer + scrolling the operator
                 // to the GitRemoteSection is the right next step.
+                // Reviewer-flagged on #390: was selecting `.section h3`
+                // (the FIRST `.section` on the page — the StatusCard's
+                // heading near the top), so the scroll landed nowhere
+                // useful. Pinned to the id we added on GitRemoteSection.
                 setWireOffered(false);
                 document
-                  .querySelector(".section h3")
-                  ?.scrollIntoView({ behavior: "smooth" });
+                  .getElementById("git-remote-section")
+                  ?.scrollIntoView({ behavior: "smooth", block: "start" });
               }}
             >
               Yes — configure mirror push above


### PR DESCRIPTION
## Motivation

Aaron's directive 2026-05-28 (verbatim):

> we should be able to use a repo to import a vault. So that way, in one place, we can be exporting our vault to git, pushing it somewhere. And then in another one, we can click import and just do that. So let's get that going. And then separately but related from that, we're gonna need to figure out how we handle if there are multiple things pushing to the same kit repository. I don't think we need to plan for that too elegantly right now, but it is important to think about.

This PR ships the symmetric counterpart to vault#382 + vault#384's git-export work. Machine A pushes a vault to a git remote; machine B clicks "Import from git" in the admin SPA, pastes (or picks via the GitHub repo picker) the same remote, and ends up with the same vault state.

## Per-cut summary

### Cut 1 — `src/mirror-import.ts` (worker)

`cloneAndImport({remoteUrl, auth, mode, store, assetsDir, ...})`:

- Creates a temp dir under `os.tmpdir()`.
- Resolves an authed clone URL — three auth shapes (`credentialsFile` / `pat` / `none`) and a sibling-of-`applyToGitRemote` `authedCloneUrl()` helper that embeds `x-access-token:<token>` for HTTPS hosts.
- Shells `git clone --depth 1` with `GIT_TERMINAL_PROMPT=0` + `GIT_ASKPASS=/bin/echo` + 60s timeout.
- Validates the clone is a portable-md vault export (`.parachute/vault.yaml` present); throws `NotAVaultExportError` otherwise.
- Delegates to `importPortableVault()` with `blowAway: opts.mode === "replace"`.
- Always cleans up the temp dir (try/finally).
- Concurrency guard: in-flight set keyed by vault name → `ImportConflictError` for duplicate imports.

Threat model: tokens in argv during the clone window — same posture as vault#384's `git ls-remote` probe. Documented inline; cloud Tier 2 needs a credential helper.

20 unit tests in `src/mirror-import.test.ts`.

### Cut 2 — `POST /.parachute/mirror/import` (HTTP route)

Wired into `routing.ts` alongside other admin-gated mirror routes. Synchronous response shape:

```
200 → { notes_imported, tags_imported, attachments_imported, notes_deleted?, warnings }
400 → validation / not-a-vault-export
409 → concurrent import
502 → clone failed (auth wall, network)
500 → other
```

10 new tests in `src/mirror-routes.test.ts` (40 pass in that file, was 30).

### Cut 3 — Admin SPA "Import from a git repo" section

`web/ui/src/routes/VaultMirror.tsx` — new section below GitRemoteSection. Affordances:

- Remote URL paste field + optional GitHub repo picker shortcut (reuses `listGithubRepos`).
- Merge / Replace mode toggle.
- **Typed-name confirmation gate** for Replace — operator types the literal vault name to unlock Start.
- One-time PAT credential checkbox for a one-shot import that doesn't touch stored credentials.
- Loading copy ("Cloning…" / "Importing…"), success summary with counts + warnings.
- **Auto-wire offer** after success ("Set this repo as the active mirror remote so future writes push back here?" — Yes scrolls to the existing GitRemoteSection where the operator runs the existing wire-up flow).

`postMirrorImport()` + types added to `lib/api.ts`.

7 new SPA tests (97 pass, was 90).

### Cut 4 — Multi-pusher caveat

Prominent warning banner in the SPA (and intended for the operator doc):

> **One vault per remote.** Multiple vaults pushing to the same git repo isn't a supported shape — the last push wins, and vaults that diverge silently overwrite each other. Today's working pattern is one vault per remote. Active two-way sync is a future direction; for now, do exports from one place and imports as snapshots elsewhere.

Per Aaron's directive: warn, **don't detect, don't block**. The auto-wire offer is opt-in so the operator deliberately chooses to chain import → push.

### Cut 5 — Operator doc

`parachute.computer/git-backup.njk` "Pull a vault from git (the import flow)" section — **deferred to a follow-up PR in the parachute.computer repo** (different repo; mentioned for tracking).

## Sharp edges handled

- Non-vault clone → `NotAVaultExportError` 400 with actionable message.
- Concurrent import → 409.
- Token redaction in all error messages (`redactRemoteUrl` + regex over stderr).
- Tempdir cleanup on every code path.
- Path-traversal: inherits the existing `importPortableVault` guards.

## Test plan

- [x] `bun test ./src ./core/src` → 1827 pass (was 1796 baseline; +31 new — 20 mirror-import + 10 mirror-routes import + 1 existing)
- [x] `bun run typecheck` → clean
- [x] `cd web/ui && bun run typecheck` → clean
- [x] `cd web/ui && bunx vitest run` → 97 pass (was 90; +7 new)
- [x] Sandboxed E2E: built a source vault with 3 notes, exported + `git init` + `git commit`, then ran `cloneAndImport` against the local repo path. All 3 notes round-tripped (content, ids, tags, wikilinks). Replace mode correctly wiped + reimported.

## DO NOT MERGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)