### PR TITLE
chore(release): 0.4.9-rc.8 — import vault from a git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.7",
+  "version": "0.4.9-rc.8",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump only. Picks up #390 (import-from-git feature). Symmetric counterpart to mirror export — operator clicks "Import from git" in the admin SPA, vault clones the remote + runs the existing portable-md import primitive + cleans up.

## Test plan

- [x] `bun test ./core ./src ./package` — 1829 pass / 0 fail
- [x] `cd web/ui && bunx vitest run` — 97 pass / 0 fail
- [x] Both typechecks clean
- [ ] After merge: tag `v0.4.9-rc.8` + push → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)