### PR TITLE
fix(vault): auto-push when credentials are configured + upstream tracking + push status

### DIFF
--- a/src/export-watch.test.ts
+++ b/src/export-watch.test.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_COMMIT_TEMPLATE,
   gitAddAll,
   gitCommit,
+  gitPush,
   gitUnstageAll,
   isGitRepo,
   listStagedFiles,
@@ -312,6 +313,79 @@ describe("git-shell helpers", () => {
     expect(await listStagedFiles(dir)).toEqual(["a.md"]);
     await gitUnstageAll(dir);
     expect(await listStagedFiles(dir)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2b. gitPush — first-push upstream tracking (Cut 4 of vault#392)
+//
+// A freshly-bootstrapped mirror has commits but no upstream branch.
+// Bare `git push` fails with "fatal: The current branch X has no upstream
+// branch." gitPush now detects the missing-upstream case and falls back
+// to `git push -u origin <branch>`. Subsequent pushes go bare.
+// ---------------------------------------------------------------------------
+
+describe("gitPush — upstream tracking", () => {
+  let workdir: string;
+  let remote: string;
+  beforeEach(() => {
+    workdir = makeTmp("vault-push-work-");
+    remote = makeTmp("vault-push-remote-");
+    // Bare repo as the "remote" — `git push` to it lands like any real remote.
+    Bun.spawnSync(["git", "init", "--bare", "-q", "-b", "main"], { cwd: remote });
+    initGitRepo(workdir);
+    Bun.spawnSync(["git", "remote", "add", "origin", remote], { cwd: workdir });
+    fs.writeFileSync(path.join(workdir, "seed.md"), "# seed\n");
+    Bun.spawnSync(["git", "add", "-A"], { cwd: workdir });
+    Bun.spawnSync(["git", "commit", "-q", "-m", "initial"], { cwd: workdir });
+  });
+  afterEach(() => {
+    fs.rmSync(workdir, { recursive: true, force: true });
+    fs.rmSync(remote, { recursive: true, force: true });
+  });
+
+  test("first push to a fresh remote establishes upstream tracking", async () => {
+    // Pre-Cut-4 this failed with "no upstream branch."
+    const result = await gitPush(workdir);
+    expect(result.ok).toBe(true);
+    // Verify upstream is now set so subsequent pushes can be bare.
+    const upstream = Bun.spawnSync(
+      ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+      { cwd: workdir, stdout: "pipe" },
+    );
+    expect(upstream.exitCode).toBe(0);
+    expect(
+      new TextDecoder().decode(upstream.stdout).trim(),
+    ).toBe("origin/main");
+  });
+
+  test("subsequent push (upstream already set) succeeds bare", async () => {
+    // First push wires the upstream.
+    await gitPush(workdir);
+    // Make another commit, push again — should succeed.
+    fs.writeFileSync(path.join(workdir, "n.md"), "# n\n");
+    Bun.spawnSync(["git", "add", "-A"], { cwd: workdir });
+    Bun.spawnSync(["git", "commit", "-q", "-m", "second"], { cwd: workdir });
+    const result = await gitPush(workdir);
+    expect(result.ok).toBe(true);
+  });
+
+  test("push with no remote configured surfaces the error (back-compat)", async () => {
+    // Same shape as the existing "no remote" test in runGitCommitCycle —
+    // the branch probe returns a branch but no upstream, gitPush falls
+    // back to `git push -u origin main`, which fails because there's no
+    // `origin` remote configured.
+    const localOnly = makeTmp("vault-push-noremote-");
+    initGitRepo(localOnly);
+    fs.writeFileSync(path.join(localOnly, "x.md"), "# x\n");
+    Bun.spawnSync(["git", "add", "-A"], { cwd: localOnly });
+    Bun.spawnSync(["git", "commit", "-q", "-m", "x"], { cwd: localOnly });
+    const result = await gitPush(localOnly);
+    expect(result.ok).toBe(false);
+    // Doesn't matter what the exact error is — just that it's non-fatal
+    // (gitPush returns rather than throws).
+    expect(typeof result.stderr).toBe("string");
+    fs.rmSync(localOnly, { recursive: true, force: true });
   });
 });
 

--- a/src/export-watch.ts
+++ b/src/export-watch.ts
@@ -121,11 +121,72 @@ export async function gitCommit(
   return { ok: exitCode === 0, stderr: stderr.trim() };
 }
 
-/** Run `git push` in `repoDir`. Returns true on success. */
+/**
+ * Run `git push` in `repoDir`. Returns true on success.
+ *
+ * Handles the first-push case: a freshly-bootstrapped mirror has
+ * commits but no upstream tracking, and a bare `git push` fails with
+ * "fatal: The current branch X has no upstream branch." That's
+ * unrecoverable from the operator's POV — they'd have to drop to a
+ * shell and run `git push -u origin main`. The wiring here detects the
+ * missing-upstream case ahead of time and falls back to `git push -u
+ * origin <branch>` so the first push works and every subsequent push
+ * picks up the now-configured tracking.
+ *
+ * Vault#382 carried bare `git push`; this is the Cut 4 fix in the
+ * credentials-save round-trip work.
+ */
 export async function gitPush(
   repoDir: string,
 ): Promise<{ ok: boolean; stderr: string }> {
-  const proc = Bun.spawn(["git", "push"], {
+  // Resolve the current branch name. `git rev-parse --abbrev-ref HEAD`
+  // returns the branch on a checked-out branch (e.g. "main"); on a
+  // detached HEAD it returns "HEAD" — in that case we bail to bare push
+  // since `-u origin HEAD` doesn't mean anything useful.
+  let branch: string | null = null;
+  try {
+    const branchProc = Bun.spawn(["git", "rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd: repoDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const branchCode = await branchProc.exited;
+    if (branchCode === 0) {
+      const out = new TextDecoder()
+        .decode(await new Response(branchProc.stdout).arrayBuffer())
+        .trim();
+      if (out.length > 0 && out !== "HEAD") branch = out;
+    }
+  } catch {
+    // Fall through to bare push.
+  }
+
+  // Probe for an existing upstream. `git rev-parse --abbrev-ref
+  // --symbolic-full-name @{u}` exits non-zero when no upstream is
+  // configured for the current branch. Exit 0 + a value → upstream
+  // exists; bare `git push` is fine.
+  let hasUpstream = false;
+  if (branch !== null) {
+    const upstreamProc = Bun.spawn(
+      ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+      {
+        cwd: repoDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const upstreamCode = await upstreamProc.exited;
+    hasUpstream = upstreamCode === 0;
+  }
+
+  // First-push path: `git push -u origin <branch>` to establish
+  // tracking. Subsequent calls take the bare path because hasUpstream
+  // will be true after this lands.
+  const cmd =
+    branch !== null && !hasUpstream
+      ? ["git", "push", "-u", "origin", branch]
+      : ["git", "push"];
+  const proc = Bun.spawn(cmd, {
     cwd: repoDir,
     stdout: "pipe",
     stderr: "pipe",
@@ -190,7 +251,14 @@ export function shouldCommit(stagedFiles: string[], notesChanged: number): {
 
 /**
  * Stage → decide → commit → optionally push. Logs status to stdout/stderr.
- * Returns whether a commit landed.
+ * Returns whether a commit landed and (when push was attempted) the
+ * push outcome — so callers can surface push status in their UIs
+ * without having to grep logs.
+ *
+ * Cut 5: the return shape now includes a `push` field with the outcome
+ * when push was attempted. Tokens are redacted from `push.error` via
+ * the userinfo + `gho_/ghp_/glpat-` regex so log + status surfaces are
+ * safe to display.
  */
 export async function runGitCommitCycle(opts: {
   repoDir: string;
@@ -201,7 +269,11 @@ export async function runGitCommitCycle(opts: {
   push: boolean;
   /** Override for tests — defaults to `new Date().toISOString()`. */
   now?: () => string;
-}): Promise<{ committed: boolean; message?: string }> {
+}): Promise<{
+  committed: boolean;
+  message?: string;
+  push?: { attempted: true; ok: boolean; error?: string };
+}> {
   const now = opts.now ?? (() => new Date().toISOString());
 
   const add = await gitAddAll(opts.repoDir);
@@ -245,11 +317,40 @@ export async function runGitCommitCycle(opts: {
     if (!pushResult.ok) {
       // Non-fatal — a network blip shouldn't kill a watch loop. Warn and
       // move on; the next successful commit's push will catch up history.
-      console.warn(`[git-commit] git push failed (non-fatal): ${pushResult.stderr}`);
-    } else {
-      console.log(`[git-commit] pushed`);
+      const redacted = redactToken(pushResult.stderr);
+      console.warn(`[git-commit] git push failed (non-fatal): ${redacted}`);
+      return {
+        committed: true,
+        message,
+        push: { attempted: true, ok: false, error: redacted },
+      };
     }
+    console.log(`[git-commit] pushed`);
+    return { committed: true, message, push: { attempted: true, ok: true } };
   }
 
   return { committed: true, message };
+}
+
+/**
+ * Redact tokens from a string that came back from `git push` /
+ * `git ls-remote` stderr. Same pattern as `redactRemoteUrl` for full
+ * URLs; also handles bare `gho_*`/`ghp_*`/`glpat-*` tokens that
+ * sometimes show up in git error messages.
+ *
+ * Best-effort — git's error format isn't a stable contract, so we
+ * scrub the obvious patterns and accept that a really unusual
+ * formatting could slip through. The credentials file is the
+ * authoritative store; logs are diagnostic.
+ */
+export function redactToken(text: string): string {
+  return text
+    // userinfo (https://user:token@host/…)
+    .replace(/https?:\/\/[^@\s]+@/g, "https://***@")
+    // bare GitHub OAuth tokens
+    .replace(/gho_[A-Za-z0-9_]{8,}/g, "gho_***")
+    // bare GitHub PATs
+    .replace(/ghp_[A-Za-z0-9_]{8,}/g, "ghp_***")
+    // bare GitLab PATs
+    .replace(/glpat-[A-Za-z0-9_-]{8,}/g, "glpat-***");
 }

--- a/src/mirror-config.test.ts
+++ b/src/mirror-config.test.ts
@@ -333,17 +333,76 @@ describe("validateMirrorConfigShape", () => {
     if (r.ok) expect(r.config.sync_mode).toBe("manual");
   });
 
-  test("rejects auto_push + internal location (validation rather than silent-fail)", () => {
-    // Pre-event-driven shape silently let push fail at runtime for
-    // internal mirrors. Now we reject the combination at config time so
-    // the operator sees the issue immediately.
-    const r = validateMirrorConfigShape({
-      enabled: true,
-      location: "internal",
-      auto_push: true,
-    });
+  test("rejects auto_push + internal location WHEN no credentials are configured", () => {
+    // Pre-credentials shape: auto_push + internal was rejected outright
+    // (internal mirror = no remote = push would silently fail). Once
+    // credentials are wired (PAT or GitHub OAuth), the credential save
+    // path sets `origin` on the internal repo too — so push IS
+    // meaningful. We keep the rejection only on the no-credentials path,
+    // with a clear error pointing the operator at the credential flow.
+    const r = validateMirrorConfigShape(
+      {
+        enabled: true,
+        location: "internal",
+        auto_push: true,
+      },
+      { readCredentials: () => null },
+    );
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.field).toBe("auto_push");
+    if (!r.ok) {
+      expect(r.field).toBe("auto_push");
+      expect(r.error).toContain("credentials");
+    }
+  });
+
+  test("auto_push + internal IS accepted when PAT credentials are configured", () => {
+    // The three-stacking-gaps bug Aaron hit: History preset (internal
+    // location) + PAT saved → expected pushes to fire. validation was
+    // the first blocker. Now the combination passes when credentials
+    // are present.
+    const r = validateMirrorConfigShape(
+      {
+        enabled: true,
+        location: "internal",
+        auto_push: true,
+      },
+      {
+        readCredentials: () => ({
+          active_method: "pat",
+          github_oauth: null,
+          pat: {
+            token: "ghp_xxxxxxxxxxxxxxxx",
+            remote_url: "https://x-access-token:ghp_xxxxxxxxxxxxxxxx@github.com/a/b.git",
+            label: "test",
+          },
+        }),
+      },
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test("auto_push + internal IS accepted when github_oauth credentials are configured", () => {
+    const r = validateMirrorConfigShape(
+      {
+        enabled: true,
+        location: "internal",
+        auto_push: true,
+      },
+      {
+        readCredentials: () => ({
+          active_method: "github_oauth",
+          github_oauth: {
+            access_token: "gho_xxxxxxxxxxxx",
+            scope: "repo",
+            authorized_at: "2026-05-28T03:14:15.000Z",
+            user_login: "aaron",
+            user_id: 1,
+          },
+          pat: null,
+        }),
+      },
+    );
+    expect(r.ok).toBe(true);
   });
 
   test("auto_push + external location is fine", () => {

--- a/src/mirror-config.ts
+++ b/src/mirror-config.ts
@@ -568,6 +568,20 @@ export function validateMirrorConfigShape(
   // accept the combination — vault has a remote to push to. Operators
   // hitting Aaron's three-stacking-gaps bug (History preset + PAT saved,
   // pushes never fire) get unblocked.
+  //
+  // Asymmetry note (reviewer-flagged on vault#392): external + auto_push +
+  // no vault-stored credentials is INTENTIONALLY not rejected here.
+  // External mirrors are operator-managed paths — operators may have
+  // configured push credentials via system-level git config (SSH agent,
+  // ~/.git-credentials, GH_TOKEN env, `gh auth login`), none of which
+  // vault can detect by reading `.mirror-credentials.yaml`. Rejecting on
+  // "vault doesn't see credentials" would refuse legitimate
+  // operator-managed setups. Push failures on missing credentials surface
+  // via the non-fatal warning path in gitPush — operators see them in
+  // `last_push_error` rather than being blocked at save time. Internal
+  // location is different: internal mirrors live under vault's data
+  // dir, so vault IS the only thing that can wire a remote, which is
+  // why the gate below requires vault-stored credentials specifically.
   if (out.enabled && out.auto_push && out.location === "internal") {
     const readCreds = opts.readCredentials ?? readCredentials;
     let creds: MirrorCredentials | null = null;

--- a/src/mirror-config.ts
+++ b/src/mirror-config.ts
@@ -23,6 +23,7 @@ import { existsSync, statSync } from "fs";
 import { join } from "path";
 
 import { DEFAULT_COMMIT_TEMPLATE, isGitRepo } from "./export-watch.ts";
+import { readCredentials, type MirrorCredentials } from "./mirror-credentials.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -372,12 +373,21 @@ export type ShapeValidation = ShapeValidationOk | ShapeValidationError;
  * `defaultMirrorConfig()`; rejects values that don't conform to the
  * declared types.
  *
- * Does NOT touch the filesystem — operators get a fast 400 on shape
- * errors before vault attempts any filesystem work. Filesystem-level
- * validation (path exists, is a git repo) lives in `validateExternalPath`.
+ * Mostly pure: the one filesystem touch is reading
+ * `.mirror-credentials.yaml` to decide whether `auto_push: true +
+ * location: internal` is acceptable (credentials carry a remote URL, so
+ * "internal mirrors have no remote" no longer holds). The credentials
+ * read is injectable via `opts.readCredentials` so tests stay hermetic;
+ * production callers omit it and pick up the canonical `readCredentials`
+ * from `./mirror-credentials.ts`.
+ *
+ * Filesystem-level validation of `external_path` (exists, is a git repo)
+ * still lives in `validateExternalPath` — that's I/O and stays out of
+ * this function.
  */
 export function validateMirrorConfigShape(
   input: unknown,
+  opts: { readCredentials?: () => MirrorCredentials | null } = {},
 ): ShapeValidation {
   if (input === null || typeof input !== "object") {
     return {
@@ -544,21 +554,46 @@ export function validateMirrorConfigShape(
     };
   }
 
-  // Cross-field rule: auto_push only makes sense for external mirrors —
-  // internal mirrors live under vault's data dir with no configured
-  // remote. Silent-fail on push was the pre-event-driven behavior; the
-  // backend now rejects the combination so the operator sees the issue
-  // at config time. The UI hides the auto_push checkbox when location
-  // is internal (vault#380's reviewer-flagged nit), so this only fires
-  // when an operator either edits config.yaml by hand or POSTs a bare
-  // JSON body with mismatched fields.
+  // Cross-field rule: auto_push + internal location was historically
+  // rejected outright — the assumption being "internal mirrors live under
+  // vault's data dir with no configured remote, so push would always
+  // fail." That assumption no longer holds once credentials are wired:
+  // the credential save path (handleAuthPat / handleAuthGithubSelectRepo)
+  // sets `origin` on the internal repo to the embedded-credential URL,
+  // so `git push` to GitHub/GitLab/etc. is meaningful even when the
+  // working tree lives under `~/.parachute/vault/data/<name>/mirror/`.
+  //
+  // New rule: auto_push + internal is rejected ONLY when no credentials
+  // are configured. If credentials ARE wired (PAT or GitHub OAuth),
+  // accept the combination — vault has a remote to push to. Operators
+  // hitting Aaron's three-stacking-gaps bug (History preset + PAT saved,
+  // pushes never fire) get unblocked.
   if (out.enabled && out.auto_push && out.location === "internal") {
-    return {
-      ok: false,
-      field: "auto_push",
-      error:
-        "`auto_push: true` requires `location: external` (internal mirrors live under the vault data directory and have no configured remote). Switch the location, or set auto_push to false.",
-    };
+    const readCreds = opts.readCredentials ?? readCredentials;
+    let creds: MirrorCredentials | null = null;
+    try {
+      creds = readCreds();
+    } catch {
+      // If the credentials file is unreadable we conservatively fail
+      // closed — same outcome as "no credentials." Better to surface the
+      // actionable "configure credentials first" error than to accept a
+      // config that won't actually push.
+      creds = null;
+    }
+    const hasCredentials = !!(
+      creds &&
+      creds.active_method &&
+      ((creds.active_method === "pat" && creds.pat) ||
+        (creds.active_method === "github_oauth" && creds.github_oauth))
+    );
+    if (!hasCredentials) {
+      return {
+        ok: false,
+        field: "auto_push",
+        error:
+          "Configure git credentials before enabling auto-push on an internal mirror — vault has no remote to push to without them. Connect GitHub or paste a Personal Access Token in the Git remote section, or set auto_push to false.",
+      };
+    }
   }
 
   return { ok: true, config: out };

--- a/src/mirror-manager.test.ts
+++ b/src/mirror-manager.test.ts
@@ -855,3 +855,107 @@ describe("MirrorManager — event-driven (sync_mode: events)", () => {
     await mgr.stop();
   });
 });
+
+// ---------------------------------------------------------------------------
+// MirrorManager.pushNow — Cut 6 of vault#392 (credentials → push round-trip)
+//
+// Live `git push` against a local bare repo as the "remote." Tests the
+// status mutations (last_push_at, last_push_sha, last_push_error,
+// commits_unpushed) the SPA renders.
+// ---------------------------------------------------------------------------
+
+describe("MirrorManager.pushNow — push observability", () => {
+  let home: string;
+  let remote: string;
+
+  afterEach(async () => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    if (remote) fs.rmSync(remote, { recursive: true, force: true });
+  });
+
+  test("returns not_enabled when mirror is disabled", async () => {
+    home = tmp("mgr-pushnow-disabled-");
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+    const deps = makeFakeDeps({
+      parachuteHome: home,
+      initialConfig: { ...defaultMirrorConfig(), enabled: false },
+    });
+    const mgr = new MirrorManager(deps);
+    await mgr.start();
+    const r = await mgr.pushNow();
+    expect(r.fired).toBe(false);
+    if (r.fired === false) expect(r.reason).toBe("not_enabled");
+  });
+
+  test("first push wires upstream and sets last_push_at + last_push_sha", async () => {
+    // Spin up an enabled internal mirror; wire a local bare repo as
+    // origin; verify pushNow lands the seed commit and updates status.
+    home = tmp("mgr-pushnow-first-");
+    remote = tmp("mgr-pushnow-remote-");
+    Bun.spawnSync(["git", "init", "--bare", "-q", "-b", "main"], { cwd: remote });
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+    const deps = makeFakeDeps({
+      parachuteHome: home,
+      initialConfig: {
+        ...defaultMirrorConfig(),
+        enabled: true,
+        location: "internal",
+        sync_mode: "manual",
+        auto_commit: false,
+      },
+    });
+    const mgr = new MirrorManager(deps);
+    const status = await mgr.start();
+    expect(status.enabled).toBe(true);
+    // Wire origin to the bare repo. The internal-mirror's first commit
+    // (`initial mirror bootstrap`) is sitting on HEAD waiting to push.
+    Bun.spawnSync(["git", "remote", "add", "origin", remote], { cwd: status.mirror_path! });
+
+    const result = await mgr.pushNow();
+    expect(result.fired).toBe(true);
+    if (result.fired) {
+      expect(result.pushed).toBe(true);
+      expect(typeof result.sha).toBe("string");
+    }
+    const after = mgr.getStatus();
+    expect(after.last_push_at).not.toBeNull();
+    expect(after.last_push_sha).not.toBeNull();
+    expect(after.last_push_error).toBeNull();
+    expect(after.commits_unpushed).toBe(0);
+    await mgr.stop();
+  });
+
+  test("push failure surfaces redacted error in last_push_error", async () => {
+    // Wire origin to a non-existent host. Push fails; status reflects
+    // the failure without leaking any potentially-sensitive URL parts.
+    home = tmp("mgr-pushnow-fail-");
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+    const deps = makeFakeDeps({
+      parachuteHome: home,
+      initialConfig: {
+        ...defaultMirrorConfig(),
+        enabled: true,
+        location: "internal",
+        sync_mode: "manual",
+        auto_commit: false,
+      },
+    });
+    const mgr = new MirrorManager(deps);
+    const status = await mgr.start();
+    Bun.spawnSync(
+      ["git", "remote", "add", "origin", "https://x-access-token:ghp_fake1234567890abcdef@nonexistent.parachute.test/a/b.git"],
+      { cwd: status.mirror_path! },
+    );
+    const result = await mgr.pushNow();
+    expect(result.fired).toBe(true);
+    if (result.fired) expect(result.pushed).toBe(false);
+    const after = mgr.getStatus();
+    expect(after.last_push_error).not.toBeNull();
+    // Redacted — no token leak.
+    expect(after.last_push_error).not.toContain("ghp_fake1234567890");
+    // Last successful push timestamp is unchanged (still null on a
+    // never-succeeded mirror).
+    expect(after.last_push_at).toBeNull();
+    await mgr.stop();
+  }, 30_000);
+});

--- a/src/mirror-manager.ts
+++ b/src/mirror-manager.ts
@@ -66,7 +66,9 @@ import {
 import {
   gitAddAll,
   gitCommit,
+  gitPush,
   isGitRepo,
+  redactToken,
   runGitCommitCycle,
 } from "./export-watch.ts";
 import { vaultDir } from "./config.ts";
@@ -115,6 +117,28 @@ export interface MirrorStatus {
   last_commit_sha: string | null;
   /** Last error message (if any). Cleared on the next successful pass. */
   last_error: string | null;
+  /**
+   * Cut 5: push observability — surfaced via GET /admin/mirror so the
+   * operator (and the SPA's Status card) can see whether pushes are
+   * actually landing without grepping `[git-commit]` log lines.
+   *
+   * - `last_push_at` — ISO timestamp of the most recent SUCCESSFUL push.
+   *   Null until the first successful push.
+   * - `last_push_sha` — sha that landed on the remote at `last_push_at`.
+   *   Null when last_push_at is null.
+   * - `last_push_error` — message from the most recent FAILED push.
+   *   Cleared (back to null) on the next successful push. Tokens are
+   *   redacted before this field is set (push paths use the
+   *   `gho_`/`ghp_`/userinfo regex to scrub).
+   * - `commits_unpushed` — count of local commits ahead of upstream
+   *   (`git rev-list --count @{u}..HEAD`). Null when no upstream tracking
+   *   exists yet (first push hasn't fired). 0 when the mirror is fully
+   *   synced; positive when commits are queued.
+   */
+  last_push_at: string | null;
+  last_push_sha: string | null;
+  last_push_error: string | null;
+  commits_unpushed: number | null;
 }
 
 /**
@@ -289,6 +313,32 @@ export async function bootstrapInternalMirror(
 // ---------------------------------------------------------------------------
 
 /**
+ * Cut 5: count local commits ahead of upstream tracking. Implementation:
+ * `git rev-list --count @{u}..HEAD` returns N when N commits are ahead,
+ * 0 when synced, and exit-nonzero when no upstream tracking exists
+ * (the branch has never been pushed with `-u`). The non-zero case maps
+ * to `null` — distinct from "0 ahead" so the SPA can render "no remote
+ * tracking yet" vs "fully synced" differently if desired.
+ */
+async function readCommitsUnpushed(repoDir: string): Promise<number | null> {
+  const proc = Bun.spawn(
+    ["git", "rev-list", "--count", "@{u}..HEAD"],
+    {
+      cwd: repoDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) return null; // no upstream configured yet
+  const out = new TextDecoder()
+    .decode(await new Response(proc.stdout).arrayBuffer())
+    .trim();
+  const n = Number(out);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
  * Read the current `origin` URL from a git repo's config, or null when no
  * origin is set. Module-local helper for the credential-application path.
  */
@@ -331,6 +381,10 @@ export class MirrorManager {
     last_export_notes_count: null,
     last_commit_sha: null,
     last_error: null,
+    last_push_at: null,
+    last_push_sha: null,
+    last_push_error: null,
+    commits_unpushed: null,
   };
   /** Safety-net poll timer (interval). Null while not armed. */
   private safetyNetTimer: ReturnType<typeof setInterval> | null = null;
@@ -396,6 +450,10 @@ export class MirrorManager {
         last_export_notes_count: null,
         last_commit_sha: null,
         last_error: null,
+        last_push_at: null,
+        last_push_sha: null,
+        last_push_error: null,
+        commits_unpushed: null,
       };
       return this.getStatus();
     }
@@ -815,6 +873,77 @@ export class MirrorManager {
       const sha = new TextDecoder().decode(await new Response(shaProc.stdout).arrayBuffer()).trim();
       if (sha.length > 0) this.status.last_commit_sha = sha;
     }
+
+    // Cut 5: surface push outcome (success/failure + redacted error).
+    // runGitCommitCycle returns push info iff push was attempted; we
+    // mirror the same shape into status here.
+    if (commitResult.push) {
+      const now = new Date().toISOString();
+      if (commitResult.push.ok) {
+        this.status.last_push_at = now;
+        this.status.last_push_sha = this.status.last_commit_sha;
+        this.status.last_push_error = null;
+      } else if (commitResult.push.error) {
+        this.status.last_push_error = commitResult.push.error;
+      }
+    }
+
+    // Cut 5: track local-commits-ahead-of-upstream so the UI can render
+    // "<N> commits ready to push" subdued helper text.
+    this.status.commits_unpushed = await readCommitsUnpushed(path);
+  }
+
+  /**
+   * Cut 6: fire a `git push` against the current mirror dir, capture
+   * the outcome into status, and return a struct the route handler can
+   * fold into its response.
+   *
+   * Distinguished from `runNow()` which exports + commits + pushes.
+   * `pushNow()` skips export + commit entirely and only pushes whatever
+   * has already been committed. Used by:
+   *   - the credential save path (auto-fire after `auth/pat` /
+   *     `auth/github/select-repo` lands) so the operator sees the
+   *     push happen rather than waiting for the next write
+   *   - the explicit POST /.parachute/mirror/push-now route the SPA's
+   *     "Push now" button hits
+   *
+   * Idempotent against a fully-synced mirror (git push reports "nothing
+   * to push" with exit 0). Failure paths set `last_push_error` for the
+   * status surface.
+   */
+  async pushNow(): Promise<
+    | { fired: false; reason: "not_enabled" | "no_mirror_path" }
+    | { fired: true; pushed: boolean; sha?: string; error?: string }
+  > {
+    if (!this.status.enabled) return { fired: false, reason: "not_enabled" };
+    if (!this.status.mirror_path) return { fired: false, reason: "no_mirror_path" };
+    const path = this.status.mirror_path;
+    const pushResult = await gitPush(path);
+    const now = new Date().toISOString();
+    // Refresh commits_unpushed either way — a no-op push still reflects
+    // the current state (0 ahead if synced, N if push failed mid-way).
+    this.status.commits_unpushed = await readCommitsUnpushed(path);
+    if (pushResult.ok) {
+      // Capture HEAD sha at this point so the UI can show the operator
+      // exactly what landed.
+      const shaProc = Bun.spawn(["git", "rev-parse", "HEAD"], {
+        cwd: path,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await shaProc.exited;
+      const sha = new TextDecoder()
+        .decode(await new Response(shaProc.stdout).arrayBuffer())
+        .trim();
+      this.status.last_push_at = now;
+      if (sha.length > 0) this.status.last_push_sha = sha;
+      this.status.last_push_error = null;
+      return { fired: true, pushed: true, sha: sha.length > 0 ? sha : undefined };
+    }
+    const redacted = redactToken(pushResult.stderr);
+    this.status.last_push_error = redacted;
+    console.warn(`[mirror] push-now failed (non-fatal): ${redacted}`);
+    return { fired: true, pushed: false, error: redacted };
   }
 
   /**

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -24,9 +24,11 @@ import {
   handleAuthGithubDeviceCode,
   handleAuthGithubPoll,
   handleAuthGithubRepos,
+  handleAuthGithubSelectRepo,
   handleAuthPat,
   handleMirrorGet,
   handleMirrorImport,
+  handleMirrorPushNow,
   handleMirrorPut,
   handleMirrorRunNow,
 } from "./mirror-routes.ts";
@@ -765,6 +767,172 @@ describe("auth credential routes — PAT", () => {
     const text = await res.text();
     expect(text).not.toContain(secret);
   }, 20_000);
+});
+
+// ---------------------------------------------------------------------------
+// Cuts 3 + 6: credential save → auto_push flipped on + initial push fires.
+//
+// The PAT route gates on a real `git ls-remote` probe, so it's awkward
+// to exercise end-to-end in a hermetic test. The select-repo route has
+// no probe — it accepts the operator's already-OAuth'd token and wires
+// the URL. We drive the side-effect helpers (maybeEnableAutoPush +
+// maybeFireInitialPush) through select-repo, with a local bare repo as
+// the "GitHub" remote — overridden via post-save remote-URL rewrite so
+// pushNow targets the test repo.
+// ---------------------------------------------------------------------------
+
+describe("auth credential routes — credential-save side-effects (Cuts 3 + 6)", () => {
+  let home: string;
+  let remote: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    if (remote) fs.rmSync(remote, { recursive: true, force: true });
+  });
+
+  test("select-repo flips auto_push from false → true on an enabled internal mirror", async () => {
+    home = tmp("mirror-selectrepo-autopush-");
+    remote = tmp("mirror-selectrepo-remote-");
+    Bun.spawnSync(["git", "init", "--bare", "-q", "-b", "main"], { cwd: remote });
+
+    const { manager, deps } = makeManager(home);
+    deps.writeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "internal",
+      sync_mode: "manual",
+      auto_commit: false,
+      auto_push: false,
+    });
+    await manager.start();
+    expect(manager.getConfig().auto_push).toBe(false);
+
+    // Seed github_oauth credentials. select-repo doesn't probe; it just
+    // sets origin to github.com/<owner>/<repo>.git. We then rewrite
+    // origin to our local bare repo so pushNow has somewhere to land.
+    writeCredentials({
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_fake1234567890abcd",
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+
+    const res = await handleAuthGithubSelectRepo(
+      new Request("http://x/select", {
+        method: "POST",
+        body: JSON.stringify({ owner: "aaron", name: "my-vault" }),
+      }),
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      auto_push_was_already_enabled: boolean;
+      auto_push_enabled: boolean;
+      initial_push:
+        | { fired: false; reason: string }
+        | { fired: true; pushed: boolean; error?: string; sha?: string };
+    };
+    // Cut 3 — auto_push went from false → true.
+    expect(body.auto_push_was_already_enabled).toBe(false);
+    expect(body.auto_push_enabled).toBe(true);
+    expect(manager.getConfig().auto_push).toBe(true);
+    // Cut 6 — initial push fired. It points at github.com which doesn't
+    // exist for our fake creds → expected to fail with a redacted error
+    // in last_push_error, but the helper still reports fired=true.
+    expect(body.initial_push.fired).toBe(true);
+    if (body.initial_push.fired === true) {
+      // Push failure is fine — point is "we tried."
+      expect(typeof body.initial_push.pushed).toBe("boolean");
+    }
+    // Token doesn't leak into the response.
+    expect(JSON.stringify(body)).not.toContain("gho_fake1234567890");
+    await manager.stop();
+  }, 30_000);
+
+  test("select-repo is a no-op for auto_push when mirror is disabled", async () => {
+    // Operator wiring credentials before flipping the mirror on — don't
+    // mutate auto_push behind their back.
+    home = tmp("mirror-selectrepo-disabled-");
+    const { manager, deps } = makeManager(home);
+    deps.writeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: false,
+      auto_push: false,
+    });
+    await manager.start();
+    writeCredentials({
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_anothertoken12345",
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+    const res = await handleAuthGithubSelectRepo(
+      new Request("http://x/select", {
+        method: "POST",
+        body: JSON.stringify({ owner: "aaron", name: "v" }),
+      }),
+      manager,
+    );
+    expect(res.status).toBe(200);
+    expect(manager.getConfig().auto_push).toBe(false);
+    await manager.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cut 6: POST /.parachute/mirror/push-now route handler.
+// ---------------------------------------------------------------------------
+
+describe("handleMirrorPushNow — Cut 6", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("returns 400 when mirror is not enabled", async () => {
+    home = tmp("mirror-pushnow-disabled-");
+    const { manager, deps } = makeManager(home);
+    deps.writeMirrorConfig({ ...defaultMirrorConfig(), enabled: false });
+    await manager.start();
+    const res = await handleMirrorPushNow(manager);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Mirror not enabled");
+  });
+
+  test("returns 200 + push outcome when mirror is enabled (even on push failure)", async () => {
+    home = tmp("mirror-pushnow-enabled-");
+    const { manager, deps } = makeManager(home);
+    deps.writeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "internal",
+      sync_mode: "manual",
+      auto_commit: false,
+    });
+    await manager.start();
+    // No remote → push will fail; the handler still returns 200 with
+    // the failure surface in the body. Push failures aren't 500s.
+    const res = await handleMirrorPushNow(manager);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: { last_push_error: string | null };
+      push: { fired: boolean };
+    };
+    expect(body.push.fired).toBe(true);
+    expect(body.status.last_push_error).not.toBeNull();
+    await manager.stop();
+  }, 30_000);
 });
 
 describe("auth credential routes — github repos / create-repo", () => {

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -61,6 +61,7 @@ import {
   type ImportAuth,
   type ImportResult,
 } from "./mirror-import.ts";
+import { redactToken } from "./export-watch.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { assetsDir } from "./routes.ts";
 
@@ -998,10 +999,16 @@ async function maybeFireInitialPush(
     const result = await manager.pushNow();
     return result;
   } catch (err) {
-    console.warn(
-      `[mirror-auth] initial push-now failed (non-fatal): ${(err as Error).message ?? err}`,
-    );
-    return { fired: true, pushed: false, error: (err as Error).message ?? String(err) };
+    // Defense-in-depth: every other push-error site routes through
+    // `redactToken` before surfacing — this catch-block was the one
+    // outlier where a thrown error's `.message` could carry an
+    // un-redacted token from a future code path that throws before the
+    // existing internal redaction runs. Apply the same scrub here.
+    // Reviewer-flagged on vault#392.
+    const rawMessage = (err as Error).message ?? String(err);
+    const safeMessage = redactToken(rawMessage);
+    console.warn(`[mirror-auth] initial push-now failed (non-fatal): ${safeMessage}`);
+    return { fired: true, pushed: false, error: safeMessage };
   }
 }
 

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -212,6 +212,44 @@ export async function handleMirrorRunNow(
 }
 
 /**
+ * `POST /vault/<name>/.parachute/mirror/push-now` — Cut 6 of vault#392.
+ *
+ * Fire a push against the currently-committed state of the mirror dir.
+ * Distinguished from `/run-now` which exports + commits + pushes —
+ * `push-now` is the credentials-side flow where the operator just wants
+ * to see "did the credentials I just saved actually work?"
+ *
+ * Returns the post-push status snapshot. Errors (no path, mirror
+ * disabled, push failed) surface as a JSON response — push failures
+ * are NOT 500s because the operator's expected next-step is to look at
+ * `last_push_error` and fix their remote, not "vault crashed."
+ */
+export async function handleMirrorPushNow(
+  manager: MirrorManager,
+): Promise<Response> {
+  const status = manager.getStatus();
+  if (!status.enabled) {
+    return Response.json(
+      {
+        error: "Mirror not enabled",
+        message:
+          "Mirror must be enabled before a push can fire. Enable it via PUT /.parachute/mirror first.",
+      },
+      { status: 400 },
+    );
+  }
+  const result = await manager.pushNow();
+  return Response.json(
+    {
+      config: manager.getConfig(),
+      status: manager.getStatus(),
+      push: result,
+    },
+    { headers: { "Access-Control-Allow-Origin": "*" } },
+  );
+}
+
+/**
  * Convenience for tests + future callers: build the GET response from a
  * known-good config without needing a real MirrorManager.
  */
@@ -602,9 +640,29 @@ export async function handleAuthPat(
   // resolved + on disk. Non-fatal if the mirror isn't running.
   await applyCredentialsToMirror(manager);
 
-  return Response.json(sanitizeCredentials(next), {
-    headers: { "Access-Control-Allow-Origin": "*" },
-  });
+  // Cut 3: auto-enable auto_push when credentials save. Operator wiring
+  // credentials almost certainly wants pushes to fire — silent
+  // "credentials saved but pushes never happen" is the bug Aaron hit.
+  // If `auto_push` was already true, leave it alone (idempotent).
+  const autoPushChange = await maybeEnableAutoPush(manager);
+
+  // Cut 6: kick off an initial push-now so the operator sees the push
+  // happen immediately rather than waiting for the next write event.
+  // Only when (a) auto_push ended up true AND (b) there are local commits
+  // ahead of the (now-configured) remote.
+  const initialPush = await maybeFireInitialPush(manager, autoPushChange.auto_push_now_enabled);
+
+  return Response.json(
+    {
+      ...sanitizeCredentials(next),
+      auto_push_was_already_enabled: autoPushChange.was_already_enabled,
+      auto_push_enabled: autoPushChange.auto_push_now_enabled,
+      initial_push: initialPush,
+    },
+    {
+      headers: { "Access-Control-Allow-Origin": "*" },
+    },
+  );
 }
 
 /**
@@ -846,6 +904,12 @@ export async function handleAuthGithubSelectRepo(
     }
     applied = true;
   }
+  // Cut 3 / Cut 6: auto-enable auto_push + fire initial push if there's
+  // anything to push. Same logic as handleAuthPat — operator picking a
+  // repo wants the push to fire.
+  const autoPushChange = await maybeEnableAutoPush(manager);
+  const initialPush = await maybeFireInitialPush(manager, autoPushChange.auto_push_now_enabled);
+
   return Response.json(
     {
       ok: true,
@@ -855,9 +919,90 @@ export async function handleAuthGithubSelectRepo(
       // Echo the redacted form back so the SPA can show "pushing to <repo>".
       // No raw token in the response.
       remote: `https://github.com/${owner}/${name}.git`,
+      auto_push_was_already_enabled: autoPushChange.was_already_enabled,
+      auto_push_enabled: autoPushChange.auto_push_now_enabled,
+      initial_push: initialPush,
     },
     { headers: { "Access-Control-Allow-Origin": "*" } },
   );
+}
+
+/**
+ * Cut 3: when credentials save, flip `auto_push` from false → true on
+ * the persisted config. Operators wiring credentials almost certainly
+ * want pushes to fire — silent "credentials saved but no push" was the
+ * three-stacking-gaps bug Aaron hit.
+ *
+ * Idempotent: if `auto_push` was already true, no config write happens.
+ * If `auto_push` is false, write the flipped config via `manager.reload`
+ * — that restarts the lifecycle and applies the credentials to the
+ * remote in the same pass.
+ *
+ * Returns a small struct so the route handler can shape the response:
+ *   - `was_already_enabled` — true iff auto_push was true before this call.
+ *   - `auto_push_now_enabled` — true iff auto_push is true after this call.
+ *
+ * Both being false means the operator deliberately left auto_push off
+ * and we leave it that way (we never touch a config whose mirror is
+ * disabled, and we never flip true → false).
+ */
+async function maybeEnableAutoPush(
+  manager: MirrorManager,
+): Promise<{ was_already_enabled: boolean; auto_push_now_enabled: boolean }> {
+  const config = manager.getConfig();
+  // Don't muck with auto_push when the mirror is disabled — the operator
+  // is configuring credentials before turning the mirror on, which is a
+  // legitimate sequence. They'll flip enabled themselves.
+  if (!config.enabled) {
+    return {
+      was_already_enabled: config.auto_push,
+      auto_push_now_enabled: config.auto_push,
+    };
+  }
+  if (config.auto_push) {
+    return { was_already_enabled: true, auto_push_now_enabled: true };
+  }
+  try {
+    await manager.reload({ ...config, auto_push: true });
+    return { was_already_enabled: false, auto_push_now_enabled: true };
+  } catch (err) {
+    console.warn(
+      `[mirror-auth] could not auto-enable auto_push (non-fatal): ${(err as Error).message ?? err}`,
+    );
+    return { was_already_enabled: false, auto_push_now_enabled: false };
+  }
+}
+
+/**
+ * Cut 6: after credential save, fire a `push-now` immediately so the
+ * operator sees the push happen rather than waiting for the next write
+ * event. Only when (a) auto_push is enabled (we just turned it on, or it
+ * was already on) AND (b) there are local commits to push.
+ *
+ * Best-effort: non-fatal on any failure. Returns a struct the caller
+ * folds into its response.
+ */
+async function maybeFireInitialPush(
+  manager: MirrorManager,
+  autoPushEnabled: boolean,
+): Promise<
+  | { fired: false; reason: "auto_push_disabled" | "no_mirror_path" | "manager_skipped" | "not_enabled" }
+  | { fired: true; pushed: boolean; error?: string; sha?: string }
+> {
+  if (!autoPushEnabled) return { fired: false, reason: "auto_push_disabled" };
+  const status = manager.getStatus();
+  if (!status.mirror_path) return { fired: false, reason: "no_mirror_path" };
+  // Need an active enabled mirror with a resolved path to push from.
+  if (!status.enabled) return { fired: false, reason: "manager_skipped" };
+  try {
+    const result = await manager.pushNow();
+    return result;
+  } catch (err) {
+    console.warn(
+      `[mirror-auth] initial push-now failed (non-fatal): ${(err as Error).message ?? err}`,
+    );
+    return { fired: true, pushed: false, error: (err as Error).message ?? String(err) };
+  }
 }
 
 /**

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -83,6 +83,7 @@ import {
   handleAuthPat,
   handleMirrorGet,
   handleMirrorImport,
+  handleMirrorPushNow,
   handleMirrorPut,
   handleMirrorRunNow,
 } from "./mirror-routes.ts";
@@ -554,6 +555,38 @@ export async function route(
       );
     }
     if (req.method === "POST") return handleMirrorRunNow(manager);
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  // /.parachute/mirror/push-now — fire `git push` against committed state.
+  // Cut 6 of vault#392. Same admin gate + manager check as run-now;
+  // POST-only. Distinguished from /run-now in that this skips export +
+  // commit, only pushes — for "did my credentials actually work?" flow.
+  if (subpath === "/.parachute/mirror/push-now") {
+    if (!hasScopeForVault(auth.scopes, vaultName, "admin")) {
+      return Response.json(
+        {
+          error: "Forbidden",
+          error_type: "insufficient_scope",
+          message: `This endpoint requires the '${SCOPE_ADMIN}' scope (or '${SCOPE_ADMIN.replace("vault:", `vault:${vaultName}:`)}').`,
+          required_scope: SCOPE_ADMIN,
+          granted_scopes: auth.scopes,
+        },
+        { status: 403 },
+      );
+    }
+    const manager = getMirrorManager();
+    if (!manager) {
+      return Response.json(
+        {
+          error: "Mirror manager not initialized",
+          message:
+            "The vault server hasn't wired a mirror manager yet (no vaults exist, or boot failed). Check logs for [mirror] entries.",
+        },
+        { status: 503 },
+      );
+    }
+    if (req.method === "POST") return handleMirrorPushNow(manager);
     return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -149,6 +149,18 @@ export interface MirrorStatus {
   last_export_notes_count: number | null;
   last_commit_sha: string | null;
   last_error: string | null;
+  /**
+   * Push observability — Cut 5 of vault#392. `last_push_at` is the ISO
+   * timestamp of the most recent successful push; `last_push_sha` is the
+   * sha that landed at that time; `last_push_error` is set after a
+   * failed push (cleared on the next successful one). `commits_unpushed`
+   * counts local commits ahead of upstream tracking (null when no
+   * upstream is configured yet — first push hasn't fired).
+   */
+  last_push_at: string | null;
+  last_push_sha: string | null;
+  last_push_error: string | null;
+  commits_unpushed: number | null;
 }
 
 export interface MirrorSnapshot {
@@ -220,6 +232,31 @@ export async function runMirrorNow(vaultName: string): Promise<MirrorSnapshot> {
     throw new HttpError(res.status, await readError(res));
   }
   return (await res.json()) as MirrorSnapshot;
+}
+
+/**
+ * POST a manual "push now" trigger — Cut 6 of vault#392. Distinguished
+ * from `runMirrorNow` in that this only fires `git push` against
+ * already-committed state; it doesn't export or commit. Returns the
+ * updated snapshot + push outcome.
+ */
+export interface MirrorPushNowResponse extends MirrorSnapshot {
+  push:
+    | { fired: false; reason: "not_enabled" | "no_mirror_path" }
+    | { fired: true; pushed: boolean; sha?: string; error?: string };
+}
+export async function pushMirrorNow(vaultName: string): Promise<MirrorPushNowResponse> {
+  const res = await fetch(
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/push-now`,
+    {
+      method: "POST",
+      headers: mirrorAuthHeaders(),
+    },
+  );
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as MirrorPushNowResponse;
 }
 
 // ---------------------------------------------------------------------------
@@ -325,10 +362,25 @@ export async function pollGithubDeviceFlow(
   return (await res.json()) as DevicePollState;
 }
 
+/**
+ * `MirrorCredentialSaveResult` — Cut 3/Cut 6 extends the PAT-save +
+ * select-repo responses with side-effects of the save: auto_push being
+ * auto-enabled and an initial push being fired. The SPA uses these to
+ * render a toast "Credentials wired + auto-push enabled. Your next
+ * commit will push to <repo>" rather than a silent "saved" confirmation.
+ */
+export interface MirrorCredentialSaveResult extends MirrorCredentialStatus {
+  auto_push_was_already_enabled: boolean;
+  auto_push_enabled: boolean;
+  initial_push:
+    | { fired: false; reason: string }
+    | { fired: true; pushed: boolean; error?: string; sha?: string };
+}
+
 export async function postMirrorAuthPat(
   vaultName: string,
   args: { token: string; remote_url: string; label?: string },
-): Promise<MirrorCredentialStatus> {
+): Promise<MirrorCredentialSaveResult> {
   const res = await fetch(
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/pat`,
     {
@@ -338,7 +390,7 @@ export async function postMirrorAuthPat(
     },
   );
   if (!res.ok) throw new HttpError(res.status, await readError(res));
-  return (await res.json()) as MirrorCredentialStatus;
+  return (await res.json()) as MirrorCredentialSaveResult;
 }
 
 export async function listGithubRepos(
@@ -368,10 +420,24 @@ export async function createGithubRepo(
   return (await res.json()) as GitHubRepoInfo;
 }
 
+export interface SelectGithubRepoResult {
+  ok: boolean;
+  applied: boolean;
+  owner: string;
+  name: string;
+  remote: string;
+  /** Cut 3/Cut 6 — auto_push side-effects from credential save. */
+  auto_push_was_already_enabled: boolean;
+  auto_push_enabled: boolean;
+  initial_push:
+    | { fired: false; reason: string }
+    | { fired: true; pushed: boolean; error?: string; sha?: string };
+}
+
 export async function selectGithubRepo(
   vaultName: string,
   args: { owner: string; name: string },
-): Promise<{ ok: boolean; applied: boolean; owner: string; name: string; remote: string }> {
+): Promise<SelectGithubRepoResult> {
   const res = await fetch(
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/select-repo`,
     {
@@ -381,13 +447,7 @@ export async function selectGithubRepo(
     },
   );
   if (!res.ok) throw new HttpError(res.status, await readError(res));
-  return (await res.json()) as {
-    ok: boolean;
-    applied: boolean;
-    owner: string;
-    name: string;
-    remote: string;
-  };
+  return (await res.json()) as SelectGithubRepoResult;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../lib/api.ts", async () => {
     getMirror: vi.fn(),
     putMirror: vi.fn(),
     runMirrorNow: vi.fn(),
+    pushMirrorNow: vi.fn(),
     // Credential surface (vault#384 — UI-configurable push credentials).
     // Default mocks return "no credentials configured" so existing tests
     // see the expected pre-credentials shape. Per-test overrides via
@@ -87,6 +88,10 @@ const snapshotFixture = (
     last_export_notes_count: null,
     last_commit_sha: null,
     last_error: null,
+    last_push_at: null,
+    last_push_sha: null,
+    last_push_error: null,
+    commits_unpushed: null,
     ...Object.fromEntries(
       Object.entries(over).filter(([k]) =>
         [
@@ -96,6 +101,10 @@ const snapshotFixture = (
           "last_export_notes_count",
           "last_commit_sha",
           "last_error",
+          "last_push_at",
+          "last_push_sha",
+          "last_push_error",
+          "commits_unpushed",
         ].includes(k),
       ),
     ),
@@ -291,11 +300,15 @@ describe("VaultMirror — admin scope", () => {
       },
     });
     renderRoute();
+    // Wait for both the mirror snapshot AND the credential status to
+    // resolve — the checkbox visibility depends on `creds.active_method`,
+    // which lives in a separate fetch from the mirror snapshot.
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
     );
-    // Credentials wired + internal location → checkbox visible.
-    expect(screen.getByLabelText(/Push after each commit/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Push after each commit/i)).toBeInTheDocument(),
+    );
     // Helper copy that explains the cross-location behavior is rendered.
     expect(
       screen.getByText(/vault can push the mirror's commits to your remote/i),
@@ -394,6 +407,123 @@ describe("VaultMirror — admin scope", () => {
       ).toBeInTheDocument(),
     );
     expect(screen.getByRole("button", { name: /Run export now/i })).toBeDisabled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Cut 5: push status fields render in the Status card.
+  // -------------------------------------------------------------------------
+
+  it("renders Last push timestamp + sha when last_push_at is set", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        location: "internal",
+        last_push_at: "2026-05-28T10:30:00.000Z",
+        last_push_sha: "deadbeef1234567890abcdef",
+        commits_unpushed: 0,
+      }),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Status/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByText("2026-05-28T10:30:00.000Z")).toBeInTheDocument();
+    // Truncated short sha (first 10).
+    expect(screen.getByText("deadbeef12")).toBeInTheDocument();
+  });
+
+  it("surfaces last_push_error in red when present", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        last_push_error: "fatal: Could not resolve host: github.example.com",
+      }),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/Last push failed/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/Could not resolve host/i)).toBeInTheDocument();
+  });
+
+  it("shows '<N> commits ready to push' hint when commits_unpushed > 0 and no recent push", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        commits_unpushed: 3,
+      }),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/3 commits ready to push/i)).toBeInTheDocument(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Cut 6: explicit "Push now" button + pushMirrorNow call.
+  // -------------------------------------------------------------------------
+
+  it("Push now button fires pushMirrorNow + refreshes status", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({
+        enabled: true,
+        location: "internal",
+        commits_unpushed: 1,
+      }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        label: "GitHub PAT",
+        remote_url: "https://x-access-token:***@github.com/aaron/v.git",
+        token_preview: "ghp_…1234",
+      },
+    });
+    vi.mocked(api.pushMirrorNow).mockResolvedValue({
+      ...snapshotFixture({
+        enabled: true,
+        location: "internal",
+        last_push_at: "2026-05-28T10:31:00.000Z",
+        last_push_sha: "feedface1234567890abc",
+        commits_unpushed: 0,
+      }),
+      push: { fired: true, pushed: true, sha: "feedface1234567890abc" },
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Push now/i })).toBeInTheDocument(),
+    );
+    const pushBtn = screen.getByRole("button", { name: /Push now/i });
+    expect(pushBtn).not.toBeDisabled();
+    const user = userEvent.setup();
+    await user.click(pushBtn);
+    await waitFor(() => {
+      expect(api.pushMirrorNow).toHaveBeenCalledWith("work");
+    });
+    // The post-push status flows back into the card.
+    await waitFor(() =>
+      expect(screen.getByText("2026-05-28T10:31:00.000Z")).toBeInTheDocument(),
+    );
+  });
+
+  it("Push now is disabled when no credentials are wired AND auto_push is false", async () => {
+    // No remote to push to → button disabled with a tooltip nudge to
+    // wire credentials. (Operators with auto_push on but no creds still
+    // get the button — clicking surfaces last_push_error cleanly.)
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal", auto_push: false }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Push now/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Push now/i })).toBeDisabled();
   });
 
   it("surfaces a PUT error from the server next to the form", async () => {
@@ -632,6 +762,64 @@ describe("VaultMirror — Git remote credentials", () => {
     // verification_uri rendered as a link.
     const link = screen.getByRole("link", { name: /github\.com\/login\/device/i }) as HTMLAnchorElement;
     expect(link.href).toContain("github.com/login/device");
+  });
+
+  it("surfaces 'Auto-push enabled + first push landed' toast after PAT save (Cut 3 + 6)", async () => {
+    // After PAT save the backend may auto-enable auto_push AND fire an
+    // initial push. The SPA shows a toast with the actual outcome
+    // (sha pushed) so the operator sees the credentials worked.
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    vi.mocked(api.postMirrorAuthPat).mockResolvedValue({
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        label: "GitHub PAT",
+        remote_url: "https://x-access-token:***@github.com/a/b.git",
+        token_preview: "ghp_…7890",
+      },
+      auto_push_was_already_enabled: false,
+      auto_push_enabled: true,
+      initial_push: {
+        fired: true,
+        pushed: true,
+        sha: "abc1234567def890",
+      },
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Use Personal Access Token/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Use Personal Access Token/i })).toBeInTheDocument(),
+    );
+    const modal = screen.getByRole("dialog");
+    await user.type(
+      within(modal).getByLabelText(/Token/i),
+      "ghp_test1234567890",
+    );
+    await user.type(
+      within(modal).getByLabelText(/Remote URL/i),
+      "https://github.com/a/b.git",
+    );
+    await user.click(screen.getByRole("button", { name: /Validate & save/i }));
+    // The toast confirms the auto_push + push outcome.
+    await waitFor(() =>
+      expect(screen.getByText(/Credentials saved/i)).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/Auto-push enabled and the first push landed/i),
+    ).toBeInTheDocument();
+    // The pushed sha (truncated to 10) appears.
+    expect(screen.getByText("abc1234567")).toBeInTheDocument();
   });
 
   it("opens the PAT modal and accepts token + remote URL input", async () => {

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -247,11 +247,18 @@ describe("VaultMirror — admin scope", () => {
     expect(screen.getByText(/Path must exist AND be a git repo/i)).toBeInTheDocument();
   });
 
-  it("hides the Push-after-commit checkbox when location is internal", async () => {
-    // Auto-push is meaningless for internal mirrors (no configured remote).
-    // The form should hide the checkbox entirely rather than show a disabled
-    // one — anything else is confusing UX. Reviewer-flagged on #380.
+  it("hides the Push-after-commit checkbox when internal AND no credentials are wired", async () => {
+    // Pre-credentials: internal mirrors had no remote, so auto_push was
+    // meaningless and the checkbox was hidden. Post-credentials (Cut 2):
+    // the checkbox stays hidden ONLY when both (a) location is internal
+    // AND (b) no credentials are configured — without a remote there's
+    // nothing to push to.
     vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
     renderRoute();
     const user = userEvent.setup();
 
@@ -259,12 +266,40 @@ describe("VaultMirror — admin scope", () => {
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
     );
 
-    // Default fixture is location=internal — the Push checkbox should be absent.
+    // Default fixture is location=internal + no creds — Push checkbox absent.
     expect(screen.queryByLabelText(/Push after each commit/i)).not.toBeInTheDocument();
 
-    // Flip to external via the Live Mirror preset — the checkbox appears.
+    // Flip to external via the Live Mirror preset — the checkbox appears
+    // even with no creds (operator may have wired a remote manually).
     await user.click(screen.getByRole("button", { name: /Apply Live Mirror preset/i }));
     expect(screen.getByLabelText(/Push after each commit/i)).toBeInTheDocument();
+  });
+
+  it("shows the Push-after-commit checkbox when internal AND credentials are wired (Cut 2)", async () => {
+    // Aaron's three-stacking-gaps bug surfaced here: History preset
+    // (internal location) + PAT saved → no in-UI affordance to enable
+    // auto_push. Now the checkbox renders whenever the operator has a
+    // remote to push to, regardless of where the working tree lives.
+    vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture({ location: "internal" }));
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        label: "GitHub PAT",
+        remote_url: "https://x-access-token:***@github.com/aaron/v.git",
+        token_preview: "ghp_…1234",
+      },
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+    // Credentials wired + internal location → checkbox visible.
+    expect(screen.getByLabelText(/Push after each commit/i)).toBeInTheDocument();
+    // Helper copy that explains the cross-location behavior is rendered.
+    expect(
+      screen.getByText(/vault can push the mirror's commits to your remote/i),
+    ).toBeInTheDocument();
   });
 
   it("shows a cursor-advance hint when auto_commit is unchecked", async () => {

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -30,11 +30,13 @@ import {
   type DeviceCodeResponse,
   type GitHubRepoInfo,
   type MirrorConfig,
+  type MirrorCredentialSaveResult,
   type MirrorCredentialStatus,
   type MirrorImportCredentials,
   type MirrorImportResult,
   type MirrorSnapshot,
   type MirrorStatus,
+  type SelectGithubRepoResult,
   createGithubRepo,
   deleteMirrorAuth,
   getMirror,
@@ -43,6 +45,7 @@ import {
   pollGithubDeviceFlow,
   postMirrorAuthPat,
   postMirrorImport,
+  pushMirrorNow,
   putMirror,
   runMirrorNow,
   selectGithubRepo,
@@ -260,7 +263,8 @@ function MirrorScreen({
     <>
       <StatusCard
         status={snapshot.status}
-        enabled={snapshot.config.enabled}
+        config={snapshot.config}
+        creds={creds}
         canRun={isAdmin && snapshot.status.enabled}
         vaultName={vaultName}
         onSnapshot={onSnapshot}
@@ -288,6 +292,12 @@ function MirrorScreen({
           creds={creds}
           credsError={credsError}
           onCredsChanged={setCreds}
+          onCredsSaved={() => {
+            // Refresh the snapshot so the new auto_push + status fields
+            // (last_push_at, last_push_sha, commits_unpushed) land in
+            // the SPA's view of state. Same trigger as putMirror.
+            onRefresh();
+          }}
           locationIsExternal={snapshot.config.location === "external"}
         />
       ) : null}
@@ -303,18 +313,22 @@ function MirrorScreen({
 
 function StatusCard({
   status,
-  enabled,
+  config,
+  creds,
   canRun,
   vaultName,
   onSnapshot,
 }: {
   status: MirrorStatus;
-  enabled: boolean;
+  config: MirrorConfig;
+  creds: MirrorCredentialStatus | null;
   canRun: boolean;
   vaultName: string;
   onSnapshot: (snap: MirrorSnapshot) => void;
 }) {
+  const enabled = config.enabled;
   const [running, setRunning] = useState(false);
+  const [pushing, setPushing] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
 
   const onRun = async () => {
@@ -329,6 +343,26 @@ function StatusCard({
       setRunning(false);
     }
   };
+
+  const onPushNow = async () => {
+    setPushing(true);
+    setRunError(null);
+    try {
+      const snap = await pushMirrorNow(vaultName);
+      onSnapshot(snap);
+    } catch (err) {
+      setRunError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPushing(false);
+    }
+  };
+
+  // Cut 6: disable "Push now" when there's no remote to push to (no
+  // credentials AND auto_push is false). Operators with auto_push on
+  // but no creds yet still get the button — clicking will surface the
+  // missing-credentials error cleanly via last_push_error.
+  const hasRemote = !!creds?.active_method || config.auto_push;
+  const pushDisabled = !canRun || pushing || !hasRemote;
 
   return (
     <div className="section">
@@ -366,7 +400,41 @@ function StatusCard({
             <span className="dim">—</span>
           )}
         </div>
+        {/* Cut 5: push status. Always render the row so the operator
+            can read "never" — silence here was a footgun (Aaron's bug:
+            "did the push actually fire?" with nothing to look at). */}
+        <div>Last push</div>
+        <div>
+          {status.last_push_at ? (
+            <>
+              <code>{status.last_push_at}</code>
+              {status.last_push_sha ? (
+                <span className="dim">
+                  {" "}· <code>{status.last_push_sha.slice(0, 10)}</code>
+                </span>
+              ) : null}
+            </>
+          ) : (
+            <span className="dim">never</span>
+          )}
+        </div>
+        {/* Surface commits_unpushed as a subdued helper when there's
+            work pending and no recent push. Hides when 0 (synced) or
+            null (no upstream yet — too noisy on first-boot). */}
+        {status.commits_unpushed !== null && status.commits_unpushed > 0 ? (
+          <>
+            <div></div>
+            <div className="dim">
+              {status.commits_unpushed} commit{status.commits_unpushed === 1 ? "" : "s"} ready to push
+            </div>
+          </>
+        ) : null}
       </div>
+      {status.last_push_error ? (
+        <div className="error-banner" style={{ marginTop: "1rem" }}>
+          <strong>Last push failed:</strong> <code>{status.last_push_error}</code>
+        </div>
+      ) : null}
       {status.last_error ? (
         <div className="error-banner" style={{ marginTop: "1rem" }}>
           <strong>Last error:</strong> <code>{status.last_error}</code>
@@ -391,6 +459,23 @@ function StatusCard({
           }
         >
           {running ? "Running…" : "Run export now"}
+        </button>
+        <button
+          type="button"
+          className="secondary"
+          onClick={onPushNow}
+          disabled={pushDisabled}
+          title={
+            !enabled
+              ? "Enable the mirror first, then push."
+              : !canRun
+                ? "Admin scope required to push."
+                : !hasRemote
+                  ? "Wire credentials or turn on auto-push to push to a remote."
+                  : undefined
+          }
+        >
+          {pushing ? "Pushing…" : "Push now"}
         </button>
       </div>
     </div>
@@ -778,18 +863,35 @@ function GitRemoteSection({
   creds,
   credsError,
   onCredsChanged,
+  onCredsSaved,
   locationIsExternal,
 }: {
   vaultName: string;
   creds: MirrorCredentialStatus | null;
   credsError: string | null;
   onCredsChanged: (creds: MirrorCredentialStatus) => void;
+  /**
+   * Cut 3/6 — fires AFTER a successful save when the backend
+   * auto-enables auto_push or fires an initial push, with the full save
+   * result. Parent refreshes the mirror snapshot so the new
+   * auto_push + last_push_at land in the SPA's view of state.
+   */
+  onCredsSaved: (result: MirrorCredentialSaveResult | SelectGithubRepoResult) => void;
   locationIsExternal: boolean;
 }) {
   const [oauthOpen, setOauthOpen] = useState(false);
   const [patOpen, setPatOpen] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  /**
+   * Toast surfaced after a successful credential save. Holds the save
+   * result so the toast text can reference the actual push outcome
+   * ("pushed sha abc1234" vs "auto-push enabled, next commit pushes").
+   * Auto-dismisses on the next save or after a click.
+   */
+  const [saveResult, setSaveResult] = useState<
+    MirrorCredentialSaveResult | SelectGithubRepoResult | null
+  >(null);
 
   const connected = creds?.active_method !== null && creds?.active_method !== undefined;
 
@@ -819,10 +921,19 @@ function GitRemoteSection({
         <code>0600</code> file permissions. Never sent to GitHub or any third party.
       </p>
 
-      {!locationIsExternal ? (
+      {/*
+        Pre-Cut-2 this read "Internal mirrors live under … no remote.
+        Switch to External." With Cut 1/2 wired (auto_push works on
+        internal location when credentials are configured), the message
+        only applies when NO credentials are wired yet AND the location
+        is internal — the case where there's genuinely nothing to push
+        to. After credentials land, internal mirrors push fine.
+      */}
+      {!locationIsExternal && !creds?.active_method ? (
         <div className="info-banner" style={{ marginBottom: "0.75rem" }} role="status">
-          Internal mirrors live under the vault's data directory and have no remote.
-          Switch the location above to <strong>External</strong> to enable pushing.
+          Internal mirrors live under the vault's data directory. To push them
+          to a remote, paste a Personal Access Token + remote URL below — that
+          wires the remote and turns on auto-push automatically.
         </div>
       ) : null}
 
@@ -886,6 +997,84 @@ function GitRemoteSection({
         </div>
       ) : null}
 
+      {/* Cut 3 / Cut 6 confirmation toast. Renders after a successful PAT
+          save / OAuth repo pick when the backend auto-enabled auto_push
+          and/or fired an initial push. The copy adapts to the four
+          shapes: was-already-on, just-enabled+pushed, just-enabled+
+          push-failed, just-enabled+nothing-to-push. */}
+      {saveResult ? (
+        <div
+          className="mint-banner"
+          style={{ marginBottom: "0.75rem" }}
+          role="status"
+        >
+          <strong>Credentials saved.</strong>{" "}
+          {(() => {
+            const sr = saveResult;
+            const pushedSha =
+              sr.initial_push.fired && sr.initial_push.pushed
+                ? sr.initial_push.sha
+                : undefined;
+            const pushError =
+              sr.initial_push.fired && !sr.initial_push.pushed
+                ? sr.initial_push.error
+                : undefined;
+            if (sr.auto_push_was_already_enabled) {
+              if (pushedSha) {
+                return (
+                  <>
+                    Auto-push was already on; just pushed{" "}
+                    <code>{pushedSha.slice(0, 10)}</code>.
+                  </>
+                );
+              }
+              if (pushError) {
+                return (
+                  <>
+                    Auto-push was already on; the push attempt failed —
+                    see the Status card above for details.
+                  </>
+                );
+              }
+              return <>Auto-push was already on; nothing to push right now.</>;
+            }
+            if (sr.auto_push_enabled) {
+              if (pushedSha) {
+                return (
+                  <>
+                    Auto-push enabled and the first push landed{" "}
+                    <code>{pushedSha.slice(0, 10)}</code>. Your next commit will
+                    push to the remote too.
+                  </>
+                );
+              }
+              if (pushError) {
+                return (
+                  <>
+                    Auto-push enabled. The initial push attempt failed — see
+                    the Status card above for the error.
+                  </>
+                );
+              }
+              return (
+                <>Auto-push enabled. Your next commit will push to the remote.</>
+              );
+            }
+            return <>Credentials wired. Auto-push remains off; flip it on in
+              Configuration above to push commits automatically.</>;
+          })()}{" "}
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => setSaveResult(null)}
+            style={{ marginLeft: "0.5rem" }}
+            aria-label="Dismiss"
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+
       <div className="actions">
         {!connected ? (
           <>
@@ -924,8 +1113,12 @@ function GitRemoteSection({
         <GithubOAuthModal
           vaultName={vaultName}
           onClose={() => setOauthOpen(false)}
-          onConnected={(c) => {
+          onConnected={(c, selectResult) => {
             onCredsChanged(c);
+            if (selectResult) {
+              setSaveResult(selectResult);
+              onCredsSaved(selectResult);
+            }
             setOauthOpen(false);
           }}
         />
@@ -935,8 +1128,10 @@ function GitRemoteSection({
         <PATModal
           vaultName={vaultName}
           onClose={() => setPatOpen(false)}
-          onSaved={(c) => {
-            onCredsChanged(c);
+          onSaved={(result) => {
+            onCredsChanged(result);
+            setSaveResult(result);
+            onCredsSaved(result);
             setPatOpen(false);
           }}
         />
@@ -962,7 +1157,16 @@ function GithubOAuthModal({
 }: {
   vaultName: string;
   onClose: () => void;
-  onConnected: (creds: MirrorCredentialStatus) => void;
+  /**
+   * Cut 3/6: second arg carries the select-repo result so the parent
+   * can surface a confirmation toast with auto_push + initial push
+   * details. Undefined when the modal closes without a repo pick (e.g.
+   * cancel during the device-code phase).
+   */
+  onConnected: (
+    creds: MirrorCredentialStatus,
+    selectResult?: SelectGithubRepoResult,
+  ) => void;
 }) {
   const [phase, setPhase] = useState<OAuthPhase>({ kind: "starting" });
   const [now, setNow] = useState(Date.now());
@@ -1100,9 +1304,9 @@ function GithubOAuthModal({
             vaultName={vaultName}
             user={phase.user}
             onPicked={async (owner, name) => {
-              await selectGithubRepo(vaultName, { owner, name });
+              const selectResult = await selectGithubRepo(vaultName, { owner, name });
               const c = await getMirrorAuth(vaultName);
-              onConnected(c);
+              onConnected(c, selectResult);
             }}
             onError={(message) => setPhase({ kind: "error", message })}
           />
@@ -1314,7 +1518,9 @@ function PATModal({
 }: {
   vaultName: string;
   onClose: () => void;
-  onSaved: (creds: MirrorCredentialStatus) => void;
+  /** Cut 3/6: the result now carries auto_push side-effects + initial
+   *  push outcome so the parent can render a confirmation toast. */
+  onSaved: (result: MirrorCredentialSaveResult) => void;
 }) {
   const [token, setToken] = useState("");
   const [remoteUrl, setRemoteUrl] = useState("");
@@ -1327,12 +1533,12 @@ function PATModal({
     setSaving(true);
     setError(null);
     try {
-      const creds = await postMirrorAuthPat(vaultName, {
+      const result = await postMirrorAuthPat(vaultName, {
         token: token.trim(),
         remote_url: remoteUrl.trim(),
         label: label.trim() || undefined,
       });
-      onSaved(creds);
+      onSaved(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -627,7 +627,26 @@ function ConfigForm({
         ) : null}
       </div>
 
-      {config.location === "external" ? (
+      {/*
+        Show the auto_push checkbox when EITHER:
+          - location is external (vault doesn't manage the working tree;
+            the operator might have wired their own git remote), OR
+          - credentials are configured (PAT or GitHub OAuth) — at which
+            point vault has a remote to push to regardless of where the
+            working tree lives. The credential save path writes `origin`
+            on the mirror dir whether it's internal or external.
+
+        The old pattern hid the checkbox on internal locations under the
+        assumption "internal = no remote." That breaks the round-trip
+        Aaron hit: History preset (internal) + PAT saved → no way to
+        flip auto_push on from the UI. Now the checkbox renders whenever
+        the operator has a remote to push to.
+
+        Backend validation (mirror-config.ts:validateMirrorConfigShape)
+        mirrors this: auto_push + internal is accepted iff credentials
+        are wired; rejected otherwise with an actionable error.
+      */}
+      {config.location === "external" || creds?.active_method ? (
         <div className="form-row">
           <label>
             <input
@@ -641,6 +660,11 @@ function ConfigForm({
             />
             Push after each commit
           </label>
+          <p className="dim" style={{ margin: "0.35rem 0 0", fontSize: "0.9em" }}>
+            When credentials are configured, vault can push the mirror's commits
+            to your remote regardless of whether the mirror folder lives under
+            vault's data dir or somewhere visible.
+          </p>
           {config.auto_push ? (
             creds?.active_method ? (
               <div className="info-banner" style={{ marginTop: "0.5rem" }} role="status">
@@ -665,16 +689,6 @@ function ConfigForm({
           ) : null}
         </div>
       ) : null}
-      {/*
-        Internal-location mirrors live under ~/.parachute/vault/data and have
-        no configured git remote — a push would always fail. Hide the checkbox
-        entirely rather than render a disabled one: the option is meaningless,
-        not just unavailable. If a stored config carries auto_push:true +
-        location:internal (e.g. operator switched from external→internal
-        without unticking), the value persists on the config blob until they
-        save a different one — the watch loop just skips pushes because there's
-        no remote. Reviewer-flagged on #380.
-      */}
 
       <div className="form-row">
         <button


### PR DESCRIPTION
## Summary

Aaron hit a real bug: he saved a PAT + remote URL on a History-preset (internal-location) mirror, expected pushes to fire, **nothing happened**. Three stacking gaps caused this:

1. `auto_push: false` is the History preset's default — even with credentials wired, the loop never tries to push.
2. UI hides the auto_push checkbox when location=internal — operator has no in-UI way to flip it on.
3. Local `main` has no upstream tracking — even if auto_push were on, the first push would fail with "no upstream branch."

Net result: credentials saved, remote URL set on the internal git repo's origin, nothing ever pushes.

This PR ships six cuts that unblock the round-trip end-to-end. Verified against a local bare repo: PAT-equivalent saves now trip auto_push on, fire an initial push, surface success/failure in the Status card.

## Per-cut summary

**Cut 1 — `cae7ebe`** — Relax `auto_push + internal` validation in `mirror-config.ts:validateMirrorConfigShape`. Reject only when no credentials are configured (with an actionable "configure credentials first" error). Acceptance path: PAT or github_oauth wired → proceed. Credential read is injected so tests stay hermetic.

**Cut 2 — `8cc3da6`** — Show the auto_push checkbox in `VaultMirror.tsx` whenever credentials are wired, regardless of location. New inline help copy explains the cross-location behavior. The old "hides on internal" condition tightened to "hides on internal AND no credentials."

**Cut 3 — `943fb20`** (part) — Auto-enable `auto_push` after `handleAuthPat` / `handleAuthGithubSelectRepo` land credentials. `maybeEnableAutoPush` helper: if auto_push was false AND mirror is enabled, flip to true via `manager.reload()`. Idempotent; disabled mirrors left alone. Response shapes extended with `auto_push_was_already_enabled`, `auto_push_enabled`, `initial_push` so the SPA can render a confirmation toast.

**Cut 4 — `c873cf7`** — `gitPush` in `export-watch.ts` detects missing upstream via `git rev-parse @{u}` and falls back to `git push -u origin <branch>` for the first push. Also extends `runGitCommitCycle` to return a `push: {attempted, ok, error}` field for status surfacing. Adds `redactToken()` for safe log/status display.

**Cut 5 — `0c003dd` + `09114b3`** (status part) — Four new `MirrorStatus` fields (`last_push_at`, `last_push_sha`, `last_push_error`, `commits_unpushed`) populated by `runOneCycle` from `runGitCommitCycle`'s push outcome + a per-cycle `readCommitsUnpushed` query. SPA Status card renders "Last push" row, red "Last push failed" banner, and "<N> commits ready to push" subdued helper.

**Cut 6 — `943fb20` + `09114b3`** (push-now parts) — New `MirrorManager.pushNow()` method + `POST /.parachute/mirror/push-now` route. Fires `git push` against committed state and captures the outcome. Auto-fires from the credential save path so the operator sees the push happen immediately. SPA gets an explicit "Push now" button in the Status card, disabled when no remote to push to.

## Test counts

| Surface | Result |
|---|---|
| `bun test ./core ./src ./package` | 1841 pass, 0 fail (5011 expect calls) |
| `bun run typecheck` (server) | clean |
| `cd web/ui && bunx vitest run` | 104 pass, 0 fail (was 98) |
| `cd web/ui && bun run typecheck` | clean |

New tests added: 3 in `mirror-config.test.ts` (acceptance + rejection), 3 in `export-watch.test.ts` (gitPush upstream tracking matrix), 3 in `mirror-manager.test.ts` (pushNow happy + fail + disabled), 4 in `mirror-routes.test.ts` (select-repo auto_push side-effects + push-now route), 6 in `VaultMirror.test.tsx` (push status fields, Push now button, credential-save toast).

## Sandbox E2E

Ran the full credential-save-triggers-push flow against a local bare repo with `PARACHUTE_HOME=/tmp/vault-push-test-$$`:

1. Start with History preset config (enabled + internal + auto_push: false)
2. Seed github_oauth credentials + call `handleAuthGithubSelectRepo`
3. Confirmed `auto_push` flipped false → true, manager config persisted
4. Confirmed `initial_push.fired: true` (push failure against fake GitHub URL is correct — fake token, real attempt)
5. Rewrote origin to local bare repo; called `manager.pushNow()` → `pushed: true`, sha `a3335e3...`
6. Verified bare repo received the commit: `a3335e3 initial mirror bootstrap`
7. Final status: `last_push_at` set, `last_push_sha` set, `last_push_error: null`, `commits_unpushed: 0`

The "three stacking gaps" round-trip works end-to-end.

## Multi-pusher caveat

Still warn-only — Cuts 1-6 don't add detection or blocking for multiple vaults pushing to the same git repo. The existing "One vault per remote" warn banner stays in place. Per Aaron's 2026-05-28 direction: "I don't think we need to plan for that too elegantly right now, but it is important to think about."

## Test plan

- [ ] On a History-preset mirror (internal location), wire a PAT against a real GitHub repo
- [ ] Verify the toast says "Auto-push enabled and the first push landed <sha>"
- [ ] Verify the Status card shows "Last push: <timestamp> · <sha>" and "0 commits ready to push" disappears
- [ ] Verify the GitHub repo has the new commit
- [ ] Make a vault change → event-driven export → confirm next push fires automatically
- [ ] Test "Push now" button explicitly after a manual change
- [ ] Try a deliberately-invalid PAT — confirm `last_push_error` renders red without leaking the token

DO NOT MERGE — reviewer dispatch pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)