### PR TITLE
chore(release): 0.4.9-rc.9 — auto-push + push status + upstream tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.8",
+  "version": "0.4.9-rc.9",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump. Picks up #392 — fixes the three-stacking-gaps bug where History-preset mirrors with PAT saved never pushed. Six cuts: validation relaxed, SPA checkbox visibility, auto-enable + toast, upstream tracking on first push, status fields surfaced, explicit "Push now" button.

## Test plan

- [x] `bun test ./core ./src ./package` — 1841 pass / 0 fail
- [x] `cd web/ui && bunx vitest run` — 104 pass / 0 fail
- [x] Both typechecks clean
- [x] Aaron testing locally on rc.9-bumped vault confirms end-to-end
- [ ] After merge: tag `v0.4.9-rc.9` + push → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)