### PR TITLE
feat(vault-spa): silent auth refresh — no more "go back to hub" on page reload

### DIFF
--- a/web/ui/src/lib/SignInBanner.tsx
+++ b/web/ui/src/lib/SignInBanner.tsx
@@ -1,0 +1,130 @@
+/**
+ * `SignInBanner` — the auth-required empty state for the vault admin SPA.
+ *
+ * Replaces the older "Open this page from the hub's directory" copy. With
+ * silent token refresh (see `auth.ts:ensureToken`) the only remaining
+ * paths into this banner are:
+ *
+ *   1. Operator isn't signed in to the hub (no session cookie). Hub's
+ *      `/admin/vault-admin-token/<name>` returns 401.
+ *   2. The session cookie expired or was revoked. Same 401 from hub.
+ *   3. Operator is signed in but isn't the first admin (the multi-user
+ *      Phase 1 gate). Hub returns 403.
+ *   4. The vault name isn't installed on this hub. Hub returns 404.
+ *
+ * For cases 1+2 the operator needs to sign in at hub's `/login`. We
+ * surface a direct link with a `?next=` continuation back to the current
+ * URL so they land back on the admin page once authenticated. Cases 3+4
+ * also show the link — there isn't a better unblock from the SPA's side
+ * (a "sign out, sign in as someone else" is rare in single-operator
+ * deploys; a 404 means the vault isn't reachable through this hub at
+ * all, which is operationally distinct but rendering-equivalent).
+ *
+ * To make the recovery loop genuinely hands-off, the banner polls
+ * `ensureToken` every 5s. The instant the operator signs into the hub
+ * in another tab, the next poll succeeds and `onRecovered()` fires so
+ * the parent route re-attempts its data load. No manual refresh needed.
+ *
+ * The poll is gated on `document.visibilityState === "visible"` so a
+ * background tab doesn't spam the hub once a minute for a session that
+ * may never materialize. The poll resumes on `visibilitychange`.
+ */
+import { useEffect } from "react";
+import { ensureToken } from "./auth.ts";
+
+const POLL_INTERVAL_MS = 5000;
+
+export interface SignInBannerProps {
+  /** Vault name. Used both for the poll-retry call and to compose the
+   *  `?next=` parameter on the hub `/login` link. */
+  vaultName: string;
+  /**
+   * Status code from the most recent attempt. Lets us tweak the copy a
+   * little — 404 means "this hub doesn't host that vault" rather than
+   * "sign in" — though all four (401/403/404 + null) surface the same
+   * sign-in CTA since hub login is the only safe unblock from the SPA's
+   * side. `null` = first attempt failed before we got a status (e.g.
+   * `getToken()` returned null at bootstrap and we never even tried the
+   * mint endpoint).
+   */
+  status?: number | null;
+  /** Called when the poll succeeds. Parent re-fires its data load. */
+  onRecovered: () => void;
+}
+
+export function SignInBanner({ vaultName, status, onRecovered }: SignInBannerProps) {
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      if (cancelled) return;
+      // Skip work when the tab is hidden — schedule another tick so the
+      // visibilitychange listener can immediately fire one on resume.
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") {
+        timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+        return;
+      }
+      const result = await ensureToken(vaultName);
+      if (cancelled) return;
+      if (result.kind === "ok") {
+        onRecovered();
+        return;
+      }
+      timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    };
+
+    // Fire a single tick on resume so a tab that returns from background
+    // doesn't wait POLL_INTERVAL_MS for the next scheduled check.
+    const onVisibility = () => {
+      if (typeof document === "undefined") return;
+      if (document.visibilityState === "visible") {
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        void poll();
+      }
+    };
+
+    timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibility);
+    }
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibility);
+      }
+    };
+  }, [vaultName, onRecovered]);
+
+  const next = composeNext();
+  const loginHref = `/login?next=${encodeURIComponent(next)}`;
+  const headline =
+    status === 404
+      ? "This hub doesn't host a vault by that name."
+      : "You're not signed in to the hub.";
+
+  return (
+    <div className="warn-banner" role="status">
+      <p style={{ margin: "0 0 0.5rem" }}>
+        {headline} <a href={loginHref}>Sign in to the hub →</a>
+      </p>
+      <p className="dim" style={{ margin: 0, fontSize: "0.85rem" }}>
+        After signing in, this page will refresh automatically.
+      </p>
+    </div>
+  );
+}
+
+/** Compose the `?next=` value for hub's login redirect. We want the
+ *  operator to land back at the current URL after they sign in, so the
+ *  vault SPA re-bootstraps + the silent-refresh path picks up a fresh
+ *  session cookie. Use the full `pathname + search + hash` — same shape
+ *  hub's login form expects (see `parachute-hub/src/admin-login-ui.ts`). */
+function composeNext(): string {
+  if (typeof window === "undefined") return "/";
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}

--- a/web/ui/src/lib/SignInBanner.tsx
+++ b/web/ui/src/lib/SignInBanner.tsx
@@ -59,10 +59,13 @@ export function SignInBanner({ vaultName, status, onRecovered }: SignInBannerPro
 
     const poll = async () => {
       if (cancelled) return;
-      // Skip work when the tab is hidden — schedule another tick so the
-      // visibilitychange listener can immediately fire one on resume.
+      // Skip work when the tab is hidden. Don't reschedule — the
+      // visibilitychange listener below fires an immediate poll on
+      // resume, which then chain-schedules the next tick. Rescheduling
+      // here would burn a setTimeout queue entry every POLL_INTERVAL_MS
+      // for the entire time the tab is backgrounded with no payoff.
+      // Reviewer-flagged on vault#395.
       if (typeof document !== "undefined" && document.visibilityState !== "visible") {
-        timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
         return;
       }
       const result = await ensureToken(vaultName);

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -1,11 +1,14 @@
 /**
- * API client surface. Two narrow tests: the public-list 404→empty path,
- * and the per-vault detail auth-error shape. The fetch surface is mocked
- * via `vi.stubGlobal`; restoreMocks in setup.ts wipes the stub between
- * tests.
+ * API client surface. Three narrow tests:
+ *   - `listVaultNames` public-list 404→empty path
+ *   - `getVaultDetail` auth-error shape
+ *   - the silent-refresh single-retry on 401 path inside `_authedFetch`
+ *
+ * The fetch surface is mocked via `vi.stubGlobal`; restoreMocks in
+ * setup.ts wipes the stub between tests.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { _setTokenForTest, clearToken } from "./auth.ts";
+import { _cancelRefreshTimerForTest, _setTokenForTest, clearToken } from "./auth.ts";
 import { HttpError, getVaultDetail, listVaultNames } from "./api.ts";
 
 function mockFetch(impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
@@ -44,12 +47,28 @@ describe("listVaultNames", () => {
 });
 
 describe("getVaultDetail", () => {
-  afterEach(() => {
-    clearToken();
+  beforeEach(() => {
+    _cancelRefreshTimerForTest();
   });
 
-  it("rejects with HttpError(401) when no token is cached", async () => {
+  afterEach(() => {
+    clearToken();
+    _cancelRefreshTimerForTest();
+  });
+
+  it("rejects with HttpError(401) when no cached token + silent refresh fails", async () => {
     _setTokenForTest(null);
+    // Mock fetch so the silent-refresh call to `/admin/vault-admin-token`
+    // returns 401 — there's no hub session to recover from.
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.startsWith("/admin/vault-admin-token/")) {
+        return new Response(JSON.stringify({ error: "unauthenticated" }), { status: 401 });
+      }
+      // Shouldn't reach the vault detail endpoint if the silent refresh
+      // failed.
+      throw new Error(`unexpected fetch: ${url}`);
+    });
 
     await expect(getVaultDetail("work")).rejects.toMatchObject({
       name: "HttpError",
@@ -94,5 +113,100 @@ describe("getVaultDetail", () => {
       status: 403,
       message: "scope mismatch",
     });
+  });
+});
+
+describe("authedFetch single-retry on 401", () => {
+  // Cut 3 — when a stale Bearer comes back 401 mid-session, the fetch
+  // wrapper silently mints a fresh one and retries once. Verifies via
+  // the `getVaultDetail` surface (which routes through `_authedFetch`).
+  beforeEach(() => {
+    _cancelRefreshTimerForTest();
+  });
+
+  afterEach(() => {
+    clearToken();
+    _cancelRefreshTimerForTest();
+  });
+
+  it("retries the request once on 401 with a freshly-minted token", async () => {
+    _setTokenForTest("stale.jwt");
+    const calls: Array<{ url: string; auth: string | null }> = [];
+    let detailCallCount = 0;
+    mockFetch(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const headers = new Headers(init?.headers);
+      calls.push({ url, auth: headers.get("authorization") });
+      if (url.startsWith("/admin/vault-admin-token/")) {
+        return new Response(
+          JSON.stringify({
+            token: "fresh.jwt",
+            expires_at: new Date(Date.now() + 600_000).toISOString(),
+            scopes: ["vault:work:admin"],
+          }),
+          { status: 200 },
+        );
+      }
+      // First detail call → 401 (stale token). Second → 200.
+      detailCallCount += 1;
+      if (detailCallCount === 1) {
+        return new Response(JSON.stringify({ error: "expired" }), { status: 401 });
+      }
+      return new Response(
+        JSON.stringify({
+          name: "work",
+          description: null,
+          createdAt: "2026-04-01T00:00:00Z",
+          stats: { totalNotes: 1, tagCount: 0, attachmentCount: 0, linkCount: 0 },
+        }),
+        { status: 200 },
+      );
+    });
+
+    const detail = await getVaultDetail("work");
+
+    expect(detail.name).toBe("work");
+    // Three calls: detail-401 → mint-200 → detail-200.
+    expect(calls.length).toBe(3);
+    expect(calls[0]?.auth).toBe("Bearer stale.jwt");
+    expect(calls[1]?.url).toBe("/admin/vault-admin-token/work");
+    expect(calls[2]?.auth).toBe("Bearer fresh.jwt");
+  });
+
+  it("throws the original 401 when both the first request AND the silent refresh fail", async () => {
+    _setTokenForTest("stale.jwt");
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.startsWith("/admin/vault-admin-token/")) {
+        // Silent refresh fails — operator has no hub session.
+        return new Response(JSON.stringify({ error: "unauthenticated" }), { status: 401 });
+      }
+      // Original request returns 401.
+      return new Response(JSON.stringify({ error: "expired" }), { status: 401 });
+    });
+
+    await expect(getVaultDetail("work")).rejects.toMatchObject({
+      name: "HttpError",
+      status: 401,
+    });
+  });
+
+  it("does not retry on non-401 errors (preserves 403, 404, 5xx semantics)", async () => {
+    _setTokenForTest("good.jwt");
+    let detailCallCount = 0;
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.startsWith("/admin/vault-admin-token/")) {
+        throw new Error("silent refresh should not fire on 403");
+      }
+      detailCallCount += 1;
+      return new Response(JSON.stringify({ error: "forbidden" }), { status: 403 });
+    });
+
+    await expect(getVaultDetail("work")).rejects.toMatchObject({
+      name: "HttpError",
+      status: 403,
+    });
+    expect(detailCallCount).toBe(1);
   });
 });

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -12,7 +12,7 @@
  * mint, config edit) will require — Phase A only reads, but the same JWT
  * carries enough to do so under the inherit rule (admin ⊇ write ⊇ read).
  */
-import { getToken } from "./auth.ts";
+import { clearToken, ensureToken, getToken } from "./auth.ts";
 
 /**
  * Counts surface in `VaultDetail.tsx`'s Stats section. Field names mirror
@@ -51,6 +51,76 @@ export class HttpError extends Error {
 }
 
 /**
+ * Bearer-authed fetch with a single silent-refresh retry on 401.
+ *
+ * The flow:
+ *   1. Read the cached token via `getToken()`. If missing, try
+ *      `ensureToken(vaultName)` first — covers the page-refresh case where
+ *      the SPA boots without a fragment-supplied token.
+ *   2. Fire the request with `Authorization: Bearer <token>`.
+ *   3. On 401, run `ensureToken(vaultName)` once more (the token may have
+ *      expired between the proactive-refresh window and the operator's
+ *      next action). If the refresh succeeds, retry the original request
+ *      with the new token. If THAT also returns 401, throw HttpError as
+ *      usual — the operator's session is genuinely gone.
+ *
+ * Why a single retry: the API call's job is one round trip; the auth
+ * layer's job is to keep a token in hand. If both fail, the caller's
+ * existing 401 handler renders the auth-required banner, whose poll loop
+ * will then attempt yet another `ensureToken` — but as a banner-level
+ * concern, not a hidden recursion in the fetch wrapper.
+ *
+ * Returns the `Response` for the caller to inspect (`.ok`, `.status`,
+ * `.json()`, …). Doesn't centralize body parsing because the callsites
+ * have heterogenous return shapes.
+ */
+interface AuthedFetchInit extends Omit<RequestInit, "headers"> {
+  headers?: Record<string, string>;
+}
+
+async function authedFetch(
+  vaultName: string,
+  url: string,
+  init: AuthedFetchInit = {},
+): Promise<Response> {
+  let token = getToken();
+  if (!token) {
+    const ensured = await ensureToken(vaultName);
+    if (ensured.kind !== "ok") {
+      throw new HttpError(401, "no admin token — sign in to the hub to refresh");
+    }
+    token = ensured.token;
+  }
+  const { headers: extraHeaders, ...rest } = init;
+  const buildHeaders = (bearer: string): Record<string, string> => ({
+    accept: "application/json",
+    ...(extraHeaders ?? {}),
+    authorization: `Bearer ${bearer}`,
+  });
+  const res = await fetch(url, { ...rest, headers: buildHeaders(token) });
+  if (res.status !== 401) return res;
+  // 401 → try one silent refresh + retry. The cached token might be stale
+  // (expired between proactive ticks; or the hub revoked it). We clear
+  // the cached token first so `ensureToken` is forced to hit the mint
+  // endpoint — without this, a stale-but-not-expired-by-our-clock token
+  // would be handed back unchanged and the retry would 401 again.
+  clearToken();
+  const refreshed = await ensureToken(vaultName);
+  if (refreshed.kind !== "ok") {
+    // Silent refresh also failed — return the original 401 response so
+    // the caller's existing handler renders the auth-required banner.
+    return res;
+  }
+  return fetch(url, { ...rest, headers: buildHeaders(refreshed.token) });
+}
+
+/**
+ * Internal helper exported for tokens-api.ts and any other authed-fetch
+ * caller in the SPA. Keeps the retry-on-401 logic centralized.
+ */
+export { authedFetch as _authedFetch };
+
+/**
  * Public vault-name list. Returns the names of every vault hosted by this
  * server. No auth — operators who want to hide vault existence set
  * `discovery: disabled` in `~/.parachute/vault/config.yaml` (the endpoint
@@ -74,16 +144,7 @@ export async function listVaultNames(): Promise<string[]> {
  * instead of a generic error.
  */
 export async function getVaultDetail(name: string): Promise<VaultDetailResult> {
-  const token = getToken();
-  if (!token) {
-    throw new HttpError(401, "no admin token — open this page from the hub directory");
-  }
-  const res = await fetch(`/vault/${encodeURIComponent(name)}/`, {
-    headers: {
-      accept: "application/json",
-      authorization: `Bearer ${token}`,
-    },
-  });
+  const res = await authedFetch(name, `/vault/${encodeURIComponent(name)}/`);
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
   }
@@ -168,22 +229,11 @@ export interface MirrorSnapshot {
   status: MirrorStatus;
 }
 
-function mirrorAuthHeaders(): Record<string, string> {
-  const token = getToken();
-  if (!token) {
-    throw new HttpError(401, "no admin token — open this page from the hub directory");
-  }
-  return {
-    accept: "application/json",
-    authorization: `Bearer ${token}`,
-  };
-}
-
 /** GET the persisted mirror config + the current runtime status snapshot. */
 export async function getMirror(vaultName: string): Promise<MirrorSnapshot> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror`,
-    { headers: mirrorAuthHeaders() },
   );
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
@@ -201,11 +251,12 @@ export async function putMirror(
   vaultName: string,
   config: Partial<MirrorConfig>,
 ): Promise<MirrorSnapshot> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror`,
     {
       method: "PUT",
-      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      headers: { "content-type": "application/json" },
       body: JSON.stringify(config),
     },
   );
@@ -221,12 +272,10 @@ export async function putMirror(
  * as the configured-but-disabled hint rather than a generic error.
  */
 export async function runMirrorNow(vaultName: string): Promise<MirrorSnapshot> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/run-now`,
-    {
-      method: "POST",
-      headers: mirrorAuthHeaders(),
-    },
+    { method: "POST" },
   );
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
@@ -246,12 +295,10 @@ export interface MirrorPushNowResponse extends MirrorSnapshot {
     | { fired: true; pushed: boolean; sha?: string; error?: string };
 }
 export async function pushMirrorNow(vaultName: string): Promise<MirrorPushNowResponse> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/push-now`,
-    {
-      method: "POST",
-      headers: mirrorAuthHeaders(),
-    },
+    { method: "POST" },
   );
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
@@ -316,18 +363,19 @@ export interface GitHubRepoInfo {
 }
 
 export async function getMirrorAuth(vaultName: string): Promise<MirrorCredentialStatus> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth`,
-    { headers: mirrorAuthHeaders() },
   );
   if (!res.ok) throw new HttpError(res.status, await readError(res));
   return (await res.json()) as MirrorCredentialStatus;
 }
 
 export async function deleteMirrorAuth(vaultName: string): Promise<MirrorCredentialStatus> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth`,
-    { method: "DELETE", headers: mirrorAuthHeaders() },
+    { method: "DELETE" },
   );
   if (!res.ok) throw new HttpError(res.status, await readError(res));
   return (await res.json()) as MirrorCredentialStatus;
@@ -336,9 +384,10 @@ export async function deleteMirrorAuth(vaultName: string): Promise<MirrorCredent
 export async function startGithubDeviceFlow(
   vaultName: string,
 ): Promise<DeviceCodeResponse> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/device-code`,
-    { method: "POST", headers: mirrorAuthHeaders() },
+    { method: "POST" },
   );
   if (!res.ok) throw new HttpError(res.status, await readError(res));
   return (await res.json()) as DeviceCodeResponse;
@@ -348,11 +397,12 @@ export async function pollGithubDeviceFlow(
   vaultName: string,
   pollingId: string,
 ): Promise<DevicePollState> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/poll`,
     {
       method: "POST",
-      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      headers: { "content-type": "application/json" },
       body: JSON.stringify({ polling_id: pollingId }),
     },
   );
@@ -381,11 +431,12 @@ export async function postMirrorAuthPat(
   vaultName: string,
   args: { token: string; remote_url: string; label?: string },
 ): Promise<MirrorCredentialSaveResult> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/pat`,
     {
       method: "POST",
-      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      headers: { "content-type": "application/json" },
       body: JSON.stringify(args),
     },
   );
@@ -396,9 +447,9 @@ export async function postMirrorAuthPat(
 export async function listGithubRepos(
   vaultName: string,
 ): Promise<{ repos: GitHubRepoInfo[]; truncated: boolean }> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/repos`,
-    { headers: mirrorAuthHeaders() },
   );
   if (!res.ok) throw new HttpError(res.status, await readError(res));
   return (await res.json()) as { repos: GitHubRepoInfo[]; truncated: boolean };
@@ -408,11 +459,12 @@ export async function createGithubRepo(
   vaultName: string,
   args: { name: string; description?: string; private?: boolean },
 ): Promise<GitHubRepoInfo> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/create-repo`,
     {
       method: "POST",
-      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      headers: { "content-type": "application/json" },
       body: JSON.stringify(args),
     },
   );
@@ -438,11 +490,12 @@ export async function selectGithubRepo(
   vaultName: string,
   args: { owner: string; name: string },
 ): Promise<SelectGithubRepoResult> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/select-repo`,
     {
       method: "POST",
-      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      headers: { "content-type": "application/json" },
       body: JSON.stringify(args),
     },
   );
@@ -489,11 +542,12 @@ export async function postMirrorImport(
   vaultName: string,
   args: MirrorImportRequest,
 ): Promise<MirrorImportResult> {
-  const res = await fetch(
+  const res = await authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/import`,
     {
       method: "POST",
-      headers: { ...mirrorAuthHeaders(), "content-type": "application/json" },
+      headers: { "content-type": "application/json" },
       body: JSON.stringify(args),
     },
   );

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -3,12 +3,22 @@
  * a token left in `window.location.hash` would leak via copy-paste and
  * `history.pushState` is the only reliable way to clean it without
  * reloading.
+ *
+ * Phase B (silent refresh) extends with:
+ *   - `ensureToken` happy path + fallback semantics
+ *   - proactive refresh timer fires at 80% of TTL
+ *   - visibilitychange pauses + resumes the timer
+ *   - mint endpoint response shape (token + expires_at)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  _cancelRefreshTimerForTest,
+  _getExpiresAtMsForTest,
+  _resetVisibilityListenerForTest,
   _setTokenForTest,
   captureTokenFromFragment,
   clearToken,
+  ensureToken,
   getToken,
   tryMintTokenFromHubSession,
 } from "./auth.ts";
@@ -67,14 +77,17 @@ describe("captureTokenFromFragment", () => {
 describe("tryMintTokenFromHubSession", () => {
   // The vault SPA boots without a token whenever the operator clicked a
   // surface that doesn't pre-mint one — notably hub's discovery-page vault
-  // tile (rendered as a plain anchor from `module.json:uiUrl`). Bypass
-  // path: same-origin GET against the hub's session-gated mint endpoint.
+  // tile (rendered as a plain anchor from `module.json:uiUrl`), or the
+  // operator just hit Cmd+R. Bypass path: same-origin GET against the
+  // hub's session-gated mint endpoint.
   beforeEach(() => {
     _setTokenForTest(null);
+    _cancelRefreshTimerForTest();
   });
 
   afterEach(() => {
     clearToken();
+    _cancelRefreshTimerForTest();
     vi.restoreAllMocks();
   });
 
@@ -83,7 +96,7 @@ describe("tryMintTokenFromHubSession", () => {
       new Response(
         JSON.stringify({
           token: "minted.jwt.abc",
-          expires_at: "2026-01-01T00:00:00.000Z",
+          expires_at: new Date(Date.now() + 600_000).toISOString(),
           scopes: ["vault:work:admin"],
         }),
         { status: 200, headers: { "content-type": "application/json" } },
@@ -119,6 +132,16 @@ describe("tryMintTokenFromHubSession", () => {
     expect(getToken()).toBeNull();
   });
 
+  it("leaves the token unset on 404 (vault not installed on this hub)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "not_found" }), { status: 404 }),
+    );
+
+    await tryMintTokenFromHubSession("work");
+
+    expect(getToken()).toBeNull();
+  });
+
   it("swallows network errors silently (no throw)", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("network down"));
 
@@ -128,9 +151,10 @@ describe("tryMintTokenFromHubSession", () => {
 
   it("URL-encodes the vault name segment", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ token: "x.y.z", expires_at: "2026", scopes: [] }), {
-        status: 200,
-      }),
+      new Response(
+        JSON.stringify({ token: "x.y.z", expires_at: new Date(Date.now() + 600_000).toISOString(), scopes: [] }),
+        { status: 200 },
+      ),
     );
 
     await tryMintTokenFromHubSession("name with spaces");
@@ -153,7 +177,7 @@ describe("tryMintTokenFromHubSession", () => {
 
   it("leaves the token unset when the 200 body has no `token` field", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ expires_at: "2026" }), {
+      new Response(JSON.stringify({ expires_at: new Date(Date.now() + 600_000).toISOString() }), {
         status: 200,
         headers: { "content-type": "application/json" },
       }),
@@ -162,5 +186,278 @@ describe("tryMintTokenFromHubSession", () => {
     await tryMintTokenFromHubSession("work");
 
     expect(getToken()).toBeNull();
+  });
+});
+
+describe("ensureToken", () => {
+  // The silent-refresh entrypoint. Three return shapes: `ok` (cached or
+  // freshly-minted token in hand), `auth-required` (401/403/404 from hub
+  // — operator needs to sign in), `network-error` (transient hub
+  // unreachable — caller renders retry).
+  beforeEach(() => {
+    _setTokenForTest(null);
+    _cancelRefreshTimerForTest();
+  });
+
+  afterEach(() => {
+    clearToken();
+    _cancelRefreshTimerForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the cached token without a network call when one is in hand", async () => {
+    _setTokenForTest("cached.jwt");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const result = await ensureToken("work");
+
+    expect(result).toEqual({ kind: "ok", token: "cached.jwt" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("mints a fresh token on 200 and caches it + the expiry", async () => {
+    const futureIso = new Date(Date.now() + 600_000).toISOString();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ token: "fresh.jwt", expires_at: futureIso, scopes: [] }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await ensureToken("work");
+
+    expect(result).toEqual({ kind: "ok", token: "fresh.jwt" });
+    expect(getToken()).toBe("fresh.jwt");
+    expect(_getExpiresAtMsForTest()).toBe(Date.parse(futureIso));
+  });
+
+  it("returns auth-required (status 401) when hub has no session", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthenticated" }), { status: 401 }),
+    );
+
+    const result = await ensureToken("work");
+
+    expect(result).toEqual({ kind: "auth-required", status: 401 });
+    expect(getToken()).toBeNull();
+  });
+
+  it("returns auth-required (status 403) when operator isn't the first admin", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "not_admin" }), { status: 403 }),
+    );
+
+    const result = await ensureToken("work");
+
+    expect(result).toEqual({ kind: "auth-required", status: 403 });
+  });
+
+  it("returns auth-required (status 404) when the vault isn't on this hub", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "not_found" }), { status: 404 }),
+    );
+
+    const result = await ensureToken("work");
+
+    expect(result).toEqual({ kind: "auth-required", status: 404 });
+  });
+
+  it("returns network-error on transient hub failure (5xx) — not the banner path", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("upstream error", { status: 503 }),
+    );
+
+    const result = await ensureToken("work");
+
+    expect(result.kind).toBe("network-error");
+  });
+
+  it("returns network-error on fetch reject (DNS / offline)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("network down"));
+
+    const result = await ensureToken("work");
+
+    expect(result.kind).toBe("network-error");
+  });
+
+  it("re-mints when the cached token is past its expiry", async () => {
+    _setTokenForTest("stale.jwt");
+    // The test seam doesn't write expiry, so set it via a successful
+    // first mint then advance time.
+    const pastIso = new Date(Date.now() - 1000).toISOString();
+    const futureIso = new Date(Date.now() + 600_000).toISOString();
+    // First mint: write a past expiry so the second `ensureToken` call
+    // sees the cached token as expired.
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ token: "first.jwt", expires_at: pastIso, scopes: [] }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ token: "second.jwt", expires_at: futureIso, scopes: [] }),
+          { status: 200 },
+        ),
+      );
+
+    // Clear the test-seam token; rely on the mint to set it (so expiry
+    // gets recorded).
+    _setTokenForTest(null);
+    const first = await ensureToken("work");
+    expect(first).toEqual({ kind: "ok", token: "first.jwt" });
+
+    const second = await ensureToken("work");
+    expect(second).toEqual({ kind: "ok", token: "second.jwt" });
+    expect(getToken()).toBe("second.jwt");
+  });
+});
+
+describe("proactive refresh timer", () => {
+  // Cut 2 — the timer fires at 80% of TTL so a long-running admin session
+  // never hits the 10-minute wall mid-work. Uses vitest fake timers so we
+  // can advance ms-by-ms without sleeping.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _setTokenForTest(null);
+    _cancelRefreshTimerForTest();
+  });
+
+  afterEach(() => {
+    _cancelRefreshTimerForTest();
+    vi.useRealTimers();
+    clearToken();
+    vi.restoreAllMocks();
+  });
+
+  it("schedules a refresh at 80% of the mint TTL", async () => {
+    const ttlMs = 600_000; // 10 minutes
+    const futureIso = new Date(Date.now() + ttlMs).toISOString();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ token: "first.jwt", expires_at: futureIso, scopes: [] }),
+        { status: 200 },
+      ),
+    );
+
+    await ensureToken("work");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(getToken()).toBe("first.jwt");
+
+    // Re-arm fetch for the proactive refresh. Wait for any pending
+    // microtasks so the new resolved value is the one the timer picks up.
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "refreshed.jwt",
+          expires_at: new Date(Date.now() + 2 * ttlMs).toISOString(),
+          scopes: [],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    // Advance to just BEFORE the 80%-TTL mark — refresh shouldn't have
+    // fired yet.
+    await vi.advanceTimersByTimeAsync(ttlMs * 0.8 - 1000);
+    expect(getToken()).toBe("first.jwt");
+
+    // Cross the 80% threshold.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(getToken()).toBe("refreshed.jwt");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fire the timer when no expiry is known (fragment-only token)", async () => {
+    // A fragment-supplied token has no associated expiry — we rely on
+    // 401-retry, not the proactive timer.
+    _setTokenForTest("fragment.jwt");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await ensureToken("work");
+
+    // Advance well past any reasonable TTL.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(getToken()).toBe("fragment.jwt");
+  });
+});
+
+describe("visibilitychange pause/resume", () => {
+  // The proactive timer should pause when the tab is hidden so we don't
+  // hammer the hub once per 8 minutes for a tab the operator never opens
+  // again. Resume on `visible` re-arms a fresh timer.
+  let visibilityState: "visible" | "hidden" = "visible";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _setTokenForTest(null);
+    _cancelRefreshTimerForTest();
+    _resetVisibilityListenerForTest();
+    visibilityState = "visible";
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+  });
+
+  afterEach(() => {
+    _cancelRefreshTimerForTest();
+    vi.useRealTimers();
+    clearToken();
+    vi.restoreAllMocks();
+  });
+
+  it("cancels the proactive timer when the tab goes hidden, re-arms on visible", async () => {
+    const ttlMs = 600_000;
+    const futureIso = new Date(Date.now() + ttlMs).toISOString();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ token: "first.jwt", expires_at: futureIso, scopes: [] }),
+        { status: 200 },
+      ),
+    );
+
+    await ensureToken("work");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Hide the tab. The visibility listener should cancel the pending
+    // proactive timer.
+    visibilityState = "hidden";
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    // Even after the 80%-TTL window, no refresh fires while hidden.
+    await vi.advanceTimersByTimeAsync(ttlMs * 0.9);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Return to visible. The listener re-arms the timer with the
+    // remaining lifetime. To prove it re-arms (rather than firing
+    // immediately), check that no extra call happened on resume itself
+    // — but a subsequent advance does trigger one. (We're already past
+    // the 80% mark, so the next arm uses a clamped MIN delay of 1000ms.)
+    visibilityState = "visible";
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Re-arm the second response for the proactive refresh.
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "second.jwt",
+          expires_at: new Date(Date.now() + ttlMs).toISOString(),
+          scopes: [],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    // The re-armed timer schedules at 80% of the *remaining* lifetime
+    // (not 80% of the original TTL — the timer doesn't track the
+    // issued-at). After being hidden for 90% of the original TTL, the
+    // remaining 10% is 60s; 80% of that is 48s. Advance past it.
+    await vi.advanceTimersByTimeAsync(50_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(getToken()).toBe("second.jwt");
   });
 });

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -4,36 +4,77 @@
  * Vault doesn't run its own session-cookie surface (unlike hub). Instead the
  * SPA expects a hub-issued JWT carrying a `vault:<name>:admin` scope — the
  * canonical token shape per scope-narrowing-and-audience. The token reaches
- * the SPA via URL fragment (`#token=…`), which the hub will append when its
- * directory page renders the "Manage" link to vault's managementUrl.
+ * the SPA via URL fragment (`#token=…`) when the operator clicks "Manage"
+ * in the hub directory.
  *
- * Flow:
- *   1. Hub renders "Manage" → navigates to
- *      `<hub-origin>/vault/<name>/admin/#token=<jwt>` (vault#252 per-vault
- *      mount; the bundle is reachable through hub's `/vault/<name>/*`
- *      proxy).
- *   2. SPA bootstrap calls `captureTokenFromFragment()`, which reads the
- *      fragment, stashes the token in module-scoped state, and rewrites the
- *      URL with `history.replaceState` so a refresh / copy-paste / screenshot
- *      can't leak it.
- *   3. API calls in `lib/api.ts` read the cached token via `getToken()` and
- *      send it as `Authorization: Bearer <jwt>`.
+ * Phase A (vault#219) was fragment-then-in-memory only — a page reload
+ * scrubbed the fragment and dropped the cached token, leaving the SPA in
+ * an "Open this page from the hub's directory" empty state. Aaron hits
+ * that papercut every time he refreshes a vault admin page.
+ *
+ * Phase B (this file, vault PR for "silent auth refresh") makes the SPA
+ * self-heal: when there's no cached token, we GET
+ * `/admin/vault-admin-token/<name>` against the hub (same-origin via hub's
+ * `/vault/<name>/*` proxy, session cookie auto-attached). On 200 we cache
+ * the freshly-minted JWT + its absolute expiry and proactively re-mint at
+ * 80% of TTL so a long-running admin session never hits the 10-minute
+ * wall mid-work. On 401/403/404 we fall back to the empty state — the
+ * banner copy now says "sign in to the hub" since that's what actually
+ * unblocks the operator, with a poll-on-banner-display that auto-recovers
+ * once the cookie's there.
  *
  * Storage: module-scoped variable, NEVER `localStorage` / `sessionStorage`.
- * Page snapshots can't carry it past a refresh, and the XSS surface is the
- * narrowest possible. Trade-off: a page reload without re-entering through
- * the hub leaves the SPA in an unauthenticated state — the operator goes
- * back to the hub directory and clicks "Manage" again. Phase B may bake in
- * a refresh path; Phase A keeps the contract minimal.
+ * Page snapshots can't carry it past a refresh (the silent-refresh path
+ * is the refresh story), and the XSS surface is the narrowest possible.
  */
 
 let cachedToken: string | null = null;
+/** Absolute expiry, ms since epoch. `null` when no token cached, or when
+ *  the mint response didn't carry an `expires_at` (we then treat the token
+ *  as opaque-but-usable and rely on 401-retry to refresh). */
+let cachedExpiresAtMs: number | null = null;
+
+/** Proactive refresh timer handle. `null` when the timer isn't scheduled. */
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+/** Vault name to use for proactive refreshes. Set when a token is cached. */
+let activeVaultName: string | null = null;
+/** Listeners installed for tab-visibility integration; tracked so we can
+ *  detach them in tests (and theoretically a future sign-out path). */
+let visibilityListenerInstalled = false;
+
+/**
+ * Refresh at 80% of TTL — gives us a 20% safety margin before the token
+ * actually expires. For the canonical 10-minute hub mint that's a refresh
+ * at 8 minutes, leaving 2 minutes of slack if the refresh fails.
+ */
+const REFRESH_FRACTION = 0.8;
+
+/**
+ * Floor on the proactive refresh delay. Below this we treat the token as
+ * effectively-expired and refresh immediately (still on the next
+ * microtask via setTimeout(0)).
+ */
+const MIN_REFRESH_DELAY_MS = 1000;
+
+/**
+ * Retry the proactive refresh once after this delay if the first attempt
+ * fails. We don't let proactive failures surface as the auth-required
+ * banner — the existing token is still valid for ~20% of its TTL when
+ * the refresh fired, so let the next 401 trigger an interactive recovery
+ * instead.
+ */
+const PROACTIVE_RETRY_DELAY_MS = 30_000;
 
 /**
  * Read `#token=<jwt>` from `window.location.hash`, store it in module
  * state, and clean the hash off the visible URL. Idempotent — safe to call
  * multiple times. Called once at SPA bootstrap before React mounts so the
  * first render already has the token in hand.
+ *
+ * Note: when a fragment token is captured we don't know its TTL (the hub
+ * doesn't surface `expires_at` in the fragment payload — only the JWT
+ * itself). We leave `cachedExpiresAtMs` null and let the silent-refresh
+ * on 401 path replace it with a fresh mint that carries a known expiry.
  */
 export function captureTokenFromFragment(): void {
   // Tests run without a window (jsdom provides one but it's worth being
@@ -45,6 +86,7 @@ export function captureTokenFromFragment(): void {
   const token = params.get("token");
   if (!token) return;
   cachedToken = token;
+  cachedExpiresAtMs = null;
   // Strip `#token=...` from the address bar without triggering navigation.
   // Preserve any other fragment params (none today, but keep the door open).
   params.delete("token");
@@ -59,67 +101,284 @@ export function getToken(): string | null {
   return cachedToken;
 }
 
-/** Drop the cached token. Used by tests; production has no sign-out yet. */
+/** Drop the cached token + tear down the proactive timer. Used by tests
+ *  and the silent-refresh helpers below; production has no sign-out yet. */
 export function clearToken(): void {
   cachedToken = null;
+  cachedExpiresAtMs = null;
+  activeVaultName = null;
+  cancelRefreshTimer();
 }
 
 /** Test seam: replace the cached token directly. */
 export function _setTokenForTest(token: string | null): void {
   cachedToken = token;
+  cachedExpiresAtMs = null;
+}
+
+/** Test seam: cancel any pending proactive timer. Tests using fake timers
+ *  call this in `afterEach` so a timer scheduled by one test doesn't leak
+ *  into the next. */
+export function _cancelRefreshTimerForTest(): void {
+  cancelRefreshTimer();
+}
+
+/** Test seam: read the current expiry (ms since epoch) for assertion. */
+export function _getExpiresAtMsForTest(): number | null {
+  return cachedExpiresAtMs;
+}
+
+// ---------------------------------------------------------------------------
+// Silent refresh
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of an attempted silent refresh. Callers branch on the `kind` to
+ * decide whether to render the auth-required banner (`auth-required`),
+ * show a transient retry button (`network-error`), or proceed with the
+ * fresh token (`ok`).
+ */
+export type RefreshResult =
+  | { kind: "ok"; token: string }
+  | { kind: "auth-required"; status: number }
+  | { kind: "network-error"; message: string };
+
+interface MintResponseBody {
+  token?: string;
+  /** ISO timestamp — the hub returns absolute, not relative. */
+  expires_at?: string;
+  scopes?: string[];
+}
+
+/**
+ * Call hub's session-cookie-gated mint endpoint. Returns the parsed result
+ * shape so callers can decide what to render. On success, caches the token
+ * + expiry and (re)arms the proactive refresh timer.
+ *
+ * Same-origin fetch carries the `parachute_hub_session` cookie because the
+ * hub proxies `/vault/<name>/*` to the vault backend, so the SPA's origin
+ * is the hub origin (vault#252 per-vault mount). No CORS preflight, no
+ * Authorization header needed — the cookie IS the auth.
+ */
+async function mintFromHubSession(vaultName: string): Promise<RefreshResult> {
+  if (typeof window === "undefined") {
+    return { kind: "network-error", message: "no window" };
+  }
+  let res: Response;
+  try {
+    res = await fetch(`/admin/vault-admin-token/${encodeURIComponent(vaultName)}`, {
+      method: "GET",
+      headers: { accept: "application/json" },
+      credentials: "same-origin",
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { kind: "network-error", message };
+  }
+  if (res.status === 401 || res.status === 403 || res.status === 404) {
+    return { kind: "auth-required", status: res.status };
+  }
+  if (!res.ok) {
+    // 5xx or other unexpected — hub is reachable but failing. Treat as a
+    // transient network condition; the caller surfaces a retry button
+    // rather than the "sign in" banner.
+    return { kind: "network-error", message: `hub returned ${res.status}` };
+  }
+  let body: MintResponseBody;
+  try {
+    body = (await res.json()) as MintResponseBody;
+  } catch (err) {
+    return {
+      kind: "network-error",
+      message: err instanceof Error ? err.message : "could not parse mint response",
+    };
+  }
+  if (typeof body.token !== "string" || body.token.length === 0) {
+    return { kind: "network-error", message: "mint response missing token" };
+  }
+  cachedToken = body.token;
+  cachedExpiresAtMs = body.expires_at ? parseExpiresAt(body.expires_at) : null;
+  activeVaultName = vaultName;
+  scheduleProactiveRefresh();
+  installVisibilityListenerOnce();
+  return { kind: "ok", token: body.token };
+}
+
+/** Parse the ISO timestamp from the hub's mint response into ms since
+ *  epoch. Returns `null` for invalid input — callers treat that the same
+ *  as a missing field (no proactive timer, rely on 401-retry). */
+function parseExpiresAt(iso: string): number | null {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  return ms;
+}
+
+/**
+ * Ensure the SPA has a usable token, refreshing silently if needed.
+ *
+ * - If a token is cached and not within the proactive-refresh window
+ *   (defined as: known-expiry past, or no expiry known but token exists),
+ *   return it as-is.
+ * - Otherwise hit the hub mint endpoint. Successful mint → return the new
+ *   token; otherwise return the failure result for the caller to render.
+ *
+ * Callers: bootstrap (main.tsx), the API fetch wrapper on 401 retry, and
+ * the banner's poll loop. Each surface treats the result kinds the same:
+ * `ok` proceeds, `auth-required` surfaces the sign-in banner,
+ * `network-error` surfaces a retry button.
+ */
+export async function ensureToken(vaultName: string): Promise<RefreshResult> {
+  // If we already have a token AND we don't believe it's expired, hand it
+  // back without a network call. (When `cachedExpiresAtMs` is null we trust
+  // the token until a 401 says otherwise — the fragment-bootstrap path
+  // doesn't carry an expiry hint.)
+  if (cachedToken) {
+    if (cachedExpiresAtMs === null || cachedExpiresAtMs > Date.now()) {
+      // Side-effect: a fragment-only token still benefits from the
+      // proactive timer once we learn its expiry — but only on the first
+      // mint, which is what `mintFromHubSession` arms. Don't arm here.
+      return { kind: "ok", token: cachedToken };
+    }
+    // Cached token is past its expiry. Drop it and re-mint below.
+    cachedToken = null;
+    cachedExpiresAtMs = null;
+    cancelRefreshTimer();
+  }
+  return mintFromHubSession(vaultName);
 }
 
 /**
  * Fallback bootstrap path: when the SPA loads at `/vault/<name>/admin/`
- * without a `#token=...` fragment (i.e. the operator clicked the vault tile
- * on hub's discovery page, or refreshed an authenticated tab), attempt to
- * mint a token from the hub-issued session cookie.
+ * without a `#token=...` fragment (page refresh after the fragment got
+ * scrubbed; or operator clicked the vault tile on hub's discovery page),
+ * attempt to mint a token from the hub-issued session cookie.
  *
- * The hub exposes `GET /admin/vault-admin-token/<name>` for exactly this
- * trade: it reads the `parachute_hub_session` cookie, verifies the operator
- * is the first admin, and returns a short-lived `vault:<name>:admin` JWT.
- * Same-origin fetch carries the cookie automatically (hub serves both `/`
- * and `/vault/<name>/admin/` from the same origin via its reverse proxy).
- *
- * Behavior:
- *   - On 200: cache the token (same module-scoped slot
- *     `captureTokenFromFragment` writes to). Subsequent `getToken()` calls
- *     return it.
- *   - On 401/403/404 or network error: leave the cache empty. The SPA
- *     proceeds to its existing `auth-required` empty state, which tells
- *     the operator to open the page from hub's directory. (404 should be
- *     impossible — the operator wouldn't have a tile to click for a vault
- *     that isn't installed — but treat it the same as 401 for safety.)
- *
- * Why fragment-first, cookie-second: the `Manage` button mints via fragment
- * because it doesn't depend on the SPA's mount being same-origin with the
- * token issuer. The cookie fallback works only when hub and the SPA share
- * an origin, which is the canonical owner-operated deploy shape but not
- * universal. Keep both paths — they're complementary, not redundant.
- *
- * Idempotent — safe to call multiple times, only sets the cache on a fresh
- * successful mint.
+ * Kept as a thin wrapper around `ensureToken` for back-compat with
+ * `main.tsx`'s bootstrap callsite. Doesn't surface failure modes — the
+ * SPA's route components run `ensureToken` themselves and render the
+ * banner accordingly.
  */
 export async function tryMintTokenFromHubSession(vaultName: string): Promise<void> {
   if (typeof window === "undefined") return;
   if (cachedToken) return;
-  try {
-    const res = await fetch(
-      `/admin/vault-admin-token/${encodeURIComponent(vaultName)}`,
-      {
-        method: "GET",
-        headers: { accept: "application/json" },
-        credentials: "same-origin",
-      },
-    );
-    if (!res.ok) return;
-    const body = (await res.json()) as { token?: string };
-    if (typeof body.token === "string" && body.token.length > 0) {
-      cachedToken = body.token;
-    }
-  } catch (_e) {
-    // Network / CORS / parse error — silent fallback to the existing
-    // auth-required empty state. The SPA still renders; the operator gets
-    // a clear message to open from the hub directory.
+  // Swallow the result — `ensureToken` already cached the token on success
+  // and the SPA's auth-required empty state handles the failure path. We
+  // don't want a bootstrap-time network error to throw.
+  await mintFromHubSession(vaultName).catch(() => {
+    /* silent — handled downstream */
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Proactive refresh
+// ---------------------------------------------------------------------------
+
+/**
+ * Schedule the next proactive refresh based on the cached expiry. Cancels
+ * any existing timer first so we never have two pending. No-op when:
+ *   - no expiry is known (fragment-only token; we'll refresh on 401),
+ *   - the tab is hidden (we install a visibility listener that re-arms on
+ *     `visibilitychange`),
+ *   - the active vault name isn't set (defensive — shouldn't happen post-mint).
+ *
+ * The fire-time is `expires_at - now` * REFRESH_FRACTION. For a 10-minute
+ * token that's 8 minutes; the remaining 2 minutes are slack if the
+ * refresh fails (we retry once after 30s, then give up and let the next
+ * 401 trigger an interactive recovery).
+ */
+function scheduleProactiveRefresh(): void {
+  cancelRefreshTimer();
+  if (cachedExpiresAtMs === null || activeVaultName === null) return;
+  if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+    // Don't fire timers while hidden — saves the API call and the
+    // visibility listener will re-arm us on the next `visible` event.
+    return;
   }
+  const now = Date.now();
+  const lifetimeRemaining = cachedExpiresAtMs - now;
+  if (lifetimeRemaining <= 0) {
+    // Already expired — let the next ensureToken / 401-retry handle it.
+    return;
+  }
+  const delay = Math.max(Math.floor(lifetimeRemaining * REFRESH_FRACTION), MIN_REFRESH_DELAY_MS);
+  refreshTimer = setTimeout(() => {
+    void runProactiveRefresh();
+  }, delay);
+}
+
+/** Cancel + null out the proactive refresh timer. */
+function cancelRefreshTimer(): void {
+  if (refreshTimer !== null) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+/**
+ * Fire a proactive refresh. Called by the timer. On success → cached
+ * token replaced + next timer armed. On failure → log + try once more
+ * after a short delay; if that fails too, do nothing (the existing
+ * token is still valid for ~20% of its TTL, and the next 401 from an
+ * API call will trigger an interactive recovery).
+ */
+async function runProactiveRefresh(): Promise<void> {
+  refreshTimer = null;
+  if (activeVaultName === null) return;
+  const result = await mintFromHubSession(activeVaultName);
+  if (result.kind === "ok") return;
+  // First-attempt failure → one retry after PROACTIVE_RETRY_DELAY_MS.
+  // We don't surface the banner here — the existing token is still
+  // valid, and an interactive 401 from a real API call will trigger
+  // the user-visible recovery path.
+  if (typeof console !== "undefined") {
+    console.warn("[vault-admin-spa] proactive token refresh failed; will retry once", result);
+  }
+  refreshTimer = setTimeout(() => {
+    refreshTimer = null;
+    if (activeVaultName === null) return;
+    void mintFromHubSession(activeVaultName).catch(() => {
+      /* terminal — give up and let the next 401 recover */
+    });
+  }, PROACTIVE_RETRY_DELAY_MS);
+}
+
+/**
+ * Wire `document.visibilitychange` so the proactive timer pauses while
+ * the tab is hidden and resumes when it becomes visible again. Idempotent
+ * — installed once on the first successful mint, never removed (a future
+ * sign-out path could detach it, but there isn't one today).
+ *
+ * Why we care: a 10-minute mint refreshes every 8 minutes. An operator
+ * who alt-tabs away for an hour would otherwise fire ~7 unnecessary
+ * mint calls against the hub. Pause + re-arm gives us a single mint on
+ * return instead.
+ */
+function installVisibilityListenerOnce(): void {
+  if (visibilityListenerInstalled) return;
+  if (typeof document === "undefined") return;
+  visibilityListenerInstalled = true;
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      cancelRefreshTimer();
+      return;
+    }
+    // Tab just became visible. If we have an active vault + a cached
+    // token + expiry, re-arm the timer based on remaining lifetime. If
+    // the token's already expired (operator was away longer than the
+    // TTL), fire a refresh immediately so the next interaction has a
+    // usable token in hand.
+    if (activeVaultName === null) return;
+    if (cachedExpiresAtMs !== null && cachedExpiresAtMs <= Date.now()) {
+      void mintFromHubSession(activeVaultName).catch(() => {
+        /* silent — interactive 401-retry covers the failure path */
+      });
+      return;
+    }
+    scheduleProactiveRefresh();
+  });
+}
+
+/** Test seam: simulate a freshly-installed visibility listener fresh. */
+export function _resetVisibilityListenerForTest(): void {
+  visibilityListenerInstalled = false;
 }

--- a/web/ui/src/lib/tokens-api.ts
+++ b/web/ui/src/lib/tokens-api.ts
@@ -10,8 +10,7 @@
  * it). The caller is responsible for stashing it and surfacing the one-time
  * banner; this module just relays the response.
  */
-import { getToken } from "./auth.ts";
-import { HttpError } from "./api.ts";
+import { _authedFetch, HttpError } from "./api.ts";
 
 export interface TokenSummary {
   id: string;
@@ -60,25 +59,12 @@ export interface MintTokenInput {
  * `/` since the server only accepts root tags in the `tags` field).
  */
 export async function listVaultTags(vaultName: string): Promise<{ name: string; count: number }[]> {
-  const res = await fetch(`/vault/${encodeURIComponent(vaultName)}/api/tags`, {
-    headers: authHeaders(),
-  });
+  const res = await _authedFetch(vaultName, `/vault/${encodeURIComponent(vaultName)}/api/tags`);
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
   }
   const body = (await res.json()) as { name: string; count: number }[];
   return Array.isArray(body) ? body : [];
-}
-
-function authHeaders(): Record<string, string> {
-  const token = getToken();
-  if (!token) {
-    throw new HttpError(401, "no admin token — open this page from the hub directory");
-  }
-  return {
-    accept: "application/json",
-    authorization: `Bearer ${token}`,
-  };
 }
 
 async function readError(res: Response): Promise<string> {
@@ -96,9 +82,7 @@ async function readError(res: Response): Promise<string> {
 }
 
 export async function listTokens(vaultName: string): Promise<TokenSummary[]> {
-  const res = await fetch(`/vault/${encodeURIComponent(vaultName)}/tokens`, {
-    headers: authHeaders(),
-  });
+  const res = await _authedFetch(vaultName, `/vault/${encodeURIComponent(vaultName)}/tokens`);
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
   }
@@ -115,9 +99,9 @@ export async function mintToken(vaultName: string, input: MintTokenInput): Promi
   if (input.tags && input.tags.length > 0) body["tags"] = input.tags;
   if (input.expires_at !== undefined) body["expires_at"] = input.expires_at;
 
-  const res = await fetch(`/vault/${encodeURIComponent(vaultName)}/tokens`, {
+  const res = await _authedFetch(vaultName, `/vault/${encodeURIComponent(vaultName)}/tokens`, {
     method: "POST",
-    headers: { ...authHeaders(), "content-type": "application/json" },
+    headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -127,12 +111,10 @@ export async function mintToken(vaultName: string, input: MintTokenInput): Promi
 }
 
 export async function revokeToken(vaultName: string, tokenId: string): Promise<void> {
-  const res = await fetch(
+  const res = await _authedFetch(
+    vaultName,
     `/vault/${encodeURIComponent(vaultName)}/tokens/${encodeURIComponent(tokenId)}`,
-    {
-      method: "DELETE",
-      headers: authHeaders(),
-    },
+    { method: "DELETE" },
   );
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -31,18 +31,26 @@ function mount(): void {
   );
 }
 
-// Fallback bootstrap path (closes vault#382 / hub-side discovery-tile bug):
-// when the operator clicked the **discovery-page** vault tile (hub.ts
-// renders one per vault via `uiUrl: "/admin/"`), the browser landed here
-// without a `#token=...` fragment — the discovery tile is a plain anchor,
-// not a Manage-flow button. Without a token the SPA boots into the
-// "auth-required" empty state ("Open this page from the hub's directory"),
-// which is exactly what the operator just *did*. So if we're under a
-// per-vault mount AND the fragment didn't carry a token, try to mint one
-// from the hub session cookie before mounting React. The hub exposes
-// `/admin/vault-admin-token/<name>` for exactly this trade; same-origin
-// fetch carries the cookie automatically. Silent failure → fall through to
-// the existing auth-required empty state.
+// Silent-refresh bootstrap (covers vault#382 / hub-side discovery-tile
+// bug AND the page-refresh papercut). Two ways the SPA boots without a
+// fragment-supplied token:
+//
+//   1. Operator clicked the **discovery-page** vault tile (hub.ts renders
+//      one per vault via `uiUrl: "/admin/"`). The tile is a plain anchor,
+//      not a Manage-flow button — no token in the URL.
+//   2. Operator hit Cmd+R on an authenticated admin page. The fragment
+//      was scrubbed by `captureTokenFromFragment` on the prior boot and
+//      the in-memory token died with the page. Aaron hits this often
+//      enough that it was a real papercut.
+//
+// In both cases, if we're under a per-vault mount AND the fragment didn't
+// carry a token, mint a fresh one from the hub session cookie before
+// mounting React. The hub exposes `/admin/vault-admin-token/<name>` for
+// exactly this trade; same-origin fetch carries the cookie automatically.
+// On success the SPA boots into a fully-authenticated state. On failure
+// (no hub session, expired session, vault not on this hub) the SPA
+// boots into the `SignInBanner` empty state, which polls + auto-recovers
+// once the operator signs in to the hub in another tab.
 //
 // We chain off a Promise instead of top-level `await` because Vite's
 // default esbuild target (chrome87/safari14) doesn't transpile TLA, and

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -11,15 +11,16 @@
  * grants table (the OAuth issuer is the source of truth), so the modular
  * play is "vault links to hub" rather than "vault inlines hub data."
  */
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { HttpError, type VaultDetailResult, getVaultDetail } from "../lib/api.ts";
 import { getIssuerOrigin } from "../lib/scope.ts";
+import { SignInBanner } from "../lib/SignInBanner.tsx";
 
 type State =
   | { kind: "loading" }
   | { kind: "ok"; vault: VaultDetailResult }
-  | { kind: "auth-required" }
+  | { kind: "auth-required"; status: number | null }
   | { kind: "missing" }
   | { kind: "error"; message: string };
 
@@ -37,6 +38,8 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
   const tokensHref = isPerVaultMount ? "/tokens" : `/vault/${encodeURIComponent(name ?? "")}/tokens`;
   const mirrorHref = isPerVaultMount ? "/mirror" : `/vault/${encodeURIComponent(name ?? "")}/mirror`;
   const [state, setState] = useState<State>({ kind: "loading" });
+  const [reloadTick, setReloadTick] = useState(0);
+  const onRecovered = useCallback(() => setReloadTick((n) => n + 1), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -44,6 +47,7 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
       setState({ kind: "missing" });
       return;
     }
+    setState({ kind: "loading" });
     getVaultDetail(name)
       .then((vault) => {
         if (cancelled) return;
@@ -53,7 +57,7 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
         if (cancelled) return;
         if (err instanceof HttpError) {
           if (err.status === 401 || err.status === 403) {
-            setState({ kind: "auth-required" });
+            setState({ kind: "auth-required", status: err.status });
             return;
           }
           if (err.status === 404) {
@@ -69,7 +73,7 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
     return () => {
       cancelled = true;
     };
-  }, [name]);
+  }, [name, reloadTick]);
 
   if (state.kind === "loading") {
     return (
@@ -86,10 +90,7 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
         <h2>
           Vault <code>{name}</code>
         </h2>
-        <div className="warn-banner">
-          Open this page from the hub's directory — the "Manage" link supplies the admin token. Direct loads of{" "}
-          <code>/vault/{name}/admin</code> can't see protected vault data.
-        </div>
+        <SignInBanner vaultName={name ?? ""} status={state.status} onRecovered={onRecovered} />
         {isPerVaultMount ? null : <Link to="/">← Back to vaults</Link>}
       </div>
     );

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -563,9 +563,13 @@ describe("VaultMirror — auth-required path", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText(/Open this page from the hub's directory/i),
+        screen.getByText(/You're not signed in to the hub/i),
       ).toBeInTheDocument(),
     );
+    // The CTA points to hub's login surface with a `?next=` continuation
+    // so the operator lands back on this page after signing in.
+    const signInLink = screen.getByRole("link", { name: /Sign in to the hub/i });
+    expect(signInLink.getAttribute("href")).toMatch(/^\/login\?next=/);
   });
 });
 

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -23,8 +23,9 @@
  * exclusive territory of the operator's own cron (or the admin SPA's
  * "Run export now" button).
  */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { SignInBanner } from "../lib/SignInBanner.tsx";
 import {
   HttpError,
   type DeviceCodeResponse,
@@ -56,7 +57,7 @@ import { hasAdminScope } from "../lib/scope.ts";
 type LoadState =
   | { kind: "loading" }
   | { kind: "ok"; snapshot: MirrorSnapshot }
-  | { kind: "auth-required" }
+  | { kind: "auth-required"; status: number | null }
   | { kind: "error"; message: string };
 
 /**
@@ -163,7 +164,7 @@ export function VaultMirror({ vaultName }: { vaultName?: string } = {}) {
       .catch((err) => {
         if (cancelled) return;
         if (err instanceof HttpError && (err.status === 401 || err.status === 403)) {
-          setState({ kind: "auth-required" });
+          setState({ kind: "auth-required", status: err.status });
           return;
         }
         const message = err instanceof Error ? err.message : String(err);
@@ -173,6 +174,8 @@ export function VaultMirror({ vaultName }: { vaultName?: string } = {}) {
       cancelled = true;
     };
   }, [name, reloadTick]);
+
+  const onRecovered = useCallback(() => setReloadTick((n) => n + 1), []);
 
   if (!name) {
     return (
@@ -198,11 +201,7 @@ export function VaultMirror({ vaultName }: { vaultName?: string } = {}) {
       {state.kind === "loading" ? <p className="muted">Loading…</p> : null}
 
       {state.kind === "auth-required" ? (
-        <div className="warn-banner">
-          Open this page from the hub's directory — the "Manage" link supplies the admin
-          token. Direct loads of <code>/vault/{name}/admin/mirror</code> can't see protected
-          vault data.
-        </div>
+        <SignInBanner vaultName={name} status={state.status} onRecovered={onRecovered} />
       ) : null}
 
       {state.kind === "error" ? (

--- a/web/ui/src/routes/VaultTokens.tsx
+++ b/web/ui/src/routes/VaultTokens.tsx
@@ -16,10 +16,11 @@
  * banner directing them to re-auth instead of getting a 403 toast on
  * every interaction.
  */
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { HttpError } from "../lib/api.ts";
 import { hasAdminScope } from "../lib/scope.ts";
+import { SignInBanner } from "../lib/SignInBanner.tsx";
 import {
   type MintTokenResult,
   type TokenSummary,
@@ -32,7 +33,7 @@ import {
 type LoadState =
   | { kind: "loading" }
   | { kind: "ok"; tokens: TokenSummary[] }
-  | { kind: "auth-required" }
+  | { kind: "auth-required"; status: number | null }
   | { kind: "error"; message: string };
 
 const KNOWN_SCOPE_VERBS = ["read", "write", "admin"] as const;
@@ -63,7 +64,7 @@ export function VaultTokens({ vaultName }: { vaultName?: string } = {}) {
       .catch((err) => {
         if (cancelled) return;
         if (err instanceof HttpError && (err.status === 401 || err.status === 403)) {
-          setState({ kind: "auth-required" });
+          setState({ kind: "auth-required", status: err.status });
           return;
         }
         const message = err instanceof Error ? err.message : String(err);
@@ -73,6 +74,8 @@ export function VaultTokens({ vaultName }: { vaultName?: string } = {}) {
       cancelled = true;
     };
   }, [name, reloadTick]);
+
+  const onRecovered = useCallback(() => setReloadTick((n) => n + 1), []);
 
   // Belt-and-suspenders for the single-emit contract: while the plaintext
   // pvt_* is on screen, prompt the browser's "leave site?" confirm on tab
@@ -144,9 +147,7 @@ export function VaultTokens({ vaultName }: { vaultName?: string } = {}) {
         <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>Existing tokens</h3>
         {state.kind === "loading" ? <p className="muted">Loading…</p> : null}
         {state.kind === "auth-required" ? (
-          <div className="warn-banner">
-            Open this page from the hub's directory — the "Manage" link supplies the admin token.
-          </div>
+          <SignInBanner vaultName={name} status={state.status} onRecovered={onRecovered} />
         ) : null}
         {state.kind === "error" ? (
           <div className="error-banner">


### PR DESCRIPTION
## Failure mode

Vault admin SPA's auth model was fragment-then-in-memory only: hub appended `#token=<jwt>` to the "Manage" link, the SPA stashed it in a module-scoped variable, replaceState'd it off, and used it for API calls. **Cmd+R / direct URL share / browser restart → token gone → SPA renders "Open this page from the hub's directory" banner**, which is exactly what the operator just *did*. Aaron hits this every refresh.

## What changed

Hub already exposes `GET /admin/vault-admin-token/<name>` (session-cookie gated, 10-min TTL mint, first-admin-gated, returns `{ token, expires_at, scopes }`). The SPA now uses it to self-heal across three surfaces:

- **Silent refresh on page-load.** `ensureToken(vaultName)` in `lib/auth.ts` returns a discriminated `{ kind: 'ok' | 'auth-required' | 'network-error' }` result. Bootstrap (`main.tsx`) and the auth-banner poll both go through it. 401/403/404 from hub → banner; 5xx / fetch reject → transient.

- **Proactive refresh at 80% of TTL.** A timer rearms after each successful mint. The 10-minute hub token thus refreshes every 8 minutes, leaving 20% slack for retry. Failed proactive refresh logs + retries once after 30s, then gives up (the existing token's still valid; let the next 401 trigger interactive recovery).

- **`document.visibilitychange` integration.** Backgrounded tab → timer cancelled. Visible → re-arm based on remaining lifetime (or refresh immediately if already past expiry).

- **Single retry on 401 from any vault API.** Centralized in `_authedFetch` in `lib/api.ts`. Stale-token-mid-session no longer surfaces a banner; the call self-heals. Single retry only — both-fail returns the original 401 for the existing handler.

- **New `SignInBanner` component.** Replaces "Open this page from the hub's directory" with "You're not signed in to the hub. [Sign in to the hub →]" linking to `/login?next=<current-url>`. Polls `ensureToken` every 5s while displayed — operator signs in in another tab, this tab auto-recovers within 5s.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx vitest run` — 119/119 pass (was 104; +15 new tests covering ensureToken, proactive timer, visibility pause, 401-retry)
- [x] Production `bun run build` clean
- [x] Bundle deployed to live hub at `parachute.taildf9ce2.ts.net` via local bun-link (`parachute restart vault`); served bundle hash matches built artifact
- [ ] Manual: Cmd+R on `/vault/<name>/admin/` while signed in to hub → no banner, page reloads fully authenticated
- [ ] Manual: sign out of hub in another tab → existing admin tab eventually hits a 401, banner appears with "Sign in to the hub" CTA
- [ ] Manual: long-running admin tab open for >10min → no mid-session 401 toast (proactive refresh fires at 8min)

## Files

- `web/ui/src/lib/auth.ts` — `ensureToken`, proactive timer, visibility listener
- `web/ui/src/lib/api.ts` — `_authedFetch` with 401 retry, refactored authed callsites
- `web/ui/src/lib/tokens-api.ts` — migrated to `_authedFetch`
- `web/ui/src/lib/SignInBanner.tsx` — new shared component (poll + auto-recover)
- `web/ui/src/routes/{VaultDetail,VaultTokens,VaultMirror}.tsx` — banner swap; `auth-required` state carries status code
- `web/ui/src/main.tsx` — bootstrap comment updated
- Tests: `web/ui/src/lib/{auth.test.ts,api.test.ts}` extended; `web/ui/src/routes/VaultMirror.test.tsx` updated for new banner copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)