### PR TITLE
chore(release): 0.4.9-rc.10 — silent auth refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.9",
+  "version": "0.4.9-rc.10",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Picks up #395 (vault admin SPA silent auth refresh — no more "go back to hub" banner on Cmd+R). 1-line bump.

## Test plan

- [x] vitest 119/0, typecheck clean (from #395)
- [ ] After merge: tag v0.4.9-rc.10 + push

🤖 Generated with [Claude Code](https://claude.com/claude-code)