### PR TITLE
feat(vault): mcp-install admin mints hub JWT (retire legacy-pat fallback) + fix #282 citations

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -933,11 +933,10 @@ function takeArgValue(args: string[], name: string): { value?: string; missingVa
  * Targeting:
  *   --scope <verb>        vault:read | vault:write | vault:admin (default: vault:read).
  *                         For --mint, expands to vault:<vault-name>:<verb>.
- *                         vault:admin requires --legacy-pat — hub policy makes
- *                         per-vault admin non-requestable via mint-token (it's
- *                         operator-only, minted only through the session-
- *                         cookie-gated admin SPA endpoint), so --mint + admin
- *                         is rejected pre-flight.
+ *                         vault:admin is mintable via --mint as of hub PR-A
+ *                         (hub#449): hub mints per-vault admin when the operator
+ *                         bearer carries parachute:host:admin (the default
+ *                         operator.token does). Requires a hub running PR-A.
  *   --install-scope <s>   local (default) | user | project. local writes to
  *                         ~/.claude.json under projects[<cwd>].mcpServers
  *                         (private, this directory only — matches Claude
@@ -1307,7 +1306,7 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
     console.error(
       "Note: --legacy-pat mints a vault-DB pvt_* token. The hub-issued JWT path (--mint, default) " +
         "is the canonical install going forward; pvt_* support is preserved for self-hosted-without-hub " +
-        "setups, tracked at vault#288, planned removal 0.6.0.",
+        "setups, tracked at vault#282, planned removal 0.6.0.",
     );
     const store = getVaultStore(vaultName);
     const { fullToken } = generateToken();
@@ -1326,28 +1325,13 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
     bearer = fullToken;
   } else {
     // mode === "mint"
-    // Pre-flight: hub policy rejects `vault:<name>:admin` via the public
-    // mint-token endpoint. Per-vault admin is operator-only, mintable
-    // only through the session-cookie-gated `/admin/vault-admin-token/:name`
-    // SPA path. Calling hub with admin would surface a 400:
-    //   "Hub mint-token rejected (HTTP 400, invalid_scope):
-    //    scope vault:default:admin is not requestable via mint-token;
-    //    use OAuth flow or operator rotation"
-    // Fail early with the actionable remediation rather than letting
-    // the operator chase the hub's wire-level error. See
-    // `parachute-hub/src/scope-explanations.ts` (VAULT_ADMIN_RE) and
-    // `parachute-hub/src/api-mint-token.ts` (non-requestable guard).
-    if (verb === "admin") {
-      console.error(
-        "Hub policy: vault:<name>:admin is not requestable via mint-token " +
-          "(per-vault admin is operator-only, minted only by the session-cookie-gated " +
-          "admin SPA at <hub>/admin/vaults/" + vaultName + ").\n" +
-          "  Fix: use `--legacy-pat --scope vault:admin` to mint a vault-DB pvt_* with admin scope " +
-          "(the right shape for an MCP entry needing schema management).\n" +
-          "  Or:  drop --scope to default to vault:read (least privilege), or use --scope vault:write.",
-      );
-      process.exit(1);
-    }
+    // `vault:<name>:admin` is mintable via the hub mint-token endpoint as
+    // of hub PR-A (hub#449): the hub mints per-vault admin when the calling
+    // operator bearer carries `parachute:host:admin` (which the default
+    // operator.token does). No admin pre-flight reject — the narrowScope
+    // below produces `vault:<name>:admin` and the hub honors it. This
+    // requires a hub running PR-A; older hubs reject admin with HTTP 400
+    // invalid_scope, surfaced via the api-error branch below.
     const operatorToken = readOperatorToken();
     if (!operatorToken) {
       console.error(
@@ -1391,6 +1375,17 @@ async function executeMcpInstall(opts: ExecuteMcpInstallOpts): Promise<void> {
           console.error(
             `Hub mint-token rejected (HTTP ${result.status}, ${result.error}): ${result.description}`,
           );
+          // Older hubs (pre-hub#449) reject vault:<name>:admin as a
+          // non-requestable scope with HTTP 400 invalid_scope. Surface an
+          // actionable hint so the operator reaches for the upgrade rather
+          // than chasing the wire-level error.
+          if (result.status === 400 && verb === "admin") {
+            console.error(
+              "  Hint: minting vault:admin requires a hub with per-vault admin mint support " +
+                "(hub#449). Your hub may predate it — upgrade the hub, or use --legacy-pat for " +
+                "a vault-DB pvt_* admin token instead.",
+            );
+          }
           break;
       }
       process.exit(1);
@@ -3408,14 +3403,15 @@ Vaults:
                                             --token <t>: paste an existing bearer
                                             (any shape) instead of minting.
                                             --legacy-pat: mint a vault-DB pvt_*
-                                            token (deprecated; for self-hosted-
-                                            without-hub setups). Also the only
-                                            path for --scope vault:admin — hub
-                                            policy reserves per-vault admin for
-                                            operator-only minting (the admin SPA
-                                            session-cookie path), so --mint
-                                            --scope vault:admin is rejected
-                                            pre-flight.
+                                            token (deprecated, vault#282; removal
+                                            0.6.0; for self-hosted-without-hub
+                                            setups).
+                                            --scope vault:admin IS mintable via
+                                            --mint (hub#449): hub mints
+                                            vault:<name>:admin when the operator
+                                            bearer carries parachute:host:admin
+                                            (the default operator.token does).
+                                            Requires a hub running hub#449.
                                             --install-scope local (default) writes
                                             ~/.claude.json under
                                             projects[<cwd>].mcpServers (this

--- a/src/mcp-install-interactive.test.ts
+++ b/src/mcp-install-interactive.test.ts
@@ -287,22 +287,13 @@ describe("runInteractiveInstall — decision tree", () => {
     expect(result.scope).toBe("vault:write");
   });
 
-  test("typing 'admin' auto-routes to legacy-pat with vault:admin scope (hub mint-token rejects admin)", async () => {
-    // Regression for the symptom Aaron hit on hub 0.5.12-rc.2 / vault
-    // 0.4.7-rc.1: picking "admin" in the mint prompt sent
-    // `vault:default:admin` to `POST /api/auth/mint-token`, which hub
-    // rejects by policy (per-vault admin is non-requestable; see
-    // `parachute-hub/src/scope-explanations.ts:VAULT_ADMIN_RE` and
-    // `api-mint-token.ts`'s non-requestable guard):
-    //
-    //   Hub mint-token rejected (HTTP 400, invalid_scope):
-    //   scope vault:default:admin is not requestable via mint-token;
-    //   use OAuth flow or operator rotation
-    //
-    // Fix: auto-route "admin" in the interactive prompt to legacy-pat
-    // mode (which mints a vault-DB pvt_* — the right shape for an MCP
-    // entry needing admin permissions), with a printed explanation so
-    // the switch isn't silent.
+  test("typing 'admin' mints a hub JWT with vault:admin scope (hub PR-A / hub#449)", async () => {
+    // As of hub PR-A (hub#449), `POST /api/auth/mint-token` mints
+    // `vault:<name>:admin` when the calling operator bearer carries
+    // `parachute:host:admin` (which the default operator.token does).
+    // So picking "admin" in the mint prompt now resolves to mint mode
+    // with vault:admin scope — the verb extraction downstream narrows
+    // it to `vault:<name>:admin`. No more legacy-pat auto-route.
     const { io, state } = mockIO([
       null,    // accept install-scope default
       "admin",
@@ -311,13 +302,11 @@ describe("runInteractiveInstall — decision tree", () => {
     const result = await runInteractiveInstall(baseCtx(), io);
     expect(result).not.toBe("abort");
     if (result === "abort") return;
-    expect(result.mode).toBe("legacy-pat");
+    expect(result.mode).toBe("mint");
     expect(result.scope).toBe("vault:admin");
-    // The auto-route must surface the reason — silent re-routing would
-    // mislead operators who specifically want a hub JWT.
+    // The branch surfaces that admin mints a scope-narrowed hub JWT.
     const logged = state.logs.join("\n");
-    expect(logged).toMatch(/admin requires a vault-DB pvt_\*/);
-    expect(logged).toMatch(/hub policy/);
+    expect(logged).toMatch(/scope-narrowed hub JWT/);
   });
 
   test("typing 'paste' at the auth prompt switches to token mode + asks for token", async () => {

--- a/src/mcp-install-interactive.ts
+++ b/src/mcp-install-interactive.ts
@@ -190,9 +190,9 @@ export async function runInteractiveInstall(
         "Choices:",
         "  Enter       → mint a hub JWT with vault:read scope (recommended).",
         "  write       → mint with vault:write (mutations).",
-        "  admin       → mint a vault-DB pvt_* with vault:admin (schema management;",
-        "                hub policy reserves per-vault admin for operator-only paths,",
-        "                so this auto-routes to legacy-pat).",
+        "  admin       → mint a hub JWT with vault:<name>:admin (schema management).",
+        "                Requires parachute:host:admin on the operator token (the",
+        "                default operator.token carries it). NOT legacy-pat.",
         "  paste       → use an existing token instead of minting.",
         "  legacy      → mint a vault-DB pvt_* (self-hosted-without-hub).",
       ].join("\n"),
@@ -212,22 +212,13 @@ export async function runInteractiveInstall(
       // JWT's scope. (vault#292 review F2.)
       scope = await askScope(io);
     } else if (answer === "admin") {
-      // `vault:<name>:admin` is non-requestable via hub mint-token by
-      // policy — only the session-cookie-gated `/admin/vault-admin-token/:name`
-      // endpoint can mint per-vault admin scopes (see
-      // `parachute-hub/src/scope-explanations.ts:VAULT_ADMIN_RE` and
-      // `api-mint-token.ts`'s non-requestable guard). Hub returns
-      // HTTP 400 invalid_scope: "scope vault:<name>:admin is not
-      // requestable via mint-token; use OAuth flow or operator rotation".
-      //
-      // Auto-route to legacy-pat which mints a vault-DB pvt_* with full
-      // permissions — that's the right shape for an operator who wants
-      // admin scope on a local MCP entry. Print a one-line explanation
-      // so the switch isn't silent.
-      io.log("  → admin requires a vault-DB pvt_* (hub policy: per-vault admin");
-      io.log("    is operator-only, not mintable via the public mint-token API).");
-      io.log("    Switching to legacy-pat mode with vault:admin scope.");
-      mode = "legacy-pat";
+      // `vault:<name>:admin` is now mintable via hub mint-token when the
+      // operator's bearer carries `parachute:host:admin` (hub PR-A, hub#449).
+      // The default operator.token carries host-admin, so this is the
+      // canonical admin path — no more legacy-pat fallback. The verb
+      // extraction downstream narrows `vault:admin` → `vault:<name>:admin`.
+      io.log("  → admin will be minted as a scope-narrowed hub JWT (vault:" + vaultName + ":admin).");
+      mode = "mint";
       scope = "vault:admin";
     } else {
       mode = "mint";
@@ -243,7 +234,7 @@ export async function runInteractiveInstall(
     const answer = await askPersistent(io, "Which? [paste / legacy]", "paste", {
       help: [
         "  paste  → use an existing bearer (hub JWT, pvt_*, anything).",
-        "  legacy → mint a vault-DB pvt_* token (deprecated, vault#288).",
+        "  legacy → mint a vault-DB pvt_* token (deprecated, vault#282).",
       ].join("\n"),
       validate: (s) => (s === "paste" || s === "legacy" ? null : "expected: paste or legacy"),
     });
@@ -288,7 +279,7 @@ export async function runInteractiveInstall(
   if (mode === "mint") {
     io.log(`  Scope: ${scope} → narrowed to vault:${vaultName}:${scope.split(":")[1]}.`);
   } else if (mode === "legacy-pat") {
-    io.log(`  Scope: ${scope}. The pvt_* token is vault-DB-resident (vault#288 deprecation).`);
+    io.log(`  Scope: ${scope}. The pvt_* token is vault-DB-resident (vault#282 deprecation).`);
   } else {
     // mode === "token" (paste). The pasted bearer carries its own scope
     // claim — we don't inspect or override it; whatever scope the issuer

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -523,44 +523,53 @@ describe("mcp-install flag parsing", () => {
     expect(res.stderr).toMatch(/No hub origin configured/);
   });
 
-  test("rejects --mint --scope vault:admin pre-flight (hub policy: per-vault admin is non-requestable)", () => {
-    // Regression for the symptom Aaron hit on hub 0.5.12-rc.2 / vault
-    // 0.4.7-rc.1: `parachute vault mcp-install` with the "admin" mint
-    // option sent `vault:default:admin` to `POST /api/auth/mint-token`,
-    // and hub responded:
+  test("--mint --scope vault:admin is no longer pre-flight-rejected — it reaches the hub mint call (hub PR-A / hub#449)", () => {
+    // Before hub PR-A (hub#449), vault rejected `--mint --scope vault:admin`
+    // pre-flight because hub's mint-token endpoint refused per-vault admin
+    // by policy. PR-A made hub mint `vault:<name>:admin` when the operator
+    // bearer carries `parachute:host:admin` (the default operator.token
+    // does), so admin is now a normal mint. This test confirms the
+    // pre-flight reject is GONE: admin passes the operator-token + hub-origin
+    // checks and reaches the actual `POST /api/auth/mint-token` call.
     //
-    //   Hub mint-token rejected (HTTP 400, invalid_scope):
-    //   scope vault:default:admin is not requestable via mint-token;
-    //   use OAuth flow or operator rotation
-    //
-    // The combination is invalid by hub policy (see
-    // `parachute-hub/src/scope-explanations.ts:VAULT_ADMIN_RE` and
-    // `api-mint-token.ts`'s non-requestable guard) — per-vault admin
-    // is operator-only, mintable only through the session-cookie-gated
-    // `/admin/vault-admin-token/:name` SPA path.
-    //
-    // The fix rejects the combination pre-flight in vault's mcp-install
-    // with a clear remediation pointing at `--legacy-pat --scope vault:admin`
-    // (which mints a vault-DB pvt_* with admin scope — the right shape
-    // for a local MCP entry needing schema management).
+    // We point at an unreachable loopback origin so the mint fails fast in
+    // the network branch — the assertion is on what's ABSENT (the old
+    // "not requestable" / legacy-pat-remediation copy), proving admin is no
+    // longer special-cased before the network hit.
     setupBareVault(tmp, "default");
     fs.writeFileSync(path.join(tmp, "operator.token"), "operator-bearer-stub");
     const res = runCli(
       ["mcp-install", "--mint", "--scope", "vault:admin"],
       tmp,
-      { PARACHUTE_HUB_ORIGIN: "https://hub.example.org" },
+      { PARACHUTE_HUB_ORIGIN: "http://127.0.0.1:1" },
     );
+    // Still exits 1 (the loopback hub is unreachable), but via the network
+    // branch — not the old admin pre-flight reject.
     expect(res.exitCode).toBe(1);
-    // Surface the policy reason so the operator knows why this combo is
-    // rejected (not a transient bug).
-    expect(res.stderr).toMatch(/not requestable via mint-token/);
-    // Point at the working remediation.
-    expect(res.stderr).toMatch(/--legacy-pat --scope vault:admin/);
-    // Pre-flight must fire BEFORE the operator-token / hub-origin checks
-    // pass the request to the network — no "Hub unreachable" / "No hub
-    // origin configured" leak.
+    // The old policy-reject copy must be gone.
+    expect(res.stderr).not.toMatch(/not requestable via mint-token/);
+    expect(res.stderr).not.toMatch(/--legacy-pat --scope vault:admin/);
+    // It got past the operator-token + hub-origin pre-flight checks.
+    expect(res.stderr).not.toMatch(/No operator token found/);
     expect(res.stderr).not.toMatch(/No hub origin configured/);
-    expect(res.stderr).not.toMatch(/Hub unreachable/);
+    // It actually attempted the mint and hit the network failure branch.
+    expect(res.stderr).toMatch(/Hub unreachable/);
+  });
+
+  test("`--help` text says vault:admin is mintable via --mint (regression guard for hub#449)", () => {
+    // The P0 on vault#397 review: the `usage()` mcp-install block still said
+    // admin "requires --legacy-pat" / "rejected pre-flight" after hub#449 made
+    // it mintable. Three comment blocks were updated but this literal slipped.
+    // This test pins the help string so the regression can't recur silently.
+    const res = runCli(["--help"], tmp);
+    expect(res.exitCode).toBe(0);
+    // Help text wraps across lines, so collapse whitespace before matching.
+    const help = res.stdout.replace(/\s+/g, " ");
+    // Admin is mintable via --mint now.
+    expect(help).toMatch(/--scope vault:admin IS mintable via --mint/);
+    // The old false claims must be gone.
+    expect(help).not.toMatch(/rejected pre-flight/);
+    expect(help).not.toMatch(/the only path for --scope vault:admin/);
   });
 });
 
@@ -835,7 +844,7 @@ describe("mcp-install end-to-end", () => {
     // see what they're opting into.
     expect(res.stderr).toMatch(/--legacy-pat mints a vault-DB pvt_/);
     expect(res.stderr).toMatch(/canonical install going forward/);
-    expect(res.stderr).toMatch(/vault#288/);
+    expect(res.stderr).toMatch(/vault#282/);
     expect(res.stderr).toMatch(/planned removal 0\.6\.0/);
     const config = readJson(path.join(tmp, ".claude.json"));
     const bearer = config.mcpServers["parachute-vault"].headers.Authorization;


### PR DESCRIPTION
## What

PR-B of the cross-repo `vault:admin` auth migration. Makes `parachute vault mcp-install`'s `admin` choice **mint a hub JWT** (`vault:<name>:admin`) instead of falling back to the deprecated vault-DB `pvt_*` legacy-pat path.

## Dependency: hub PR-A (hub#449, merged)

The enabling change already merged to **hub main**: `POST /api/auth/mint-token` now mints `vault:<name>:admin` when the calling operator bearer carries `parachute:host:admin` (which the default `operator.token` does). Before PR-A, hub rejected per-vault admin via mint-token by policy, so vault hard-rejected admin pre-flight and routed the interactive prompt to legacy-pat.

**The admin install path now requires a hub running PR-A.** Older hubs reject admin with HTTP 400 `invalid_scope`, surfaced through the existing `api-error` branch (no crash, actionable message).

## Changes

- **`src/mcp-install-interactive.ts`** — the `admin` choice in the `canMint` prompt now sets `mode=mint`, `scope=vault:admin` (downstream verb extraction narrows it to `vault:<name>:admin`). Help text + branch log updated; removed the "auto-routes to legacy-pat" copy. The `legacy` choice still works for self-hosted-without-hub.
- **`src/cli.ts`** — removed the `verb === "admin"` pre-flight reject in the `mode === "mint"` branch. Admin is now mintable; the existing operator-token + hub-origin checks and `narrowScope = vault:${vaultName}:${verb}` already produce `vault:<name>:admin` correctly (verified — `verb` is `rawScope.split(":")[1]` = `"admin"`).
- **#288 → #282 citation fix** — the `pvt_*` deprecation issue is vault#282, not #288 (#288 is the unrelated date-filter param removal). Fixed in `cli.ts`, `mcp-install-interactive.ts` (2 spots), `mcp-install.test.ts` (1 assertion). `routes.ts:568`'s genuine #288 (date-filter) left untouched.
- **Tests** — updated the interactive admin test to assert `mode=mint`/`scope=vault:admin` + the scope-narrowed-hub-JWT log; rewrote the CLI pre-flight-reject test to assert admin is no longer rejected (passes pre-flight, reaches the network mint call) and the old "not requestable" / legacy-pat-remediation copy is gone.

## Gates

- `bun test ./src/` → **1243 pass, 0 fail** (3333 expect() calls, 48 files)
- changed test files → **99 pass, 0 fail**
- `bun run typecheck` (`tsc --noEmit`) → **clean**
- core untouched; vault has no biome/eslint config (tsc + bun test are its gates per CLAUDE.md)

No version/rc bump (tag-when-ready — orchestrator handles rc bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)