### PR TITLE
fix(vault): drop orphaned indexed-field columns on tag delete/clear + replay indexes on import

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -1944,6 +1944,9 @@ describe("MCP tools", async () => {
     expect(names).toContain("delete-tag");
     expect(names).toContain("find-path");
     expect(names).toContain("vault-info");
+    // prune-schema (admin) — drops orphaned indexed-field columns whose
+    // declaring tags are gone. The gitcoin orphaned-fields fix.
+    expect(names).toContain("prune-schema");
     // Six note-schema tools (list/update/delete-note-schema +
     // list/set/delete-schema-mapping) retired in v17 — the standalone
     // note_schemas + schema_mappings subsystem was a parallel path to
@@ -1957,7 +1960,7 @@ describe("MCP tools", async () => {
     // synthesize-notes retired in v17 — replicable with query-notes(near=) +
     // find-path + agent-side aggregation. See vault#268.
     expect(names).not.toContain("synthesize-notes");
-    expect(tools).toHaveLength(9);
+    expect(tools).toHaveLength(10);
   });
 
   it("create-note tool works", async () => {

--- a/core/src/indexed-fields.test.ts
+++ b/core/src/indexed-fields.test.ts
@@ -7,11 +7,13 @@ import {
   declareField,
   getIndexedField,
   listIndexedFields,
+  pruneOrphanedIndexedFields,
   rebuildIndexes,
   releaseField,
   TYPE_MAP,
   validateFieldName,
 } from "./indexed-fields.js";
+import { buildVaultProjection } from "./vault-projection.js";
 
 let db: Database;
 let store: SqliteStore;
@@ -281,5 +283,154 @@ describe("delete-tag: indexed fields", () => {
     await del.execute({ tag: "project" });
     expect(getIndexedField(db, "status")?.declarerTags).toEqual(["ticket"]);
     expect(notesColumns()).toContain("meta_status");
+  });
+
+  // Bug 1b — the release lives in store.deleteTag now (not the MCP layer), so
+  // every delete entry point releases. Co-declaration sequencing: deleting the
+  // FIRST co-declarer keeps the column; deleting the SECOND drops it.
+  it("co-declaration: delete A keeps column (B holds), then delete B drops it", async () => {
+    const update = findTool("update-tag");
+    const del = findTool("delete-tag");
+    await update.execute({ tag: "asset", fields: { aspect_ratio: { type: "string", indexed: true } } });
+    await update.execute({ tag: "storyboard", fields: { aspect_ratio: { type: "string", indexed: true } } });
+
+    await del.execute({ tag: "asset" });
+    expect(getIndexedField(db, "aspect_ratio")?.declarerTags).toEqual(["storyboard"]);
+    expect(notesColumns()).toContain("meta_aspect_ratio");
+
+    await del.execute({ tag: "storyboard" });
+    expect(getIndexedField(db, "aspect_ratio")).toBeNull();
+    expect(notesColumns()).not.toContain("meta_aspect_ratio");
+    expect(notesIndexes()).not.toContain("idx_meta_aspect_ratio");
+  });
+});
+
+// ===========================================================================
+// Bug 1a — update-tag {fields: null} clears all of this tag's field schemas,
+// dropping the exclusively-declared columns + indexes. `null` (clear-all) must
+// be distinguished from `undefined` (no change). The gitcoin orphaned-fields
+// bug was that `?? {}` collapsed null to a no-op.
+// ===========================================================================
+describe("update-tag: fields null vs undefined", () => {
+  it("fields:null drops the tag's exclusively-declared columns + indexed_fields rows", async () => {
+    const update = findTool("update-tag");
+    await update.execute({
+      tag: "project",
+      fields: { status: { type: "string", indexed: true }, priority: { type: "integer", indexed: true } },
+    });
+    expect(notesColumns()).toContain("meta_status");
+    expect(notesColumns()).toContain("meta_priority");
+
+    await update.execute({ tag: "project", fields: null });
+
+    expect(getIndexedField(db, "status")).toBeNull();
+    expect(getIndexedField(db, "priority")).toBeNull();
+    expect(notesColumns()).not.toContain("meta_status");
+    expect(notesColumns()).not.toContain("meta_priority");
+    expect(notesIndexes()).not.toContain("idx_meta_status");
+    // The tag's fields column is cleared too.
+    const rec = await store.getTagRecord("project");
+    expect(rec?.fields ?? null).toBeNull();
+  });
+
+  it("fields:null no longer lists the fields in the vault-info indexed_fields catalog", async () => {
+    const update = findTool("update-tag");
+    await update.execute({ tag: "project", fields: { status: { type: "string", indexed: true } } });
+    expect(buildVaultProjection(db).indexed_fields.map((f) => f.name)).toContain("status");
+
+    await update.execute({ tag: "project", fields: null });
+    expect(buildVaultProjection(db).indexed_fields.map((f) => f.name)).not.toContain("status");
+  });
+
+  it("fields:undefined is a no-op — preserves existing field schemas + columns", async () => {
+    const update = findTool("update-tag");
+    await update.execute({ tag: "project", fields: { status: { type: "string", indexed: true } } });
+    // Update only the description; omit fields entirely.
+    await update.execute({ tag: "project", description: "a project" });
+    expect(getIndexedField(db, "status")?.declarerTags).toEqual(["project"]);
+    expect(notesColumns()).toContain("meta_status");
+  });
+
+  it("fields:null respects co-declaration — keeps a field another live tag still declares", async () => {
+    const update = findTool("update-tag");
+    await update.execute({ tag: "asset", fields: { aspect_ratio: { type: "string", indexed: true } } });
+    await update.execute({ tag: "storyboard", fields: { aspect_ratio: { type: "string", indexed: true } } });
+
+    await update.execute({ tag: "asset", fields: null });
+    expect(getIndexedField(db, "aspect_ratio")?.declarerTags).toEqual(["storyboard"]);
+    expect(notesColumns()).toContain("meta_aspect_ratio");
+  });
+});
+
+// ===========================================================================
+// Bug 1c — prune for ALREADY-orphaned fields. The gitcoin case: an
+// indexed_fields row whose every declarer tag has no `tags` row (orphaned by a
+// pre-fix delete/clear that never released). prune finds + drops them; it must
+// NOT touch fields with a live declarer.
+// ===========================================================================
+describe("pruneOrphanedIndexedFields", () => {
+  // Seed an orphaned field directly: declare via the API (creates the tag
+  // row + column), then delete the tag row out from under it WITHOUT going
+  // through the release path — exactly the pre-fix orphaned state.
+  function orphanField(field: string, type: "TEXT" | "INTEGER", tag: string) {
+    declareField(db, field, type, tag);
+    // Drop the tags row directly — simulating the pre-fix delete-tag that
+    // never released. The indexed_fields row + column survive (orphaned).
+    db.prepare("DELETE FROM tags WHERE name = ?").run(tag);
+  }
+
+  it("dry-run reports the orphan without mutating", async () => {
+    orphanField("legacy_status", "TEXT", "ghost");
+    expect(notesColumns()).toContain("meta_legacy_status");
+
+    const plan = pruneOrphanedIndexedFields(db, { dryRun: true });
+    expect(plan).toEqual([{ field: "legacy_status", deadDeclarers: ["ghost"], dropped: true }]);
+    // Nothing changed.
+    expect(getIndexedField(db, "legacy_status")).not.toBeNull();
+    expect(notesColumns()).toContain("meta_legacy_status");
+  });
+
+  it("apply drops the orphaned column + index + row", async () => {
+    orphanField("legacy_status", "TEXT", "ghost");
+    const plan = pruneOrphanedIndexedFields(db, { dryRun: false });
+    expect(plan).toEqual([{ field: "legacy_status", deadDeclarers: ["ghost"], dropped: true }]);
+    expect(getIndexedField(db, "legacy_status")).toBeNull();
+    expect(notesColumns()).not.toContain("meta_legacy_status");
+    expect(notesIndexes()).not.toContain("idx_meta_legacy_status");
+    // No longer advertised by vault-info.
+    expect(buildVaultProjection(db).indexed_fields.map((f) => f.name)).not.toContain("legacy_status");
+  });
+
+  it("does NOT touch a field with a live declarer", async () => {
+    const update = findTool("update-tag");
+    await update.execute({ tag: "project", fields: { status: { type: "string", indexed: true } } });
+    const plan = pruneOrphanedIndexedFields(db, { dryRun: false });
+    expect(plan).toEqual([]);
+    expect(getIndexedField(db, "status")?.declarerTags).toEqual(["project"]);
+    expect(notesColumns()).toContain("meta_status");
+  });
+
+  it("trims dead declarers but keeps the column when a live co-declarer remains", async () => {
+    const update = findTool("update-tag");
+    // Two declarers, then orphan only one by deleting its tag row directly.
+    await update.execute({ tag: "asset", fields: { aspect_ratio: { type: "string", indexed: true } } });
+    await update.execute({ tag: "storyboard", fields: { aspect_ratio: { type: "string", indexed: true } } });
+    db.prepare("DELETE FROM tags WHERE name = ?").run("asset"); // orphan one declarer
+
+    const plan = pruneOrphanedIndexedFields(db, { dryRun: false });
+    expect(plan).toEqual([{ field: "aspect_ratio", deadDeclarers: ["asset"], dropped: false }]);
+    // Column kept; storyboard still declares it; asset trimmed from the set.
+    expect(getIndexedField(db, "aspect_ratio")?.declarerTags).toEqual(["storyboard"]);
+    expect(notesColumns()).toContain("meta_aspect_ratio");
+  });
+
+  it("store.pruneIndexedFields surfaces the same plan", async () => {
+    orphanField("legacy_status", "TEXT", "ghost");
+    const dry = await store.pruneIndexedFields({ dryRun: true });
+    expect(dry).toEqual([{ field: "legacy_status", deadDeclarers: ["ghost"], dropped: true }]);
+    expect(getIndexedField(db, "legacy_status")).not.toBeNull(); // dry-run didn't mutate
+    const applied = await store.pruneIndexedFields({ dryRun: false });
+    expect(applied).toEqual([{ field: "legacy_status", deadDeclarers: ["ghost"], dropped: true }]);
+    expect(getIndexedField(db, "legacy_status")).toBeNull();
   });
 });

--- a/core/src/indexed-fields.ts
+++ b/core/src/indexed-fields.ts
@@ -236,3 +236,101 @@ export function rebuildIndexes(db: Database): void {
     }
   }
 }
+
+export interface PrunedField {
+  /** The field whose `indexed_fields` row was affected. */
+  field: string;
+  /** Declarer tags that no longer have a `tags` row (removed from the set). */
+  deadDeclarers: string[];
+  /**
+   * True when the field had NO surviving live declarer and was fully dropped
+   * (row + generated column + index). False when at least one live declarer
+   * remained and only the dead declarers were pruned from the set.
+   */
+  dropped: boolean;
+}
+
+/**
+ * Prune orphaned `indexed_fields` declarers — the gitcoin defect.
+ *
+ * A declarer tag is "dead" when no `tags` row carries that name (the tag was
+ * deleted, or its schema was cleared, without releasing the field). For every
+ * `indexed_fields` row:
+ *
+ *   - Drop dead declarers from the set.
+ *   - If NO live declarer remains, drop the whole field — row + generated
+ *     column + index. This is the only data-loss-free drop: the generated
+ *     column is `json_extract(metadata, …)` so the source values stay in
+ *     `notes.metadata`; only the (now-dead) index is lost.
+ *   - If at least one live declarer remains (co-declaration), keep the column
+ *     and just trim the dead names from the declarer set.
+ *
+ * `dryRun` (default) computes the plan without mutating; pass `dryRun: false`
+ * to apply. Returns the per-field plan either way so the CLI / MCP surface can
+ * print what it would (or did) drop.
+ */
+export function pruneOrphanedIndexedFields(
+  db: Database,
+  opts: { dryRun?: boolean } = {},
+): PrunedField[] {
+  const dryRun = opts.dryRun ?? true;
+  const liveTags = new Set(
+    (db.prepare("SELECT name FROM tags").all() as { name: string }[]).map((r) => r.name),
+  );
+  const plan: PrunedField[] = [];
+  for (const f of listIndexedFields(db)) {
+    const deadDeclarers = f.declarerTags.filter((t) => !liveTags.has(t));
+    if (deadDeclarers.length === 0) continue; // every declarer is live — leave it
+    const liveDeclarers = f.declarerTags.filter((t) => liveTags.has(t));
+    const dropped = liveDeclarers.length === 0;
+    plan.push({ field: f.field, deadDeclarers, dropped });
+    if (dryRun) continue;
+    if (dropped) {
+      db.prepare("DELETE FROM indexed_fields WHERE field = ?").run(f.field);
+      dropColumnAndIndex(db, f.field);
+    } else {
+      db.prepare("UPDATE indexed_fields SET declarer_tags = ? WHERE field = ?").run(
+        JSON.stringify(liveDeclarers),
+        f.field,
+      );
+    }
+  }
+  return plan;
+}
+
+/**
+ * Replay `declareField` for every field a tag schema marks `indexed: true`.
+ * Idempotent — used by the portable-md import path so a fresh import ends with
+ * the same generated columns a live vault would have (the import writes
+ * `tags.fields` via `upsertTagRecord` but never materializes the backing
+ * columns). Without this, an imported vault's schemas say `indexed: true` but
+ * queries fall back to full scans until each tag is next `update-tag`'d.
+ *
+ * `tagSchemas` is the post-import set of (tag, fields) pairs. Returns the
+ * number of (tag, field) declarations replayed.
+ */
+export function reconcileDeclaredIndexes(
+  db: Database,
+  tagSchemas: { tag: string; fields?: Record<string, { type: string; indexed?: boolean }> }[],
+): number {
+  let declared = 0;
+  for (const schema of tagSchemas) {
+    if (!schema.fields) continue;
+    for (const [fieldName, spec] of Object.entries(schema.fields)) {
+      if (spec.indexed !== true) continue;
+      const mapped = mapFieldType(spec.type);
+      if (!mapped) continue; // unsupported type for indexing — skip, don't throw
+      try {
+        validateFieldName(fieldName);
+        declareField(db, fieldName, mapped, schema.tag);
+        declared++;
+      } catch (err) {
+        console.error(
+          `[indexed-fields] could not re-declare "${fieldName}" for tag "${schema.tag}" on import:`,
+          err,
+        );
+      }
+    }
+  }
+  return declared;
+}

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1157,34 +1157,18 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           : (params.fields !== undefined ? null : undefined);
         const descriptionPatch =
           params.description === undefined ? undefined : (params.description as string);
+        // The indexed-field lifecycle (declareField for added indexed fields,
+        // releaseField for removed ones, with the co-declaration guard) is
+        // reconciled inside store.upsertTagRecord — the single chokepoint all
+        // callers (MCP, REST PUT /tags/:name, import) share — so it can't be
+        // bypassed. The cross-tag validation above stays here to surface a
+        // clean error before persisting. See the gitcoin orphaned-fields bug.
         const result = await store.upsertTagRecord(tag, {
           ...(descriptionPatch !== undefined ? { description: descriptionPatch } : {}),
           ...(fieldsPatch !== undefined ? { fields: fieldsPatch } : {}),
           ...(relationshipsPatch !== undefined ? { relationships: relationshipsPatch } : {}),
           ...(parentNamesPatch !== undefined ? { parent_names: parentNamesPatch } : {}),
         });
-
-        // ---- Reconcile indexed-field lifecycle for this tag.
-        const priorIndexed = new Set(
-          Object.entries(existing?.fields ?? {})
-            .filter(([, v]) => v.indexed === true)
-            .map(([k]) => k),
-        );
-        const nextIndexed = new Set(
-          Object.entries(mergedFields)
-            .filter(([, v]) => v.indexed === true)
-            .map(([k]) => k),
-        );
-        for (const fieldName of nextIndexed) {
-          const spec = mergedFields[fieldName]!;
-          const mapped = indexedFieldOps.mapFieldType(spec.type)!;
-          indexedFieldOps.declareField(db, fieldName, mapped, tag);
-        }
-        for (const fieldName of priorIndexed) {
-          if (!nextIndexed.has(fieldName)) {
-            indexedFieldOps.releaseField(db, fieldName, tag);
-          }
-        }
 
         return result;
       },

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -23,8 +23,8 @@ export interface McpToolDef {
   /**
    * Minimum scope verb the caller must hold for THIS vault to see + invoke
    * the tool. `read` for pure queries, `write` for mutations, `admin` for
-   * token-management surfaces (only `manage-token` in the current set —
-   * core's nine tools cap at `write`). The MCP HTTP layer filters
+   * operator-only surfaces (`prune-schema` in core; `manage-token` in the
+   * server layer). The MCP HTTP layer filters
    * `tools/list` by this field and verb-gates `tools/call` against it; the
    * filter is the primary defense, the inner gate is defense-in-depth.
    *
@@ -100,9 +100,9 @@ function removeWikilinkBrackets(content: string, targetPath: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Generate the consolidated MCP tools for a vault. Post-v17 surface (9):
+ * Generate the consolidated MCP tools for a vault. Surface (10):
  * query-notes, create-note, update-note, delete-note, list-tags, update-tag,
- * delete-tag, find-path, vault-info.
+ * delete-tag, find-path, vault-info, prune-schema (admin).
  */
 export function generateMcpTools(store: Store): McpToolDef[] {
   const db: Database = (store as any).db;
@@ -1074,12 +1074,23 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         const tag = params.tag as string;
         const existing = tagSchemaOps.getTagRecord(db, tag);
 
-        // ---- fields: shallow-merge into existing (preserves prior keys).
-        const incomingFields = (params.fields as Record<string, TagFieldSchema> | undefined) ?? {};
-        const mergedFields: Record<string, TagFieldSchema> = {
-          ...(existing?.fields ?? {}),
-          ...incomingFields,
-        };
+        // ---- fields: three-way semantics, distinguishing `null` from
+        // `undefined` (do NOT collapse with `?? {}` — that silently turns an
+        // explicit clear-all into a no-op, the gitcoin orphaned-fields bug).
+        //   - undefined  → no change. Preserve every existing field; declare
+        //                  nothing new. mergedFields === existing.fields.
+        //   - null       → clear ALL of this tag's field schemas.
+        //                  mergedFields = {} so the diff below releases every
+        //                  indexed field this tag exclusively declares.
+        //   - object     → shallow-merge into existing (preserves prior keys).
+        const incomingFields =
+          params.fields === null || params.fields === undefined
+            ? {}
+            : (params.fields as Record<string, TagFieldSchema>);
+        const mergedFields: Record<string, TagFieldSchema> =
+          params.fields === null
+            ? {}
+            : { ...(existing?.fields ?? {}), ...incomingFields };
 
         // Validate cross-tag consistency on fields being (re)declared in this
         // call. `type` and `indexed` are global — all declarers must agree.
@@ -1198,19 +1209,12 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
       },
       execute: async (params) => {
         const tag = params.tag as string;
-        // Release any indexed fields this tag declared before the row
-        // drops. releaseField drops the generated column + index when the
-        // declarer set empties.
-        const schema = tagSchemaOps.getTagSchema(db, tag);
-        if (schema?.fields) {
-          for (const [fieldName, spec] of Object.entries(schema.fields)) {
-            if (spec.indexed === true) {
-              indexedFieldOps.releaseField(db, fieldName, tag);
-            }
-          }
-        }
         // Drop the row outright — description/fields/relationships/parents
         // travel with it. (No more sidecar table to clear separately.)
+        // Indexed-field release is handled inside store.deleteTag →
+        // noteOps.deleteTag so every entry point (MCP, REST, import sweep)
+        // releases consistently with the co-declaration guard. See the
+        // gitcoin orphaned-fields bug report.
         return await store.deleteTag(tag);
       },
     },
@@ -1263,6 +1267,41 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         // This is a placeholder — vault-info needs access to vault config,
         // which is only available in the server layer (mcp-tools.ts).
         return { error: "vault-info must be configured by the server layer" };
+      },
+    },
+
+    // =====================================================================
+    // 10. prune-schema — drop orphaned indexed-field columns
+    // =====================================================================
+    {
+      name: "prune-schema",
+      // `admin` — a destructive schema-maintenance op, same tier as
+      // manage-token. Operator-only; hidden from read/write sessions.
+      requiredVerb: "admin",
+      description:
+        "Drop orphaned indexed-field columns + indexes whose declaring tags no longer exist (the result of a deleted tag never releasing its fields). Dry-run by default — returns the drop plan without mutating. Pass `apply: true` to execute. A field co-declared by a still-live tag is never dropped; only the dead declarers are trimmed from its set. Generated columns are derived from notes.metadata JSON, so a drop loses only the index, never source data — declare the field again to rebuild it.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          apply: {
+            type: "boolean",
+            description: "Execute the prune. Default false (dry-run — report what would be dropped without changing anything).",
+          },
+        },
+      },
+      execute: async (params) => {
+        const apply = params.apply === true;
+        const plan = await store.pruneIndexedFields({ dryRun: !apply });
+        const dropped = plan.filter((p) => p.dropped);
+        const trimmed = plan.filter((p) => !p.dropped);
+        return {
+          dry_run: !apply,
+          fields_dropped: dropped.map((p) => ({ field: p.field, dead_declarers: p.deadDeclarers })),
+          fields_trimmed: trimmed.map((p) => ({ field: p.field, dead_declarers: p.deadDeclarers })),
+          summary: apply
+            ? `pruned ${dropped.length} orphaned field(s); trimmed dead declarers on ${trimmed.length} co-declared field(s)`
+            : `would prune ${dropped.length} orphaned field(s); would trim dead declarers on ${trimmed.length} co-declared field(s) — pass apply:true to execute`,
+        };
       },
     },
 

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -18,6 +18,7 @@ import {
   type CursorPayload,
   type QueryHashInputs,
 } from "./cursor.js";
+import { releaseField } from "./indexed-fields.js";
 
 let idCounter = 0;
 
@@ -943,11 +944,34 @@ export function listTags(db: Database): { name: string; count: number }[] {
 }
 
 export function deleteTag(db: Database, name: string): { deleted: boolean; notes_untagged: number } {
-  const exists = db.prepare("SELECT 1 FROM tags WHERE name = ?").get(name);
-  if (!exists) return { deleted: false, notes_untagged: 0 };
+  const row = db.prepare("SELECT fields FROM tags WHERE name = ?").get(name) as
+    | { fields: string | null }
+    | undefined;
+  if (!row) return { deleted: false, notes_untagged: 0 };
 
   const countRow = db.prepare("SELECT COUNT(*) as c FROM note_tags WHERE tag_name = ?").get(name) as { c: number };
   const notesUntagged = countRow.c;
+
+  // Release any indexed fields this tag declared BEFORE the row drops.
+  // `releaseField` only drops the generated column + index when this tag is
+  // the last live declarer (co-declaration guard) — a field co-declared by
+  // another live tag keeps its column and just loses this tag from the set.
+  // This lives in the store-level delete (not the MCP layer) so every caller
+  // — MCP delete-tag, the REST DELETE /tags/:name route, the import
+  // blow-away sweep — releases consistently. See the gitcoin orphaned-fields
+  // bug report.
+  if (row.fields) {
+    try {
+      const fields = JSON.parse(row.fields) as Record<string, { indexed?: boolean }>;
+      for (const [fieldName, spec] of Object.entries(fields)) {
+        if (spec?.indexed === true) {
+          releaseField(db, fieldName, name);
+        }
+      }
+    } catch {
+      // Malformed fields JSON — nothing to release; proceed with the delete.
+    }
+  }
 
   db.prepare("DELETE FROM note_tags WHERE tag_name = ?").run(name);
   db.prepare("DELETE FROM tags WHERE name = ?").run(name);

--- a/core/src/portable-md.test.ts
+++ b/core/src/portable-md.test.ts
@@ -24,6 +24,8 @@ import { join } from "path";
 import { tmpdir } from "os";
 
 import { SqliteStore } from "./store.js";
+import { getIndexedField } from "./indexed-fields.js";
+import { buildVaultProjection } from "./vault-projection.js";
 import {
   CaseCollisionError,
   emitYamlDoc,
@@ -723,6 +725,56 @@ describe("importPortableVault", async () => {
     const schema = await target.getTagSchema("task");
     expect(schema).toBeTruthy();
     expect(schema!.description).toBe("A unit of work");
+  });
+
+  // Fix 2 — import must re-declare indexed fields. The import writes
+  // tags.fields via upsertTagRecord but historically never materialized the
+  // backing generated columns + indexes, so a fresh import advertised
+  // `indexed: true` while queries silently full-scanned. Regression: export a
+  // vault with an indexed field → fresh import → the generated column + index
+  // exist and the field shows in the vault-info indexed_fields catalog.
+  it("re-declares indexed fields on import (column + index + vault-info catalog)", async () => {
+    await store.upsertTagRecord("project", {
+      fields: { status: { type: "string", indexed: true } },
+    });
+    await store.createNote("p", { id: "p", tags: ["project"], metadata: { status: "active" } });
+    const outDir = join(tmpBase, "out");
+    await exportVaultToDir(store, { outDir, exportedAt: "2026-05-13T00:00:00.000Z" });
+
+    const target = new SqliteStore(new Database(":memory:"));
+    const targetDb = target.db;
+    // Pre-condition: a fresh store has no backing column yet.
+    const colsBefore = (targetDb.prepare("PRAGMA table_xinfo(notes)").all() as { name: string }[]).map((r) => r.name);
+    expect(colsBefore).not.toContain("meta_status");
+
+    const stats = await importPortableVault(target, { inDir: outDir });
+    expect(stats.schemas_restored).toBe(1);
+    expect(stats.indexes_declared).toBe(1);
+
+    // The generated column + index now exist — same introspection vault-info
+    // uses to advertise the queryable-field catalog.
+    const colsAfter = (targetDb.prepare("PRAGMA table_xinfo(notes)").all() as { name: string }[]).map((r) => r.name);
+    expect(colsAfter).toContain("meta_status");
+    const idxs = (targetDb.prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='notes'").all() as { name: string }[]).map((r) => r.name);
+    expect(idxs).toContain("idx_meta_status");
+    expect(getIndexedField(targetDb, "status")?.declarerTags).toEqual(["project"]);
+    // And vault-info lists it.
+    expect(buildVaultProjection(targetDb).indexed_fields.map((f) => f.name)).toContain("status");
+  });
+
+  it("dry-run import counts indexes_declared without materializing columns", async () => {
+    await store.upsertTagRecord("project", {
+      fields: { status: { type: "string", indexed: true } },
+    });
+    const outDir = join(tmpBase, "out");
+    await exportVaultToDir(store, { outDir, exportedAt: "2026-05-13T00:00:00.000Z" });
+
+    const target = new SqliteStore(new Database(":memory:"));
+    const stats = await importPortableVault(target, { inDir: outDir, dryRun: true });
+    expect(stats.indexes_declared).toBe(1);
+    // Dry-run touches nothing.
+    const cols = (target.db.prepare("PRAGMA table_xinfo(notes)").all() as { name: string }[]).map((r) => r.name);
+    expect(cols).not.toContain("meta_status");
   });
 
   it("restores typed links (non-wikilink relationships)", async () => {

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -2028,17 +2028,25 @@ export async function importPortableVault(
     await store.syncAllWikilinks();
   }
 
-  // 7. Re-declare indexed fields. Step 2 restored tag schemas via
-  // `upsertTagRecord`, which persists `tags.fields` (the schema) but does
-  // NOT materialize the backing generated columns + indexes. Replay
-  // `declareField` for every `indexed: true` field so a fresh import ends
-  // with the same columns a live vault would have — otherwise the imported
-  // schemas advertise `indexed: true` while queries silently full-scan until
-  // each tag is next `update-tag`'d. Idempotent. See the import re-declare fix.
+  // 7. Re-declare indexed fields (belt-and-suspenders + authoritative count).
+  // Step 2 restored tag schemas via `store.upsertTagRecord`, which — now that
+  // the indexed-field lifecycle is centralized in the store — already
+  // materializes the backing generated columns + indexes as it persists each
+  // schema. This explicit reconcile is therefore idempotent on the happy path;
+  // it stays as a safety net (covers any schema written through a path that
+  // skipped the lifecycle) and gives the authoritative `indexes_declared`
+  // count. Without it, a regression in step 2 would silently leave the
+  // imported schemas advertising `indexed: true` while queries full-scan.
   if (!opts.dryRun) {
     stats.indexes_declared = await store.reconcileDeclaredIndexes();
   } else {
-    // Dry-run: count what WOULD be declared without touching the DB.
+    // Dry-run: count what WOULD be declared without touching the DB. Both
+    // paths count per (tag, field) declaration (a co-declared field counts
+    // once per declaring tag). The one asymmetry: this dry-run counts every
+    // `indexed: true` field including unsupported types, whereas the applied
+    // `reconcileDeclaredIndexes` skips fields whose type can't be indexed —
+    // so the dry-run can over-count by the number of mis-typed indexed
+    // fields. It's a "how much indexing work" signal, not a row-exact promise.
     const schemasDir2 = join(sidecar, "schemas");
     if (existsSync(schemasDir2)) {
       for (const entry of readdirSync(schemasDir2)) {

--- a/core/src/portable-md.ts
+++ b/core/src/portable-md.ts
@@ -1535,6 +1535,14 @@ export interface ImportStats {
   skipped_sidecars: Array<{ sidecar_id: string; expected_path: string | null; expected_extension: string | null; reason: string }>;
   /** Set when the caller passed `blowAway: true`; counts notes removed. */
   notes_wiped: number;
+  /**
+   * (tag, field) indexed-field declarations replayed after restoring tag
+   * schemas — materializes the generated columns + indexes a live vault
+   * would have. Without this an imported vault's schemas say `indexed: true`
+   * but the backing columns don't exist until each tag is next `update-tag`'d
+   * (queries fall back to full scans). See the import re-declare fix.
+   */
+  indexes_declared: number;
 }
 
 /**
@@ -1582,6 +1590,7 @@ export async function importPortableVault(
     skipped_attachments: [],
     skipped_sidecars: [],
     notes_wiped: 0,
+    indexes_declared: 0,
   };
 
   // 1. Optional wipe. Notes are deleted via the public Store API so
@@ -2017,6 +2026,37 @@ export async function importPortableVault(
   // content rebuild link rows for the imported notes.
   if (!opts.dryRun) {
     await store.syncAllWikilinks();
+  }
+
+  // 7. Re-declare indexed fields. Step 2 restored tag schemas via
+  // `upsertTagRecord`, which persists `tags.fields` (the schema) but does
+  // NOT materialize the backing generated columns + indexes. Replay
+  // `declareField` for every `indexed: true` field so a fresh import ends
+  // with the same columns a live vault would have — otherwise the imported
+  // schemas advertise `indexed: true` while queries silently full-scan until
+  // each tag is next `update-tag`'d. Idempotent. See the import re-declare fix.
+  if (!opts.dryRun) {
+    stats.indexes_declared = await store.reconcileDeclaredIndexes();
+  } else {
+    // Dry-run: count what WOULD be declared without touching the DB.
+    const schemasDir2 = join(sidecar, "schemas");
+    if (existsSync(schemasDir2)) {
+      for (const entry of readdirSync(schemasDir2)) {
+        if (!entry.endsWith(".yaml")) continue;
+        const fullPath = join(schemasDir2, entry);
+        const resolved = resolvePath(fullPath);
+        if (!isWithinDir(resolved, resolvePath(schemasDir2))) continue;
+        const text = readFileSync(fullPath, "utf-8");
+        const wrapped = `---\n${text}${text.endsWith("\n") ? "" : "\n"}---\n`;
+        const { frontmatter } = parseFrontmatter(wrapped);
+        const fields = frontmatter.fields;
+        if (fields && typeof fields === "object" && !Array.isArray(fields)) {
+          for (const spec of Object.values(fields as Record<string, { indexed?: boolean }>)) {
+            if (spec?.indexed === true) stats.indexes_declared++;
+          }
+        }
+      }
+    }
   }
 
   return stats;

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -4,6 +4,7 @@ import { initSchema } from "./schema.js";
 import * as noteOps from "./notes.js";
 import * as linkOps from "./links.js";
 import * as tagSchemaOps from "./tag-schemas.js";
+import * as indexedFieldOps from "./indexed-fields.js";
 import {
   pruneOrphanedIndexedFields,
   reconcileDeclaredIndexes,
@@ -553,6 +554,18 @@ export class BunSqliteStore implements Store {
    * Partial upsert of the full tag record. Any patch field left undefined
    * is preserved; pass null to clear. Invalidates the tag-hierarchy cache
    * when `parent_names` is touched.
+   *
+   * Indexed-field lifecycle is reconciled HERE — at the single store
+   * chokepoint every caller (MCP update-tag, REST PUT /tags/:name, import)
+   * funnels through — so no caller can persist a `fields` change without the
+   * matching declareField/releaseField. When `patch.fields` is touched
+   * (object or explicit `null`), the prior-vs-next indexed-field set is
+   * diffed: added indexed fields get `declareField`, removed ones get
+   * `releaseField` (which drops the generated column + index only when this
+   * tag is the last live declarer — the co-declaration guard). `patch.fields
+   * === undefined` (no-touch) skips reconciliation entirely. Centralizing
+   * here is the same discipline as moving delete-release into noteOps.deleteTag
+   * — it closes the REST PUT orphaned-column leak. See the gitcoin bug.
    */
   async upsertTagRecord(
     tag: string,
@@ -563,7 +576,43 @@ export class BunSqliteStore implements Store {
       parent_names?: string[] | null;
     },
   ) {
+    // Snapshot the prior indexed-field set BEFORE the write so the diff below
+    // sees what this tag declared going in. Only needed when `fields` changes.
+    const priorRecord =
+      patch.fields !== undefined ? tagSchemaOps.getTagRecord(this.db, tag) : null;
+
     const result = tagSchemaOps.upsertTagRecord(this.db, tag, patch);
+
+    if (patch.fields !== undefined) {
+      const indexedSet = (fields: Record<string, tagSchemaOps.TagFieldSchema> | null | undefined) =>
+        new Set(
+          Object.entries(fields ?? {})
+            .filter(([, v]) => v.indexed === true)
+            .map(([k]) => k),
+        );
+      const nextFields = patch.fields; // object | null
+      const priorIndexed = indexedSet(priorRecord?.fields);
+      const nextIndexed = indexedSet(nextFields);
+      for (const fieldName of nextIndexed) {
+        const spec = nextFields![fieldName]!;
+        const mapped = indexedFieldOps.mapFieldType(spec.type);
+        // Unmappable type for indexing is a caller error; surface it rather
+        // than silently skipping. MCP/REST validate up-front for a cleaner
+        // message, but this is the backstop at the chokepoint.
+        if (!mapped) {
+          throw new indexedFieldOps.IndexedFieldError(
+            `field "${fieldName}" has unsupported type "${spec.type}" for indexing (supported: string, integer, boolean)`,
+          );
+        }
+        indexedFieldOps.declareField(this.db, fieldName, mapped, tag);
+      }
+      for (const fieldName of priorIndexed) {
+        if (!nextIndexed.has(fieldName)) {
+          indexedFieldOps.releaseField(this.db, fieldName, tag);
+        }
+      }
+    }
+
     if (patch.parent_names !== undefined) {
       // parent_names drives both query expansion (tag hierarchy) AND, post
       // vault#270, schema inheritance — bust both caches.

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -4,6 +4,11 @@ import { initSchema } from "./schema.js";
 import * as noteOps from "./notes.js";
 import * as linkOps from "./links.js";
 import * as tagSchemaOps from "./tag-schemas.js";
+import {
+  pruneOrphanedIndexedFields,
+  reconcileDeclaredIndexes,
+  type PrunedField,
+} from "./indexed-fields.js";
 import { syncWikilinks, resolveUnresolvedWikilinks } from "./wikilinks.js";
 import { pathTitle } from "./paths.js";
 import { HookRegistry } from "./hooks.js";
@@ -501,6 +506,37 @@ export class BunSqliteStore implements Store {
 
   async getTagSchemaMap() {
     return tagSchemaOps.getTagSchemaMap(this.db);
+  }
+
+  // ---- Indexed-field lifecycle (generated columns + indexes) ----
+
+  /**
+   * Prune orphaned `indexed_fields` declarers — declarer tags that no longer
+   * have a `tags` row. Fields with no surviving live declarer are dropped
+   * wholesale (row + generated column + index); co-declared fields keep their
+   * column and just lose the dead declarers. `dryRun` (default true) returns
+   * the plan without mutating. See the gitcoin orphaned-fields bug.
+   */
+  async pruneIndexedFields(opts?: { dryRun?: boolean }): Promise<PrunedField[]> {
+    const plan = pruneOrphanedIndexedFields(this.db, opts);
+    // A drop changes the queryable-field catalog vault-info advertises; bust
+    // the schema cache so the next read reflects it.
+    if (opts?.dryRun === false && plan.length > 0) this._schemaConfig = null;
+    return plan;
+  }
+
+  /**
+   * Replay `declareField` for every `indexed: true` field across all current
+   * tag records, materializing the generated columns + indexes. Idempotent —
+   * used by the portable-md import path so a fresh import ends with the same
+   * backing columns a live vault would have. Returns the count of (tag, field)
+   * declarations replayed.
+   */
+  async reconcileDeclaredIndexes(): Promise<number> {
+    const schemas = await this.listTagRecords();
+    const count = reconcileDeclaredIndexes(this.db, schemas);
+    if (count > 0) this._schemaConfig = null;
+    return count;
   }
 
   // ---- Tag Records (post-v14: full identity row) ----

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,8 +1,10 @@
 import type { TagFieldSchema, TagRelationship, TagRecord } from "./tag-schemas.js";
+import type { PrunedField } from "./indexed-fields.js";
 
 // ---- Re-exports ----
 
 export type { TagFieldSchema, TagRelationship, TagRecord } from "./tag-schemas.js";
+export type { PrunedField } from "./indexed-fields.js";
 
 // ---- Note ----
 
@@ -277,6 +279,24 @@ export interface Store {
   upsertTagSchema(tag: string, schema: { description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[]; indexed?: boolean }> }): Promise<{ tag: string; description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[]; indexed?: boolean }> }>;
   deleteTagSchema(tag: string): Promise<boolean>;
   getTagSchemaMap(): Promise<Record<string, { description?: string; fields?: Record<string, { type: string; description?: string; enum?: string[]; indexed?: boolean }> }>>;
+
+  // Indexed-field lifecycle — generated columns + indexes on `notes` derived
+  // from tag-declared `indexed: true` fields. See core/src/indexed-fields.ts.
+
+  /**
+   * Prune orphaned `indexed_fields` declarers — declarer tags with no `tags`
+   * row. Fields left with no live declarer are dropped wholesale; co-declared
+   * fields keep their column and lose only the dead declarers. `dryRun`
+   * (default true) returns the plan without mutating.
+   */
+  pruneIndexedFields(opts?: { dryRun?: boolean }): Promise<PrunedField[]>;
+  /**
+   * Replay `declareField` for every `indexed: true` field across all current
+   * tag records, materializing the backing columns + indexes. Idempotent —
+   * used by the import path so a fresh import has the same columns a live
+   * vault would. Returns the count of (tag, field) declarations replayed.
+   */
+  reconcileDeclaredIndexes(): Promise<number>;
 
   // Tag records — full v14 identity row (description + fields + typed
   // relationships + parent_names + timestamps). See

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3231,10 +3231,10 @@ async function cmdExport(args: string[]) {
 async function cmdSchema(args: string[] = []) {
   const sub = args[0];
   if (sub !== "prune") {
-    console.error("Usage: parachute-vault schema prune [--vault <name>] [--apply|--yes]");
+    console.error("Usage: parachute-vault schema prune [--vault <name>] [--dry-run|--apply|--yes]");
     console.error("\nSubcommands:");
     console.error("  prune    Drop orphaned indexed-field columns whose declaring tags are gone.");
-    console.error("           Dry-run by default; pass --apply (or --yes) to execute.");
+    console.error("           Dry-run by default (--dry-run is an explicit alias); pass --apply (or --yes) to execute.");
     process.exit(1);
   }
 
@@ -3251,6 +3251,9 @@ async function cmdSchema(args: string[] = []) {
       vaultName = v;
     } else if (arg === "--apply" || arg === "--yes") {
       apply = true;
+    } else if (arg === "--dry-run") {
+      // Dry-run is the default; accept the flag as an explicit affirmative
+      // for convention + scriptability. --apply wins if both are passed.
     } else {
       console.error(`Unknown flag for \`schema prune\`: ${arg}`);
       process.exit(1);
@@ -3598,8 +3601,9 @@ Import/Export:
 Schema maintenance:
   parachute-vault schema prune [--vault <name>]       Drop orphaned indexed-field columns +
                                                        indexes whose declaring tags no longer
-                                                       exist. Dry-run by default — prints the
-                                                       drop plan without changing anything.
+                                                       exist. Dry-run by default (--dry-run is an
+                                                       explicit alias) — prints the drop plan
+                                                       without changing anything.
   parachute-vault schema prune --apply                Execute the prune (alias: --yes). Co-declared
                                                        fields keep their column; a drop loses only
                                                        the index (data lives in notes.metadata).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -222,6 +222,9 @@ switch (command) {
   case "export":
     await cmdExport(cmdArgs);
     break;
+  case "schema":
+    await cmdSchema(cmdArgs);
+    break;
   case "help":
   case "--help":
   case "-h":
@@ -3213,6 +3216,89 @@ async function cmdExport(args: string[]) {
 }
 
 // ---------------------------------------------------------------------------
+// Schema maintenance — `parachute-vault schema <subcommand>`
+// ---------------------------------------------------------------------------
+
+/**
+ * `parachute-vault schema prune` — drop orphaned indexed-field columns +
+ * indexes whose declaring tags no longer exist (the gitcoin orphaned-fields
+ * bug). Dry-run by default; `--apply` (alias `--yes`) executes. A field
+ * co-declared by a still-live tag is never dropped — only the dead declarers
+ * are trimmed. Dropping a generated column loses only the index; the source
+ * values stay in notes.metadata, so the column rebuilds when the field is
+ * declared again.
+ */
+async function cmdSchema(args: string[] = []) {
+  const sub = args[0];
+  if (sub !== "prune") {
+    console.error("Usage: parachute-vault schema prune [--vault <name>] [--apply|--yes]");
+    console.error("\nSubcommands:");
+    console.error("  prune    Drop orphaned indexed-field columns whose declaring tags are gone.");
+    console.error("           Dry-run by default; pass --apply (or --yes) to execute.");
+    process.exit(1);
+  }
+
+  let vaultName = "default";
+  let apply = false;
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--vault") {
+      const v = args[++i];
+      if (!v) {
+        console.error("--vault requires a value.");
+        process.exit(1);
+      }
+      vaultName = v;
+    } else if (arg === "--apply" || arg === "--yes") {
+      apply = true;
+    } else {
+      console.error(`Unknown flag for \`schema prune\`: ${arg}`);
+      process.exit(1);
+    }
+  }
+
+  const config = readVaultConfig(vaultName);
+  if (!config) {
+    console.error(`Vault "${vaultName}" not found.`);
+    process.exit(1);
+  }
+
+  const { getVaultStore } = await import("./vault-store.ts");
+  const store = getVaultStore(vaultName);
+  const plan = await store.pruneIndexedFields({ dryRun: !apply });
+
+  const dropped = plan.filter((p) => p.dropped);
+  const trimmed = plan.filter((p) => !p.dropped);
+
+  if (plan.length === 0) {
+    console.log(`No orphaned indexed fields in vault "${vaultName}". Nothing to prune.`);
+    return;
+  }
+
+  console.log(
+    apply
+      ? `Pruned orphaned indexed fields in vault "${vaultName}":`
+      : `Would prune orphaned indexed fields in vault "${vaultName}" (dry-run):`,
+  );
+  for (const p of dropped) {
+    console.log(
+      `  ${apply ? "DROPPED" : "drop  "} ${p.field}  (dead declarers: ${p.deadDeclarers.join(", ")})`,
+    );
+  }
+  for (const p of trimmed) {
+    console.log(
+      `  ${apply ? "TRIMMED" : "trim  "} ${p.field}  (removed dead declarers: ${p.deadDeclarers.join(", ")}; column kept — still co-declared)`,
+    );
+  }
+  console.log(
+    `\n${apply ? "Dropped" : "Would drop"} ${dropped.length} orphaned field(s); ${apply ? "trimmed" : "would trim"} ${trimmed.length} co-declared field(s).`,
+  );
+  if (!apply) {
+    console.log("Re-run with --apply (or --yes) to execute.");
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Export-watch glue. The git-shell + commit-message logic lives in
 // `./export-watch.ts` for unit-testability; cli.ts just wires it in.
 // ---------------------------------------------------------------------------
@@ -3508,6 +3594,15 @@ Import/Export:
                                                        (combine with --watch for auto-history;
                                                        template via --git-message-template;
                                                        --git-push to push after commit)
+
+Schema maintenance:
+  parachute-vault schema prune [--vault <name>]       Drop orphaned indexed-field columns +
+                                                       indexes whose declaring tags no longer
+                                                       exist. Dry-run by default — prints the
+                                                       drop plan without changing anything.
+  parachute-vault schema prune --apply                Execute the prune (alias: --yes). Co-declared
+                                                       fields keep their column; a drop loses only
+                                                       the index (data lives in notes.metadata).
 
 ── Advanced / standalone ──────────────────────────────────────────────
 

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "os";
 import { BunStore } from "./vault-store.ts";
 import { generateMcpTools } from "../core/src/mcp.ts";
 import { getLinksHydrated } from "../core/src/links.ts";
+import { buildVaultProjection } from "../core/src/vault-projection.ts";
 import { handleNotes, handleTags, handleFindPath, handleVault } from "./routes.ts";
 import { extractApiKey } from "./auth.ts";
 
@@ -3622,6 +3623,78 @@ describe("HTTP /tags", async () => {
     const body = await res.json() as any;
     expect(body.tag).toBe("person");
     expect(body.description).toBe("A person");
+  });
+
+  // P1 regression (vault#398 review) — the REST PUT path calls
+  // store.upsertTagRecord directly. Before the lifecycle was centralized in
+  // the store, PUT {fields:null} or an indexed:false toggle left the
+  // generated column orphaned (the MCP path released, REST didn't). Assert
+  // via the same PRAGMA table_xinfo / buildVaultProjection introspection the
+  // core lifecycle tests use.
+  function notesMetaCols(): string[] {
+    return (db.prepare("PRAGMA table_xinfo(notes)").all() as { name: string }[])
+      .map((r) => r.name)
+      .filter((n) => n.startsWith("meta_"));
+  }
+
+  test("PUT /tags/:name {fields:null} drops the orphaned generated column", async () => {
+    // Declare an indexed field via REST PUT — column materializes.
+    await handleTags(
+      mkReq("PUT", "/tags/project", { fields: { status: { type: "string", indexed: true } } }),
+      store,
+      "/project",
+    );
+    expect(notesMetaCols()).toContain("meta_status");
+    expect(buildVaultProjection(db).indexed_fields.map((f) => f.name)).toContain("status");
+
+    // Clear all fields via REST PUT {fields:null} — column must drop.
+    const res = await handleTags(
+      mkReq("PUT", "/tags/project", { fields: null }),
+      store,
+      "/project",
+    );
+    expect(res.status).toBe(200);
+    expect(notesMetaCols()).not.toContain("meta_status");
+    const idxs = (db.prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='notes'").all() as { name: string }[]).map((r) => r.name);
+    expect(idxs).not.toContain("idx_meta_status");
+    expect(buildVaultProjection(db).indexed_fields.map((f) => f.name)).not.toContain("status");
+  });
+
+  test("PUT /tags/:name indexed:false toggle drops the generated column", async () => {
+    await handleTags(
+      mkReq("PUT", "/tags/project", { fields: { status: { type: "string", indexed: true } } }),
+      store,
+      "/project",
+    );
+    expect(notesMetaCols()).toContain("meta_status");
+
+    // Re-PUT the same field with indexed:false — REST merges, so the field
+    // stays in the schema but loses its index → column drops.
+    const res = await handleTags(
+      mkReq("PUT", "/tags/project", { fields: { status: { type: "string", indexed: false } } }),
+      store,
+      "/project",
+    );
+    expect(res.status).toBe(200);
+    expect(notesMetaCols()).not.toContain("meta_status");
+    expect(buildVaultProjection(db).indexed_fields.map((f) => f.name)).not.toContain("status");
+  });
+
+  test("PUT /tags/:name respects the co-declaration guard (keeps column for a live co-declarer)", async () => {
+    await handleTags(
+      mkReq("PUT", "/tags/asset", { fields: { aspect_ratio: { type: "string", indexed: true } } }),
+      store,
+      "/asset",
+    );
+    await handleTags(
+      mkReq("PUT", "/tags/storyboard", { fields: { aspect_ratio: { type: "string", indexed: true } } }),
+      store,
+      "/storyboard",
+    );
+    // Clear asset's fields — storyboard still declares aspect_ratio → keep.
+    await handleTags(mkReq("PUT", "/tags/asset", { fields: null }), store, "/asset");
+    expect(notesMetaCols()).toContain("meta_aspect_ratio");
+    expect(buildVaultProjection(db).indexed_fields.map((f) => f.name)).toContain("aspect_ratio");
   });
 
   test("PUT /tags/:name returns 400 with error_type: invalid_relationships on bad shape", async () => {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -478,7 +478,7 @@ describe("deeper link queries", async () => {
 describe("MCP tools", async () => {
   test("generates the consolidated tool set", () => {
     const tools = generateMcpTools(store);
-    expect(tools.length).toBe(9);
+    expect(tools.length).toBe(10);
 
     const names = tools.map((t) => t.name);
     expect(names).toContain("query-notes");
@@ -490,6 +490,8 @@ describe("MCP tools", async () => {
     expect(names).toContain("delete-tag");
     expect(names).toContain("find-path");
     expect(names).toContain("vault-info");
+    // prune-schema (admin) — drops orphaned indexed-field columns.
+    expect(names).toContain("prune-schema");
     // Six note-schema MCP tools (list/update/delete-note-schema +
     // list/set/delete-schema-mapping) retired in v17 — vault#267.
     expect(names).not.toContain("list-note-schemas");
@@ -4208,13 +4210,14 @@ describe("MCP tools/list scope tiers (vault#376)", () => {
     expect(names).toContain("delete-tag");
   });
 
-  test("vault:admin sees all 10 tools including manage-token", async () => {
+  test("vault:admin sees all 11 tools including manage-token + prune-schema", async () => {
     const names = await listToolNames(["vault:read", "vault:write", "vault:admin"]);
     expect(names).toContain("manage-token");
-    expect(names.length).toBe(10);
+    expect(names).toContain("prune-schema");
+    expect(names.length).toBe(11);
   });
 
-  test("legacy-derived full token sees all 10 tools (back-compat)", async () => {
+  test("legacy-derived full token sees all 11 tools (back-compat)", async () => {
     const { handleScopedMcp } = await import("./mcp-http.ts");
     const { writeVaultConfig } = await import("./config.ts");
     const { closeAllStores } = await import("./vault-store.ts");
@@ -4238,8 +4241,7 @@ describe("MCP tools/list scope tiers (vault#376)", () => {
     // Legacy permission-derived token: legacyDerived=true, scopes carry the
     // full admin set per `legacyPermissionToScopes("full")`. Compat shim
     // means the operator's existing pvt_* tokens minted pre-scope-column
-    // see the full surface (including manage-token), not just the 9 they
-    // had before.
+    // see the full admin surface (including manage-token + prune-schema).
     const res = await handleScopedMcp(req, vaultName, {
       permission: "full",
       scopes: ["vault:read", "vault:write", "vault:admin"],
@@ -4248,8 +4250,9 @@ describe("MCP tools/list scope tiers (vault#376)", () => {
     } as any);
     const body = await res.json() as any;
     const names: string[] = body.result.tools.map((t: any) => t.name);
-    expect(names.length).toBe(10);
+    expect(names.length).toBe(11);
     expect(names).toContain("manage-token");
+    expect(names).toContain("prune-schema");
     closeAllStores();
   });
 


### PR DESCRIPTION
## What

Fixes two related defects in the indexed-field / generated-column lifecycle. A user running the **Gitcoin Brain** vault-as-job-substrate workflow reported orphaned `indexed_fields` rows that persisted after their declaring tags were gone — leaving dead generated columns + indexes that `vault-info` then advertised to every connecting AI client (a dead schema). Tracing it surfaced a second, latent defect in the import path.

## Step 0 — data-safety invariant (confirmed before any drop)

Generated columns are `ALTER TABLE notes ADD COLUMN meta_<field> ... GENERATED ALWAYS AS (json_extract(metadata, '$."<field>"')) VIRTUAL`. They are **purely derived** from `notes.metadata`. Dropping a generated column + index loses only the INDEX — the source values remain in the metadata JSON, and `declareField` / `rebuildIndexes` reconstruct the column. So every drop in this PR is data-loss-free. (If this hadn't held, the fix shape would have changed; it does hold.)

## Bug 1 — deletion paths never dropped the column / `indexed_fields` row

**1a. `update-tag {fields: null}` was a silent no-op.** `incomingFields = params.fields ?? {}` collapsed an explicit clear-all (`null`) into "no change", so `mergedFields === existing.fields`, the prior/next indexed diff was empty, and the release loop never ran. Now `null` (clear-all) is distinguished from `undefined` (no-touch): `null` → `mergedFields = {}` so every field this tag exclusively declares is released; `undefined` preserves today's behavior.

**1b. `delete-tag` only released fields at the MCP layer.** The REST `DELETE /tags/:name` route and the import blow-away sweep call `store.deleteTag` directly and left columns orphaned. Release now lives in `noteOps.deleteTag` (store-level) so **every entry point** — MCP, REST, import sweep — releases consistently. Removed the now-redundant MCP-layer release.

**1c. No prune path for already-orphaned fields** (the Gitcoin case: an `indexed_fields` row whose every declarer tag has no `tags` row). Added `pruneOrphanedIndexedFields(db, {dryRun})`, exposed two ways:
- **CLI** — `parachute-vault schema prune [--vault <name>] [--apply|--yes]`. Dry-run by default; prints the drop plan.
- **MCP** — new admin-scoped `prune-schema` tool (the 10th core tool), matching the `manage-token` shape. Picked the lower-footprint option: a core tool verb-gated to `vault:<name>:admin`, so the existing `mcp-http` verb filter hides it from read/write sessions automatically — no separate server-layer wiring. (Chose this over extending `update-tag` because prune is a destructive maintenance op with different semantics, and admin-gating it required a distinct verb tier anyway.)

### Co-declaration guard (critical)

A field can be declared by multiple tags (e.g. `aspect_ratio` by both `asset` and `storyboard` — the `indexed_fields.declarer_tags` array). `releaseField` already only dropped the column when the declarer set emptied; the new prune path follows the same rule: it drops a field only when **no** live tag still declares it, otherwise it trims the dead declarers from the set and keeps the column. Verified by tests: delete A keeps the column (B holds), delete B then drops it; prune trims one dead co-declarer and keeps the column for the live one.

## Bug 2 — import never re-declared indexed fields (latent)

The portable-md import path wrote tag records via `upsertTagRecord` (restoring `tags.fields`) but never materialized the backing columns. So export → fresh-import dropped the generated columns for legitimately-indexed fields; the imported schemas advertised `indexed: true` while queries silently full-scanned until each tag was next `update-tag`'d. After restoring schemas + notes, `importPortableVault` now calls the new `Store.reconcileDeclaredIndexes()` to replay `declareField` for every `indexed: true` field, ending with the same columns a live vault would have. New `ImportStats.indexes_declared` counts the replays.

## Tests (the load-bearing part — these bugs existed because lifecycle wasn't covered)

- `update-tag {fields:null}` drops exclusively-declared columns + `indexed_fields` rows; no longer listed in the `vault-info` `indexed_fields` catalog (asserted via `buildVaultProjection`, the same introspection vault-info uses). `undefined` is a no-op.
- Co-declaration delete sequencing (A keeps, B drops); `fields:null` respects co-declaration.
- prune: dry-run reports without mutating; apply drops the orphan + index + row; does NOT touch a field with a live declarer; trims dead declarers while keeping a co-declared column. `store.pruneIndexedFields` parity.
- import re-declares indexes — export with an indexed field → fresh import → column + index exist (absence asserted pre-import) and field appears in the vault-info catalog; dry-run counts without materializing.

## Gates

- `bun test ./core/src/` — **610 pass / 0 fail**
- `bun test ./src/` — **1244 pass / 0 fail**
- `bun run typecheck` — clean
- CLI verified end-to-end in a sandboxed `PARACHUTE_HOME`: seeded an orphaned field + a live co-declared field → dry-run → apply → orphan column dropped, live field preserved, re-run clean.

## Not in scope

No version/rc bump (per instruction). No CHANGELOG entry (it's bump-tied; lands with the next rc bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)