### PR TITLE
fix(vault): per-vault mirror remote + PAT (was server-wide, leaked across vaults)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,16 +41,24 @@ mirror:
 now offers "Connect GitHub" (Device Flow — works on any vault host, no
 callback URL setup needed; same flow as `gh auth login`) and "Use
 Personal Access Token" (for GitLab/Gitea/Bitbucket/anything else
-HTTPS+token). Tokens are stored at
-`~/.parachute/vault/.mirror-credentials.yaml` with 0600 perms, never
-appear in API responses, and are embedded into the mirror's
-`.git/config` origin URL for push.
+HTTPS+token). Tokens are stored **per vault** at
+`~/.parachute/vault/data/<vaultName>/.mirror-credentials.yaml` with 0600
+perms, never appear in API responses, and are embedded into the mirror's
+`.git/config` origin URL for push. (Before vault#399 these lived in a
+single server-wide `~/.parachute/vault/.mirror-credentials.yaml`, which
+leaked the first vault's remote + PAT onto every other vault. On first
+boot after upgrade, the legacy server-wide file is migrated to its owning
+vault — the default/first vault the mirror was bound to — and preserved as
+`.mirror-credentials.yaml.bak`. Other vaults start with no mirror
+credentials; configure each separately.)
 
 **Auto-push semantics:**
 
-- `auto_push: true` + `location: internal` is rejected at the backend
-  (internal mirrors have no remote; the watch loop would log push
-  failures forever). Pick `external` if you want pushes.
+- `auto_push: true` + `location: internal` is accepted when git
+  credentials are wired (a PAT or GitHub OAuth saved via the SPA flows —
+  vault sets the mirror's `origin` from them), and rejected only when no
+  credentials are configured (an internal mirror has no remote to push to
+  otherwise). Connect GitHub / paste a PAT first, or pick `external`.
 - The "Push after each commit" checkbox is hidden in the SPA when
   location=internal. (Bare config edit can still set the flag — the
   watch loop logs a non-fatal warning on each push attempt and

--- a/src/mirror-config.ts
+++ b/src/mirror-config.ts
@@ -387,7 +387,17 @@ export type ShapeValidation = ShapeValidationOk | ShapeValidationError;
  */
 export function validateMirrorConfigShape(
   input: unknown,
-  opts: { readCredentials?: () => MirrorCredentials | null } = {},
+  opts: {
+    /**
+     * Vault whose credentials gate `auto_push + internal`. Required for the
+     * production credential read (per-vault since vault#399). Omitting it
+     * AND `readCredentials` means the auto_push/internal credential check
+     * treats credentials as absent (fail-closed) — fine for callers that
+     * never set that combination.
+     */
+    vaultName?: string;
+    readCredentials?: () => MirrorCredentials | null;
+  } = {},
 ): ShapeValidation {
   if (input === null || typeof input !== "object") {
     return {
@@ -583,7 +593,12 @@ export function validateMirrorConfigShape(
   // dir, so vault IS the only thing that can wire a remote, which is
   // why the gate below requires vault-stored credentials specifically.
   if (out.enabled && out.auto_push && out.location === "internal") {
-    const readCreds = opts.readCredentials ?? readCredentials;
+    // Per-vault credentials (vault#399): bind the read to opts.vaultName.
+    // When neither an injected reader nor a vaultName is supplied, treat
+    // credentials as absent (fail-closed) rather than reading a wrong file.
+    const readCreds =
+      opts.readCredentials ??
+      (opts.vaultName ? () => readCredentials(opts.vaultName!) : () => null);
     let creds: MirrorCredentials | null = null;
     try {
       creds = readCreds();

--- a/src/mirror-credentials.test.ts
+++ b/src/mirror-credentials.test.ts
@@ -25,6 +25,8 @@ import {
   deleteCredentials,
   emptyCredentials,
   githubAuthedRemoteUrl,
+  legacyServerWideCredentialsPath,
+  migrateLegacyServerWideCredentials,
   mirrorCredentialsPath,
   parseCredentials,
   previewToken,
@@ -194,7 +196,7 @@ describe("serialize + parse round-trip", () => {
 describe("readCredentials / writeCredentials", () => {
   test("returns null when no file exists", () => {
     withSandbox(() => {
-      expect(readCredentials()).toBeNull();
+      expect(readCredentials("default")).toBeNull();
     });
   });
 
@@ -211,8 +213,8 @@ describe("readCredentials / writeCredentials", () => {
         },
         pat: null,
       };
-      writeCredentials(creds);
-      const read = readCredentials();
+      writeCredentials("default", creds);
+      const read = readCredentials("default");
       expect(read).toEqual(creds);
     });
   });
@@ -228,8 +230,8 @@ describe("readCredentials / writeCredentials", () => {
           label: "test",
         },
       };
-      writeCredentials(creds);
-      const p = mirrorCredentialsPath();
+      writeCredentials("default", creds);
+      const p = mirrorCredentialsPath("default");
       const stat = fs.statSync(p);
       const perms = stat.mode & 0o777;
       expect(perms).toBe(0o600);
@@ -241,13 +243,50 @@ describe("readCredentials / writeCredentials", () => {
     process.env.PARACHUTE_HOME = home;
     process.env.HOME = home;
     try {
-      // Note: don't pre-create the vault subdir.
+      // Note: don't pre-create the vault data subdir.
       const creds: MirrorCredentials = { ...emptyCredentials() };
-      writeCredentials(creds);
-      expect(fs.existsSync(path.join(home, "vault", ".mirror-credentials.yaml"))).toBe(true);
+      writeCredentials("default", creds);
+      expect(
+        fs.existsSync(
+          path.join(home, "vault", "data", "default", ".mirror-credentials.yaml"),
+        ),
+      ).toBe(true);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
+  });
+
+  test("two vaults' credentials are isolated — no bleed (vault#399)", () => {
+    withSandbox(() => {
+      const aCreds: MirrorCredentials = {
+        ...emptyCredentials(),
+        active_method: "pat",
+        pat: {
+          token: "ghp_vaultA1234567890abc",
+          remote_url: "https://x-access-token:ghp_vaultA1234567890abc@github.com/aaron/vault-a.git",
+          label: "vault A",
+        },
+      };
+      const bCreds: MirrorCredentials = {
+        ...emptyCredentials(),
+        active_method: "pat",
+        pat: {
+          token: "ghp_vaultB9876543210xyz",
+          remote_url: "https://x-access-token:ghp_vaultB9876543210xyz@github.com/aaron/vault-b.git",
+          label: "vault B",
+        },
+      };
+      writeCredentials("alpha", aCreds);
+      writeCredentials("beta", bCreds);
+      // Each vault reads back ITS OWN remote + token — never the other's.
+      expect(readCredentials("alpha")).toEqual(aCreds);
+      expect(readCredentials("beta")).toEqual(bCreds);
+      expect(readCredentials("alpha")?.pat?.remote_url).toContain("vault-a.git");
+      expect(readCredentials("beta")?.pat?.remote_url).toContain("vault-b.git");
+      expect(readCredentials("alpha")?.pat?.token).not.toBe(readCredentials("beta")?.pat?.token);
+      // Files live in separate per-vault dirs.
+      expect(mirrorCredentialsPath("alpha")).not.toBe(mirrorCredentialsPath("beta"));
+    });
   });
 
   test("write is atomic — partial file not left on failure path", () => {
@@ -263,17 +302,17 @@ describe("readCredentials / writeCredentials", () => {
         },
         pat: null,
       };
-      writeCredentials(creds);
+      writeCredentials("default", creds);
       // Subsequent write replaces atomically (.tmp rename onto final).
       const updated: MirrorCredentials = {
         ...creds,
         github_oauth: { ...creds.github_oauth!, access_token: "gho_updated123456789" },
       };
-      writeCredentials(updated);
-      const read = readCredentials();
+      writeCredentials("default", updated);
+      const read = readCredentials("default");
       expect(read?.github_oauth?.access_token).toBe("gho_updated123456789");
       // No leftover .tmp file.
-      expect(fs.existsSync(`${mirrorCredentialsPath()}.tmp`)).toBe(false);
+      expect(fs.existsSync(`${mirrorCredentialsPath("default")}.tmp`)).toBe(false);
     });
   });
 });
@@ -281,17 +320,129 @@ describe("readCredentials / writeCredentials", () => {
 describe("deleteCredentials", () => {
   test("idempotent — missing file is a no-op (doesn't throw)", () => {
     withSandbox(() => {
-      expect(() => deleteCredentials()).not.toThrow();
+      expect(() => deleteCredentials("default")).not.toThrow();
     });
   });
 
   test("removes the file when present", () => {
     withSandbox(() => {
-      writeCredentials({ ...emptyCredentials(), active_method: null });
-      expect(fs.existsSync(mirrorCredentialsPath())).toBe(true);
-      deleteCredentials();
-      expect(fs.existsSync(mirrorCredentialsPath())).toBe(false);
+      writeCredentials("default", { ...emptyCredentials(), active_method: null });
+      expect(fs.existsSync(mirrorCredentialsPath("default"))).toBe(true);
+      deleteCredentials("default");
+      expect(fs.existsSync(mirrorCredentialsPath("default"))).toBe(false);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration — legacy server-wide → per-vault (vault#399)
+// ---------------------------------------------------------------------------
+
+describe("migrateLegacyServerWideCredentials", () => {
+  function writeLegacyFile(_home: string, creds: MirrorCredentials): string {
+    const legacyPath = legacyServerWideCredentialsPath();
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(legacyPath, serializeCredentials(creds), { mode: 0o600 });
+    return legacyPath;
+  }
+
+  const sampleCreds: MirrorCredentials = {
+    ...emptyCredentials(),
+    active_method: "pat",
+    pat: {
+      token: "ghp_legacy1234567890abc",
+      remote_url: "https://x-access-token:ghp_legacy1234567890abc@github.com/aaron/first-vault.git",
+      label: "legacy",
+    },
+  };
+
+  test("no legacy file → no-op", () => {
+    withSandbox(() => {
+      const r = migrateLegacyServerWideCredentials("default");
+      expect(r.migrated).toBe(false);
+      expect((r as { reason: string }).reason).toBe("no_legacy_file");
+    });
+  });
+
+  test("legacy file → attributed to the FIRST vault, others stay empty", () => {
+    const home = tmp("mirror-migrate-");
+    process.env.PARACHUTE_HOME = home;
+    process.env.HOME = home;
+    try {
+      const legacyPath = writeLegacyFile(home, sampleCreds);
+      const r = migrateLegacyServerWideCredentials("first");
+      expect(r.migrated).toBe(true);
+      // First vault now owns the legacy creds.
+      expect(readCredentials("first")).toEqual(sampleCreds);
+      // A second vault that never had its own file starts EMPTY — the bug
+      // would have made it read the same remote. It must not.
+      expect(readCredentials("second")).toBeNull();
+      // Legacy file preserved as .bak — nothing silently lost.
+      expect(fs.existsSync(legacyPath)).toBe(false);
+      expect(fs.existsSync(`${legacyPath}.bak`)).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("idempotent — second run is a no-op once target has creds", () => {
+    const home = tmp("mirror-migrate-idem-");
+    process.env.PARACHUTE_HOME = home;
+    process.env.HOME = home;
+    try {
+      writeLegacyFile(home, sampleCreds);
+      expect(migrateLegacyServerWideCredentials("first").migrated).toBe(true);
+      // Run again: no legacy file remains, so no-op.
+      const r2 = migrateLegacyServerWideCredentials("first");
+      expect(r2.migrated).toBe(false);
+      // First vault's creds unchanged.
+      expect(readCredentials("first")).toEqual(sampleCreds);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("does not clobber an existing per-vault file", () => {
+    const home = tmp("mirror-migrate-noclobber-");
+    process.env.PARACHUTE_HOME = home;
+    process.env.HOME = home;
+    try {
+      writeLegacyFile(home, sampleCreds);
+      // Target vault already has its own (different) creds.
+      const existing: MirrorCredentials = {
+        ...emptyCredentials(),
+        active_method: "pat",
+        pat: {
+          token: "ghp_already1234567890ab",
+          remote_url: "https://x-access-token:ghp_already1234567890ab@github.com/aaron/already.git",
+          label: "already",
+        },
+      };
+      writeCredentials("first", existing);
+      const r = migrateLegacyServerWideCredentials("first");
+      expect(r.migrated).toBe(false);
+      expect((r as { reason: string }).reason).toBe("target_already_has_creds");
+      // Existing per-vault creds preserved, NOT overwritten by legacy.
+      expect(readCredentials("first")).toEqual(existing);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("no target vault → leaves legacy file in place for a later boot", () => {
+    const home = tmp("mirror-migrate-notarget-");
+    process.env.PARACHUTE_HOME = home;
+    process.env.HOME = home;
+    try {
+      const legacyPath = writeLegacyFile(home, sampleCreds);
+      const r = migrateLegacyServerWideCredentials(null);
+      expect(r.migrated).toBe(false);
+      expect((r as { reason: string }).reason).toBe("no_target_vault");
+      // Legacy file untouched — a future boot (after a vault exists) migrates.
+      expect(fs.existsSync(legacyPath)).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/mirror-credentials.ts
+++ b/src/mirror-credentials.ts
@@ -23,16 +23,27 @@
  *     embeds them in the mirror's remote URL. Works against GitHub, GitLab,
  *     Codeberg, Gitea, anything that accepts an HTTPS token in the URL.
  *
- * **Storage:** `<configDir>/vault/.mirror-credentials.yaml`, perms `0o600`,
- * **not encrypted at rest**. Rationale: encryption-at-rest with the key on
- * the same disk doesn't add real security; OS perms ARE the protection. Same
- * trust model as `~/.git-credentials` (which most operators already use).
- * The file is documented as sensitive; redaction in logs is enforced by
- * `sanitizeCredentials` + a discipline of "never log the raw token."
+ * **Storage:** `<configDir>/vault/data/<vaultName>/.mirror-credentials.yaml`,
+ * perms `0o600`, **not encrypted at rest**. Rationale: encryption-at-rest
+ * with the key on the same disk doesn't add real security; OS perms ARE the
+ * protection. Same trust model as `~/.git-credentials` (which most operators
+ * already use). The file is documented as sensitive; redaction in logs is
+ * enforced by `sanitizeCredentials` + a discipline of "never log the raw
+ * token."
+ *
+ * **Per-vault (vault#399).** Credentials — both the PAT and the embedded
+ * `remote_url` — live under each vault's own data dir, alongside its SQLite
+ * DB + vault.yaml. This is the existing per-vault-state pattern. Before
+ * vault#399 they lived in a single SERVER-WIDE file
+ * (`<configDir>/vault/.mirror-credentials.yaml`); that leaked the first
+ * vault's remote + PAT onto every other vault that configured git sync —
+ * pointing vault B at vault A's GitHub repo. The legacy server-wide file is
+ * migrated to its owning vault on first per-vault read (see
+ * `migrateLegacyServerWideCredentials`).
  *
  * **One credential set per vault.** Multi-credential ("I want repo A pushed
- * with token X, repo B with token Y") isn't supported — vault#382 ships one
- * mirror per vault server today; one credential set per vault matches.
+ * with token X, repo B with token Y") within a single vault isn't supported —
+ * vault#382 ships one mirror per vault; one credential set per vault matches.
  */
 
 import {
@@ -98,8 +109,10 @@ export interface PATCredential {
 }
 
 /**
- * The on-disk + on-the-wire shape. One file per vault server (matches the
- * "one mirror per vault server today" invariant from mirror-config.ts).
+ * The on-disk + on-the-wire shape. One file per VAULT (vault#399) — keyed by
+ * the vault's data dir, not the server. Each vault has its own PAT + its own
+ * `remote_url`, so configuring git sync for vault B never reuses vault A's
+ * remote.
  */
 export interface MirrorCredentials {
   /**
@@ -137,23 +150,38 @@ export interface MirrorCredentialsPublic {
 // Path resolution
 // ---------------------------------------------------------------------------
 
-/**
- * Path to the per-vault-server credentials file.
- *
- * Note: this is a SERVER-wide credentials file (`<configDir>/vault/.mirror-credentials.yaml`),
- * not a per-vault file. The mirror manager itself is server-wide (one mirror
- * per vault server today) so the credentials follow that scope. When multi-
- * vault mirroring lands (open question 2 in the design doc), this becomes
- * per-vault and gets keyed by name. Today's shape: one file.
- *
- * Path resolution mirrors `config.ts:vaultHomePath()` — re-reads
- * `PARACHUTE_HOME` on every call so test sandboxes (`PARACHUTE_VAULT_HOME`
- * is a vault-internal var that doesn't override here — we use the canonical
- * `PARACHUTE_HOME` that the rest of vault honors).
- */
-export function mirrorCredentialsPath(): string {
+/** The vault home root — `<configDir>/vault`. Re-reads PARACHUTE_HOME per call. */
+function vaultHomeRoot(): string {
   const root = process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
-  return join(root, "vault", ".mirror-credentials.yaml");
+  return join(root, "vault");
+}
+
+/**
+ * Path to a vault's per-vault credentials file (vault#399).
+ *
+ * `<configDir>/vault/data/<vaultName>/.mirror-credentials.yaml` — under the
+ * vault's own data dir, alongside its SQLite DB (`vault.db`) + config
+ * (`vault.yaml`). This is the canonical per-vault-state location; every
+ * vault carries its own PAT + remote_url so git sync for one vault never
+ * reuses another vault's remote.
+ *
+ * Path resolution mirrors `config.ts:vaultDir()` rather than importing it —
+ * mirror-config.ts imports this module and config.ts imports mirror-config.ts,
+ * so importing config.ts here would close an import cycle. We re-derive the
+ * path from `PARACHUTE_HOME` (the canonical override the rest of vault honors)
+ * instead, which keeps this module dependency-light.
+ */
+export function mirrorCredentialsPath(vaultName: string): string {
+  return join(vaultHomeRoot(), "data", vaultName, ".mirror-credentials.yaml");
+}
+
+/**
+ * Path to the LEGACY server-wide credentials file
+ * (`<configDir>/vault/.mirror-credentials.yaml`) used before vault#399.
+ * Retained only so the migration can find + attribute + rename it.
+ */
+export function legacyServerWideCredentialsPath(): string {
+  return join(vaultHomeRoot(), ".mirror-credentials.yaml");
 }
 
 // ---------------------------------------------------------------------------
@@ -344,12 +372,18 @@ export function parseCredentials(yaml: string): MirrorCredentials {
 // ---------------------------------------------------------------------------
 
 /**
- * Read credentials from disk. Returns `null` when the file doesn't exist
- * (operator hasn't connected anything yet); throws when the file is present
- * but unreadable (a permission error is a loud configuration problem).
+ * Read a vault's credentials from disk. Returns `null` when the file doesn't
+ * exist (operator hasn't connected anything yet); throws when the file is
+ * present but unreadable (a permission error is a loud configuration problem).
+ *
+ * vault#399 migration: if the per-vault file is absent but the legacy
+ * server-wide file exists, `migrateLegacyServerWideCredentials` may have
+ * promoted it to THIS vault (when it's the migration target). The migration
+ * runs at boot (server.ts) and is idempotent; this read just picks up
+ * whatever landed on disk.
  */
-export function readCredentials(): MirrorCredentials | null {
-  const path = mirrorCredentialsPath();
+export function readCredentials(vaultName: string): MirrorCredentials | null {
+  const path = mirrorCredentialsPath(vaultName);
   if (!existsSync(path)) return null;
   const raw = readFileSync(path, "utf8");
   return parseCredentials(raw);
@@ -366,8 +400,8 @@ export function readCredentials(): MirrorCredentials | null {
  * surface a 500 with the underlying message — quietly losing credentials
  * would be worse than crashing the request.
  */
-export function writeCredentials(creds: MirrorCredentials): void {
-  const path = mirrorCredentialsPath();
+export function writeCredentials(vaultName: string, creds: MirrorCredentials): void {
+  const path = mirrorCredentialsPath(vaultName);
   const dir = dirname(path);
   // Vault home may not exist yet (tests, fresh installs); create it.
   if (!existsSync(dir)) {
@@ -401,9 +435,98 @@ export function writeCredentials(creds: MirrorCredentials): void {
  * Delete the credentials file. Idempotent — missing file is a no-op (the
  * Disconnect UX should succeed even if the file was already removed).
  */
-export function deleteCredentials(): void {
-  const path = mirrorCredentialsPath();
+export function deleteCredentials(vaultName: string): void {
+  const path = mirrorCredentialsPath(vaultName);
   if (existsSync(path)) unlinkSync(path);
+}
+
+// ---------------------------------------------------------------------------
+// Migration — legacy server-wide → per-vault (vault#399)
+// ---------------------------------------------------------------------------
+
+/**
+ * One-time migration of the legacy server-wide credentials file to the
+ * per-vault layout (vault#399).
+ *
+ * The bug: pre-vault#399, credentials (PAT + embedded `remote_url`) lived in a
+ * single `<configDir>/vault/.mirror-credentials.yaml` shared across ALL
+ * vaults. Configuring git sync for a second vault reused the first vault's
+ * remote, pointing it at the wrong GitHub repo.
+ *
+ * Attribution policy (SAFEST per the design): attribute the legacy creds to
+ * the FIRST vault — the earliest-created one, which is what
+ * `resolveMirrorVaultName()` already bound the single server-wide mirror to.
+ * That's the vault whose remote/PAT the legacy file actually corresponds to.
+ * We do NOT copy the same remote/PAT onto every vault — that would recreate
+ * the leak.
+ *
+ * Safety:
+ *   - No-op when no legacy file exists (fresh installs, already-migrated).
+ *   - No-op when the target vault already has a per-vault file (don't clobber
+ *     creds the operator set post-migration).
+ *   - Leaves the legacy file in place renamed `.bak` (never silently deleted)
+ *     so nothing is lost if attribution was wrong — the operator can recover.
+ *   - Logs the attribution decision clearly.
+ *
+ * @param targetVaultName the vault to attribute the legacy creds to (caller
+ *   passes the result of `resolveMirrorVaultName()`, i.e. default-or-first).
+ * @returns a struct describing what happened, for logging + tests.
+ */
+export function migrateLegacyServerWideCredentials(
+  targetVaultName: string | null,
+):
+  | { migrated: false; reason: "no_legacy_file" | "no_target_vault" | "target_already_has_creds" }
+  | { migrated: true; targetVaultName: string; backupPath: string } {
+  const legacyPath = legacyServerWideCredentialsPath();
+  if (!existsSync(legacyPath)) {
+    return { migrated: false, reason: "no_legacy_file" };
+  }
+  if (!targetVaultName) {
+    // Legacy file present but no vault to attribute it to. Leave it in
+    // place — a future boot (once a vault exists) migrates it.
+    return { migrated: false, reason: "no_target_vault" };
+  }
+  const targetPath = mirrorCredentialsPath(targetVaultName);
+  if (existsSync(targetPath)) {
+    // The target vault already has per-vault creds (operator configured
+    // them post-migration, or a prior migration ran). Don't clobber.
+    // Still rename the legacy file so we don't re-evaluate it forever.
+    const backupPath = `${legacyPath}.bak`;
+    try {
+      if (!existsSync(backupPath)) renameSync(legacyPath, backupPath);
+    } catch {
+      // Non-fatal — worst case we re-check next boot and short-circuit here.
+    }
+    return { migrated: false, reason: "target_already_has_creds" };
+  }
+
+  // Read the legacy creds + write them to the target vault's per-vault file.
+  const raw = readFileSync(legacyPath, "utf8");
+  const creds = parseCredentials(raw);
+  writeCredentials(targetVaultName, creds);
+
+  // Rename the legacy file to .bak rather than deleting — never silently
+  // lose an operator's only copy of a token/remote.
+  const backupPath = `${legacyPath}.bak`;
+  try {
+    renameSync(legacyPath, backupPath);
+  } catch {
+    // If the rename fails (e.g. .bak already exists from a partial prior
+    // run), fall back to unlinking the original — the creds are now safely
+    // in the per-vault file.
+    try {
+      unlinkSync(legacyPath);
+    } catch {
+      // Leave it; the target_already_has_creds branch short-circuits next boot.
+    }
+  }
+
+  console.log(
+    `[mirror] migrated legacy server-wide mirror credentials → vault "${targetVaultName}" (per-vault, vault#399). ` +
+      `Other vaults start with no mirror credentials (configure each separately). ` +
+      `Legacy file preserved at ${backupPath}.`,
+  );
+  return { migrated: true, targetVaultName, backupPath };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mirror-import.test.ts
+++ b/src/mirror-import.test.ts
@@ -112,13 +112,13 @@ afterEach(() => {
 
 describe("authedCloneUrl", () => {
   test("returns null for unparseable URL", () => {
-    expect(authedCloneUrl("not-a-url", { kind: "none" })).toBeNull();
+    expect(authedCloneUrl("not-a-url", { kind: "none" }, "v")).toBeNull();
   });
 
   test("passes git:// URLs verbatim (no userinfo to embed)", () => {
     // `git://github.com/owner/repo.git` parses as a URL with protocol
     // `git:`, not http/https — our helper returns it verbatim.
-    const r = authedCloneUrl("git://github.com/owner/repo.git", { kind: "pat", token: "ghp_x" });
+    const r = authedCloneUrl("git://github.com/owner/repo.git", { kind: "pat", token: "ghp_x" }, "v");
     expect(r).not.toBeNull();
     expect(r!.authedUrl).toBe("git://github.com/owner/repo.git");
     expect(r!.appliedAuth).toBe("none");
@@ -134,7 +134,7 @@ describe("authedCloneUrl", () => {
     const r = authedCloneUrl("git@github.com:owner/repo.git", {
       kind: "pat",
       token: "ghp_should_not_appear",
-    });
+    }, "v");
     expect(r).not.toBeNull();
     expect(r!.authedUrl).toBe("git@github.com:owner/repo.git");
     expect(r!.authedUrl).not.toContain("ghp_should_not_appear");
@@ -145,7 +145,7 @@ describe("authedCloneUrl", () => {
     const r = authedCloneUrl("ssh://git@github.com/owner/repo.git", {
       kind: "pat",
       token: "ghp_x",
-    });
+    }, "v");
     expect(r).not.toBeNull();
     expect(r!.authedUrl).toBe("ssh://git@github.com/owner/repo.git");
     expect(r!.appliedAuth).toBe("none");
@@ -155,7 +155,7 @@ describe("authedCloneUrl", () => {
     const r = authedCloneUrl("https://user:pass@github.com/owner/repo.git", {
       kind: "pat",
       token: "ghp_x",
-    });
+    }, "v");
     expect(r).not.toBeNull();
     expect(r!.authedUrl).toContain("user:pass@");
     expect(r!.appliedAuth).toBe("none");
@@ -165,14 +165,14 @@ describe("authedCloneUrl", () => {
     const r = authedCloneUrl("https://github.com/owner/repo.git", {
       kind: "pat",
       token: "ghp_abc123",
-    });
+    }, "v");
     expect(r).not.toBeNull();
     expect(r!.authedUrl).toContain("x-access-token:ghp_abc123@");
     expect(r!.appliedAuth).toBe("per_call_pat");
   });
 
   test("none auth returns verbatim URL", () => {
-    const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "none" });
+    const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "none" }, "v");
     expect(r).not.toBeNull();
     expect(r!.authedUrl).toBe("https://github.com/owner/repo.git");
     expect(r!.appliedAuth).toBe("none");
@@ -190,7 +190,7 @@ describe("authedCloneUrl", () => {
     });
 
     test("no credentials file → verbatim URL", () => {
-      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" });
+      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" }, "default");
       expect(r!.appliedAuth).toBe("none");
     });
 
@@ -206,8 +206,8 @@ describe("authedCloneUrl", () => {
           user_id: 1,
         },
       };
-      writeCredentials(creds);
-      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" });
+      writeCredentials("default", creds);
+      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" }, "default");
       expect(r!.authedUrl).toContain("x-access-token:gho_abc@");
       expect(r!.appliedAuth).toBe("stored_oauth");
     });
@@ -224,8 +224,8 @@ describe("authedCloneUrl", () => {
           user_id: 1,
         },
       };
-      writeCredentials(creds);
-      const r = authedCloneUrl("https://gitlab.com/owner/repo.git", { kind: "credentialsFile" });
+      writeCredentials("default", creds);
+      const r = authedCloneUrl("https://gitlab.com/owner/repo.git", { kind: "credentialsFile" }, "default");
       expect(r!.appliedAuth).toBe("none");
     });
 
@@ -239,8 +239,8 @@ describe("authedCloneUrl", () => {
           label: "GitLab PAT",
         },
       };
-      writeCredentials(creds);
-      const r = authedCloneUrl("https://gitlab.com/owner/repo.git", { kind: "credentialsFile" });
+      writeCredentials("default", creds);
+      const r = authedCloneUrl("https://gitlab.com/owner/repo.git", { kind: "credentialsFile" }, "default");
       expect(r!.authedUrl).toContain("x-access-token:glpat_xyz@");
       expect(r!.appliedAuth).toBe("stored_pat");
     });
@@ -255,8 +255,8 @@ describe("authedCloneUrl", () => {
           label: "GitLab PAT",
         },
       };
-      writeCredentials(creds);
-      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" });
+      writeCredentials("default", creds);
+      const r = authedCloneUrl("https://github.com/owner/repo.git", { kind: "credentialsFile" }, "default");
       expect(r!.appliedAuth).toBe("none");
     });
   });

--- a/src/mirror-import.ts
+++ b/src/mirror-import.ts
@@ -209,6 +209,8 @@ export class CloneFailedError extends Error {
  *   - `credentialsFile` → if stored creds are GitHub OAuth, embed the
  *     token. If stored creds are a PAT with a saved URL whose host
  *     matches, reuse the stored URL. Otherwise pass the URL verbatim.
+ *     The stored creds are read from the target vault's PER-VAULT file
+ *     (vault#399) — `vaultName` is required for this auth kind.
  *   - `none` → return the URL verbatim.
  *
  * Returns `null` when the URL is unparseable (caller surfaces a 400).
@@ -216,6 +218,7 @@ export class CloneFailedError extends Error {
 export function authedCloneUrl(
   remoteUrl: string,
   auth: ImportAuth,
+  vaultName: string,
 ): { authedUrl: string; appliedAuth: "stored_oauth" | "stored_pat" | "per_call_pat" | "none" } | null {
   // Local-path / SSH-shorthand pass-through. Git accepts three URL shapes:
   //   - HTTPS/HTTP — what we embed auth into below.
@@ -267,8 +270,8 @@ export function authedCloneUrl(
     return { authedUrl: u.toString(), appliedAuth: "per_call_pat" };
   }
 
-  // credentialsFile path — read from disk.
-  const creds = readCredentials();
+  // credentialsFile path — read the target vault's per-vault creds (vault#399).
+  const creds = readCredentials(vaultName);
   if (!creds || !creds.active_method) {
     return { authedUrl: remoteUrl, appliedAuth: "none" };
   }
@@ -372,7 +375,7 @@ export async function cloneAndImport(opts: ImportOpts): Promise<ImportResult> {
   const workDirRoot = opts.workDirRoot ?? tmpdir();
   const cloneTimeoutMs = opts.cloneTimeoutMs ?? 60_000;
 
-  const authResult = authedCloneUrl(opts.remoteUrl, opts.auth);
+  const authResult = authedCloneUrl(opts.remoteUrl, opts.auth, opts.vaultName);
   if (!authResult) {
     inFlight.delete(opts.vaultName);
     throw new CloneFailedError(

--- a/src/mirror-manager.ts
+++ b/src/mirror-manager.ts
@@ -411,6 +411,15 @@ export class MirrorManager {
   }
 
   /**
+   * The vault this mirror manager belongs to. Credential reads/writes are
+   * per-vault (vault#399); route handlers thread this into the credential
+   * functions so they touch the right vault's `.mirror-credentials.yaml`.
+   */
+  getVaultName(): string {
+    return this.deps.vaultName;
+  }
+
+  /**
    * Read the current config snapshot. Returns a copy so callers can't
    * accidentally mutate the manager's internal state.
    */
@@ -963,7 +972,7 @@ export class MirrorManager {
    */
   private async applyCredentialsToRemote(repoDir: string): Promise<void> {
     try {
-      const creds = readCredentials();
+      const creds = readCredentials(this.deps.vaultName);
       if (!creds || !creds.active_method) {
         // No UI-configured credentials. Leave the remote alone — the
         // operator may have set one up via `git remote add` manually.

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -506,8 +506,8 @@ describe("auth credential routes — GET /auth", () => {
 
   test("returns fully-null sanitized shape when no credentials stored", async () => {
     home = tmp("mirror-auth-empty-");
-    makeManager(home);
-    const res = handleAuthGet();
+    const { manager } = makeManager(home);
+    const res = handleAuthGet(manager);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { active_method: null; github_oauth: null; pat: null };
     expect(body.active_method).toBeNull();
@@ -517,7 +517,7 @@ describe("auth credential routes — GET /auth", () => {
 
   test("returns sanitized shape when github_oauth credentials present (no token leaks)", async () => {
     home = tmp("mirror-auth-oauth-");
-    makeManager(home);
+    const { manager } = makeManager(home);
     const creds: MirrorCredentials = {
       active_method: "github_oauth",
       github_oauth: {
@@ -529,8 +529,8 @@ describe("auth credential routes — GET /auth", () => {
       },
       pat: null,
     };
-    writeCredentials(creds);
-    const res = handleAuthGet();
+    writeCredentials("default", creds);
+    const res = handleAuthGet(manager);
     expect(res.status).toBe(200);
     const text = await res.text();
     expect(text).not.toContain("gho_secret");
@@ -550,7 +550,7 @@ describe("auth credential routes — DELETE /auth", () => {
   test("wipes credentials from disk", async () => {
     home = tmp("mirror-auth-delete-");
     const { manager } = makeManager(home);
-    writeCredentials({
+    writeCredentials("default", {
       active_method: "pat",
       github_oauth: null,
       pat: {
@@ -559,10 +559,10 @@ describe("auth credential routes — DELETE /auth", () => {
         label: "test",
       },
     });
-    expect(fs.existsSync(mirrorCredentialsPath())).toBe(true);
+    expect(fs.existsSync(mirrorCredentialsPath("default"))).toBe(true);
     const res = await handleAuthDelete(manager);
     expect(res.status).toBe(200);
-    expect(fs.existsSync(mirrorCredentialsPath())).toBe(false);
+    expect(fs.existsSync(mirrorCredentialsPath("default"))).toBe(false);
   });
 
   test("idempotent — missing credentials file still 200", async () => {
@@ -686,7 +686,7 @@ describe("auth credential routes — device flow", () => {
     expect(grantBody.user.id).toBe(12345);
     // Credentials persisted; no token leak in response.
     expect(JSON.stringify(grantBody)).not.toContain("gho_real");
-    const saved = readCredentials();
+    const saved = readCredentials("default");
     expect(saved?.active_method).toBe("github_oauth");
     expect(saved?.github_oauth?.access_token).toBe("gho_real1234567890");
     expect(saved?.github_oauth?.user_login).toBe("aaron");
@@ -809,7 +809,7 @@ describe("auth credential routes — credential-save side-effects (Cuts 3 + 6)",
     // Seed github_oauth credentials. select-repo doesn't probe; it just
     // sets origin to github.com/<owner>/<repo>.git. We then rewrite
     // origin to our local bare repo so pushNow has somewhere to land.
-    writeCredentials({
+    writeCredentials("default", {
       active_method: "github_oauth",
       github_oauth: {
         access_token: "gho_fake1234567890abcd",
@@ -865,7 +865,7 @@ describe("auth credential routes — credential-save side-effects (Cuts 3 + 6)",
       auto_push: false,
     });
     await manager.start();
-    writeCredentials({
+    writeCredentials("default", {
       active_method: "github_oauth",
       github_oauth: {
         access_token: "gho_anothertoken12345",
@@ -943,15 +943,15 @@ describe("auth credential routes — github repos / create-repo", () => {
 
   test("repos returns 400 when not connected to GitHub", async () => {
     home = tmp("mirror-auth-repos-noauth-");
-    makeManager(home);
-    const res = await handleAuthGithubRepos();
+    const { manager } = makeManager(home);
+    const res = await handleAuthGithubRepos(manager);
     expect(res.status).toBe(400);
   });
 
   test("repos returns list when authed", async () => {
     home = tmp("mirror-auth-repos-ok-");
-    makeManager(home);
-    writeCredentials({
+    const { manager } = makeManager(home);
+    writeCredentials("default", {
       active_method: "github_oauth",
       github_oauth: {
         access_token: "gho_test1234567890",
@@ -979,7 +979,7 @@ describe("auth credential routes — github repos / create-repo", () => {
         ],
       },
     ]);
-    const res = await handleAuthGithubRepos(fetcher);
+    const res = await handleAuthGithubRepos(manager, fetcher);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { repos: Array<{ full_name: string }> };
     expect(body.repos).toHaveLength(1);
@@ -988,8 +988,8 @@ describe("auth credential routes — github repos / create-repo", () => {
 
   test("create-repo proxies through with mocked fetch", async () => {
     home = tmp("mirror-auth-create-repo-");
-    makeManager(home);
-    writeCredentials({
+    const { manager } = makeManager(home);
+    writeCredentials("default", {
       active_method: "github_oauth",
       github_oauth: {
         access_token: "gho_test1234567890",
@@ -1020,7 +1020,7 @@ describe("auth credential routes — github repos / create-repo", () => {
       method: "POST",
       body: JSON.stringify({ name: "new-vault" }),
     });
-    const res = await handleAuthGithubCreateRepo(req, fetcher);
+    const res = await handleAuthGithubCreateRepo(req, manager, fetcher);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { full_name: string };
     expect(body.full_name).toBe("aaron/new-vault");
@@ -1263,7 +1263,7 @@ describe("handleMirrorImport", () => {
     await bootstrapVault(home);
     fixture = await buildExportFixture();
     // Write a stored PAT credential matching github.com.
-    writeCredentials({
+    writeCredentials("default", {
       active_method: "pat",
       github_oauth: null,
       pat: {
@@ -1301,7 +1301,7 @@ describe("handleMirrorImport", () => {
     await bootstrapVault(home);
     fixture = await buildExportFixture();
     // Stored credentials should be IGNORED when per-call PAT is supplied.
-    writeCredentials({
+    writeCredentials("default", {
       active_method: "pat",
       github_oauth: null,
       pat: {

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -130,7 +130,9 @@ export async function handleMirrorPut(
     );
   }
 
-  const shape = validateMirrorConfigShape(body);
+  // Per-vault (vault#399): bind the auto_push/internal credential gate to
+  // the mirror-owning vault so it reads that vault's own credentials file.
+  const shape = validateMirrorConfigShape(body, { vaultName: manager.getVaultName() });
   if (!shape.ok) {
     return Response.json(
       {
@@ -456,7 +458,8 @@ export async function handleAuthGithubPoll(
       );
     }
     // Persist credentials. Keep any existing PAT — only swap active method.
-    const existing = readCredentials() ?? emptyCredentials();
+    const vaultName = manager.getVaultName();
+    const existing = readCredentials(vaultName) ?? emptyCredentials();
     const next: MirrorCredentials = {
       ...existing,
       active_method: "github_oauth",
@@ -469,7 +472,7 @@ export async function handleAuthGithubPoll(
       },
     };
     try {
-      writeCredentials(next);
+      writeCredentials(vaultName, next);
     } catch (err) {
       return Response.json(
         {
@@ -615,9 +618,12 @@ export async function handleAuthPat(
   }
 
   // Save the userinfo'd URL — that's what gets embedded as `origin` so
-  // bare `git push` works without needing GIT_ASKPASS etc.
+  // bare `git push` works without needing GIT_ASKPASS etc. Per-vault
+  // (vault#399): the PAT + remote_url land in this vault's own file, not a
+  // server-wide one — so configuring vault B never reuses vault A's remote.
+  const vaultName = manager.getVaultName();
   const next: MirrorCredentials = {
-    ...(readCredentials() ?? emptyCredentials()),
+    ...(readCredentials(vaultName) ?? emptyCredentials()),
     active_method: "pat",
     pat: {
       token,
@@ -626,7 +632,7 @@ export async function handleAuthPat(
     },
   };
   try {
-    writeCredentials(next);
+    writeCredentials(vaultName, next);
   } catch (err) {
     return Response.json(
       {
@@ -721,10 +727,11 @@ async function probeGitLsRemote(
 }
 
 /**
- * `GET /.parachute/mirror/auth` — connection status (no secrets).
+ * `GET /.parachute/mirror/auth` — connection status (no secrets). Reads the
+ * mirror-owning vault's per-vault credentials (vault#399).
  */
-export function handleAuthGet(): Response {
-  const creds = readCredentials();
+export function handleAuthGet(manager: MirrorManager): Response {
+  const creds = readCredentials(manager.getVaultName());
   return Response.json(sanitizeCredentials(creds), {
     headers: { "Access-Control-Allow-Origin": "*" },
   });
@@ -735,7 +742,7 @@ export function handleAuthGet(): Response {
  * remote URL on the mirror dir.
  */
 export async function handleAuthDelete(manager: MirrorManager): Promise<Response> {
-  deleteCredentials();
+  deleteCredentials(manager.getVaultName());
   // Strip origin from the mirror dir if one is set.
   const status = manager.getStatus();
   if (status.mirror_path) {
@@ -757,9 +764,10 @@ export async function handleAuthDelete(manager: MirrorManager): Promise<Response
  * the stored OAuth token. Requires `active_method === "github_oauth"`.
  */
 export async function handleAuthGithubRepos(
+  manager: MirrorManager,
   fetchImpl?: FetchLike,
 ): Promise<Response> {
-  const creds = readCredentials();
+  const creds = readCredentials(manager.getVaultName());
   if (!creds || creds.active_method !== "github_oauth" || !creds.github_oauth) {
     return Response.json(
       {
@@ -794,9 +802,10 @@ export async function handleAuthGithubRepos(
  */
 export async function handleAuthGithubCreateRepo(
   req: Request,
+  manager: MirrorManager,
   fetchImpl?: FetchLike,
 ): Promise<Response> {
-  const creds = readCredentials();
+  const creds = readCredentials(manager.getVaultName());
   if (!creds || creds.active_method !== "github_oauth" || !creds.github_oauth) {
     return Response.json(
       {
@@ -849,7 +858,7 @@ export async function handleAuthGithubSelectRepo(
   req: Request,
   manager: MirrorManager,
 ): Promise<Response> {
-  const creds = readCredentials();
+  const creds = readCredentials(manager.getVaultName());
   if (!creds || creds.active_method !== "github_oauth" || !creds.github_oauth) {
     return Response.json(
       {
@@ -1023,7 +1032,7 @@ export async function applyCredentialsToMirror(
 ): Promise<void> {
   const status = manager.getStatus();
   if (!status.mirror_path) return;
-  const creds = readCredentials();
+  const creds = readCredentials(manager.getVaultName());
   if (!creds || !creds.active_method) {
     await unsetGitRemote(status.mirror_path);
     return;

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -644,7 +644,7 @@ export async function route(
     }
 
     if (subpath === "/.parachute/mirror/auth") {
-      if (req.method === "GET") return handleAuthGet();
+      if (req.method === "GET") return handleAuthGet(manager);
       if (req.method === "DELETE") return handleAuthDelete(manager);
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
@@ -657,11 +657,11 @@ export async function route(
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
     if (subpath === "/.parachute/mirror/auth/github/repos") {
-      if (req.method === "GET") return handleAuthGithubRepos();
+      if (req.method === "GET") return handleAuthGithubRepos(manager);
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
     if (subpath === "/.parachute/mirror/auth/github/create-repo") {
-      if (req.method === "POST") return handleAuthGithubCreateRepo(req);
+      if (req.method === "POST") return handleAuthGithubCreateRepo(req, manager);
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
     if (subpath === "/.parachute/mirror/auth/github/select-repo") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import { resolveBindHostname } from "./bind.ts";
 import { MirrorManager } from "./mirror-manager.ts";
 import { setMirrorManager } from "./mirror-registry.ts";
 import { buildMirrorDeps, resolveMirrorVaultName } from "./mirror-deps.ts";
+import { migrateLegacyServerWideCredentials } from "./mirror-credentials.ts";
 import { selfRegister } from "./self-register.ts";
 import pkg from "../package.json" with { type: "json" };
 
@@ -249,6 +250,22 @@ let mirrorManager: MirrorManager | null = null;
   // exactly one place; multi-vault-mirror work (design-doc open
   // question 2) only has to touch one site.
   const mirrorVaultName = resolveMirrorVaultName(listVaults);
+  // vault#399: migrate the legacy SERVER-WIDE credentials file
+  // (`<configDir>/vault/.mirror-credentials.yaml`) to the per-vault layout.
+  // Attribute to the mirror-owning vault (default_vault → first listed) —
+  // the same vault the single server-wide mirror was bound to, so the
+  // legacy remote/PAT lands on the vault it actually corresponds to. Other
+  // vaults start with no mirror credentials (configure each separately).
+  // Idempotent + safe: no-op when no legacy file / already migrated, and the
+  // legacy file is renamed `.bak` rather than deleted. Runs even when no
+  // vault exists yet (no-op) so we don't gate the migration on enabled state.
+  try {
+    migrateLegacyServerWideCredentials(mirrorVaultName);
+  } catch (err) {
+    console.warn(
+      `[mirror] legacy credential migration failed (non-fatal): ${(err as Error).message ?? err}`,
+    );
+  }
   if (mirrorVaultName) {
     try {
       mirrorManager = new MirrorManager(buildMirrorDeps(mirrorVaultName));


### PR DESCRIPTION
## The bug (Aaron hit it live, 2026-05-28)

Git-sync / mirror credentials were **server-wide, not per-vault**.
`mirrorCredentialsPath()` returned a single
`<configDir>/vault/.mirror-credentials.yaml` shared across ALL vaults, and
`readCredentials()`/`writeCredentials()` took no vault name. So both the
**PAT** and the **`remote_url`** were global: setting up git sync for a
second vault reused the first vault's remote, pointing vault B at vault A's
GitHub repo. Each vault must have its own remote URL and its own PAT.

## Storage-model map (pre-fix)

| Piece | Where | Scope |
|---|---|---|
| Mirror **credentials** (PAT + embedded `remote_url`) | `<configDir>/vault/.mirror-credentials.yaml` (`mirror-credentials.ts:154`) | **server-wide** — the bug |
| Mirror **config** (`enabled`, `location`, `external_path`, `sync_mode`, `auto_commit`, `auto_push`, …) | `mirror:` block in `<configDir>/vault/config.yaml` (`mirror-config.ts`) | server-wide (one mirror per server today; not the leak) |
| Mirror **git working dir** (the dir that gets `git remote set-url origin`) | internal → `<vaultDataDir>/mirror` via `resolveMirrorPath` (`mirror-config.ts:336`); external → operator path | **already per-vault** — confirmed not shared |
| Manager singleton | one per server, bound to `resolveMirrorVaultName()` (default-or-first vault) (`mirror-deps.ts:119`) | per-server |

Routes are `/vault/<name>/.parachute/mirror/*` and had `vaultName` in scope,
but every credential handler called `readCredentials()`/`writeCredentials()`
without it → the same server-wide file regardless of which vault's URL was hit.

There was **no per-vault config surface** for `remote_url` — it lived only in
the credentials file. The fix puts the whole credential record (PAT + URL)
per-vault rather than splitting it.

## The fix — per-vault credentials file

Matches the existing per-vault-state pattern (each vault already owns its
SQLite DB + vault.yaml under `<configDir>/vault/data/<vaultName>/`):

- New layout: `<configDir>/vault/data/<vaultName>/.mirror-credentials.yaml` (0600).
- `mirrorCredentialsPath(vaultName)`, `readCredentials(vaultName)`,
  `writeCredentials(vaultName, creds)`, `deleteCredentials(vaultName)`.
- `vaultName` threaded through every call site:
  - `MirrorManager` via `deps.vaultName`, exposed as `getVaultName()`
    (`applyCredentialsToRemote` reads the right vault).
  - all `mirror-routes.ts` handlers (`handleAuthGet/Delete/Pat/GithubPoll/
    Repos/CreateRepo/SelectRepo`, `applyCredentialsToMirror`) derive
    `vaultName` from `manager.getVaultName()`.
  - import path `authedCloneUrl(remoteUrl, auth, vaultName)` (credentialsFile branch).
  - `validateMirrorConfigShape(body, { vaultName })` for the
    `auto_push + internal` credential gate.
- Mirror git working dir was already per-vault — left as-is.
- API response shapes unchanged (same `sanitizeCredentials` output) → no SPA change.

## Migration (Aaron has live data)

On boot, `migrateLegacyServerWideCredentials(targetVaultName)` runs in
`server.ts`:

- Attributes the legacy server-wide file to the **mirror-owning vault**
  (`resolveMirrorVaultName` → default-or-first — the same vault the single
  server-wide mirror was bound to, i.e. the vault the legacy remote/PAT
  actually corresponds to).
- **Does NOT** copy the same remote/PAT onto every vault (that would recreate
  the bug). Other vaults start with no mirror credentials — configure each
  separately.
- Legacy file preserved as `.mirror-credentials.yaml.bak`, never deleted.
- Idempotent + safe: no-op when no legacy file / already migrated / the target
  vault already has its own per-vault file (won't clobber).

## Tests + gates

- New unit/integration tests: two vaults with different remotes + PATs don't
  bleed; reading vault A never returns vault B's; migration → first vault,
  others empty, `.bak` preserved, idempotent, no-clobber.
- `bun test ./src/` → **1253 pass / 0 fail**.
- `bun test ./core/src/` → **610 pass / 0 fail**.
- `bun run typecheck` → clean.

## Sandbox E2E (fresh `PARACHUTE_HOME`, never Aaron's live `~/.parachute`)

Two vaults (`alpha`, `beta`) configured with DIFFERENT remotes + PATs via the
route path (`writeCredentials` + `applyCredentialsToMirror`, the exact steps
`handleAuthPat` runs), each with its own mirror git dir:

```
alpha origin: https://x-access-token:tokenAAAAAAAAAA@github.com/aaron/vault-a.git
beta  origin: https://x-access-token:tokenBBBBBBBBBB@github.com/aaron/vault-b.git

PASS: alpha stored creds = vault-a remote
PASS: beta stored creds = vault-b remote
PASS: alpha does NOT see vault-b remote
PASS: beta does NOT see vault-a remote
PASS: stored tokens distinct (no bleed)
PASS: alpha git origin = vault-a (not shared)
PASS: beta git origin = vault-b (not shared)
PASS: the two mirror git dirs have DIFFERENT origins
PASS: GET /auth alpha shows vault-a (redacted)  /  beta shows vault-b
PASS: GET /auth alpha redacts the token

migration: legacy server-wide → vault "alpha" (first), beta stays empty
PASS: legacy attributed to FIRST vault (alpha)
PASS: OTHER vault (beta) starts EMPTY — leak not recreated
PASS: legacy file preserved as .bak, not lost
```

No version/rc bump (per governance, rc bumps happen at release time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)