### PR TITLE
feat(vault): enforce tag-scoping from hub-JWT permissions claim (C0) — consume scope-guard 0.4.0-rc.2 native permissions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "parachute-vault",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@openparachute/scope-guard": "^0.3.0",
+        "@openparachute/scope-guard": "^0.4.0-rc.2",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode-terminal": "^0.12.0",
@@ -26,7 +26,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
-    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.3.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-3ZDgPGEeC5YDmXcZmby2+Kq8g7DozYNEQdfMMquGWEZ5h9aea4DmW1zbJ13XyeMT7U1GoXmHze4Ujjy5fz0GGg=="],
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.4.0-rc.2", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-QIEnQyYDLEuf9rueE7c0P5Mycnk0ZLybjsFWNuC82VVhGsQJs7EQygrVODsB3qFe1VYmYLKrf2Ca7otjDZLXBg=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@openparachute/scope-guard": "^0.3.0",
+    "@openparachute/scope-guard": "^0.4.0-rc.2",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode-terminal": "^0.12.0"

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -105,6 +105,13 @@ interface SignOpts {
    * a hub-minted admin token; provide `["<name>"]` for a non-admin user.
    */
   vaultScope?: string[];
+  /**
+   * `permissions` claim (auth-unification arc, C0). Undefined → omit
+   * entirely (today's hub-JWT shape → unscoped). Provide
+   * `{ scoped_tags: [...] }` for a tag-scoped token, or a deliberately
+   * malformed value to exercise the fail-closed path.
+   */
+  permissions?: unknown;
 }
 
 async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
@@ -115,6 +122,7 @@ async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
     client_id: "test-client",
   };
   if (opts.vaultScope !== undefined) payload.vault_scope = opts.vaultScope;
+  if (opts.permissions !== undefined) payload.permissions = opts.permissions;
   return await new SignJWT(payload)
     .setProtectedHeader({ alg: "RS256", kid: kp.kid })
     .setIssuer(opts.iss)
@@ -517,4 +525,143 @@ describe("authenticateVaultRequest — hub JWT integration", () => {
       warnSpy.mockRestore();
     }
   });
+});
+
+describe("authenticateVaultRequest — hub JWT tag-scoping (auth-unification C0)", () => {
+  // Helper: pull a successful AuthResult out of authenticateVaultRequest,
+  // failing the test loudly if auth returned an error Response.
+  async function authOk(
+    token: string,
+    vaultName: string,
+  ): Promise<import("./auth.ts").AuthResult> {
+    const config = readVaultConfig(vaultName)!;
+    const store = getVaultStore(vaultName);
+    const result = await authenticateVaultRequest(bearer(token), config, store.db);
+    if ("error" in result) {
+      const body = await result.error.json();
+      throw new Error(`expected AuthResult, got ${result.error.status}: ${JSON.stringify(body)}`);
+    }
+    return result;
+  }
+
+  test("permissions.scoped_tags:[health] → AuthResult.scoped_tags=[health]; query-notes enforces (health visible, work hidden)", async () => {
+    seedVault("journal");
+    const store = getVaultStore("journal");
+    // Seed two notes: one tagged health, one tagged work.
+    await store.createNote("blood pressure log", { path: "h1", tags: ["health"] });
+    await store.createNote("quarterly OKRs", { path: "w1", tags: ["work"] });
+
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:read",
+      permissions: { scoped_tags: ["health"] },
+    });
+
+    const auth = await authOk(token, "journal");
+    // The READ side: the allowlist is lifted off the validated token.
+    expect(auth.scoped_tags).toEqual(["health"]);
+
+    // End-to-end enforcement: the tag-scope-wrapped query-notes tool must
+    // hide the `work` note and surface the `health` note.
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const tools = generateScopedMcpTools("journal", auth);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = (await query.execute({})) as any;
+    const notes = Array.isArray(result) ? result : result.notes;
+    const paths = notes.map((n: any) => n.path).sort();
+    expect(paths).toEqual(["h1"]);
+    expect(paths).not.toContain("w1");
+  });
+
+  test("no permissions claim → scoped_tags=null (unscoped, full vault — regression: unchanged)", async () => {
+    seedVault("journal");
+    const store = getVaultStore("journal");
+    await store.createNote("a", { path: "h1", tags: ["health"] });
+    await store.createNote("b", { path: "w1", tags: ["work"] });
+
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:read",
+      // permissions intentionally omitted — today's hub-JWT shape
+    });
+
+    const auth = await authOk(token, "journal");
+    expect(auth.scoped_tags).toBeNull();
+
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const tools = generateScopedMcpTools("journal", auth);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = (await query.execute({})) as any;
+    const notes = Array.isArray(result) ? result : result.notes;
+    const paths = notes.map((n: any) => n.path).sort();
+    // Unscoped: BOTH notes visible.
+    expect(paths).toEqual(["h1", "w1"]);
+  });
+
+  test("permissions present but scoped_tags absent → scoped_tags=null (unscoped)", async () => {
+    seedVault("journal");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:read",
+      permissions: { some_other_perm: true },
+    });
+    const auth = await authOk(token, "journal");
+    expect(auth.scoped_tags).toBeNull();
+  });
+
+  test("permissions.scoped_tags:null → scoped_tags=null (explicit unscoped)", async () => {
+    seedVault("journal");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:read",
+      permissions: { scoped_tags: null },
+    });
+    const auth = await authOk(token, "journal");
+    expect(auth.scoped_tags).toBeNull();
+  });
+
+  // ---- Fail-closed cases: present-but-malformed scoped_tags MUST 401, ----
+  // ---- never silently widen to full-vault. ----
+  for (const [label, badValue] of [
+    ["a string", "health"],
+    ["a number", 42],
+    ["an object", { health: true }],
+    ["an array with a non-string", ["health", 5]],
+    ["an array with an empty string", ["health", ""]],
+    ["an empty array", []],
+  ] as Array<[string, unknown]>) {
+    test(`malformed scoped_tags (${label}) → 401 fail-closed (does NOT widen to full vault)`, async () => {
+      seedVault("journal");
+      const token = await signJwt(kp, {
+        iss: fixture.origin,
+        aud: "vault.journal",
+        scope: "vault:journal:read",
+        permissions: { scoped_tags: badValue },
+      });
+      const config = readVaultConfig("journal")!;
+      const store = getVaultStore("journal");
+
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const result = await authenticateVaultRequest(bearer(token), config, store.db);
+        // The whole request is rejected — NOT served with scoped_tags=null
+        // (full vault) or scoped_tags=[] (also full vault on the MCP path).
+        expect("error" in result).toBe(true);
+        if ("error" in result) {
+          expect(result.error.status).toBe(401);
+          const body = (await result.error.json()) as { error: string; message: string };
+          expect(body.error).toBe("Unauthorized");
+          expect(body.message).toContain("malformed tag-scope");
+        }
+        // Audit log carries the diagnostic.
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  }
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -332,6 +332,75 @@ export async function authenticateVaultRequest(
 }
 
 /**
+ * Sentinel thrown when a hub JWT carries a `permissions.scoped_tags` claim
+ * that is present but malformed (not an array of non-empty strings). See
+ * `parseScopedTagsFromPermissions` for why this MUST fail closed.
+ */
+class MalformedScopedTagsError extends Error {}
+
+/**
+ * Map a validated hub JWT's `permissions` claim into the `scoped_tags`
+ * allowlist for `AuthResult` (auth-unification arc, C0 — the READ side).
+ *
+ * Wire contract (the shape the SPA + manage-token mint sides target):
+ *
+ *   permissions: { scoped_tags: string[] }   // root tag names
+ *
+ * Same semantics as the deprecated `pvt_*` `scoped_tags` DB column: each
+ * entry is a ROOT tag name; the token sees notes carrying that tag or a
+ * sub-tag thereof (hierarchy expansion happens in tag-scope.ts).
+ *
+ * Three outcomes, chosen for a strict FAIL-CLOSED invariant — tag-scoping is
+ * always a RESTRICTION, so a misread must NEVER widen access:
+ *
+ *   1. Claim absent (no `permissions`, or no `scoped_tags` key) → returns
+ *      `null` = UNSCOPED = full vault. This is legitimate and is today's
+ *      behavior for every hub JWT. Absence genuinely means "not tag-scoped".
+ *
+ *   2. `scoped_tags` is a non-empty array of non-empty strings → returns
+ *      that array. The token is tag-scoped; the allowlist is enforced.
+ *
+ *   3. `scoped_tags` is present but MALFORMED — a string, a number, an
+ *      object, an array containing a non-string / empty-string, or an empty
+ *      array `[]` — throws `MalformedScopedTagsError`. The caller REJECTS
+ *      the request (401). We do NOT coerce to `null` or `[]`:
+ *
+ *      - Coercing to `null` would WIDEN a token that was MEANT to be scoped
+ *        up to full-vault — a privilege leak. Forbidden.
+ *      - Coercing to `[]` is NOT reliably fail-closed across enforcement
+ *        paths. The MCP read-tool wrappers fast-path out on
+ *        `scoped_tags.length === 0` (mcp-tools.ts ~L178) and the REST path
+ *        collapses `[]` → null inside `expandTokenTagScope` (tag-scope.ts
+ *        ~L35) — both treat `[]` as UNSCOPED = full vault. So `[]` would
+ *        ALSO widen. (Note: `filterNotesByTagScope`/`noteWithinTagScope`
+ *        would treat a raw `[]` as "matches nothing", but the call sites
+ *        never reach them with `[]` because of the upstream short-circuits —
+ *        the two enforcement paths disagree on `[]`, which is exactly why we
+ *        refuse to manufacture it here.)
+ *
+ *      The only correct fail-closed action for a present-but-unreadable
+ *      scope is to reject the whole request — never serve it wide.
+ */
+function parseScopedTagsFromPermissions(
+  permissions: Record<string, unknown> | undefined,
+): string[] | null {
+  if (!permissions || !("scoped_tags" in permissions)) return null;
+  const raw = permissions.scoped_tags;
+  if (raw === null || raw === undefined) return null; // explicit "unscoped"
+  if (
+    Array.isArray(raw) &&
+    raw.length > 0 &&
+    raw.every((t) => typeof t === "string" && t.length > 0)
+  ) {
+    return raw as string[];
+  }
+  // Present but malformed (incl. `[]`): fail closed — never widen.
+  throw new MalformedScopedTagsError(
+    "hub JWT permissions.scoped_tags is present but not a non-empty array of tag names",
+  );
+}
+
+/**
  * Validate a JWT-shaped bearer and convert the result into an `AuthResult`.
  * The token's scope claim becomes the granted scopes; permission is derived
  * for back-compat with code paths that still branch on `permission` (MCP
@@ -353,6 +422,12 @@ export async function authenticateVaultRequest(
  * unchanged. The 403 (not 401) signals "your credential is valid but
  * doesn't grant access to this vault" — distinct from authentication
  * failures upstream. See hub#283 + scope-guard 0.3.0 for the mint side.
+ *
+ * Tag-scoping (auth-unification arc, C0): the token's `permissions.scoped_tags`
+ * claim (when present and well-formed) maps into `AuthResult.scoped_tags`,
+ * restricting which notes the token sees. A present-but-malformed claim FAILS
+ * CLOSED with a 401 rather than widening to full-vault — see
+ * `parseScopedTagsFromPermissions`.
  */
 async function authenticateHubJwt(
   token: string,
@@ -413,11 +488,15 @@ async function authenticateHubJwt(
       hasScope(claims.scopes, SCOPE_WRITE) || hasScope(claims.scopes, SCOPE_ADMIN)
         ? "full"
         : "read";
+    // C0: read tag-scoping from the validated token's `permissions` claim.
+    // Throws MalformedScopedTagsError (caught below → 401) on a present-but-
+    // malformed claim so we never widen access on a misread.
+    const scoped_tags = parseScopedTagsFromPermissions(claims.permissions);
     return {
       permission,
       scopes: claims.scopes,
       legacyDerived: false,
-      scoped_tags: null,
+      scoped_tags,
       vault_name: null,
       // claims.jti is `undefined` when the issuer didn't stamp one. Pass it
       // through verbatim — manage-token's session-pin will be null in that
@@ -425,6 +504,19 @@ async function authenticateHubJwt(
       caller_jti: claims.jti ?? null,
     };
   } catch (err) {
+    if (err instanceof MalformedScopedTagsError) {
+      // Fail-closed (C0): a present-but-malformed `permissions.scoped_tags`
+      // means the token wanted to be tag-scoped but we can't read the
+      // allowlist. Reject rather than widen to full-vault. The audit log
+      // carries the diagnostic; the client gets a generic 401.
+      console.warn(`[auth] hub JWT rejected: ${err.message}`);
+      return {
+        error: Response.json(
+          { error: "Unauthorized", message: "token has a malformed tag-scope claim" },
+          { status: 401 },
+        ),
+      };
+    }
     if (err instanceof HubJwtError) {
       // Revocation-related codes get sanitized client messages: server-side
       // audit log carries the full diagnostic (jti for `revoked`,

--- a/src/hub-jwt.test.ts
+++ b/src/hub-jwt.test.ts
@@ -87,15 +87,19 @@ interface SignOpts {
   expiresAtSeconds?: number;
   omitKid?: boolean;
   kid?: string;
+  /** `permissions` claim (auth-unification C0). Undefined → omit. */
+  permissions?: unknown;
 }
 
 async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
   const iat = Math.floor(Date.now() / 1000);
   const exp = opts.expiresAtSeconds ?? iat + (opts.ttlSeconds ?? 60);
-  const builder = new SignJWT({
+  const claims: Record<string, unknown> = {
     scope: opts.scope ?? "vault:read vault:write",
     client_id: opts.clientId ?? "test-client",
-  })
+  };
+  if (opts.permissions !== undefined) claims.permissions = opts.permissions;
+  const builder = new SignJWT(claims)
     .setProtectedHeader(opts.omitKid ? { alg: "RS256" } : { alg: "RS256", kid: opts.kid ?? kp.kid })
     .setIssuer(opts.iss ?? "http://issuer.invalid")
     .setSubject(opts.sub ?? "user-1")
@@ -186,6 +190,27 @@ describe("validateHubJwt — happy path", () => {
     const token = await signJwt(kp, { iss: fixture.origin, aud: "vault.work" });
     const claims = await validateHubJwt(token, { expectedAudience: "vault.work" });
     expect(claims.aud).toBe("vault.work");
+  });
+
+  test("permissions claim surfaces on the validated result (C0)", async () => {
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      permissions: { scoped_tags: ["health", "finance"] },
+    });
+    const claims = await validateHubJwt(token);
+    expect(claims.permissions).toEqual({ scoped_tags: ["health", "finance"] });
+  });
+
+  test("no permissions claim → permissions is undefined", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin });
+    const claims = await validateHubJwt(token);
+    expect(claims.permissions).toBeUndefined();
+  });
+
+  test("non-object permissions claim → permissions is undefined (not surfaced)", async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, permissions: "not-an-object" });
+    const claims = await validateHubJwt(token);
+    expect(claims.permissions).toBeUndefined();
   });
 });
 

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -59,6 +59,16 @@ const guard = createScopeGuard({ hubOrigin: () => getHubOrigin() });
  * Scope-shape policy (e.g. "hub-issued tokens may not carry broad
  * `vault:<verb>` scopes") is enforced one layer up in `authenticateHubJwt`,
  * not here — this function stays focused on JWT-level concerns.
+ *
+ * The returned `HubJwtClaims` carries the native `permissions` claim
+ * (scope-guard ≥0.4.0-rc.2 parses + surfaces it; `undefined` when absent or
+ * not a JSON object). Tag-scope enforcement reads `permissions.scoped_tags`
+ * in `authenticateHubJwt` — see auth-unification arc C0.
+ *
+ * jti policy: scope-guard's `createScopeGuard` defaults `allowMissingJti:
+ * false` (per hub#218 / scope-guard #322), so a hub JWT lacking a `jti`
+ * claim is rejected here. Vault doesn't opt out — every hub mint stamps a
+ * jti, and revocation can't be enforced on tokens we can't index.
  */
 export async function validateHubJwt(
   token: string,


### PR DESCRIPTION
Auth-unification arc, **C0** — the READ side of hub-JWT tag-scoping.

## What & why

Today vault hard-codes `scoped_tags: null` for every hub JWT (`authenticateHubJwt`), so a hub-minted token always sees the whole vault; tag-scoped tokens were only possible via the deprecated `pvt_*` DB column. Hub's `mint-token` already accepts and embeds a `permissions` claim (the mint side exists). This PR is the READ side: vault now reads `permissions.scoped_tags` and enforces it. This unblocks retiring `pvt_*` — the SPA tokens page + manage-token need tag-scoped HUB JWTs.

## Approach: consume scope-guard 0.4.0-rc.2's native `permissions` claim

scope-guard **0.4.0-rc.2** (published) parses and surfaces the `permissions` claim natively on `HubJwtClaims` (`permissions?: Record<string, unknown>`, `undefined` when absent or non-object). So vault reads `claims.permissions` directly off `guard.validateHubJwt` — no vault-side JWT-payload decode. (An earlier revision of this PR did a local payload decode as a workaround; that's now removed in favour of the native field.)

- **`package.json`** — bumped `@openparachute/scope-guard` `^0.3.0` → `^0.4.0-rc.2`; lockfile + node_modules updated.
- **`src/hub-jwt.ts`** — removed the manual `decodeJwtPayload` + `HubJwtClaimsWithPermissions`; the `validateHubJwt` wrapper returns scope-guard's `HubJwtClaims` (now carrying native `permissions`).
- **`src/auth.ts`** — `authenticateHubJwt` calls `parseScopedTagsFromPermissions(claims.permissions)` (unchanged logic; only the SOURCE of `permissions` changed — native claim vs decode) and maps it into `AuthResult.scoped_tags`.

## jti-required adoption (from the dep bump) — verified safe

The 0.3.0 → 0.4.0-rc.2 bump also adopts scope-guard's **jti-required hardening** (#322, landed 0.4.0-rc.1): `createScopeGuard` defaults `allowMissingJti: false`, so a hub JWT lacking a `jti` claim is now rejected. Verified this does NOT regress vault:
- **Production path is fine** — every hub mint stamps a jti; vault doesn't opt out of strict rejection (revocation can't be enforced on tokens we can't index).
- **No test fixture lags** — all three test files that hand-mint JWTs (`hub-jwt.test.ts`, `auth-hub-jwt.test.ts`, `tokens-routes.test.ts`) already stamp a jti in their shared `signJwt` helper. The full suite is green with **zero fixture changes**.

## Fail-closed decision (malformed claims) — unchanged

Tag-scoping is always a **restriction**; a misread must never **widen** access. Three outcomes:

- **Absent / null** `scoped_tags` → `null` = unscoped = full vault. Legitimate; today's behavior, unchanged.
- **Non-empty array of non-empty strings** → enforce that allowlist.
- **Present but malformed** (a string, number, object, empty array `[]`, or array containing a non-string/empty-string) → **401, fail closed**. We deliberately do NOT coerce to `null` or `[]`:
  - `null` would widen a meant-to-be-scoped token to full-vault — a privilege leak.
  - `[]` is **not** reliably fail-closed: the MCP read-tool wrappers fast-path out on `scoped_tags.length === 0` (`src/mcp-tools.ts` ~L178) and the REST path collapses `[]` → null inside `expandTokenTagScope` (`src/tag-scope.ts` L35) — **both treat `[]` as unscoped = full vault**.

  Rejecting the whole request is the only correct fail-closed action for a present-but-unreadable scope.

## Wire contract

```
permissions: { scoped_tags: string[] }   // root tag names
```

Same semantics as the deprecated `pvt_*` `scoped_tags` column. This is the contract the SPA + manage-token mint sides target (a later PR).

## Follow-up #402 — RESOLVED by this approach

#402 (scope-guard: surface `permissions` on HubJwtClaims, replacing the vault-side decode) is now **resolved** by consuming the native 0.4.0-rc.2 field. It will be closed on merge.

## Tests (unchanged from the C0 suite; now exercised against the native source)

- hub JWT `permissions: {scoped_tags: ["health"]}` → `AuthResult.scoped_tags=["health"]`; `query-notes` end-to-end hides a `work` note, surfaces a `health` note.
- no `permissions` claim → `scoped_tags=null` → full vault (regression).
- `permissions` present but `scoped_tags` absent / `scoped_tags: null` → unscoped null.
- malformed `scoped_tags` (string, number, object, array-with-non-string, array-with-empty-string, empty array) → 401 fail-closed.
- `hub-jwt.test.ts`: native `permissions` surfaces on the validated result; absent/non-object → `undefined`.

Gates: `bun test ./src/` **1266 pass / 0 fail**; `bun test ./core/src/` **610 pass / 0 fail**; `bun run typecheck` clean.

No version/rc bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)