### PR TITLE
feat(vault): manage-token MCP mints hub JWTs via attenuation proxy (retire pvt_* mint path)

### DIFF
--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { normalizePath } from "./paths.js";
 import { rebuildIndexes } from "./indexed-fields.js";
 
-export const SCHEMA_VERSION = 19;
+export const SCHEMA_VERSION = 20;
 
 export const SCHEMA_SQL = `
 -- Notes: the universal record.
@@ -149,6 +149,30 @@ CREATE TABLE IF NOT EXISTS tokens (
   revoked_at TEXT
 );
 
+-- mcp_mint_ledger (v20) — session-pinned record of HUB JWTs minted by the
+-- manage-token MCP tool (vault#403, MGT). After the auth-unification arc,
+-- manage-token mints hub JWTs (via hub mint-token attenuation proxy), not
+-- pvt_* vault-DB tokens — so the mints no longer live in the tokens table.
+-- This ledger is a lightweight local index of (parent_jti to minted hub jti)
+-- so the tool list/revoke surface can stay session-scoped: a session sees
+-- and revokes only the hub JWTs it minted. Rows are NOT credentials — the
+-- signed JWT is never stored, only its jti (the revocation handle) plus
+-- display metadata. revoked_at mirrors the tokens-table soft-revoke marker
+-- so a second revoke is idempotent even if the hub round-trip is skipped.
+-- The authoritative revocation state lives in hub token registry; this is
+-- the attribution index only.
+CREATE TABLE IF NOT EXISTS mcp_mint_ledger (
+  jti TEXT PRIMARY KEY,
+  parent_jti TEXT NOT NULL,
+  vault_name TEXT NOT NULL,
+  label TEXT NOT NULL,
+  scopes TEXT,
+  scoped_tags TEXT,
+  created_at TEXT NOT NULL,
+  expires_at TEXT,
+  revoked_at TEXT
+);
+
 -- OAuth: registered clients (Dynamic Client Registration)
 -- VESTIGIAL after vault 0.4.x workstream E (2026-05-25). The standalone
 -- OAuth issuer that wrote these rows was retired (hub is the issuer now;
@@ -214,6 +238,10 @@ CREATE INDEX IF NOT EXISTS idx_note_tags_tag ON note_tags(tag_name, note_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_note ON attachments(note_id);
 CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_id);
 CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_id);
+-- Session-pinned manage-token ledger lookup (v20): list/revoke scope on
+-- (parent_jti, vault_name). The mcp_mint_ledger table is created
+-- unconditionally above, so this index is safe in SCHEMA_SQL.
+CREATE INDEX IF NOT EXISTS idx_mcp_mint_ledger_session ON mcp_mint_ledger(parent_jti, vault_name);
 -- idx_tokens_vault_name is created in migrateToV16, not here. SCHEMA_SQL
 -- runs BEFORE migrations; an upgrading v15 vault doesn't yet have the
 -- vault_name column when this section evaluates, so the index has to
@@ -402,6 +430,13 @@ export function initSchema(db: Database): void {
   // All three are nullable; existing rows backfill to NULL which means
   // "non-MCP-minted, not revoked" — identical pre-v19 semantics.
   migrateToV19(db);
+
+  // Migrate v19 → v20: the `mcp_mint_ledger` table (session-pinned record of
+  // hub JWTs minted by the manage-token MCP tool). Created by SCHEMA_SQL's
+  // `CREATE TABLE IF NOT EXISTS` above, so this is a no-op confirmation hook
+  // — present for symmetry with the other migration steps and to anchor the
+  // version bump. See vault#403 (MGT — manage-token mints hub JWTs).
+  migrateToV20(db);
 
   // Rebuild any generated columns + indexes declared in indexed_fields.
   // No-op for a fresh vault; idempotent on existing vaults.
@@ -999,6 +1034,34 @@ function migrateToV19(db: Database): void {
       db.exec(`ALTER TABLE tokens ADD COLUMN ${col} ${type}`);
     }
   }
+}
+
+/**
+ * Migrate v19 → v20: ensure the `mcp_mint_ledger` table exists. SCHEMA_SQL's
+ * `CREATE TABLE IF NOT EXISTS` already covers fresh vaults AND upgrading
+ * vaults (SCHEMA_SQL runs unconditionally on every open before the migration
+ * steps), so this is a defensive no-op confirmation — there is no ALTER to
+ * perform. Kept as a named step so the version-bump arc reads cleanly and a
+ * future column addition has an obvious home. See vault#403 (MGT).
+ */
+function migrateToV20(db: Database): void {
+  if (hasTable(db, "mcp_mint_ledger")) return;
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS mcp_mint_ledger (
+      jti TEXT PRIMARY KEY,
+      parent_jti TEXT NOT NULL,
+      vault_name TEXT NOT NULL,
+      label TEXT NOT NULL,
+      scopes TEXT,
+      scoped_tags TEXT,
+      created_at TEXT NOT NULL,
+      expires_at TEXT,
+      revoked_at TEXT
+    )
+  `);
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_mcp_mint_ledger_session ON mcp_mint_ledger(parent_jti, vault_name)",
+  );
 }
 
 function hasTable(db: Database, name: string): boolean {

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -45,13 +45,34 @@ function requiredVerbForTool(tool: { requiredVerb?: VaultVerb }): VaultVerb {
   return tool.requiredVerb ?? "write";
 }
 
-/** Handle scoped MCP at /vault/{name}/mcp (single vault). */
-export async function handleScopedMcp(req: Request, vaultName: string, auth: AuthResult): Promise<Response> {
+/**
+ * Handle scoped MCP at /vault/{name}/mcp (single vault).
+ *
+ * `callerBearer` is the RAW credential the session presented (from
+ * `extractApiKey`). It's threaded into `generateScopedMcpTools` so the
+ * manage-token tool can forward it to hub's mint-token attenuation proxy
+ * (vault#403, MGT). NULL when the request carried no bearer (auth would have
+ * already rejected) — the tool treats a missing/non-JWT bearer as
+ * non-forwardable and returns a clear error on mint.
+ */
+export async function handleScopedMcp(
+  req: Request,
+  vaultName: string,
+  auth: AuthResult,
+  callerBearer?: string | null,
+): Promise<Response> {
   // Auth flows through to getServerInstruction so the connect-time
   // markdown brief is filtered by `scoped_tags` — symmetric with the
   // JSON `vault-info` wrapper.
   const instruction = await getServerInstruction(vaultName, auth);
-  return handleMcp(req, () => generateScopedMcpTools(vaultName, auth), `parachute-vault/${vaultName}`, vaultName, auth, instruction);
+  return handleMcp(
+    req,
+    () => generateScopedMcpTools(vaultName, auth, callerBearer ?? null),
+    `parachute-vault/${vaultName}`,
+    vaultName,
+    auth,
+    instruction,
+  );
 }
 
 async function handleMcp(

--- a/src/mcp-install.test.ts
+++ b/src/mcp-install.test.ts
@@ -27,6 +27,7 @@ import {
   readOperatorToken,
   removeMcpConfig,
   resolveInstallTarget,
+  revokeHubJwt,
 } from "./mcp-install.ts";
 
 const CLI = path.resolve(import.meta.dir, "cli.ts");
@@ -427,6 +428,107 @@ describe("mintHubJwt", () => {
       fetchImpl: mockFetch,
     });
     expect("kind" in res && res.kind === "api-error").toBe(true);
+  });
+
+  test("forwards permissions claim to hub when provided (vault#403, MGT)", async () => {
+    const calls: Array<{ body: any }> = [];
+    const mockFetch: typeof fetch = async (_url, init) => {
+      calls.push({ body: JSON.parse(String(init?.body)) });
+      return new Response(
+        JSON.stringify({
+          jti: "jti-tag",
+          token: "eyJ.signed.jwt",
+          expires_at: "2026-08-09T00:00:00.000Z",
+          scope: "vault:default:read",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    await mintHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "bearer",
+      scope: "vault:default:read",
+      permissions: { scoped_tags: ["task"] },
+      fetchImpl: mockFetch,
+    });
+    expect(calls[0]!.body.permissions).toEqual({ scoped_tags: ["task"] });
+  });
+
+  test("omits permissions from the body when not provided", async () => {
+    const calls: Array<{ body: any }> = [];
+    const mockFetch: typeof fetch = async (_url, init) => {
+      calls.push({ body: JSON.parse(String(init?.body)) });
+      return new Response(
+        JSON.stringify({
+          jti: "j",
+          token: "eyJ.x.y",
+          expires_at: "2026-08-09T00:00:00.000Z",
+          scope: "vault:default:read",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    await mintHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "bearer",
+      scope: "vault:default:read",
+      fetchImpl: mockFetch,
+    });
+    expect("permissions" in calls[0]!.body).toBe(false);
+  });
+});
+
+describe("revokeHubJwt (vault#403, MGT)", () => {
+  test("happy path posts jti + caller bearer, returns revoked_at", async () => {
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const mockFetch: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({ jti: "hub_jti_1", revoked_at: "2026-05-28T00:00:00.000Z" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    const res = await revokeHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "caller-bearer",
+      jti: "hub_jti_1",
+      fetchImpl: mockFetch,
+    });
+    expect("revoked_at" in res).toBe(true);
+    expect(calls[0]!.url).toBe("https://hub.example/api/auth/revoke-token");
+    expect(new Headers(calls[0]!.init?.headers).get("authorization")).toBe("Bearer caller-bearer");
+    expect(JSON.parse(String(calls[0]!.init?.body)).jti).toBe("hub_jti_1");
+  });
+
+  test("network error returns { kind: 'network' }", async () => {
+    const mockFetch: typeof fetch = async () => { throw new Error("connection refused"); };
+    const res = await revokeHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "b",
+      jti: "j",
+      fetchImpl: mockFetch,
+    });
+    expect(res).toEqual({ kind: "network", cause: "connection refused", origin: "https://hub.example" });
+  });
+
+  test("API error surfaces hub error + description", async () => {
+    const mockFetch: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({ error: "insufficient_scope", error_description: "bearer lacks parachute:host:auth" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    const res = await revokeHubJwt({
+      hubOrigin: "https://hub.example",
+      operatorToken: "b",
+      jti: "j",
+      fetchImpl: mockFetch,
+    });
+    expect(res).toEqual({
+      kind: "api-error",
+      status: 403,
+      error: "insufficient_scope",
+      description: "bearer lacks parachute:host:auth",
+    });
   });
 });
 

--- a/src/mcp-install.ts
+++ b/src/mcp-install.ts
@@ -257,18 +257,34 @@ export type MintHubJwtError =
 
 export interface MintHubJwtOpts {
   hubOrigin: string;
+  /**
+   * Bearer presented on the mint-token request. For the CLI install path this
+   * is `~/.parachute/operator.token`; for the manage-token MCP proxy
+   * (vault#403, MGT) it's the RAW caller bearer the MCP session presented (a
+   * hub JWT carrying `vault:<name>:admin`). Hub's capability-attenuation guard
+   * (hub#452) decides what the bearer may mint.
+   */
   operatorToken: string;
   scope: string;
   subject?: string;
   expiresInSeconds?: number;
+  /**
+   * Optional `permissions` claim forwarded verbatim to hub's mint-token body
+   * (e.g. `{ scoped_tags: [...] }` so the minted JWT carries the tag
+   * restriction vault enforces via C0). Omitted from the request body when
+   * undefined. See `parachute-hub/src/api-mint-token.ts` (permissions claim).
+   */
+  permissions?: Record<string, unknown>;
   /** Test seam — defaults to global fetch. */
   fetchImpl?: typeof fetch;
 }
 
 /**
- * POST to `<hub>/api/auth/mint-token`. The operator-token bearer must carry
- * `parachute:host:auth` (the admin scope-set covers it). Returns the minted
- * JWT or a discriminated error the caller turns into a clear message.
+ * POST to `<hub>/api/auth/mint-token`. The bearer must carry minting authority
+ * per hub's attenuation rules — `parachute:host:auth` (CLI operator token) or
+ * `vault:<name>:admin` (the manage-token MCP proxy's caller bearer). Returns
+ * the minted JWT or a discriminated error the caller turns into a clear
+ * message.
  *
  * Network errors are caught and returned as `{ kind: "network" }` rather
  * than bubbling — the CLI doesn't want stack traces, and the operator wants
@@ -281,6 +297,7 @@ export async function mintHubJwt(opts: MintHubJwtOpts): Promise<MintedHubJwt | M
     expires_in: opts.expiresInSeconds ?? HUB_MINT_DEFAULT_TTL_SECONDS,
   };
   if (opts.subject) body.subject = opts.subject;
+  if (opts.permissions !== undefined) body.permissions = opts.permissions;
 
   const fetchFn = opts.fetchImpl ?? fetch;
   let res: Response;
@@ -332,6 +349,84 @@ export async function mintHubJwt(opts: MintHubJwtOpts): Promise<MintedHubJwt | M
     expires_at: payload.expires_at,
     scope: payload.scope,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Hub revoke-token client (vault#403, MGT)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated failure modes from `revokeHubJwt`. `network` mirrors
+ * `mintHubJwt`; `api-error` carries hub's `{ error, error_description }`.
+ * Note: hub's revoke-token is idempotent (re-revoking an already-revoked
+ * jti returns 200), so a successful idempotent re-revoke is NOT an error.
+ */
+export type RevokeHubJwtError =
+  | { kind: "network"; cause: string; origin: string }
+  | { kind: "api-error"; status: number; error: string; description: string };
+
+export interface RevokeHubJwtOpts {
+  hubOrigin: string;
+  /** RAW caller bearer (a hub JWT carrying `parachute:host:auth`). */
+  operatorToken: string;
+  /** The hub jti to revoke. */
+  jti: string;
+  /** Test seam — defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface RevokedHubJwt {
+  jti: string;
+  revoked_at: string;
+}
+
+/**
+ * POST to `<hub>/api/auth/revoke-token` with `{ jti }`. The bearer must carry
+ * `parachute:host:auth` (the manage-token caller's `vault:<name>:admin` does
+ * NOT cover this — see the proxy's revokeAction for how it surfaces a
+ * partial-success ledger soft-revoke when hub's registry revoke is gated).
+ * Idempotent on hub's side. Network failures are caught and returned, not
+ * thrown.
+ */
+export async function revokeHubJwt(opts: RevokeHubJwtOpts): Promise<RevokedHubJwt | RevokeHubJwtError> {
+  const url = `${opts.hubOrigin.replace(/\/$/, "")}/api/auth/revoke-token`;
+  const fetchFn = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${opts.operatorToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ jti: opts.jti }),
+    });
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    return { kind: "network", cause, origin: opts.hubOrigin };
+  }
+
+  if (!res.ok) {
+    let error = "unknown_error";
+    let description = `HTTP ${res.status}`;
+    try {
+      const payload = (await res.json()) as { error?: unknown; error_description?: unknown };
+      if (typeof payload.error === "string") error = payload.error;
+      if (typeof payload.error_description === "string") description = payload.error_description;
+    } catch {}
+    return { kind: "api-error", status: res.status, error, description };
+  }
+
+  const payload = (await res.json()) as Partial<RevokedHubJwt>;
+  if (typeof payload.jti !== "string" || typeof payload.revoked_at !== "string") {
+    return {
+      kind: "api-error",
+      status: res.status,
+      error: "malformed_response",
+      description: "hub revoke-token response is missing required fields (jti/revoked_at)",
+    };
+  }
+  return { jti: payload.jti, revoked_at: payload.revoked_at };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp-install.ts
+++ b/src/mcp-install.ts
@@ -367,7 +367,13 @@ export type RevokeHubJwtError =
 
 export interface RevokeHubJwtOpts {
   hubOrigin: string;
-  /** RAW caller bearer (a hub JWT carrying `parachute:host:auth`). */
+  /**
+   * RAW caller bearer. As of hub#454, a `vault:<N>:admin` hub JWT is
+   * sufficient to revoke any jti whose scopes it could have minted (same-vault
+   * capability attenuation, symmetric to mint) — so the manage-token proxy
+   * forwards the caller's own `vault:<N>:admin` bearer here. A
+   * `parachute:host:auth` operator bearer also works (it can revoke anything).
+   */
   operatorToken: string;
   /** The hub jti to revoke. */
   jti: string;
@@ -381,12 +387,17 @@ export interface RevokedHubJwt {
 }
 
 /**
- * POST to `<hub>/api/auth/revoke-token` with `{ jti }`. The bearer must carry
- * `parachute:host:auth` (the manage-token caller's `vault:<name>:admin` does
- * NOT cover this — see the proxy's revokeAction for how it surfaces a
- * partial-success ledger soft-revoke when hub's registry revoke is gated).
- * Idempotent on hub's side. Network failures are caught and returned, not
- * thrown.
+ * POST to `<hub>/api/auth/revoke-token` with `{ jti }`.
+ *
+ * As of hub#454, hub's revoke-token applies capability attenuation symmetric
+ * to mint: a `vault:<N>:admin` bearer may revoke any jti whose scopes it could
+ * have minted (same-vault subsets), and `parachute:host:auth` may revoke
+ * anything. So the manage-token proxy's caller `vault:<N>:admin` bearer is the
+ * expected-success path for revoking tokens it minted within that vault's
+ * authority — `parachute:host:auth` is no longer required.
+ *
+ * Idempotent on hub's side (re-revoking an already-revoked jti returns 200).
+ * Network failures are caught and returned, not thrown.
  */
 export async function revokeHubJwt(opts: RevokeHubJwtOpts): Promise<RevokedHubJwt | RevokeHubJwtError> {
   const url = `${opts.hubOrigin.replace(/\/$/, "")}/api/auth/revoke-token`;

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -639,6 +639,13 @@ async function mintAction(
   // legacy pvt_*) can't be forwarded — and wouldn't carry mint authority at
   // hub anyway — so fail with a clear, actionable error rather than
   // fabricating a bearer.
+  //
+  // `looksLikeJwt` is a SYNTACTIC hint only (startsWith("eyJ") — the base64url
+  // of a JWS header `{"`). It does NOT verify the signature, issuer, scopes,
+  // or that the bearer actually grants mint authority. That's intentional:
+  // hub's mint-token attenuation guard is the authoritative gate (it validates
+  // the bearer and rejects anything it couldn't have minted). This check just
+  // avoids forwarding a credential we already know can't be a hub JWT.
   if (!callerBearer || !looksLikeJwt(callerBearer)) {
     return {
       action: "mint",
@@ -793,11 +800,19 @@ async function revokeAction(
   }
 
   // Forward the revoke to hub's token registry (the authoritative revocation
-  // surface — vault is resource-server-only). The caller's bearer is forwarded
-  // as on mint. Hub's revoke-token is idempotent. If the round-trip fails we
-  // still flip the local ledger marker so list reflects the operator's intent,
-  // but we surface the hub failure so the caller knows the registry-side
-  // revoke may not have landed (the short TTL is the backstop either way).
+  // surface — vault is resource-server-only). The caller's `vault:<N>:admin`
+  // bearer is forwarded, same as on mint. As of hub#454 this is the
+  // expected-SUCCESS path: hub's revoke-token applies capability attenuation
+  // symmetric to mint, so a `vault:<N>:admin` bearer may revoke any jti whose
+  // scopes it could have minted (and these are exactly the tokens this session
+  // minted within that vault's authority). Hub's revoke-token is idempotent.
+  //
+  // The `"kind" in revoked` branch below is now the EXCEPTION, not the norm —
+  // it only fires on a genuine edge (network blip, or a hub-side rejection
+  // that shouldn't happen for an in-authority jti). When it does, we still
+  // flip the local ledger marker so list reflects the operator's intent, and
+  // surface the hub failure so the caller knows the registry-side revoke may
+  // not have landed (the short TTL is the backstop either way).
   if (callerBearer && looksLikeJwt(callerBearer)) {
     const hub = resolveHubOrigin();
     const revoked = await revokeHubJwt({
@@ -806,8 +821,9 @@ async function revokeAction(
       jti,
     });
     if ("kind" in revoked) {
-      // Local ledger still flips (operator asked to revoke), but report the
-      // hub-side failure so a network blip / scope gap is visible.
+      // Unexpected hub failure. Local ledger still flips (operator asked to
+      // revoke), but report the hub-side failure so a network blip / scope
+      // gap is visible.
       markMcpMintLedgerRevoked(store.db, jti, auth.caller_jti, vaultName);
       if (revoked.kind === "network") {
         return {

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -14,7 +14,7 @@ import {
 } from "../core/src/vault-projection.ts";
 import { readVaultConfig, writeVaultConfig } from "./config.ts";
 import { getVaultStore } from "./vault-store.ts";
-import { hasScopeForVault, parseScopes, validateMintedScopes, hasScope, SCOPE_WRITE, SCOPE_ADMIN } from "./scopes.ts";
+import { hasScopeForVault, parseScopes, validateMintedScopes } from "./scopes.ts";
 import type { AuthResult } from "./auth.ts";
 import {
   expandTokenTagScope,
@@ -23,12 +23,14 @@ import {
 } from "./tag-scope.ts";
 import {
   findTokensReferencingTag,
-  generateToken,
-  createToken,
-  listMcpMintedTokens,
-  softRevokeMcpToken,
-  type TokenPermission,
+  recordMcpMintLedger,
+  listMcpMintedHubJwts,
+  findMcpMintLedgerEntry,
+  markMcpMintLedgerRevoked,
 } from "./token-store.ts";
+import { chooseHubOrigin, mintHubJwt, revokeHubJwt } from "./mcp-install.ts";
+import { looksLikeJwt } from "./hub-jwt.ts";
+import { readGlobalConfig, DEFAULT_PORT } from "./config.ts";
 
 /**
  * Filter a vault projection to entries an in-scope tag contributes to.
@@ -109,7 +111,11 @@ export async function getServerInstruction(
  * When omitted (internal callers that only inspect the tool list — no execute
  * path exercised), the description-update branch is disabled entirely.
  */
-export function generateScopedMcpTools(vaultName: string, auth?: AuthResult): McpToolDef[] {
+export function generateScopedMcpTools(
+  vaultName: string,
+  auth?: AuthResult,
+  callerBearer?: string | null,
+): McpToolDef[] {
   const store = getVaultStore(vaultName);
   const tools = generateMcpTools(store);
 
@@ -120,8 +126,9 @@ export function generateScopedMcpTools(vaultName: string, auth?: AuthResult): Mc
   // manage-token is server-only (needs token-store + auth context), so it
   // lives here rather than in core. Always appended to the surface; the
   // `requiredVerb: "admin"` filter in mcp-http.ts hides it from non-admin
-  // callers. See vault#376.
-  tools.push(buildManageTokenTool(vaultName, auth));
+  // callers. See vault#376. The raw caller bearer (vault#403, MGT) is
+  // forwarded to hub's mint-token attenuation proxy on mint.
+  tools.push(buildManageTokenTool(vaultName, auth, callerBearer ?? null));
 
   return tools;
 }
@@ -433,45 +440,70 @@ function overrideVaultInfo(
 const MANAGE_TOKEN_DEFAULT_TTL_SECONDS = 900; // 15 minutes
 const MANAGE_TOKEN_MAX_TTL_SECONDS = 3600; // 1 hour
 
-function permissionForScopes(scopes: string[]): TokenPermission {
-  return hasScope(scopes, SCOPE_WRITE) || hasScope(scopes, SCOPE_ADMIN) ? "full" : "read";
+/**
+ * Resolve the bare hub origin for the mint/revoke proxy calls. Reuses
+ * `chooseHubOrigin` (PARACHUTE_HUB_ORIGIN → expose-state FQDN → loopback) so
+ * the manage-token proxy targets the same hub the rest of vault talks to.
+ * The port is read from global config (same source the server binds on).
+ */
+function resolveHubOrigin(): { url: string; source: string } {
+  let port = DEFAULT_PORT;
+  try {
+    port = readGlobalConfig().port || DEFAULT_PORT;
+  } catch {
+    // Config unreadable (fresh / test fixture) — fall back to the default
+    // port; chooseHubOrigin still honors PARACHUTE_HUB_ORIGIN / expose-state.
+  }
+  return chooseHubOrigin(port);
 }
 
 /**
  * Build the manage-token MCP tool, wired to the calling session's auth.
  *
- * Closure-captured context:
- *   - `vaultName`: every mint pins `vault_name` to this; cross-vault mints
- *     are rejected by `validateMintedScopes` (it refuses any
- *     `vault:<other>:<verb>` scope).
- *   - `auth.scopes`: defense-in-depth subset check on mint. The outer
- *     filter already required vault:admin to see the tool, but a hand-
- *     crafted JSON-RPC `tools/call` of `manage-token` from a non-admin
- *     session would bypass the visibility filter — `validateMintedScopes`
- *     plus the `hasScopeForVault(auth.scopes, vaultName, "admin")` guard
- *     below catch that case.
- *   - `auth.caller_jti`: stamped as `parent_jti` on each mint; list+revoke
- *     scope to this jti so each MCP session sees only its own mints.
- *     When NULL (legacy / env-var operator / hub JWT without jti), mints
- *     still succeed but list/revoke return empty — the operator hits the
- *     CLI / REST surface instead for revocation in that path.
+ * After the auth-unification arc (vault#403, MGT) the tool is a thin proxy to
+ * hub's mint-token attenuation endpoint: it mints short-TTL HUB JWTs, not
+ * deprecated `pvt_*` vault-DB tokens. The DROP step removes the pvt_* mint
+ * infra entirely once every consumer has migrated.
  *
- * The execute function is async (token mint touches the store + DB) and
+ * Closure-captured context:
+ *   - `vaultName`: every mint requests `vault:<vaultName>:<verb>`; cross-vault
+ *     and over-scope requests are rejected locally by `validateMintedScopes`
+ *     (fail-fast) AND by hub's attenuation guard (authoritative).
+ *   - `auth.scopes`: the caller must hold `vault:<vaultName>:admin` to see the
+ *     tool (mcp-http.ts visibleTools filter) and to mint; `validateMintedScopes`
+ *     enforces the requested scope is a same-vault subset of what's held.
+ *   - `auth.caller_jti`: the minting MCP session's id, recorded as the
+ *     `parent_jti` in the local ledger so list/revoke stay session-scoped.
+ *     When NULL (env-var operator / hub JWT without jti) there's no stable
+ *     session id → list returns empty + revoke returns not_found.
+ *   - `callerBearer`: the RAW credential the session presented. Only forwarded
+ *     to hub when JWT-shaped (a hub JWT carrying `vault:<name>:admin`). A
+ *     non-forwardable credential (env-var secret, legacy pvt_*) yields a clear
+ *     "mint requires a hub-JWT session" error rather than a fabricated bearer.
+ *
+ * The execute function is async (mint/revoke do an HTTP round-trip to hub) and
  * returns a discriminated-union response shape: `{action, …}` with `action`
  * matching the requested action. The MCP HTTP layer serializes the result
  * via `JSON.stringify`, so caller-side parsing keys off the action field.
  */
-function buildManageTokenTool(vaultName: string, auth: AuthResult | undefined): McpToolDef {
+function buildManageTokenTool(
+  vaultName: string,
+  auth: AuthResult | undefined,
+  callerBearer: string | null,
+): McpToolDef {
   return {
     name: "manage-token",
     requiredVerb: "admin",
     description:
-      "Mint, revoke, or list short-TTL vault tokens within this MCP session. " +
+      "Mint, revoke, or list short-TTL hub JWTs within this MCP session. " +
       "Designed for one-shot AI-driven workflows: mint a narrow token, run a " +
-      "script with it, revoke immediately. Token lifetime defaults to 15 min " +
-      "(max 1 hour). Mints are pinned to this vault and to the caller's scope " +
-      "subset — you cannot escalate. List + revoke are scoped to tokens this " +
-      "session minted; CLI/REST-minted tokens are not surfaced here.\n\n" +
+      "script with it, revoke immediately. Minted tokens are short-lived hub " +
+      "JWTs (revocable via the hub's token registry), not legacy vault-DB " +
+      "tokens. Lifetime defaults to 15 min (max 1 hour). Mints are pinned to " +
+      "this vault and attenuated to a subset of the caller's scope — you cannot " +
+      "escalate. Minting requires a hub-JWT session holding 'vault:" + vaultName +
+      ":admin'. List + revoke are scoped to tokens this session minted; " +
+      "CLI/REST-minted tokens are not surfaced here.\n\n" +
       "Actions (discriminator: `action`):\n" +
       "- `mint` — { scope: string|string[], ttl_seconds?: number, description?: string } → { action: \"mint\", token, jti, expires_at }\n" +
       "- `revoke` — { jti: string } → { action: \"revoke\", ok: boolean }\n" +
@@ -525,8 +557,8 @@ function buildManageTokenTool(vaultName: string, auth: AuthResult | undefined): 
         };
       }
 
-      if (action === "mint") return await mintAction(params, vaultName, auth);
-      if (action === "revoke") return revokeAction(params, vaultName, auth);
+      if (action === "mint") return await mintAction(params, vaultName, auth, callerBearer);
+      if (action === "revoke") return await revokeAction(params, vaultName, auth, callerBearer);
       if (action === "list") return listAction(vaultName, auth);
 
       return {
@@ -537,10 +569,29 @@ function buildManageTokenTool(vaultName: string, auth: AuthResult | undefined): 
   };
 }
 
+/**
+ * Normalize a requested scope to the resource-narrowed `vault:<name>:<verb>`
+ * shape hub expects. Callers may pass either the broad `vault:<verb>` form
+ * (the manage-token v1 surface accepted this) or the explicit
+ * `vault:<name>:<verb>` form. We rewrite the broad form to name THIS vault so
+ * hub's attenuation guard — which only knows resource-narrowed scopes — sees a
+ * `vault:<vaultName>:<verb>` request. A scope already naming a different vault
+ * is left untouched (validateMintedScopes rejects it before we get here).
+ */
+function narrowScopeForVault(scope: string, vaultName: string): string {
+  const parts = scope.split(":");
+  // `vault:<verb>` (2 parts) → `vault:<name>:<verb>`.
+  if (parts.length === 2 && parts[0] === "vault") {
+    return `vault:${vaultName}:${parts[1]}`;
+  }
+  return scope;
+}
+
 async function mintAction(
   params: Record<string, unknown>,
   vaultName: string,
   auth: AuthResult,
+  callerBearer: string | null,
 ): Promise<Record<string, unknown>> {
   // Scope parsing: accept string or string[]. Empty/missing is rejected
   // explicitly (no implicit "full scope" default — manage-token always
@@ -568,6 +619,10 @@ async function mintAction(
     };
   }
 
+  // Fail-fast local guard (defense-in-depth — hub's attenuation is
+  // authoritative): cross-vault + over-scope requests are rejected here with a
+  // clear message before any HTTP round-trip. The caller cannot request a
+  // scope outside their own vault/authority.
   const validation = validateMintedScopes(requested, vaultName, auth.scopes);
   if (!validation.ok) {
     return {
@@ -575,6 +630,24 @@ async function mintAction(
       error: "forbidden",
       message: "manage-token mint: scope rejected (must be a subset of the caller's scope on this vault).",
       rejected: validation.rejected,
+    };
+  }
+
+  // Forwardability: minting is a proxy to hub's attenuation endpoint, so the
+  // caller must present a forwardable hub-JWT bearer carrying
+  // `vault:<name>:admin`. A non-JWT credential (env-var operator secret,
+  // legacy pvt_*) can't be forwarded — and wouldn't carry mint authority at
+  // hub anyway — so fail with a clear, actionable error rather than
+  // fabricating a bearer.
+  if (!callerBearer || !looksLikeJwt(callerBearer)) {
+    return {
+      action: "mint",
+      error: "forbidden",
+      message:
+        `manage-token mint requires a hub-JWT session holding 'vault:${vaultName}:admin'. ` +
+        "This session authenticated with a non-forwardable credential (operator " +
+        "env-var token or legacy vault-DB token); mint a token via the hub admin " +
+        "UI / CLI instead, or reconnect MCP with a hub-issued JWT.",
     };
   }
 
@@ -600,49 +673,87 @@ async function mintAction(
     }
     ttl = params.ttl_seconds;
   }
-  const expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
 
   const description = typeof params.description === "string" && params.description.length > 0
     ? params.description
     : null;
   const label = description ?? `mcp-mint (parent=${auth.caller_jti ?? "unknown"})`;
 
-  const store = getVaultStore(vaultName);
-  const { fullToken } = generateToken();
-  const created = createToken(store.db, fullToken, {
-    label,
-    permission: permissionForScopes(requested),
-    scopes: requested,
-    // Tag scoping: inherit the caller's allowlist verbatim. We don't expose
-    // a `tags` param on manage-token yet — the design doc keeps the v1
-    // surface minimal. When the caller is tag-scoped, the minted token
-    // carries the same allowlist (no narrowing, no widening); when the
-    // caller is unscoped, the mint is unscoped. Future widening of the
-    // surface should re-use tokens-routes.ts' validation path so the rules
-    // stay in lockstep.
-    scoped_tags: auth.scoped_tags,
-    vault_name: vaultName,
-    expires_at: expiresAt,
-    created_via: "mcp_mint",
-    parent_jti: auth.caller_jti,
+  // Resolve hub origin (PARACHUTE_HUB_ORIGIN → expose-state FQDN → loopback).
+  const hub = resolveHubOrigin();
+
+  // Build the mint-token request. Scopes are narrowed to the resource-named
+  // `vault:<name>:<verb>` form hub's attenuation guard requires. Tag-scoping
+  // (when the caller is tag-scoped) rides along as `permissions.scoped_tags`
+  // so the minted hub JWT carries the same restriction — vault enforces it on
+  // read via C0 (vault#403). Unscoped callers omit `permissions`.
+  const narrowedScopes = requested.map((s) => narrowScopeForVault(s, vaultName));
+  const permissions =
+    auth.scoped_tags && auth.scoped_tags.length > 0
+      ? { scoped_tags: auth.scoped_tags }
+      : undefined;
+
+  const minted = await mintHubJwt({
+    hubOrigin: hub.url,
+    operatorToken: callerBearer,
+    scope: narrowedScopes.join(" "),
+    expiresInSeconds: ttl,
+    ...(permissions !== undefined ? { permissions } : {}),
   });
+
+  if ("kind" in minted) {
+    // Surface a clear, action-keyed error. Network → "hub unreachable";
+    // api-error → hub's own error_description (e.g. attenuation rejection).
+    if (minted.kind === "network") {
+      return {
+        action: "mint",
+        error: "hub_unreachable",
+        message: `manage-token mint: could not reach hub at ${minted.origin} (${minted.cause}). Check PARACHUTE_HUB_ORIGIN / that the hub is running.`,
+      };
+    }
+    return {
+      action: "mint",
+      error: "hub_rejected",
+      message: `manage-token mint: hub rejected the request (${minted.error}: ${minted.description}).`,
+      hub_status: minted.status,
+    };
+  }
+
+  // Record in the session-pinned ledger so list/revoke can scope to this
+  // session's mints. The signed JWT is never stored — only its jti (the
+  // revocation handle) + display metadata. NULL caller_jti (env-var / no-jti
+  // sessions) can't pass the forwardability gate above, so by here caller_jti
+  // is effectively the JWT's jti; we still guard defensively.
+  const store = getVaultStore(vaultName);
+  if (auth.caller_jti) {
+    recordMcpMintLedger(store.db, {
+      jti: minted.jti,
+      parentJti: auth.caller_jti,
+      vaultName,
+      label,
+      scopes: narrowedScopes,
+      scopedTags: auth.scoped_tags,
+      expiresAt: minted.expires_at,
+    });
+  }
 
   return {
     action: "mint",
-    token: fullToken,
-    jti: `t_${created.token_hash.slice(7, 19)}`,
-    expires_at: expiresAt,
-    scopes: requested,
+    token: minted.token,
+    jti: minted.jti,
+    expires_at: minted.expires_at,
+    scopes: narrowedScopes,
     scoped_tags: auth.scoped_tags,
     vault_name: vaultName,
   };
 }
 
-function revokeAction(
+async function revokeAction(
   params: Record<string, unknown>,
   vaultName: string,
   auth: AuthResult,
-): Record<string, unknown> {
+  callerBearer: string | null,
+): Promise<Record<string, unknown>> {
   if (typeof params.jti !== "string" || params.jti.length === 0) {
     return {
       action: "revoke",
@@ -651,30 +762,73 @@ function revokeAction(
       message: "manage-token revoke: `jti` is required (string).",
     };
   }
-  // Session-pin: revoke is restricted to tokens this MCP session minted.
+  const jti = params.jti;
+
+  // Session-pin: revoke is restricted to hub JWTs THIS MCP session minted.
   // When auth.caller_jti is null (no stable session id — env-var operator,
-  // legacy YAML key, hub JWT without jti), there are no MCP-minted tokens
-  // attributable to this session, so revoke returns not_found.
+  // legacy YAML key, hub JWT without jti), there are no attributable mints,
+  // so revoke returns not_found.
   if (!auth.caller_jti) {
     return {
       action: "revoke",
       ok: false,
       error: "not_found",
-      message: "manage-token revoke: this session has no stable id; revoke via the CLI or REST surface.",
+      message: "manage-token revoke: this session has no stable id; revoke via the hub admin UI / CLI.",
     };
   }
+
   const store = getVaultStore(vaultName);
-  const result = softRevokeMcpToken(store.db, params.jti, auth.caller_jti, vaultName);
-  if (!result.ok) {
-    // Idempotency: not-found returns ok=true so the AI's "mint → run →
-    // revoke" loop doesn't surface a confusing failure when a network
-    // blip causes a duplicate revoke call. The spec calls this out
-    // explicitly (vault#376). The "already minted by another session"
-    // case also lands here; we don't differentiate (no information leak
-    // about other sessions' jti space).
+  const entry = findMcpMintLedgerEntry(store.db, jti, auth.caller_jti, vaultName);
+  if (!entry) {
+    // Idempotency: not-in-this-session's-ledger returns ok=true so the AI's
+    // "mint → run → revoke" loop doesn't surface a confusing failure on a
+    // duplicate revoke or a network-blip retry. The "minted by another
+    // session" case also lands here; we don't differentiate (no information
+    // leak about other sessions' jti space).
     return { action: "revoke", ok: true, note: "no matching token in this session" };
   }
-  return { action: "revoke", ok: true, already_revoked: result.already_revoked };
+  if (entry.revoked_at) {
+    // Already revoked locally — idempotent success, no second hub round-trip.
+    return { action: "revoke", ok: true, already_revoked: true };
+  }
+
+  // Forward the revoke to hub's token registry (the authoritative revocation
+  // surface — vault is resource-server-only). The caller's bearer is forwarded
+  // as on mint. Hub's revoke-token is idempotent. If the round-trip fails we
+  // still flip the local ledger marker so list reflects the operator's intent,
+  // but we surface the hub failure so the caller knows the registry-side
+  // revoke may not have landed (the short TTL is the backstop either way).
+  if (callerBearer && looksLikeJwt(callerBearer)) {
+    const hub = resolveHubOrigin();
+    const revoked = await revokeHubJwt({
+      hubOrigin: hub.url,
+      operatorToken: callerBearer,
+      jti,
+    });
+    if ("kind" in revoked) {
+      // Local ledger still flips (operator asked to revoke), but report the
+      // hub-side failure so a network blip / scope gap is visible.
+      markMcpMintLedgerRevoked(store.db, jti, auth.caller_jti, vaultName);
+      if (revoked.kind === "network") {
+        return {
+          action: "revoke",
+          ok: false,
+          error: "hub_unreachable",
+          message: `manage-token revoke: could not reach hub at ${revoked.origin} (${revoked.cause}); local ledger marked revoked but the hub registry may still list it. The token's short TTL is the backstop.`,
+        };
+      }
+      return {
+        action: "revoke",
+        ok: false,
+        error: "hub_rejected",
+        message: `manage-token revoke: hub rejected the request (${revoked.error}: ${revoked.description}); local ledger marked revoked. The token's short TTL is the backstop.`,
+        hub_status: revoked.status,
+      };
+    }
+  }
+
+  markMcpMintLedgerRevoked(store.db, jti, auth.caller_jti, vaultName);
+  return { action: "revoke", ok: true, already_revoked: false };
 }
 
 function listAction(vaultName: string, auth: AuthResult): Record<string, unknown> {
@@ -685,6 +839,9 @@ function listAction(vaultName: string, auth: AuthResult): Record<string, unknown
     return { action: "list", tokens: [] };
   }
   const store = getVaultStore(vaultName);
-  const tokens = listMcpMintedTokens(store.db, auth.caller_jti, vaultName);
+  // Read from the hub-JWT mint ledger (vault#403, MGT) — mints now live in
+  // hub's registry, not the pvt_* tokens table; the ledger is the local
+  // session-attribution index.
+  const tokens = listMcpMintedHubJwts(store.db, auth.caller_jti, vaultName);
   return { action: "list", tokens };
 }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -438,7 +438,15 @@ export async function route(
 
   // MCP (per-vault, single-vault session).
   if (isScopedMcp) {
-    return handleScopedMcp(req, vaultName, auth);
+    // Thread the RAW caller bearer (the exact credential the session
+    // presented) into the MCP layer so the manage-token tool can forward it
+    // to hub's mint-token attenuation proxy (vault#403, MGT). Only the raw
+    // validated bearer — never a fabricated one. extractApiKey returns the
+    // same value `authenticateVaultRequest` validated above; non-forwardable
+    // credentials (env-var secret, legacy pvt_*) are handled by manage-token
+    // itself (it only forwards JWT-shaped bearers).
+    const callerBearer = extractApiKey(req);
+    return handleScopedMcp(req, vaultName, auth, callerBearer);
   }
 
   // Bare `/vault/<name>` — single-vault root. Returns name, description,

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -431,9 +431,13 @@ export function softRevokeMcpToken(
 /**
  * Record a hub-minted JWT in the session-pinned ledger. `jti` is hub's
  * returned jti; `parentJti` is the minting MCP session (the caller's
- * `caller_jti`). Idempotent on `jti` via INSERT OR REPLACE — a hub jti is
- * unique, so a duplicate record (shouldn't happen) overwrites rather than
- * erroring.
+ * `caller_jti`).
+ *
+ * Uses INSERT OR IGNORE, NOT OR REPLACE: hub guarantees jti uniqueness, so a
+ * pre-existing row with this jti shouldn't happen. If it does, it's a real bug
+ * (a hub jti collision) — we log a warning and KEEP the existing row rather
+ * than overwriting it, because OR REPLACE would silently reset a previously-set
+ * `revoked_at` and resurrect a revoked token in the list/revoke surface.
  */
 export function recordMcpMintLedger(
   db: Database,
@@ -448,8 +452,8 @@ export function recordMcpMintLedger(
   },
 ): void {
   const scopedTags = entry.scopedTags && entry.scopedTags.length > 0 ? entry.scopedTags : null;
-  db.prepare(`
-    INSERT OR REPLACE INTO mcp_mint_ledger
+  const result = db.prepare(`
+    INSERT OR IGNORE INTO mcp_mint_ledger
       (jti, parent_jti, vault_name, label, scopes, scoped_tags, created_at, expires_at, revoked_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
   `).run(
@@ -462,6 +466,14 @@ export function recordMcpMintLedger(
     new Date().toISOString(),
     entry.expiresAt,
   );
+  if (result.changes === 0) {
+    // Row already existed — IGNORE swallowed the conflict. Surface it: a hub
+    // jti collision is a real bug worth investigating (the existing row is
+    // left untouched, including any `revoked_at`).
+    console.warn(
+      `[manage-token] mcp_mint_ledger already has a row for jti '${entry.jti}' — skipped insert (kept existing row). A hub jti collision shouldn't happen; investigate.`,
+    );
+  }
 }
 
 /**

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -419,6 +419,136 @@ export function softRevokeMcpToken(
   return { ok: true, already_revoked: false };
 }
 
+// ---------------------------------------------------------------------------
+// mcp_mint_ledger — session-pinned index of HUB JWTs minted by manage-token
+// (vault#403, MGT). After the auth-unification arc the tool mints hub JWTs,
+// not pvt_* rows, so the session attribution (parent_jti → minted jti) lives
+// here instead of in the `tokens` table. Rows are NOT credentials — only the
+// hub `jti` (the revocation handle) plus display metadata is stored; the
+// signed token never touches the vault DB.
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a hub-minted JWT in the session-pinned ledger. `jti` is hub's
+ * returned jti; `parentJti` is the minting MCP session (the caller's
+ * `caller_jti`). Idempotent on `jti` via INSERT OR REPLACE — a hub jti is
+ * unique, so a duplicate record (shouldn't happen) overwrites rather than
+ * erroring.
+ */
+export function recordMcpMintLedger(
+  db: Database,
+  entry: {
+    jti: string;
+    parentJti: string;
+    vaultName: string;
+    label: string;
+    scopes: string[];
+    scopedTags: string[] | null;
+    expiresAt: string | null;
+  },
+): void {
+  const scopedTags = entry.scopedTags && entry.scopedTags.length > 0 ? entry.scopedTags : null;
+  db.prepare(`
+    INSERT OR REPLACE INTO mcp_mint_ledger
+      (jti, parent_jti, vault_name, label, scopes, scoped_tags, created_at, expires_at, revoked_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+  `).run(
+    entry.jti,
+    entry.parentJti,
+    entry.vaultName,
+    entry.label,
+    serializeScopes(entry.scopes),
+    scopedTags ? JSON.stringify(scopedTags) : null,
+    new Date().toISOString(),
+    entry.expiresAt,
+  );
+}
+
+/**
+ * List hub JWTs minted by a given MCP session (parent_jti) against a vault.
+ * Mirrors `listMcpMintedTokens`' shape so the manage-token list surface is
+ * unchanged on the wire. Includes `revoked_at` so callers can render a
+ * tombstone for soft-revoked rows.
+ */
+export function listMcpMintedHubJwts(
+  db: Database,
+  parentJti: string,
+  vaultName: string,
+): Array<{
+  jti: string;
+  label: string;
+  scopes: string[];
+  scoped_tags: string[] | null;
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+}> {
+  const rows = db.prepare(`
+    SELECT jti, label, scopes, scoped_tags, created_at, expires_at, revoked_at
+    FROM mcp_mint_ledger
+    WHERE parent_jti = ? AND vault_name = ?
+    ORDER BY created_at DESC
+  `).all(parentJti, vaultName) as {
+    jti: string;
+    label: string;
+    scopes: string | null;
+    scoped_tags: string | null;
+    created_at: string;
+    expires_at: string | null;
+    revoked_at: string | null;
+  }[];
+  return rows.map((r) => ({
+    jti: r.jti,
+    label: r.label,
+    scopes: parseScopes(r.scopes),
+    scoped_tags: parseScopedTags(r.scoped_tags),
+    created_at: r.created_at,
+    expires_at: r.expires_at,
+    revoked_at: r.revoked_at,
+  }));
+}
+
+/**
+ * Look up a single ledger row by (jti, parent_jti, vault_name) — the
+ * session-pin gate for revoke. Returns null when the jti isn't in THIS
+ * session's ledger (a different session's mint, or a never-minted jti),
+ * which the caller turns into the not_found path. Returns the row (incl.
+ * `revoked_at`) when it belongs to this session.
+ */
+export function findMcpMintLedgerEntry(
+  db: Database,
+  jti: string,
+  parentJti: string,
+  vaultName: string,
+): { jti: string; revoked_at: string | null } | null {
+  const row = db.prepare(`
+    SELECT jti, revoked_at FROM mcp_mint_ledger
+    WHERE jti = ? AND parent_jti = ? AND vault_name = ?
+    LIMIT 1
+  `).get(jti, parentJti, vaultName) as { jti: string; revoked_at: string | null } | null;
+  return row ?? null;
+}
+
+/**
+ * Mark a ledger row revoked (the local attribution-side soft-revoke; the
+ * authoritative revocation happens in hub's registry via the revoke-token
+ * call). Idempotent: a second call on an already-revoked row leaves the
+ * existing timestamp in place. Only flips rows belonging to the given
+ * session — defense-in-depth on top of the caller's `findMcpMintLedgerEntry`
+ * gate.
+ */
+export function markMcpMintLedgerRevoked(
+  db: Database,
+  jti: string,
+  parentJti: string,
+  vaultName: string,
+): void {
+  db.prepare(`
+    UPDATE mcp_mint_ledger SET revoked_at = ?
+    WHERE jti = ? AND parent_jti = ? AND vault_name = ? AND revoked_at IS NULL
+  `).run(new Date().toISOString(), jti, parentJti, vaultName);
+}
+
 /**
  * Find tokens whose `scoped_tags` allowlist references the given root tag.
  * Used by tag-delete and tag-merge to fail-closed (409) when removing a

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -4377,12 +4377,73 @@ describe("MCP tools/list scope tiers (vault#376)", () => {
 // vault#376 — Change 2: manage-token mint/revoke/list
 // ===========================================================================
 
-describe("manage-token MCP tool (vault#376)", () => {
+describe("manage-token MCP tool (vault#403, MGT — hub-JWT attenuation proxy)", () => {
+  // A JWT-shaped bearer the session presents; the manage-token mint path only
+  // forwards JWT-shaped credentials, so tests must thread one through.
+  const JWT_BEARER = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1In0.sig";
+
+  // --- Hub fetch stub --------------------------------------------------------
+  // mintAction/revokeAction call mintHubJwt/revokeHubJwt, which use global
+  // fetch (no fetchImpl seam on that path). Each test installs a stub that
+  // records the requests and returns a canned hub response. We capture every
+  // call so assertions can inspect the URL / Authorization header / body.
+  let realFetch: typeof globalThis.fetch;
+  let hubCalls: Array<{ url: string; init: RequestInit | undefined; body: any }>;
+  let mintSeq: number;
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+    hubCalls = [];
+    mintSeq = 0;
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  /** Install a hub stub that mints a fresh jti per mint + idempotent revoke. */
+  function installHubStub(opts?: { revokeFails?: "network" | "api-error" }) {
+    globalThis.fetch = (async (input: any, init?: RequestInit) => {
+      const url = String(input);
+      let body: any = undefined;
+      try { body = init?.body ? JSON.parse(String(init.body)) : undefined; } catch {}
+      hubCalls.push({ url, init, body });
+      if (url.endsWith("/api/auth/mint-token")) {
+        const jti = `hub_jti_${++mintSeq}`;
+        const ttl = typeof body?.expires_in === "number" ? body.expires_in : 900;
+        return new Response(
+          JSON.stringify({
+            jti,
+            token: `eyJ.minted.${jti}`,
+            expires_at: new Date(Date.now() + ttl * 1000).toISOString(),
+            scope: body?.scope ?? "",
+            ...(body?.permissions ? { permissions: body.permissions } : {}),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith("/api/auth/revoke-token")) {
+        if (opts?.revokeFails === "network") throw new Error("connection refused");
+        if (opts?.revokeFails === "api-error") {
+          return new Response(
+            JSON.stringify({ error: "insufficient_scope", error_description: "bearer lacks parachute:host:auth" }),
+            { status: 403, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({ jti: body?.jti, revoked_at: new Date().toISOString() }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`unexpected fetch in test: ${url}`);
+    }) as typeof globalThis.fetch;
+  }
+
   async function callTool(
     vaultName: string,
     auth: any,
     toolName: string,
     args: Record<string, unknown>,
+    callerBearer: string | null = JWT_BEARER,
   ) {
     const { handleScopedMcp } = await import("./mcp-http.ts");
     const req = new Request(`http://localhost:1940/vault/${vaultName}/mcp`, {
@@ -4390,6 +4451,7 @@ describe("manage-token MCP tool (vault#376)", () => {
       headers: {
         "content-type": "application/json",
         "accept": "application/json, text/event-stream",
+        ...(callerBearer ? { authorization: `Bearer ${callerBearer}` } : {}),
       },
       body: JSON.stringify({
         jsonrpc: "2.0",
@@ -4398,7 +4460,7 @@ describe("manage-token MCP tool (vault#376)", () => {
         params: { name: toolName, arguments: args },
       }),
     });
-    const res = await handleScopedMcp(req, vaultName, auth);
+    const res = await handleScopedMcp(req, vaultName, auth, callerBearer);
     const body = await res.json() as any;
     if (body.result?.content?.[0]?.text) {
       try {
@@ -4410,7 +4472,7 @@ describe("manage-token MCP tool (vault#376)", () => {
     return { isError: false, parsed: null, raw: body };
   }
 
-  async function setupAdminSession(prefix: string) {
+  async function setupAdminSession(prefix: string, scopedTags: string[] | null = null) {
     const { writeVaultConfig } = await import("./config.ts");
     const vaultName = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     writeVaultConfig({
@@ -4418,139 +4480,179 @@ describe("manage-token MCP tool (vault#376)", () => {
       api_keys: [],
       created_at: new Date().toISOString(),
     });
-    // Stable caller_jti so list/revoke can find the mints; we don't go
-    // through the actual auth flow here (that would require a real pvt_
-    // token; the unit-level test point is the manage-token logic itself).
+    // Stable caller_jti so the session-pinned ledger can attribute mints.
+    // Scopes carry the resource-narrowed admin scope so validateMintedScopes +
+    // the visibility filter pass for THIS vault.
     const auth: any = {
       permission: "full",
-      scopes: ["vault:read", "vault:write", "vault:admin"],
+      scopes: [`vault:${vaultName}:read`, `vault:${vaultName}:write`, `vault:${vaultName}:admin`],
       legacyDerived: false,
-      scoped_tags: null,
+      scoped_tags: scopedTags,
       vault_name: vaultName,
       caller_jti: `t_session${Math.random().toString(36).slice(2, 12)}`,
     };
     return { vaultName, auth };
   }
 
-  test("mint with default TTL returns valid token + jti + expires_at ~15min out", async () => {
-    const { vaultName, auth } = await setupAdminSession("mint-default");
+  test("mint proxies to hub mint-token with caller bearer + narrowed scope + ttl", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("mint-proxy");
     const { closeAllStores } = await import("./vault-store.ts");
-    const before = Date.now();
     const { parsed } = await callTool(vaultName, auth, "manage-token", {
       action: "mint",
       scope: "vault:read",
     });
     expect(parsed.action).toBe("mint");
-    expect(parsed.token).toMatch(/^pvt_/);
-    expect(parsed.jti).toMatch(/^t_/);
-    const expiresAt = Date.parse(parsed.expires_at);
-    expect(expiresAt - before).toBeGreaterThan(890 * 1000);
-    expect(expiresAt - before).toBeLessThan(910 * 1000);
+    // Token is now a hub JWT (not pvt_*); jti is hub's returned jti.
+    expect(parsed.token).toMatch(/^eyJ\.minted\./);
+    expect(parsed.jti).toBe("hub_jti_1");
+    expect(parsed.scopes).toEqual([`vault:${vaultName}:read`]);
+    expect(parsed.vault_name).toBe(vaultName);
+    // One hub mint-token call carrying the caller bearer + narrowed scope.
+    const mint = hubCalls.find((c) => c.url.endsWith("/api/auth/mint-token"));
+    expect(mint).toBeDefined();
+    const headers = new Headers(mint!.init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${JWT_BEARER}`);
+    expect(mint!.body.scope).toBe(`vault:${vaultName}:read`);
+    expect(mint!.body.expires_in).toBe(900);
+    expect(mint!.body.permissions).toBeUndefined(); // unscoped caller
     closeAllStores();
   });
 
-  test("mint with custom TTL=3600 returns expires_at ~1 hour out", async () => {
+  test("mint with custom TTL=3600 forwards expires_in=3600", async () => {
+    installHubStub();
     const { vaultName, auth } = await setupAdminSession("mint-max");
     const { closeAllStores } = await import("./vault-store.ts");
-    const before = Date.now();
-    const { parsed } = await callTool(vaultName, auth, "manage-token", {
-      action: "mint",
-      scope: "vault:read",
-      ttl_seconds: 3600,
-    });
-    expect(parsed.action).toBe("mint");
-    const expiresAt = Date.parse(parsed.expires_at);
-    expect(expiresAt - before).toBeGreaterThan(3590 * 1000);
-    expect(expiresAt - before).toBeLessThan(3610 * 1000);
+    await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read", ttl_seconds: 3600 });
+    const mint = hubCalls.find((c) => c.url.endsWith("/api/auth/mint-token"));
+    expect(mint!.body.expires_in).toBe(3600);
     closeAllStores();
   });
 
-  test("mint with TTL=0 is rejected", async () => {
+  test("tag-scoped caller's mint includes permissions.scoped_tags", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("mint-scoped", ["task", "project"]);
+    const { closeAllStores } = await import("./vault-store.ts");
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read" });
+    expect(parsed.scoped_tags).toEqual(["task", "project"]);
+    const mint = hubCalls.find((c) => c.url.endsWith("/api/auth/mint-token"));
+    expect(mint!.body.permissions).toEqual({ scoped_tags: ["task", "project"] });
+    closeAllStores();
+  });
+
+  test("mint with TTL=0 is rejected locally (no hub call)", async () => {
+    installHubStub();
     const { vaultName, auth } = await setupAdminSession("mint-zero");
     const { closeAllStores } = await import("./vault-store.ts");
-    const { parsed } = await callTool(vaultName, auth, "manage-token", {
-      action: "mint",
-      scope: "vault:read",
-      ttl_seconds: 0,
-    });
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read", ttl_seconds: 0 });
     expect(parsed.error).toBe("invalid_request");
+    expect(hubCalls.length).toBe(0);
     closeAllStores();
   });
 
-  test("mint with TTL=3601 is rejected (over the 3600 cap)", async () => {
+  test("mint with TTL=3601 is rejected locally (over the 3600 cap)", async () => {
+    installHubStub();
     const { vaultName, auth } = await setupAdminSession("mint-over");
     const { closeAllStores } = await import("./vault-store.ts");
-    const { parsed } = await callTool(vaultName, auth, "manage-token", {
-      action: "mint",
-      scope: "vault:read",
-      ttl_seconds: 3601,
-    });
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read", ttl_seconds: 3601 });
     expect(parsed.error).toBe("invalid_request");
+    expect(hubCalls.length).toBe(0);
     closeAllStores();
   });
 
-  test("mint with scope outside caller's subset is rejected", async () => {
+  test("cross-vault / over-scope request is rejected locally (no hub call)", async () => {
+    installHubStub();
     const { vaultName, auth } = await setupAdminSession("mint-subset");
     const { closeAllStores } = await import("./vault-store.ts");
-    // Caller's auth carries admin/write/read for THIS vault. Asking for a
-    // scope naming a different vault is the canonical privilege-escalation
-    // surface — must reject.
     const { parsed } = await callTool(vaultName, auth, "manage-token", {
       action: "mint",
       scope: "vault:other-vault:write",
     });
     expect(parsed.error).toBe("forbidden");
     expect(parsed.rejected).toBeDefined();
+    expect(hubCalls.length).toBe(0);
     closeAllStores();
   });
 
-  test("revoke own minted token returns ok=true; second revoke is idempotent", async () => {
+  test("non-forwardable session (no JWT bearer) → clear mint error, no hub call", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("mint-nonfwd");
+    const { closeAllStores } = await import("./vault-store.ts");
+    // Env-var operator path: caller_jti present but the presented credential
+    // is a non-JWT secret → mint must refuse with a hub-JWT-required message.
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read" }, "operator-env-secret");
+    expect(parsed.error).toBe("forbidden");
+    expect(parsed.message).toContain("hub-JWT session");
+    expect(hubCalls.length).toBe(0);
+    closeAllStores();
+  });
+
+  test("revoke own minted jti posts to hub revoke-token + idempotent second revoke", async () => {
+    installHubStub();
     const { vaultName, auth } = await setupAdminSession("revoke-idem");
     const { closeAllStores } = await import("./vault-store.ts");
-    const mint = await callTool(vaultName, auth, "manage-token", {
-      action: "mint",
-      scope: "vault:read",
-    });
+    const mint = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read" });
     const jti = mint.parsed.jti;
-    const first = await callTool(vaultName, auth, "manage-token", {
-      action: "revoke",
-      jti,
-    });
+    const first = await callTool(vaultName, auth, "manage-token", { action: "revoke", jti });
     expect(first.parsed.ok).toBe(true);
     expect(first.parsed.already_revoked).toBe(false);
-    const second = await callTool(vaultName, auth, "manage-token", {
-      action: "revoke",
-      jti,
-    });
+    // First revoke posted to hub revoke-token with the caller bearer + jti.
+    const revoke = hubCalls.find((c) => c.url.endsWith("/api/auth/revoke-token"));
+    expect(revoke).toBeDefined();
+    expect(revoke!.body.jti).toBe(jti);
+    expect(new Headers(revoke!.init?.headers).get("authorization")).toBe(`Bearer ${JWT_BEARER}`);
+    // Second revoke is idempotent and does NOT re-hit hub (already revoked locally).
+    const revokeCallsBefore = hubCalls.filter((c) => c.url.endsWith("/api/auth/revoke-token")).length;
+    const second = await callTool(vaultName, auth, "manage-token", { action: "revoke", jti });
     expect(second.parsed.ok).toBe(true);
     expect(second.parsed.already_revoked).toBe(true);
+    const revokeCallsAfter = hubCalls.filter((c) => c.url.endsWith("/api/auth/revoke-token")).length;
+    expect(revokeCallsAfter).toBe(revokeCallsBefore);
     closeAllStores();
   });
 
-  test("list returns this session's mints, not other sessions' or CLI mints", async () => {
+  test("cannot revoke another session's jti (session-pinned)", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("revoke-other");
+    const { closeAllStores, getVaultStore } = await import("./vault-store.ts");
+    const { recordMcpMintLedger } = await import("./token-store.ts");
+    // Seed a ledger row attributed to a DIFFERENT session.
+    const store = getVaultStore(vaultName);
+    recordMcpMintLedger(store.db, {
+      jti: "hub_jti_other",
+      parentJti: "t_othersession",
+      vaultName,
+      label: "other",
+      scopes: [`vault:${vaultName}:read`],
+      scopedTags: null,
+      expiresAt: new Date(Date.now() + 900_000).toISOString(),
+    });
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "revoke", jti: "hub_jti_other" });
+    // Not in THIS session's ledger → idempotent ok=true, but NO hub revoke call.
+    expect(parsed.ok).toBe(true);
+    expect(hubCalls.filter((c) => c.url.endsWith("/api/auth/revoke-token")).length).toBe(0);
+    closeAllStores();
+  });
+
+  test("list returns this session's hub-JWT mints, not other sessions'", async () => {
+    installHubStub();
     const { vaultName, auth } = await setupAdminSession("list-session");
     const { closeAllStores, getVaultStore } = await import("./vault-store.ts");
-    const { createToken, generateToken } = await import("./token-store.ts");
+    const { recordMcpMintLedger } = await import("./token-store.ts");
 
-    // Mint two via manage-token in THIS session.
     const m1 = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read", description: "alpha" });
     const m2 = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read", description: "beta" });
 
-    // Mint one CLI-style (no created_via) and one from another session.
+    // Seed another session's ledger row — must NOT appear in this list.
     const store = getVaultStore(vaultName);
-    createToken(store.db, generateToken().fullToken, {
-      label: "cli-token",
-      permission: "full",
-      scopes: ["vault:read"],
-      vault_name: vaultName,
-    });
-    createToken(store.db, generateToken().fullToken, {
+    recordMcpMintLedger(store.db, {
+      jti: "hub_jti_foreign",
+      parentJti: "t_othersession",
+      vaultName,
       label: "other-session-mint",
-      permission: "full",
-      scopes: ["vault:read"],
-      vault_name: vaultName,
-      created_via: "mcp_mint",
-      parent_jti: "t_othersession",
+      scopes: [`vault:${vaultName}:read`],
+      scopedTags: null,
+      expiresAt: null,
     });
 
     const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "list" });
@@ -4558,26 +4660,21 @@ describe("manage-token MCP tool (vault#376)", () => {
     const jtis = parsed.tokens.map((t: any) => t.jti);
     expect(jtis).toContain(m1.parsed.jti);
     expect(jtis).toContain(m2.parsed.jti);
+    expect(jtis).not.toContain("hub_jti_foreign");
     expect(parsed.tokens.length).toBe(2);
     closeAllStores();
   });
 
-  test("audit-log integration: minted row carries created_via='mcp_mint' and parent_jti", async () => {
-    const { vaultName, auth } = await setupAdminSession("audit");
+  test("ledger row records parent_jti + hub jti for the minting session", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("ledger");
     const { closeAllStores, getVaultStore } = await import("./vault-store.ts");
-
-    const { parsed } = await callTool(vaultName, auth, "manage-token", {
-      action: "mint",
-      scope: "vault:read",
-    });
-    const jti = parsed.jti;
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read" });
     const store = getVaultStore(vaultName);
-    const hashPrefix = jti.slice(2);
-    const row = store.db.prepare(`
-      SELECT created_via, parent_jti, vault_name FROM tokens
-      WHERE token_hash LIKE ?
-    `).get(`sha256:${hashPrefix}%`) as { created_via: string | null; parent_jti: string | null; vault_name: string | null };
-    expect(row.created_via).toBe("mcp_mint");
+    const row = store.db.prepare(
+      "SELECT jti, parent_jti, vault_name FROM mcp_mint_ledger WHERE jti = ?",
+    ).get(parsed.jti) as { jti: string; parent_jti: string; vault_name: string };
+    expect(row.jti).toBe(parsed.jti);
     expect(row.parent_jti).toBe(auth.caller_jti);
     expect(row.vault_name).toBe(vaultName);
     closeAllStores();

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -4679,6 +4679,133 @@ describe("manage-token MCP tool (vault#403, MGT — hub-JWT attenuation proxy)",
     expect(row.vault_name).toBe(vaultName);
     closeAllStores();
   });
+
+  // hub#454 made `vault:<N>:admin` sufficient to revoke an in-authority jti
+  // (capability attenuation, symmetric to mint), so the hub round-trip is now
+  // the expected-SUCCESS path. This asserts the success contract end-to-end:
+  // the caller's `vault:<N>:admin` bearer is forwarded, hub returns 200, and
+  // the local ledger row is flipped to revoked.
+  test("revoke success path: caller's vault:admin bearer revokes at hub + marks ledger (hub#454)", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("revoke-success");
+    const { closeAllStores, getVaultStore } = await import("./vault-store.ts");
+    const mint = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:admin" });
+    const jti = mint.parsed.jti;
+
+    const res = await callTool(vaultName, auth, "manage-token", { action: "revoke", jti });
+    expect(res.parsed.ok).toBe(true);
+    expect(res.parsed.already_revoked).toBe(false);
+    expect(res.parsed.error).toBeUndefined();
+
+    // Hub revoke-token was called with the caller's vault:admin bearer + jti.
+    const revoke = hubCalls.find((c) => c.url.endsWith("/api/auth/revoke-token"));
+    expect(revoke).toBeDefined();
+    expect(revoke!.body.jti).toBe(jti);
+    expect(new Headers(revoke!.init?.headers).get("authorization")).toBe(`Bearer ${JWT_BEARER}`);
+
+    // Local ledger row is now marked revoked.
+    const store = getVaultStore(vaultName);
+    const row = store.db.prepare(
+      "SELECT revoked_at FROM mcp_mint_ledger WHERE jti = ?",
+    ).get(jti) as { revoked_at: string | null };
+    expect(row.revoked_at).not.toBeNull();
+    closeAllStores();
+  });
+
+  test("caller_jti: null session → list returns empty", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("null-list");
+    const { closeAllStores } = await import("./vault-store.ts");
+    // Env-var operator / legacy session: no stable session id.
+    auth.caller_jti = null;
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "list" });
+    expect(parsed.action).toBe("list");
+    expect(parsed.tokens).toEqual([]);
+    closeAllStores();
+  });
+
+  test("caller_jti: null session → revoke returns not_found, no hub call", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("null-revoke");
+    const { closeAllStores } = await import("./vault-store.ts");
+    auth.caller_jti = null;
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "revoke", jti: "hub_jti_anything" });
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("not_found");
+    expect(hubCalls.filter((c) => c.url.endsWith("/api/auth/revoke-token")).length).toBe(0);
+    closeAllStores();
+  });
+
+  test("list isolation across vaults: vault-A session never sees a vault-B ledger row", async () => {
+    installHubStub();
+    const { vaultName, auth } = await setupAdminSession("list-vault-iso");
+    const { closeAllStores, getVaultStore } = await import("./vault-store.ts");
+    const { recordMcpMintLedger } = await import("./token-store.ts");
+
+    // Mint one in THIS (vault-A) session.
+    const m1 = await callTool(vaultName, auth, "manage-token", { action: "mint", scope: "vault:read" });
+
+    // Seed a ledger row attributed to the SAME parent_jti but a DIFFERENT
+    // vault — the list query scopes on (parent_jti, vault_name), so this
+    // foreign-vault row must not leak into vault-A's list.
+    const store = getVaultStore(vaultName);
+    recordMcpMintLedger(store.db, {
+      jti: "hub_jti_vaultB",
+      parentJti: auth.caller_jti, // same session id, different vault
+      vaultName: `${vaultName}-OTHER`,
+      label: "vault-B mint",
+      scopes: [`vault:${vaultName}-OTHER:read`],
+      scopedTags: null,
+      expiresAt: null,
+    });
+
+    const { parsed } = await callTool(vaultName, auth, "manage-token", { action: "list" });
+    const jtis = parsed.tokens.map((t: any) => t.jti);
+    expect(jtis).toContain(m1.parsed.jti);
+    expect(jtis).not.toContain("hub_jti_vaultB");
+    expect(parsed.tokens.length).toBe(1);
+    closeAllStores();
+  });
+
+  // INSERT OR IGNORE (not OR REPLACE): a duplicate jti record (a hub jti
+  // collision — shouldn't happen) must NOT overwrite the existing row, because
+  // that would silently reset a previously-set revoked_at and resurrect a
+  // revoked token.
+  test("recordMcpMintLedger duplicate jti preserves the existing row's revoked_at", async () => {
+    const { vaultName, auth } = await setupAdminSession("ledger-dup");
+    const { closeAllStores, getVaultStore } = await import("./vault-store.ts");
+    const { recordMcpMintLedger, markMcpMintLedgerRevoked, findMcpMintLedgerEntry } =
+      await import("./token-store.ts");
+    const store = getVaultStore(vaultName);
+
+    recordMcpMintLedger(store.db, {
+      jti: "hub_jti_dup",
+      parentJti: auth.caller_jti,
+      vaultName,
+      label: "first",
+      scopes: [`vault:${vaultName}:read`],
+      scopedTags: null,
+      expiresAt: null,
+    });
+    // Revoke it (sets revoked_at).
+    markMcpMintLedgerRevoked(store.db, "hub_jti_dup", auth.caller_jti, vaultName);
+    const before = findMcpMintLedgerEntry(store.db, "hub_jti_dup", auth.caller_jti, vaultName);
+    expect(before!.revoked_at).not.toBeNull();
+
+    // A second record with the same jti must be IGNORED — revoked_at survives.
+    recordMcpMintLedger(store.db, {
+      jti: "hub_jti_dup",
+      parentJti: auth.caller_jti,
+      vaultName,
+      label: "second (collision)",
+      scopes: [`vault:${vaultName}:read`],
+      scopedTags: null,
+      expiresAt: null,
+    });
+    const after = findMcpMintLedgerEntry(store.db, "hub_jti_dup", auth.caller_jti, vaultName);
+    expect(after!.revoked_at).toBe(before!.revoked_at); // unchanged, not reset to NULL
+    closeAllStores();
+  });
 });
 
 describe("extractApiKey", () => {


### PR DESCRIPTION
Auth-unification arc, **MGT step** (tracker row: [`parachute-patterns/migrations/2026-05-28-operator-mintable-vault-admin.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/migrations/2026-05-28-operator-mintable-vault-admin.md)). Converts the `manage-token` MCP tool from minting deprecated `pvt_*` vault-DB tokens to a thin proxy to hub's `/api/auth/mint-token` attenuation endpoint — it now issues hub JWTs. This is the change that lets `pvt_*` be dropped entirely (the DROP step). Enabling pieces already merged: hub mint-token attenuation (hub#452 — a `vault:<N>:admin` bearer may mint same-vault subsets) and vault reading tag-scoping from a hub JWT's `permissions.scoped_tags` (vault#403 C0).

> **Update 2026-05-28 — reviewer P1 RESOLVED upstream.** The reviewer's P1 was "revoke forwards `vault:<N>:admin` to a `host:auth`-gated endpoint → always 403, so registry-side revoke can't actually land." **hub#454 (merged)** makes `/api/auth/revoke-token` apply capability attenuation symmetric to mint: a `vault:<N>:admin` bearer may revoke any jti whose scopes it could have minted. So manage-token's revoke now works **end-to-end** against current hub `main` with the caller's own `vault:<N>:admin` bearer — `host:auth` is no longer required. Folded in the latest commit: stale "host:auth required / vault:admin doesn't cover it" comments rewritten; `revokeAction`'s hub round-trip reframed as the expected-**success** path (the non-200 branch is now the exception — network blip / edge — not the norm, with graceful-degradation retained); reviewer nits (INSERT OR IGNORE + collision warning so a duplicate jti never resets `revoked_at`; `looksLikeJwt`-is-syntactic-only comment; new tests for `caller_jti: null` list/revoke, cross-vault list isolation, and the revoke-success path).

## Step-1 map (investigated before coding)

- **`src/mcp-tools.ts`** — `buildManageTokenTool` (L464+), `mintAction`/`revokeAction`/`listAction`. `auth: AuthResult` flows in via `generateScopedMcpTools`. `AuthResult` (src/auth.ts) carries `scopes` + `caller_jti` + `scoped_tags` but **not** the raw bearer.
- **Session-pinned tracking (old)** — `createToken(..., created_via:"mcp_mint", parent_jti)`, `softRevokeMcpToken`, `listMcpMintedTokens` in `src/token-store.ts`; stored `mcp_mint`-tagged rows in the `tokens` table.
- **MCP HTTP layer** — `src/routing.ts` L432-441: `authenticateVaultRequest` then `handleScopedMcp(req, vaultName, auth)`. `extractApiKey(req)` (src/auth.ts) returns the raw bearer. This is where the raw bearer is threaded through.
- **Hub-mint client** — `mcp-install.ts` `mintHubJwt` (POST `<hub>/api/auth/mint-token`, fetchImpl seam) + `chooseHubOrigin` (PARACHUTE_HUB_ORIGIN → expose-state FQDN → loopback). Reused, not reinvented.
- **Hub** — mint-token accepts + echoes a `permissions` object; revoke-token is `POST /api/auth/revoke-token {jti}`, idempotent.

## Proxy design

- **`mintAction`** POSTs to hub mint-token (via `mintHubJwt`) with the caller's bearer. Scopes narrowed to resource-named `vault:<name>:<verb>`; cross-vault/over-scope rejected locally (`validateMintedScopes`, fail-fast) before any round-trip — hub re-enforces authoritatively. TTL logic unchanged (default 900s / max 3600s). Return shape unchanged; `token` is now a hub JWT, `jti` is hub's jti.
- **Tag-scope inheritance** — a tag-scoped caller's `auth.scoped_tags` rides along as `permissions: { scoped_tags: [...] }` so the minted hub JWT carries the restriction (vault enforces via C0). Unscoped callers omit `permissions`.

## Raw-bearer threading

`routing.ts` (`extractApiKey`) → `handleScopedMcp(req, vaultName, auth, callerBearer)` → `generateScopedMcpTools(..., callerBearer)` → `buildManageTokenTool(..., callerBearer)`. Only the exact validated credential the session presented — never fabricated. Mint forwards it **only when JWT-shaped** (`looksLikeJwt`).

## Session-pinned ledger

Since mints now live in hub's registry, a lightweight vault-side `mcp_mint_ledger` table (schema **v20**) records `(parent_jti → hub jti)` + display metadata. **Not credentials** — the signed JWT is never stored, only the jti (revocation handle). `listAction` reads the ledger; `revokeAction` gates on the session's ledger (can't revoke another session's jti) then POSTs hub revoke-token (idempotent); `caller_jti === null` → list empty / revoke not_found. New table created via `CREATE TABLE IF NOT EXISTS` in SCHEMA_SQL + a defensive `migrateToV20`; verified fresh + v19-upgrade + idempotent re-run.

## Non-forwardable session handling

A session authenticated via a non-forwardable credential (env-var `VAULT_AUTH_TOKEN` secret, or legacy `pvt_*` — neither JWT-shaped, neither carrying `vault:<N>:admin` mint authority at hub) gets a clear error on mint: *"manage-token mint requires a hub-JWT session holding `vault:<name>:admin`…"*. No fabricated bearer, no hub call.

## Deferred

`pvt_*` mint infra (`generateToken`/`createToken`, `softRevokeMcpToken`, `listMcpMintedTokens`) stays — the SPA still uses it until its own migration; DROP removes it last.

## Gates

- `bun test ./src/` — **1279 pass, 0 fail**
- `bun test ./core/src/` — **610 pass, 0 fail**
- `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
