### PR TITLE
feat(vault): admin SPA tokens page mints hub JWTs (retire pvt_* mint in UI)

### DIFF
--- a/web/ui/src/lib/host-admin-auth.test.ts
+++ b/web/ui/src/lib/host-admin-auth.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Host-admin auth helper — the separate bearer the tokens page mints from
+ * hub's session-cookie-gated `/admin/host-admin-token` to call the
+ * `/api/auth/*` registry endpoints.
+ *
+ * Covered:
+ *   - `ensureHostAdminToken` — 200 caches; cached returned without a network
+ *     call; 401/404 → auth-required; 403 → forbidden; 5xx → network-error;
+ *     expiry → re-mint.
+ *   - `hostAdminAuthedFetch` — sends the bearer; 401-retry re-mints + retries;
+ *     a failed refresh throws `HostAdminError` with the right disposition.
+ *   - `redirectToAccountHome` — 403 → `<issuer>/account/`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _setTokenForTest, clearToken } from "./auth.ts";
+import {
+  HostAdminError,
+  _getHostAdminTokenForTest,
+  clearHostAdminToken,
+  ensureHostAdminToken,
+  hostAdminAuthedFetch,
+  redirectToAccountHome,
+} from "./host-admin-auth.ts";
+
+function mintResponse(token = "ha.jwt", ttlMs = 600_000): Response {
+  return new Response(
+    JSON.stringify({
+      token,
+      expires_at: new Date(Date.now() + ttlMs).toISOString(),
+      scopes: ["parachute:host:admin", "parachute:host:auth"],
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+beforeEach(() => {
+  clearHostAdminToken();
+  clearToken();
+});
+
+afterEach(() => {
+  clearHostAdminToken();
+  clearToken();
+  vi.restoreAllMocks();
+});
+
+describe("ensureHostAdminToken", () => {
+  it("mints on 200 and caches the token", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mintResponse());
+
+    const result = await ensureHostAdminToken();
+
+    expect(result).toEqual({ kind: "ok", token: "ha.jwt" });
+    expect(_getHostAdminTokenForTest()).toBe("ha.jwt");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/admin/host-admin-token",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+
+  it("returns the cached token without a second network call", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mintResponse());
+    await ensureHostAdminToken();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const again = await ensureHostAdminToken();
+
+    expect(again).toEqual({ kind: "ok", token: "ha.jwt" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // still 1 — served from cache.
+  });
+
+  it("returns auth-required on 401 (no hub session)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthenticated" }), { status: 401 }),
+    );
+
+    const result = await ensureHostAdminToken();
+
+    expect(result).toEqual({ kind: "auth-required", status: 401 });
+    expect(_getHostAdminTokenForTest()).toBeNull();
+  });
+
+  it("returns auth-required on 404 (vault not on this hub)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "not_found" }), { status: 404 }),
+    );
+
+    const result = await ensureHostAdminToken();
+
+    expect(result).toEqual({ kind: "auth-required", status: 404 });
+  });
+
+  it("returns forbidden on 403 (friend account, not the hub admin)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "not_admin" }), { status: 403 }),
+    );
+
+    const result = await ensureHostAdminToken();
+
+    expect(result).toEqual({ kind: "forbidden" });
+    expect(_getHostAdminTokenForTest()).toBeNull();
+  });
+
+  it("returns network-error on 5xx", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("upstream", { status: 503 }));
+
+    const result = await ensureHostAdminToken();
+
+    expect(result.kind).toBe("network-error");
+  });
+
+  it("re-mints when the cached token is past its expiry", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mintResponse("first.jwt", -1000)) // already expired
+      .mockResolvedValueOnce(mintResponse("second.jwt", 600_000));
+
+    const first = await ensureHostAdminToken();
+    expect(first).toEqual({ kind: "ok", token: "first.jwt" });
+
+    // Cached token's expiry is in the past → next call re-mints.
+    const second = await ensureHostAdminToken();
+    expect(second).toEqual({ kind: "ok", token: "second.jwt" });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("hostAdminAuthedFetch", () => {
+  it("attaches the host-admin bearer", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/admin/host-admin-token") return mintResponse();
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    const res = await hostAdminAuthedFetch("/api/auth/tokens");
+
+    expect(res.ok).toBe(true);
+    const apiCall = fetchSpy.mock.calls.find(([u]) => String(u) === "/api/auth/tokens");
+    const headers = new Headers((apiCall![1] as RequestInit).headers);
+    expect(headers.get("authorization")).toBe("Bearer ha.jwt");
+  });
+
+  it("on 401 clears the cached token, re-mints, and retries once", async () => {
+    let mintCount = 0;
+    let apiCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/admin/host-admin-token") {
+        mintCount++;
+        return mintResponse(`mint-${mintCount}`);
+      }
+      apiCount++;
+      // First API hit 401s (stale token); the retry (with the re-minted
+      // bearer) succeeds.
+      return apiCount === 1
+        ? new Response("unauthorized", { status: 401 })
+        : new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    const res = await hostAdminAuthedFetch("/api/auth/tokens");
+
+    expect(res.status).toBe(200);
+    expect(mintCount).toBe(2); // initial mint + re-mint on 401.
+    expect(apiCount).toBe(2); // original + retry.
+  });
+
+  it("throws HostAdminError(auth-required) when the (re)mint can't get a session", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthenticated" }), { status: 401 }),
+    );
+
+    await expect(hostAdminAuthedFetch("/api/auth/tokens")).rejects.toMatchObject({
+      name: "HostAdminError",
+      disposition: "auth-required",
+    });
+  });
+
+  it("throws HostAdminError(forbidden) when the operator is a friend account", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "not_admin" }), { status: 403 }),
+    );
+
+    const err = await hostAdminAuthedFetch("/api/auth/tokens").catch((e) => e);
+    expect(err).toBeInstanceOf(HostAdminError);
+    expect((err as HostAdminError).disposition).toBe("forbidden");
+  });
+});
+
+describe("redirectToAccountHome", () => {
+  // Capture the REAL `window.location` property descriptor so we can restore
+  // it byte-for-byte after each test. Replacing `window.location` with a stub
+  // and then rebuilding it from a string leaks a non-jsdom Location into
+  // sibling suites that share the worker (caused a flaky VaultMirror failure
+  // when the run order put it after this block). Precise restore avoids that.
+  const originalLocationDescriptor = Object.getOwnPropertyDescriptor(window, "location");
+
+  function stubLocationHref(): string[] {
+    const assigned: string[] = [];
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        set href(v: string) {
+          assigned.push(v);
+        },
+        get href() {
+          return assigned[assigned.length - 1] ?? "";
+        },
+      } as unknown as Location,
+    });
+    return assigned;
+  }
+
+  afterEach(() => {
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, "location", originalLocationDescriptor);
+    }
+  });
+
+  it("redirects to <issuer>/account/ using the JWT issuer origin", () => {
+    // The vault-admin JWT carries the `iss` claim getIssuerOrigin reads.
+    // Build a token whose payload has iss=https://hub.example.com.
+    const payload = btoa(JSON.stringify({ iss: "https://hub.example.com/" }));
+    _setTokenForTest(`h.${payload}.s`);
+
+    const assigned = stubLocationHref();
+    redirectToAccountHome();
+
+    expect(assigned[0]).toBe("https://hub.example.com/account/");
+  });
+
+  it("falls back to a relative /account/ when no issuer is known", () => {
+    _setTokenForTest(null);
+
+    const assigned = stubLocationHref();
+    redirectToAccountHome();
+
+    expect(assigned[0]).toBe("/account/");
+  });
+});

--- a/web/ui/src/lib/host-admin-auth.ts
+++ b/web/ui/src/lib/host-admin-auth.ts
@@ -1,0 +1,260 @@
+/**
+ * Host-admin auth helper for the vault admin SPA's tokens page.
+ *
+ * Background — the auth-unification arc. The tokens page used to mint
+ * deprecated `pvt_*` vault-DB tokens via the per-vault REST surface
+ * (`POST /vault/<name>/tokens`), authed with the vault-admin JWT that
+ * `auth.ts:mintFromHubSession` caches. As of this step the page mints
+ * **hub JWTs** instead, via hub's `/api/auth/*` registry endpoints
+ * (`mint-token` / `tokens` / `revoke-token`).
+ *
+ * Those endpoints require a bearer carrying `parachute:host:auth` — the
+ * LIST endpoint hard-requires it, which the vault-admin token
+ * (`vault:<name>:admin`) doesn't hold. So this module mints a SEPARATE
+ * **host-admin** bearer from hub's session-cookie-gated
+ * `GET /admin/host-admin-token` and uses it uniformly for all three token
+ * operations. We deliberately keep one bearer for the whole tokens-page
+ * surface rather than splitting mint/revoke (vault-admin, would work via
+ * attenuation) from list (host-admin, required) — a single auth model is
+ * simpler to reason about.
+ *
+ * This is INTENTIONALLY a parallel cache to `auth.ts`'s vault-admin token.
+ * Other SPA pages (vault detail, mirror config, the legacy-tokens list in
+ * this same page) still depend on the vault-admin bearer via
+ * `api.ts:authedFetch` / `_authedFetch`; we must not clobber it. The two
+ * bearers coexist: vault-admin talks to `/vault/<name>/*`, host-admin
+ * talks to hub's `/api/auth/*` + `/vaults` admin surface.
+ *
+ * Storage: module-scoped variable, NEVER `localStorage` / `sessionStorage`
+ * — same posture as the vault-admin token. The host-admin JWT is even more
+ * sensitive (it carries `parachute:host:admin` + `parachute:host:auth`), so
+ * keeping it in memory with the narrowest XSS surface matters more here.
+ *
+ * The endpoint mints a 10-minute TTL token; we cache it + its absolute
+ * expiry and rely on `hostAdminAuthedFetch`'s 401-retry to re-mint when it
+ * lapses (the tokens page is interactive and short-lived enough that the
+ * proactive-timer machinery `auth.ts` carries for the vault-admin token
+ * isn't worth duplicating here).
+ */
+import { getIssuerOrigin } from "./scope.ts";
+
+/** Cached host-admin JWT. `null` when none minted yet / cleared on 401. */
+let cachedHostAdminToken: string | null = null;
+/** Absolute expiry, ms since epoch. `null` when no token cached or the
+ *  mint response carried no parseable `expires_at`. */
+let cachedHostAdminExpiresAtMs: number | null = null;
+
+/**
+ * Result of an attempted host-admin token mint. Callers branch on `kind`:
+ *   - `ok` — bearer in hand.
+ *   - `auth-required` — 401 (no hub session) / 404. Render the sign-in
+ *     banner; the operator needs to sign in at the hub.
+ *   - `forbidden` — 403 `not_admin`. The signed-in account is a friend, not
+ *     the hub admin. The caller redirects to the issuer's `/account/` home.
+ *   - `network-error` — transient (5xx / fetch reject / parse failure).
+ */
+export type HostAdminResult =
+  | { kind: "ok"; token: string }
+  | { kind: "auth-required"; status: number }
+  | { kind: "forbidden" }
+  | { kind: "network-error"; message: string };
+
+interface HostAdminMintBody {
+  token?: string;
+  /** ISO timestamp — hub returns absolute expiry. */
+  expires_at?: string;
+  scopes?: string[];
+}
+
+/** Parse an ISO timestamp to ms-since-epoch; `null` on invalid input. */
+function parseExpiresAt(iso: string): number | null {
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Mint a fresh host-admin bearer from the hub session cookie.
+ *
+ * Same-origin GET against `/admin/host-admin-token` — the
+ * `parachute_hub_session` cookie auto-attaches because the SPA is served
+ * same-origin-as-hub through hub's `/vault/<name>/*` proxy (vault#252).
+ * Mirrors `auth.ts:mintFromHubSession`'s shape, but:
+ *   - no vault-name segment (host-admin tokens carry no per-vault pin);
+ *   - 403 is surfaced as a distinct `forbidden` kind so the caller can do
+ *     the friend-account → `/account/` redirect (the host-admin endpoint
+ *     gates on first-admin identity, unlike the vault-admin endpoint).
+ */
+async function mintHostAdminToken(): Promise<HostAdminResult> {
+  if (typeof window === "undefined") {
+    return { kind: "network-error", message: "no window" };
+  }
+  let res: Response;
+  try {
+    res = await fetch("/admin/host-admin-token", {
+      method: "GET",
+      headers: { accept: "application/json" },
+      credentials: "same-origin",
+    });
+  } catch (err) {
+    return { kind: "network-error", message: err instanceof Error ? err.message : String(err) };
+  }
+  if (res.status === 403) {
+    // Friend account (signed in but not the hub admin). Distinct from
+    // 401/404 — the operator can't unblock by signing in, they're the
+    // wrong identity. Caller redirects to the issuer's account home.
+    return { kind: "forbidden" };
+  }
+  if (res.status === 401 || res.status === 404) {
+    return { kind: "auth-required", status: res.status };
+  }
+  if (!res.ok) {
+    return { kind: "network-error", message: `hub returned ${res.status}` };
+  }
+  let body: HostAdminMintBody;
+  try {
+    body = (await res.json()) as HostAdminMintBody;
+  } catch (err) {
+    return {
+      kind: "network-error",
+      message: err instanceof Error ? err.message : "could not parse host-admin mint response",
+    };
+  }
+  if (typeof body.token !== "string" || body.token.length === 0) {
+    return { kind: "network-error", message: "host-admin mint response missing token" };
+  }
+  cachedHostAdminToken = body.token;
+  cachedHostAdminExpiresAtMs = body.expires_at ? parseExpiresAt(body.expires_at) : null;
+  return { kind: "ok", token: body.token };
+}
+
+/**
+ * Ensure a usable host-admin bearer, minting silently if needed.
+ *
+ * Returns the cached token when one is in hand and not past its known
+ * expiry; otherwise hits the mint endpoint. The token registry endpoints'
+ * 401-retry (see `hostAdminAuthedFetch`) covers the case where the cached
+ * token lapses between our clock check and the actual request.
+ */
+export async function ensureHostAdminToken(): Promise<HostAdminResult> {
+  if (cachedHostAdminToken) {
+    if (cachedHostAdminExpiresAtMs === null || cachedHostAdminExpiresAtMs > Date.now()) {
+      return { kind: "ok", token: cachedHostAdminToken };
+    }
+    // Past expiry — drop + re-mint.
+    cachedHostAdminToken = null;
+    cachedHostAdminExpiresAtMs = null;
+  }
+  return mintHostAdminToken();
+}
+
+/** Drop the cached host-admin bearer. Used by the 401-retry path + tests. */
+export function clearHostAdminToken(): void {
+  cachedHostAdminToken = null;
+  cachedHostAdminExpiresAtMs = null;
+}
+
+/** Test seam: read the current host-admin token directly. */
+export function _getHostAdminTokenForTest(): string | null {
+  return cachedHostAdminToken;
+}
+
+/** Test seam: read the cached expiry (ms since epoch) for assertion. */
+export function _getHostAdminExpiresAtMsForTest(): number | null {
+  return cachedHostAdminExpiresAtMs;
+}
+
+/**
+ * Error carrying both an HTTP-ish status and a `kind` so the tokens-page
+ * route can branch: `auth-required` → sign-in banner, `forbidden` →
+ * `/account/` redirect, everything else → error banner.
+ *
+ * Mirrors `api.ts:HttpError` but adds the auth-disposition so the host-admin
+ * surface's three failure modes survive the throw boundary.
+ */
+export class HostAdminError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly disposition: "auth-required" | "forbidden" | "network-error" | "http",
+  ) {
+    super(message);
+    this.name = "HostAdminError";
+  }
+}
+
+interface HostAdminFetchInit extends Omit<RequestInit, "headers"> {
+  headers?: Record<string, string>;
+}
+
+/**
+ * Bearer-authed fetch against hub's `/api/auth/*` surface using the
+ * host-admin token, with a single silent-refresh retry on 401.
+ *
+ * Mirrors `api.ts:authedFetch` (the vault-admin equivalent) but threads
+ * `ensureHostAdminToken` instead. On the first 401 we clear the cached
+ * token (forcing a fresh mint rather than handing back a
+ * stale-but-not-expired-by-our-clock token) and retry once. A failed
+ * refresh throws `HostAdminError` with the right disposition so the route
+ * renders the matching empty state.
+ *
+ * Returns the `Response` for the caller to inspect — body parsing lives at
+ * the callsites (heterogenous shapes), same as `api.ts`.
+ */
+export async function hostAdminAuthedFetch(
+  url: string,
+  init: HostAdminFetchInit = {},
+): Promise<Response> {
+  let token: string;
+  const ensured = await ensureHostAdminToken();
+  if (ensured.kind !== "ok") {
+    throw resultToError(ensured);
+  }
+  token = ensured.token;
+
+  const { headers: extraHeaders, ...rest } = init;
+  const buildHeaders = (bearer: string): Record<string, string> => ({
+    accept: "application/json",
+    ...(extraHeaders ?? {}),
+    authorization: `Bearer ${bearer}`,
+  });
+
+  const res = await fetch(url, { ...rest, headers: buildHeaders(token) });
+  if (res.status !== 401) return res;
+  // 401 → one silent refresh + retry. Clear first so `ensureHostAdminToken`
+  // is forced to hit the mint endpoint.
+  clearHostAdminToken();
+  const refreshed = await ensureHostAdminToken();
+  if (refreshed.kind !== "ok") {
+    throw resultToError(refreshed);
+  }
+  return fetch(url, { ...rest, headers: buildHeaders(refreshed.token) });
+}
+
+/** Map a non-ok mint result to a `HostAdminError` for the throw boundary. */
+function resultToError(result: Exclude<HostAdminResult, { kind: "ok" }>): HostAdminError {
+  if (result.kind === "forbidden") {
+    return new HostAdminError(403, "host-admin token mint forbidden — not the hub admin", "forbidden");
+  }
+  if (result.kind === "auth-required") {
+    return new HostAdminError(
+      result.status,
+      "no host-admin session — sign in to the hub to manage tokens",
+      "auth-required",
+    );
+  }
+  return new HostAdminError(0, result.message, "network-error");
+}
+
+/**
+ * Redirect a friend account to the hub's `/account/` home. Called by the
+ * tokens page when it catches a `forbidden` host-admin result — the
+ * operator is signed in but isn't the hub admin, so token management isn't
+ * theirs to reach. We send them to their account home on the issuer origin
+ * (decoded from the vault-admin JWT's `iss` claim, which the SPA already
+ * holds). Falls back to a relative `/account/` when no issuer is known.
+ */
+export function redirectToAccountHome(): void {
+  if (typeof window === "undefined") return;
+  const issuer = getIssuerOrigin();
+  window.location.href = issuer ? `${issuer}/account/` : "/account/";
+}

--- a/web/ui/src/lib/tokens-api.test.ts
+++ b/web/ui/src/lib/tokens-api.test.ts
@@ -1,12 +1,26 @@
 /**
- * Tokens REST client. Tests cover the auth gate (no cached token → 401), the
- * shape of the GET / POST / DELETE calls (URL, method, headers), and the
- * server-error surfacing path that matches `getVaultDetail`'s behavior.
+ * Tokens REST client — the auth-unification arc (SPA step).
+ *
+ * Two surfaces under test:
+ *   - **Hub JWTs** (`mintHubToken` / `listHubTokens` / `revokeHubToken`) hit
+ *     hub's `/api/auth/*` registry with the host-admin bearer. The host-admin
+ *     token is minted lazily from `/admin/host-admin-token`, so the mock
+ *     fetch routes that URL to a fresh bearer and the `/api/auth/*` URLs to
+ *     the registry shapes.
+ *   - **Legacy `pvt_*`** (`listLegacyTokens` / `revokeLegacyToken`) hit the
+ *     vault's per-vault REST surface with the vault-admin bearer.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { _setTokenForTest, clearToken } from "./auth.ts";
+import { clearHostAdminToken } from "./host-admin-auth.ts";
 import { HttpError } from "./api.ts";
-import { listTokens, mintToken, revokeToken } from "./tokens-api.ts";
+import {
+  listHubTokens,
+  listLegacyTokens,
+  mintHubToken,
+  revokeHubToken,
+  revokeLegacyToken,
+} from "./tokens-api.ts";
 
 interface Call {
   url: string;
@@ -37,49 +51,364 @@ function mockFetch(impl: (call: Call) => Promise<Response>) {
   return calls;
 }
 
-describe("tokens-api auth gate", () => {
-  afterEach(() => {
-    clearToken();
-  });
+/** Standard host-admin mint response for `/admin/host-admin-token`. */
+function hostAdminMint(token = "host.admin.jwt"): Response {
+  return new Response(
+    JSON.stringify({
+      token,
+      expires_at: new Date(Date.now() + 600_000).toISOString(),
+      scopes: ["parachute:host:admin", "parachute:host:auth"],
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
 
-  it("listTokens throws HttpError(401) when no token is cached", async () => {
-    _setTokenForTest(null);
-    await expect(listTokens("work")).rejects.toMatchObject({
-      name: "HttpError",
-      status: 401,
+beforeEach(() => {
+  clearHostAdminToken();
+  clearToken();
+});
+
+afterEach(() => {
+  clearHostAdminToken();
+  clearToken();
+  vi.restoreAllMocks();
+});
+
+describe("mintHubToken", () => {
+  it("POSTs the SINGULAR scope string per verb, with subject + expires_in", async () => {
+    const calls = mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(
+        JSON.stringify({
+          jti: "j_new",
+          token: "vault.scoped.jwt",
+          scope: "vault:work:write",
+          expires_at: new Date(Date.now() + 90 * 86400_000).toISOString(),
+        }),
+        { status: 200 },
+      );
     });
+
+    const result = await mintHubToken("work", {
+      verb: "write",
+      label: "ci",
+      scopedTags: [],
+      ttlDays: 90,
+    });
+
+    // Reveal field is `token` (banner works unchanged) + the jti round-trips.
+    expect(result.token).toBe("vault.scoped.jwt");
+    expect(result.jti).toBe("j_new");
+
+    const mintCall = calls.find((c) => c.url === "/api/auth/mint-token");
+    expect(mintCall?.method).toBe("POST");
+    expect(mintCall?.auth).toBe("Bearer host.admin.jwt");
+    expect(mintCall?.contentType).toBe("application/json");
+    const parsed = JSON.parse(mintCall!.body!);
+    // SINGULAR `scope` string, not a `scopes` array.
+    expect(parsed.scope).toBe("vault:work:write");
+    expect(parsed).not.toHaveProperty("scopes");
+    expect(parsed.subject).toBe("ci");
+    expect(parsed.expires_in).toBe(90 * 86400);
+    // Audience auto-derives server-side — we omit it.
+    expect(parsed).not.toHaveProperty("audience");
   });
 
-  it("mintToken throws HttpError(401) when no token is cached", async () => {
-    _setTokenForTest(null);
-    await expect(mintToken("work", { label: "test" })).rejects.toBeInstanceOf(HttpError);
+  it("uses the admin verb in the scope string", async () => {
+    const calls = mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(
+        JSON.stringify({ jti: "j", token: "t", scope: "vault:work:admin", expires_at: null }),
+        { status: 200 },
+      );
+    });
+
+    await mintHubToken("work", { verb: "admin", label: "x", scopedTags: [], ttlDays: 30 });
+
+    const parsed = JSON.parse(calls.find((c) => c.url === "/api/auth/mint-token")!.body!);
+    expect(parsed.scope).toBe("vault:work:admin");
+    expect(parsed.expires_in).toBe(30 * 86400);
   });
 
-  it("revokeToken throws HttpError(401) when no token is cached", async () => {
-    _setTokenForTest(null);
-    await expect(revokeToken("work", "t_abc")).rejects.toBeInstanceOf(HttpError);
+  it("adds permissions.scoped_tags when tags are selected", async () => {
+    const calls = mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(
+        JSON.stringify({
+          jti: "j",
+          token: "t",
+          scope: "vault:work:read",
+          permissions: { scoped_tags: ["work", "health"] },
+          expires_at: null,
+        }),
+        { status: 200 },
+      );
+    });
+
+    await mintHubToken("work", {
+      verb: "read",
+      label: "scoped",
+      scopedTags: ["work", "health"],
+      ttlDays: 180,
+    });
+
+    const parsed = JSON.parse(calls.find((c) => c.url === "/api/auth/mint-token")!.body!);
+    expect(parsed.permissions).toEqual({ scoped_tags: ["work", "health"] });
+  });
+
+  it("OMITS permissions entirely when no tags selected (vault C0 fail-closes on empty)", async () => {
+    const calls = mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(
+        JSON.stringify({ jti: "j", token: "t", scope: "vault:work:read", expires_at: null }),
+        { status: 200 },
+      );
+    });
+
+    await mintHubToken("work", { verb: "read", label: "unscoped", scopedTags: [], ttlDays: 90 });
+
+    const parsed = JSON.parse(calls.find((c) => c.url === "/api/auth/mint-token")!.body!);
+    expect(parsed).not.toHaveProperty("permissions");
+  });
+
+  it("surfaces the server message on a 400 (e.g. expires_in too large)", async () => {
+    mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(
+        JSON.stringify({ error: "invalid_request", error_description: "expires_in exceeds 365d cap" }),
+        { status: 400 },
+      );
+    });
+
+    await expect(
+      mintHubToken("work", { verb: "read", label: "x", scopedTags: [], ttlDays: 9999 }),
+    ).rejects.toMatchObject({ status: 400, message: "expires_in exceeds 365d cap" });
   });
 });
 
-describe("listTokens", () => {
-  afterEach(() => {
-    clearToken();
+describe("listHubTokens", () => {
+  it("client-filters to only this vault's vault:<name>:* rows", async () => {
+    mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(
+        JSON.stringify({
+          tokens: [
+            {
+              jti: "j1",
+              user_id: null,
+              subject: "ci",
+              client_id: "parachute-hub",
+              scopes: ["vault:work:write"],
+              expires_at: "2026-09-01T00:00:00Z",
+              revoked_at: null,
+              created_at: "2026-05-01T00:00:00Z",
+              created_via: "cli_mint",
+              permissions: null,
+            },
+            {
+              // Different vault — must be filtered out.
+              jti: "j2",
+              user_id: null,
+              subject: "other",
+              client_id: "parachute-hub",
+              scopes: ["vault:other:admin"],
+              expires_at: "2026-09-01T00:00:00Z",
+              revoked_at: null,
+              created_at: "2026-05-01T00:00:00Z",
+              created_via: "cli_mint",
+              permissions: null,
+            },
+            {
+              // Host-admin row — also filtered out.
+              jti: "j3",
+              user_id: "u1",
+              subject: null,
+              client_id: "parachute-hub-spa",
+              scopes: ["parachute:host:admin", "parachute:host:auth"],
+              expires_at: "2026-09-01T00:00:00Z",
+              revoked_at: null,
+              created_at: "2026-05-01T00:00:00Z",
+              created_via: "oauth_refresh",
+              permissions: null,
+            },
+          ],
+          next_cursor: null,
+        }),
+        { status: 200 },
+      );
+    });
+
+    const tokens = await listHubTokens("work");
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.jti).toBe("j1");
+    expect(tokens[0]?.label).toBe("ci");
+    expect(tokens[0]?.scopes).toEqual(["vault:work:write"]);
   });
 
-  it("hits the right URL with the cached token and returns body.tokens", async () => {
-    _setTokenForTest("jwt-here");
+  it("requests ?revoked=all and sends the host-admin bearer", async () => {
+    const calls = mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(JSON.stringify({ tokens: [], next_cursor: null }), { status: 200 });
+    });
+
+    await listHubTokens("work");
+
+    const listCall = calls.find((c) => c.url.startsWith("/api/auth/tokens"));
+    expect(listCall?.url).toContain("revoked=all");
+    expect(listCall?.auth).toBe("Bearer host.admin.jwt");
+  });
+
+  it("follows next_cursor and accumulates ALL pages before filtering", async () => {
+    let listPage = 0;
+    const calls = mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      if (call.url.startsWith("/api/auth/tokens")) {
+        listPage++;
+        if (call.url.includes("cursor=")) {
+          // Page 2 — final page, carries the matching vault row.
+          return new Response(
+            JSON.stringify({
+              tokens: [
+                {
+                  jti: "page2-work",
+                  user_id: null,
+                  subject: "second-page-token",
+                  client_id: "parachute-hub",
+                  scopes: ["vault:work:admin"],
+                  expires_at: "2026-09-01T00:00:00Z",
+                  revoked_at: null,
+                  created_at: "2026-04-01T00:00:00Z",
+                  created_via: "cli_mint",
+                  permissions: null,
+                },
+              ],
+              next_cursor: null,
+            }),
+            { status: 200 },
+          );
+        }
+        // Page 1 — only an unrelated vault, plus a cursor to page 2.
+        return new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                jti: "page1-other",
+                user_id: null,
+                subject: "x",
+                client_id: "parachute-hub",
+                scopes: ["vault:other:read"],
+                expires_at: "2026-09-01T00:00:00Z",
+                revoked_at: null,
+                created_at: "2026-05-01T00:00:00Z",
+                created_via: "cli_mint",
+                permissions: null,
+              },
+            ],
+            next_cursor: "CURSOR_TO_PAGE_2",
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected url ${call.url}`);
+    });
+
+    const tokens = await listHubTokens("work");
+
+    // The matching row lives on PAGE 2 — single-page filtering would miss it.
+    expect(listPage).toBe(2);
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.jti).toBe("page2-work");
+    expect(tokens[0]?.label).toBe("second-page-token");
+    // The cursor from page 1 was threaded into the page-2 request.
+    const page2Call = calls.find((c) => c.url.includes("cursor="));
+    expect(page2Call?.url).toContain("cursor=CURSOR_TO_PAGE_2");
+  });
+
+  it("reads permissions.scoped_tags as a parsed object (no JSON.parse) and maps revoked rows", async () => {
+    mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(
+        JSON.stringify({
+          tokens: [
+            {
+              jti: "j-scoped",
+              user_id: null,
+              subject: "scoped-token",
+              client_id: "parachute-hub",
+              scopes: ["vault:work:read"],
+              expires_at: "2026-09-01T00:00:00Z",
+              revoked_at: "2026-05-10T00:00:00Z",
+              created_at: "2026-05-01T00:00:00Z",
+              created_via: "cli_mint",
+              // permissions is already a PARSED object on the wire.
+              permissions: { scoped_tags: ["health"] },
+            },
+          ],
+          next_cursor: null,
+        }),
+        { status: 200 },
+      );
+    });
+
+    const tokens = await listHubTokens("work");
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.scoped_tags).toEqual(["health"]);
+    expect(tokens[0]?.revoked_at).toBe("2026-05-10T00:00:00Z");
+  });
+});
+
+describe("revokeHubToken", () => {
+  it("POSTs { jti } (not { id }) with the host-admin bearer", async () => {
+    const calls = mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(
+        JSON.stringify({ jti: "j_abc", revoked_at: "2026-05-10T00:00:00Z" }),
+        { status: 200 },
+      );
+    });
+
+    await revokeHubToken("j_abc");
+
+    const revokeCall = calls.find((c) => c.url === "/api/auth/revoke-token");
+    expect(revokeCall?.method).toBe("POST");
+    expect(revokeCall?.auth).toBe("Bearer host.admin.jwt");
+    const parsed = JSON.parse(revokeCall!.body!);
+    expect(parsed).toEqual({ jti: "j_abc" });
+    expect(parsed).not.toHaveProperty("id");
+  });
+
+  it("is idempotent — re-revoking an already-revoked jti resolves (200)", async () => {
+    mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      // Server returns the existing revoked_at + 200 for an already-revoked jti.
+      return new Response(
+        JSON.stringify({ jti: "j_abc", revoked_at: "2026-05-09T00:00:00Z" }),
+        { status: 200 },
+      );
+    });
+
+    await expect(revokeHubToken("j_abc")).resolves.toBeUndefined();
+  });
+});
+
+describe("legacy pvt_* surface", () => {
+  it("listLegacyTokens hits /vault/<name>/tokens with the VAULT-ADMIN bearer", async () => {
+    _setTokenForTest("vault.admin.jwt");
     const calls = mockFetch(async () =>
       new Response(
         JSON.stringify({
           tokens: [
             {
-              id: "t_abc123",
-              label: "ci",
+              id: "t_legacy",
+              label: "old-ci",
               permission: "full",
               scopes: ["vault:work:write"],
+              scoped_tags: null,
+              vault_name: "work",
               expires_at: null,
-              created_at: "2026-05-01T00:00:00Z",
-              last_used_at: null,
+              created_at: "2026-01-01T00:00:00Z",
             },
           ],
         }),
@@ -87,91 +416,34 @@ describe("listTokens", () => {
       ),
     );
 
-    const tokens = await listTokens("work");
+    const tokens = await listLegacyTokens("work");
 
     expect(tokens).toHaveLength(1);
-    expect(tokens[0]?.label).toBe("ci");
+    expect(tokens[0]?.label).toBe("old-ci");
+    // Vault-admin bearer + per-vault URL — NOT host-admin, NOT /api/auth/*.
     expect(calls[0]?.url).toBe("/vault/work/tokens");
-    expect(calls[0]?.method).toBe("GET");
-    expect(calls[0]?.auth).toBe("Bearer jwt-here");
-  });
-});
-
-describe("mintToken", () => {
-  afterEach(() => {
-    clearToken();
+    expect(calls[0]?.auth).toBe("Bearer vault.admin.jwt");
   });
 
-  it("POSTs label + scopes as JSON, returns the plaintext token", async () => {
-    _setTokenForTest("jwt-here");
-    const calls = mockFetch(async () =>
-      new Response(
-        JSON.stringify({
-          id: "t_new",
-          token: "pvt_secret_value",
-          label: "ci",
-          permission: "full",
-          scopes: ["vault:work:write"],
-          expires_at: null,
-          created_at: "2026-05-02T00:00:00Z",
-          last_used_at: null,
-        }),
-        { status: 201 },
-      ),
-    );
+  it("revokeLegacyToken DELETEs /vault/<name>/tokens/<id> with the vault-admin bearer", async () => {
+    _setTokenForTest("vault.admin.jwt");
+    const calls = mockFetch(async () => new Response(JSON.stringify({ revoked: true }), { status: 200 }));
 
-    const result = await mintToken("work", { label: "ci", scopes: ["vault:work:write"] });
+    await revokeLegacyToken("work", "t_legacy");
 
-    expect(result.token).toBe("pvt_secret_value");
-    expect(calls[0]?.method).toBe("POST");
-    expect(calls[0]?.contentType).toBe("application/json");
-    const parsed = calls[0]?.body ? JSON.parse(calls[0].body) : {};
-    expect(parsed).toEqual({ label: "ci", scopes: ["vault:work:write"] });
-  });
-
-  it("omits empty fields from the request body", async () => {
-    _setTokenForTest("jwt-here");
-    const calls = mockFetch(async () =>
-      new Response(JSON.stringify({ id: "t_x", token: "pvt_x", label: "API token", permission: "full", scopes: [], expires_at: null, created_at: "x", last_used_at: null }), { status: 201 }),
-    );
-
-    await mintToken("work", {});
-
-    const parsed = calls[0]?.body ? JSON.parse(calls[0].body) : null;
-    expect(parsed).toEqual({});
-  });
-
-  it("surfaces the server message on a 400 (e.g. scope rejected)", async () => {
-    _setTokenForTest("jwt-here");
-    mockFetch(async () =>
-      new Response(
-        JSON.stringify({ error: "Bad Request", message: "scope rejected", rejected: ["vault:other:write"] }),
-        { status: 400 },
-      ),
-    );
-
-    await expect(mintToken("work", { scopes: ["vault:other:write"] })).rejects.toMatchObject({
-      status: 400,
-      message: "scope rejected",
-    });
-  });
-});
-
-describe("revokeToken", () => {
-  afterEach(() => {
-    clearToken();
-  });
-
-  it("DELETEs the right URL with the cached token", async () => {
-    _setTokenForTest("jwt-here");
-    const calls = mockFetch(async () =>
-      new Response(JSON.stringify({ revoked: true }), { status: 200 }),
-    );
-
-    await revokeToken("work", "t_abc123");
-
-    expect(calls[0]?.url).toBe("/vault/work/tokens/t_abc123");
+    expect(calls[0]?.url).toBe("/vault/work/tokens/t_legacy");
     expect(calls[0]?.method).toBe("DELETE");
-    expect(calls[0]?.auth).toBe("Bearer jwt-here");
+    expect(calls[0]?.auth).toBe("Bearer vault.admin.jwt");
+  });
+});
+
+describe("HttpError propagation", () => {
+  it("listHubTokens surfaces a non-ok registry response", async () => {
+    mockFetch(async (call) => {
+      if (call.url === "/admin/host-admin-token") return hostAdminMint();
+      return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+    });
+
+    await expect(listHubTokens("work")).rejects.toBeInstanceOf(HttpError);
   });
 });

--- a/web/ui/src/lib/tokens-api.ts
+++ b/web/ui/src/lib/tokens-api.ts
@@ -1,62 +1,277 @@
 /**
- * HTTP client for the per-vault tokens REST surface.
+ * HTTP client for the vault admin SPA's tokens page.
  *
- * Hits `GET|POST /vault/<name>/tokens` (list + mint) and
- * `DELETE /vault/<name>/tokens/<id>` (revoke). Backed by `src/tokens-routes.ts`
- * — the server enforces `vault:<name>:admin` for all three; we send the cached
- * hub-issued JWT as `Authorization: Bearer <jwt>`.
+ * Two surfaces, two bearers (the auth-unification arc — SPA step):
  *
- * Mint returns the plaintext `pvt_*` token exactly once (server can't re-emit
- * it). The caller is responsible for stashing it and surfacing the one-time
- * banner; this module just relays the response.
+ *   1. **Hub JWTs** (the live mint path) — hub's token registry at
+ *      `/api/auth/mint-token` (mint), `/api/auth/tokens` (list),
+ *      `/api/auth/revoke-token` (revoke). Authed with the **host-admin**
+ *      bearer from `host-admin-auth.ts` (carries `parachute:host:auth`, which
+ *      the list endpoint hard-requires). These mint canonical
+ *      `vault:<name>:<verb>` hub JWTs — the replacement for deprecated
+ *      `pvt_*` tokens (vault#282).
+ *
+ *   2. **Legacy `pvt_*` tokens** (read + revoke only, no mint) — the vault's
+ *      own per-vault REST surface at `GET|DELETE /vault/<name>/tokens[/<id>]`,
+ *      authed with the **vault-admin** bearer via `api.ts:_authedFetch`. These
+ *      rows live in the vault DB until the DROP (vault#282, later); the SPA
+ *      surfaces them read-only so an operator can see + rotate them, but can
+ *      no longer mint new ones. Fresh installs have none.
+ *
+ * The two bearers coexist cleanly: host-admin talks to hub's `/api/auth/*`,
+ * vault-admin talks to `/vault/<name>/*`.
  */
-import { _authedFetch, HttpError } from "./api.ts";
+import { HttpError, _authedFetch } from "./api.ts";
+import { hostAdminAuthedFetch } from "./host-admin-auth.ts";
 
-export interface TokenSummary {
+// ---------------------------------------------------------------------------
+// Hub JWT tokens — the live mint/list/revoke path.
+// ---------------------------------------------------------------------------
+
+/** TTL options for the mint form's dropdown, in days. Hub caps at 365d. */
+export const TTL_DAY_OPTIONS = [30, 90, 180, 365] as const;
+/** Default TTL the mint form selects, in days. */
+export const DEFAULT_TTL_DAYS = 90;
+
+const DAY_SECONDS = 24 * 60 * 60;
+
+/**
+ * Display shape for a hub-JWT row, mapped from the `/api/auth/tokens` wire
+ * row. The registry has no human-label column — the operator's label
+ * round-trips through `subject` (set at mint, read back here for display).
+ */
+export interface HubTokenSummary {
+  /** Revocation key (the registry's `jti`). */
+  jti: string;
+  /** Operator-supplied label, carried in the JWT `subject` claim. */
+  label: string | null;
+  /** Canonical `vault:<name>:<verb>` scopes (+ any others on the row). */
+  scopes: string[];
+  /**
+   * Tag-allowlist (root tags) from the `permissions.scoped_tags` claim.
+   * `null` = unscoped (sees the whole vault). Read directly off the parsed
+   * `permissions` object — hub parses it server-side, no JSON.parse here.
+   */
+  scoped_tags: string[] | null;
+  expires_at: string | null;
+  /** ISO timestamp when revoked, else `null`. Drives the "revoked" pill. */
+  revoked_at: string | null;
+  created_at: string;
+}
+
+export interface MintHubTokenResult {
+  jti: string;
+  /** One-time-reveal hub JWT. Same field name as the old `pvt_*` path so the
+   *  reveal banner works unchanged. */
+  token: string;
+  scope: string;
+  expires_at: string | null;
+}
+
+/** Verb for the minted scope. */
+export type ScopeVerb = "read" | "write" | "admin";
+
+/** Wire row shape from `GET /api/auth/tokens`. `permissions` is a PARSED
+ *  object (hub parses the JSON-string column server-side). */
+interface HubTokenWireRow {
+  jti: string;
+  user_id: string | null;
+  subject: string | null;
+  client_id: string;
+  scopes: string[];
+  expires_at: string;
+  revoked_at: string | null;
+  created_at: string;
+  created_via: string;
+  permissions: Record<string, unknown> | null;
+}
+
+interface HubTokensListResponse {
+  tokens?: HubTokenWireRow[];
+  next_cursor?: string | null;
+}
+
+/** Pull `scoped_tags` (a `string[]`) out of a parsed permissions object, or
+ *  `null` when absent/malformed. */
+function scopedTagsFromPermissions(permissions: Record<string, unknown> | null): string[] | null {
+  if (!permissions) return null;
+  const raw = permissions["scoped_tags"];
+  if (!Array.isArray(raw)) return null;
+  const tags = raw.filter((t): t is string => typeof t === "string" && t.length > 0);
+  return tags.length > 0 ? tags : null;
+}
+
+function mapHubRow(row: HubTokenWireRow): HubTokenSummary {
+  return {
+    jti: row.jti,
+    label: row.subject,
+    scopes: Array.isArray(row.scopes) ? row.scopes : [],
+    scoped_tags: scopedTagsFromPermissions(row.permissions),
+    expires_at: row.expires_at ?? null,
+    revoked_at: row.revoked_at ?? null,
+    created_at: row.created_at,
+  };
+}
+
+/**
+ * Mint a hub JWT scoped to this vault.
+ *
+ * Hits `POST /api/auth/mint-token` with the host-admin bearer. Body uses the
+ * SINGULAR space-joined `scope` string (not a `scopes` array) per the hub
+ * contract. The minted token is pinned to `vault:<name>:<verb>`; the audience
+ * auto-derives to `vault.<name>` so we omit it. The operator label rides in
+ * `subject` (the registry's only place to round-trip a human label).
+ *
+ * Tag-scoping: when `scopedTags` is non-empty we add
+ * `permissions: { scoped_tags: [...] }`. We OMIT `permissions` ENTIRELY when
+ * no tags are selected — vault C0 fail-closes on an empty/malformed
+ * `scoped_tags` array (it would 401 at request time), so an empty array must
+ * never reach the wire.
+ */
+export async function mintHubToken(
+  vaultName: string,
+  args: { verb: ScopeVerb; label: string; scopedTags: string[]; ttlDays: number },
+): Promise<MintHubTokenResult> {
+  const body: Record<string, unknown> = {
+    scope: `vault:${vaultName}:${args.verb}`,
+    expires_in: args.ttlDays * DAY_SECONDS,
+    subject: args.label,
+  };
+  // OMIT permissions when no tags — vault C0 fail-closes on empty scoped_tags.
+  if (args.scopedTags.length > 0) {
+    body["permissions"] = { scoped_tags: args.scopedTags };
+  }
+
+  const res = await hostAdminAuthedFetch("/api/auth/mint-token", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  const parsed = (await res.json()) as {
+    jti: string;
+    token: string;
+    scope: string;
+    expires_at?: string | null;
+  };
+  return {
+    jti: parsed.jti,
+    token: parsed.token,
+    scope: parsed.scope,
+    expires_at: parsed.expires_at ?? null,
+  };
+}
+
+/**
+ * List the hub JWTs scoped to this vault.
+ *
+ * Hits `GET /api/auth/tokens` (host-admin bearer). The endpoint has NO
+ * server-side vault filter and pages at 50 rows, so we:
+ *   1. Follow `next_cursor` and accumulate ALL pages (a single-page filter
+ *      would silently hide vault rows once the registry exceeds 50 entries).
+ *   2. Client-filter to rows carrying any `vault:<name>:*` scope.
+ *
+ * `?revoked=all` so revoked rows show too (the UI renders a "revoked" pill).
+ */
+export async function listHubTokens(vaultName: string): Promise<HubTokenSummary[]> {
+  const scopePrefix = `vault:${vaultName}:`;
+  const all: HubTokenWireRow[] = [];
+  let cursor: string | null = null;
+  // Bound the loop defensively — a registry pathologically large or a
+  // server bug returning a non-advancing cursor shouldn't spin forever.
+  for (let page = 0; page < 1000; page++) {
+    const qs = new URLSearchParams({ revoked: "all" });
+    if (cursor) qs.set("cursor", cursor);
+    const res: Response = await hostAdminAuthedFetch(`/api/auth/tokens?${qs.toString()}`);
+    if (!res.ok) {
+      throw new HttpError(res.status, await readError(res));
+    }
+    const body = (await res.json()) as HubTokensListResponse;
+    const rows = Array.isArray(body.tokens) ? body.tokens : [];
+    all.push(...rows);
+    cursor = body.next_cursor ?? null;
+    if (!cursor) break;
+  }
+  return all
+    .filter((r) => Array.isArray(r.scopes) && r.scopes.some((s) => s.startsWith(scopePrefix)))
+    .map(mapHubRow);
+}
+
+/**
+ * Revoke a hub JWT by jti.
+ *
+ * Hits `POST /api/auth/revoke-token` (host-admin bearer) with `{ jti }`.
+ * Idempotent server-side (re-revoking returns the existing `revoked_at`).
+ */
+export async function revokeHubToken(jti: string): Promise<void> {
+  const res = await hostAdminAuthedFetch("/api/auth/revoke-token", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jti }),
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy `pvt_*` tokens — read + revoke only (no mint). Vault-admin bearer.
+// ---------------------------------------------------------------------------
+
+/**
+ * Legacy `pvt_*` token row (vault DB). Read-only in the SPA — no mint path.
+ * Kept until the DROP (vault#282).
+ */
+export interface LegacyTokenSummary {
   id: string;
   label: string;
   permission: "read" | "full";
   scopes: string[];
-  /**
-   * Tag-allowlist (root tags). `null` = unscoped (sees the whole vault).
-   * Sub-tags inherit at request time via the `_tags/<name>` hierarchy —
-   * see patterns/tag-scoped-tokens.md.
-   */
+  /** Tag-allowlist (root tags). `null` = unscoped. */
   scoped_tags: string[] | null;
-  /**
-   * Vault binding (schema v16). `null` = legacy server-wide token (pre-v16
-   * mint or explicitly minted with `--all`). Non-null = bound to that
-   * single vault; the server rejects cross-vault use.
-   */
+  /** Vault binding (schema v16). `null` = legacy server-wide token. */
   vault_name: string | null;
   expires_at: string | null;
   created_at: string;
-  last_used_at: string | null;
-}
-
-export interface MintTokenResult extends TokenSummary {
-  /** Plaintext `pvt_*` token. Shown once; the server never re-emits. */
-  token: string;
-}
-
-export interface MintTokenInput {
-  label?: string;
-  /** Optional narrowing. Omit to inherit caller's full scope set. */
-  scopes?: string[];
-  /**
-   * Optional tag-allowlist. Each entry must be an existing root-tag name
-   * (no `/`). Omit (or pass null) for an unscoped token. The server
-   * enforces a subset rule against the minter's own allowlist.
-   */
-  tags?: string[] | null;
-  expires_at?: string | null;
 }
 
 /**
+ * List the vault's legacy `pvt_*` tokens. Hits `GET /vault/<name>/tokens`
+ * with the VAULT-ADMIN bearer (`_authedFetch`), NOT the host-admin bearer —
+ * these rows live in the vault DB, reached through the per-vault REST
+ * surface. Returns `[]` on a fresh install (no legacy rows).
+ */
+export async function listLegacyTokens(vaultName: string): Promise<LegacyTokenSummary[]> {
+  const res = await _authedFetch(vaultName, `/vault/${encodeURIComponent(vaultName)}/tokens`);
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  const body = (await res.json()) as { tokens?: LegacyTokenSummary[] };
+  return body.tokens ?? [];
+}
+
+/** Revoke a legacy `pvt_*` token by its vault-DB id. Vault-admin bearer. */
+export async function revokeLegacyToken(vaultName: string, tokenId: string): Promise<void> {
+  const res = await _authedFetch(
+    vaultName,
+    `/vault/${encodeURIComponent(vaultName)}/tokens/${encodeURIComponent(tokenId)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tag picker — unchanged. Vault-admin bearer.
+// ---------------------------------------------------------------------------
+
+/**
  * Tag listing for the mint form's tag-picker. Hits `GET /vault/<name>/api/tags`
- * — the same endpoint that backs `query-notes`-adjacent tag UIs. The mint
- * picker only needs root-tag names (the picker filters out anything with a
- * `/` since the server only accepts root tags in the `tags` field).
+ * with the vault-admin bearer. The picker only needs root-tag names (it
+ * filters out anything with a `/` — only root tags are valid `scoped_tags`).
  */
 export async function listVaultTags(vaultName: string): Promise<{ name: string; count: number }[]> {
   const res = await _authedFetch(vaultName, `/vault/${encodeURIComponent(vaultName)}/api/tags`);
@@ -70,7 +285,11 @@ export async function listVaultTags(vaultName: string): Promise<{ name: string; 
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();
-    const parsed = JSON.parse(text) as { error?: string; error_description?: string; message?: string };
+    const parsed = JSON.parse(text) as {
+      error?: string;
+      error_description?: string;
+      message?: string;
+    };
     if (parsed.error_description) return parsed.error_description;
     if (parsed.message) return parsed.message;
     if (parsed.error) return parsed.error;
@@ -79,44 +298,4 @@ async function readError(res: Response): Promise<string> {
     // not JSON
   }
   return `${res.status} ${res.statusText}`;
-}
-
-export async function listTokens(vaultName: string): Promise<TokenSummary[]> {
-  const res = await _authedFetch(vaultName, `/vault/${encodeURIComponent(vaultName)}/tokens`);
-  if (!res.ok) {
-    throw new HttpError(res.status, await readError(res));
-  }
-  const body = (await res.json()) as { tokens?: TokenSummary[] };
-  return body.tokens ?? [];
-}
-
-export async function mintToken(vaultName: string, input: MintTokenInput): Promise<MintTokenResult> {
-  const body: Record<string, unknown> = {};
-  if (input.label && input.label.length > 0) body["label"] = input.label;
-  if (input.scopes && input.scopes.length > 0) body["scopes"] = input.scopes;
-  // `tags: []` would be rejected by the server (non-empty required) — we
-  // either send a populated array or omit the field entirely (= unscoped).
-  if (input.tags && input.tags.length > 0) body["tags"] = input.tags;
-  if (input.expires_at !== undefined) body["expires_at"] = input.expires_at;
-
-  const res = await _authedFetch(vaultName, `/vault/${encodeURIComponent(vaultName)}/tokens`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    throw new HttpError(res.status, await readError(res));
-  }
-  return (await res.json()) as MintTokenResult;
-}
-
-export async function revokeToken(vaultName: string, tokenId: string): Promise<void> {
-  const res = await _authedFetch(
-    vaultName,
-    `/vault/${encodeURIComponent(vaultName)}/tokens/${encodeURIComponent(tokenId)}`,
-    { method: "DELETE" },
-  );
-  if (!res.ok) {
-    throw new HttpError(res.status, await readError(res));
-  }
 }

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -491,11 +491,15 @@ describe("VaultMirror — admin scope", () => {
       push: { fired: true, pushed: true, sha: "feedface1234567890abc" },
     });
     renderRoute();
+    // The "Push now" button renders once `getMirror` resolves, but its
+    // ENABLED state depends on `getMirrorAuth` (active_method: "pat")
+    // resolving too. Wait for not-disabled rather than asserting it
+    // synchronously after only waiting for presence — the two async loads
+    // can settle a tick apart, which was a flaky failure here.
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: /Push now/i })).toBeInTheDocument(),
+      expect(screen.getByRole("button", { name: /Push now/i })).not.toBeDisabled(),
     );
     const pushBtn = screen.getByRole("button", { name: /Push now/i });
-    expect(pushBtn).not.toBeDisabled();
     const user = userEvent.setup();
     await user.click(pushBtn);
     await waitFor(() => {

--- a/web/ui/src/routes/VaultTokens.test.tsx
+++ b/web/ui/src/routes/VaultTokens.test.tsx
@@ -1,10 +1,11 @@
 /**
- * VaultTokens smoke tests — list render, scope-gated mutate UI, mint banner
- * single-emit, revoke confirm flow.
+ * VaultTokens smoke tests — hub-JWT list render, scope-gated mutate UI, mint
+ * banner single-emit, revoke confirm flow, and the legacy `pvt_*` section
+ * (shown only when the legacy list is non-empty).
  *
- * `lib/tokens-api.ts` is mocked so the wire isn't touched; `lib/scope.ts` is
- * mocked so we control admin-vs-read gating without crafting JWTs in every
- * test (decode is tested separately in scope.test.ts).
+ * `lib/tokens-api.ts` is mocked so the wire isn't touched; `lib/scope.ts` and
+ * `lib/host-admin-auth.ts` are mocked so we control admin gating + the
+ * forbidden-redirect side effect without crafting JWTs in every test.
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -17,17 +18,35 @@ import { VaultTokens } from "./VaultTokens.tsx";
 
 vi.mock("../lib/tokens-api.ts");
 vi.mock("../lib/scope.ts");
+vi.mock("../lib/host-admin-auth.ts", async (importOriginal) => {
+  // Keep the real HostAdminError class (the component does `instanceof`),
+  // stub the redirect side effect.
+  const actual = await importOriginal<typeof import("../lib/host-admin-auth.ts")>();
+  return { ...actual, redirectToAccountHome: vi.fn() };
+});
 
-const tokenFixture = (over: Partial<tokensApi.TokenSummary> = {}): tokensApi.TokenSummary => ({
-  id: "t_abc123",
+const hubFixture = (over: Partial<tokensApi.HubTokenSummary> = {}): tokensApi.HubTokenSummary => ({
+  jti: "j_abc123",
   label: "ci",
+  scopes: ["vault:work:write"],
+  scoped_tags: null,
+  expires_at: null,
+  revoked_at: null,
+  created_at: "2026-05-01T00:00:00Z",
+  ...over,
+});
+
+const legacyFixture = (
+  over: Partial<tokensApi.LegacyTokenSummary> = {},
+): tokensApi.LegacyTokenSummary => ({
+  id: "t_legacy1",
+  label: "old-pvt",
   permission: "full",
   scopes: ["vault:work:write"],
   scoped_tags: null,
   vault_name: "work",
   expires_at: null,
-  created_at: "2026-05-01T00:00:00Z",
-  last_used_at: null,
+  created_at: "2026-01-01T00:00:00Z",
   ...over,
 });
 
@@ -44,9 +63,14 @@ function renderRoute() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // Default the tag-picker fetch to "no tags" so existing tests don't need
-  // to mock it. Per-test cases override this when checking picker behavior.
   vi.mocked(tokensApi.listVaultTags).mockResolvedValue([]);
+  // Default both lists; per-test cases override.
+  vi.mocked(tokensApi.listHubTokens).mockResolvedValue([]);
+  vi.mocked(tokensApi.listLegacyTokens).mockResolvedValue([]);
+  // Re-expose the const re-exports the component imports from tokens-api
+  // (vi.mock auto-stubs the module — restore the value exports the form needs).
+  vi.mocked(tokensApi).TTL_DAY_OPTIONS = [30, 90, 180, 365];
+  vi.mocked(tokensApi).DEFAULT_TTL_DAYS = 90;
 });
 
 afterEach(() => {
@@ -58,24 +82,25 @@ describe("VaultTokens — admin scope", () => {
     vi.mocked(scope.hasAdminScope).mockReturnValue(true);
   });
 
-  it("renders the existing-tokens list", async () => {
-    vi.mocked(tokensApi.listTokens).mockResolvedValue([
-      tokenFixture({ label: "ci" }),
-      tokenFixture({ id: "t_def456", label: "paraclaw" }),
+  it("renders the existing hub-token list", async () => {
+    vi.mocked(tokensApi.listHubTokens).mockResolvedValue([
+      hubFixture({ label: "ci" }),
+      hubFixture({ jti: "j_def456", label: "paraclaw" }),
     ]);
 
     renderRoute();
 
     await waitFor(() => expect(screen.getByText("ci")).toBeInTheDocument());
     expect(screen.getByText("paraclaw")).toBeInTheDocument();
-    expect(screen.getByText("t_abc123")).toBeInTheDocument();
+    expect(screen.getByText("j_abc123")).toBeInTheDocument();
   });
 
-  it("shows the mint form and minted-token banner on success", async () => {
-    vi.mocked(tokensApi.listTokens).mockResolvedValue([]);
-    vi.mocked(tokensApi.mintToken).mockResolvedValue({
-      ...tokenFixture({ label: "new-token" }),
-      token: "pvt_super_secret",
+  it("shows the mint form (with TTL dropdown) and minted-token banner on success", async () => {
+    vi.mocked(tokensApi.mintHubToken).mockResolvedValue({
+      jti: "j_new",
+      token: "hub.jwt.value",
+      scope: "vault:work:admin",
+      expires_at: null,
     });
 
     renderRoute();
@@ -84,26 +109,31 @@ describe("VaultTokens — admin scope", () => {
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /mint token/i })).toBeInTheDocument(),
     );
-    await user.type(screen.getByLabelText(/label/i), "new-token");
+    // TTL dropdown is present.
+    expect(screen.getByLabelText(/expires after/i)).toBeInTheDocument();
+    await user.type(screen.getByLabelText(/^label/i), "new-token");
     await user.click(screen.getByRole("button", { name: /mint token/i }));
 
     await waitFor(() =>
       expect(screen.getByText(/new token \(shown once\)/i)).toBeInTheDocument(),
     );
-    expect(screen.getByText("pvt_super_secret")).toBeInTheDocument();
-    expect(screen.getByText(/don't dismiss this banner/i)).toBeInTheDocument();
-    expect(tokensApi.mintToken).toHaveBeenCalledWith("work", {
+    // Reveal field is `token` (banner works unchanged) — and it's NOT a pvt_*.
+    expect(screen.getByText("hub.jwt.value")).toBeInTheDocument();
+    expect(screen.queryByText(/pvt_/)).not.toBeInTheDocument();
+    expect(tokensApi.mintHubToken).toHaveBeenCalledWith("work", {
+      verb: "admin",
       label: "new-token",
-      scopes: ["vault:work:admin"],
-      tags: null,
+      scopedTags: [],
+      ttlDays: 90,
     });
   });
 
-  it("attaches a beforeunload guard while the pvt_* banner is showing and detaches on dismiss", async () => {
-    vi.mocked(tokensApi.listTokens).mockResolvedValue([]);
-    vi.mocked(tokensApi.mintToken).mockResolvedValue({
-      ...tokenFixture({ label: "ci" }),
-      token: "pvt_super_secret",
+  it("attaches a beforeunload guard while the reveal banner shows and detaches on dismiss", async () => {
+    vi.mocked(tokensApi.mintHubToken).mockResolvedValue({
+      jti: "j_new",
+      token: "hub.jwt.value",
+      scope: "vault:work:admin",
+      expires_at: null,
     });
 
     const addSpy = vi.spyOn(window, "addEventListener");
@@ -117,7 +147,7 @@ describe("VaultTokens — admin scope", () => {
     );
     expect(addSpy.mock.calls.some(([type]) => type === "beforeunload")).toBe(false);
 
-    await user.type(screen.getByLabelText(/label/i), "ci");
+    await user.type(screen.getByLabelText(/^label/i), "ci");
     await user.click(screen.getByRole("button", { name: /mint token/i }));
 
     await waitFor(() =>
@@ -127,9 +157,6 @@ describe("VaultTokens — admin scope", () => {
     expect(beforeunloadCall).toBeDefined();
     const handler = beforeunloadCall![1] as (e: BeforeUnloadEvent) => void;
 
-    // The handler must call preventDefault + set returnValue so Chrome /
-    // Firefox actually fire the "leave site?" confirm. Browsers gate the
-    // prompt on both signals; missing either makes the guard a no-op.
     const fakeEvent = {
       preventDefault: vi.fn(),
       returnValue: undefined as unknown as string,
@@ -141,31 +168,29 @@ describe("VaultTokens — admin scope", () => {
     await user.click(screen.getByRole("button", { name: /done — i've saved the token/i }));
 
     await waitFor(() =>
-      expect(removeSpy.mock.calls.some(([type, fn]) => type === "beforeunload" && fn === handler)).toBe(true),
+      expect(
+        removeSpy.mock.calls.some(([type, fn]) => type === "beforeunload" && fn === handler),
+      ).toBe(true),
     );
   });
 
-  it("rejects mint when label is empty (no API call, error shown)", async () => {
-    vi.mocked(tokensApi.listTokens).mockResolvedValue([]);
-
+  it("rejects mint when label is empty (button disabled, no API call)", async () => {
     renderRoute();
     const user = userEvent.setup();
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /mint token/i })).toBeInTheDocument(),
     );
-    // Submit button is disabled when label is empty — type then clear to
-    // exercise the form-onSubmit guard rather than the disabled state alone.
-    const labelInput = screen.getByLabelText(/label/i);
+    const labelInput = screen.getByLabelText(/^label/i);
     await user.type(labelInput, "x");
     await user.clear(labelInput);
     expect(screen.getByRole("button", { name: /mint token/i })).toBeDisabled();
-    expect(tokensApi.mintToken).not.toHaveBeenCalled();
+    expect(tokensApi.mintHubToken).not.toHaveBeenCalled();
   });
 
-  it("revoke shows a confirm step before deleting", async () => {
-    vi.mocked(tokensApi.listTokens).mockResolvedValue([tokenFixture()]);
-    vi.mocked(tokensApi.revokeToken).mockResolvedValue();
+  it("revoke keys on jti and shows a confirm step before deleting", async () => {
+    vi.mocked(tokensApi.listHubTokens).mockResolvedValue([hubFixture()]);
+    vi.mocked(tokensApi.revokeHubToken).mockResolvedValue();
 
     renderRoute();
     const user = userEvent.setup();
@@ -175,13 +200,83 @@ describe("VaultTokens — admin scope", () => {
     );
     await user.click(screen.getByRole("button", { name: /^revoke$/i }));
 
-    // Confirm step replaces the bare Revoke button with Confirm + Cancel.
     expect(screen.getByRole("button", { name: /confirm revoke/i })).toBeInTheDocument();
-    expect(tokensApi.revokeToken).not.toHaveBeenCalled();
+    expect(tokensApi.revokeHubToken).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: /confirm revoke/i }));
+    await waitFor(() => expect(tokensApi.revokeHubToken).toHaveBeenCalledWith("j_abc123"));
+  });
+
+  it("shows a 'revoked' pill and hides the revoke button for already-revoked rows", async () => {
+    vi.mocked(tokensApi.listHubTokens).mockResolvedValue([
+      hubFixture({ jti: "j_rev", label: "dead", revoked_at: "2026-05-10T00:00:00Z" }),
+    ]);
+
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByText("dead")).toBeInTheDocument());
+    expect(screen.getByText("revoked")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^revoke$/i })).not.toBeInTheDocument();
+  });
+
+  it("renders scoped_tags pills from permissions.scoped_tags", async () => {
+    vi.mocked(tokensApi.listHubTokens).mockResolvedValue([
+      hubFixture({ jti: "j_tagged", label: "scoped", scoped_tags: ["health", "work"] }),
+    ]);
+
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByText("scoped")).toBeInTheDocument());
+    expect(screen.getByText("#health")).toBeInTheDocument();
+    expect(screen.getByText("#work")).toBeInTheDocument();
+  });
+});
+
+describe("VaultTokens — legacy pvt_* section", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(true);
+  });
+
+  it("hidden when the legacy list is empty (fresh install)", async () => {
+    vi.mocked(tokensApi.listLegacyTokens).mockResolvedValue([]);
+
+    renderRoute();
+
     await waitFor(() =>
-      expect(tokensApi.revokeToken).toHaveBeenCalledWith("work", "t_abc123"),
+      expect(screen.getByRole("button", { name: /mint token/i })).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/legacy tokens/i)).not.toBeInTheDocument();
+  });
+
+  it("shown when the legacy list is non-empty, listed via the vault-admin path", async () => {
+    vi.mocked(tokensApi.listLegacyTokens).mockResolvedValue([legacyFixture()]);
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() => expect(screen.getByText(/legacy tokens/i)).toBeInTheDocument());
+    // listLegacyTokens hit the per-vault surface for THIS vault.
+    expect(tokensApi.listLegacyTokens).toHaveBeenCalledWith("work");
+
+    // Collapsible — defaults closed; expand to reveal the row + revoke.
+    await user.click(screen.getByText(/legacy tokens/i));
+    expect(screen.getByText("old-pvt")).toBeInTheDocument();
+  });
+
+  it("revokes a legacy token via revokeLegacyToken (vault-admin path)", async () => {
+    vi.mocked(tokensApi.listLegacyTokens).mockResolvedValue([legacyFixture()]);
+    vi.mocked(tokensApi.revokeLegacyToken).mockResolvedValue();
+
+    renderRoute();
+    const user = userEvent.setup();
+
+    await waitFor(() => expect(screen.getByText(/legacy tokens/i)).toBeInTheDocument());
+    await user.click(screen.getByText(/legacy tokens/i));
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+    await user.click(screen.getByRole("button", { name: /confirm revoke/i }));
+
+    await waitFor(() =>
+      expect(tokensApi.revokeLegacyToken).toHaveBeenCalledWith("work", "t_legacy1"),
     );
   });
 });
@@ -191,8 +286,8 @@ describe("VaultTokens — read scope", () => {
     vi.mocked(scope.hasAdminScope).mockReturnValue(false);
   });
 
-  it("hides the mint form and the per-token revoke buttons", async () => {
-    vi.mocked(tokensApi.listTokens).mockResolvedValue([tokenFixture()]);
+  it("hides the mint form and per-token revoke buttons", async () => {
+    vi.mocked(tokensApi.listHubTokens).mockResolvedValue([hubFixture()]);
 
     renderRoute();
 

--- a/web/ui/src/routes/VaultTokens.tsx
+++ b/web/ui/src/routes/VaultTokens.tsx
@@ -1,74 +1,140 @@
 /**
  * `/vault/:name/tokens` — token management.
  *
- * Phase B (vault#217). Three operations against `/vault/<name>/tokens`:
+ * The auth-unification arc (SPA step). New tokens are **hub JWTs** minted via
+ * hub's registry (`/api/auth/*`) with the host-admin bearer
+ * (`host-admin-auth.ts`). The deprecated `pvt_*` mint path is GONE — the only
+ * remaining trace of `pvt_*` is a read-only + revoke-only "Legacy tokens"
+ * section, shown when the vault still has live `pvt_*` rows (until the DROP,
+ * vault#282). Fresh installs never see it.
  *
- *   - **List**     — table of label / scopes / created / last-used.
- *   - **Mint**     — form for label + (optional) scope-narrowing. On 201
- *     the plaintext `pvt_*` is rendered exactly once in a banner with copy
- *     + dismissal warning. Server can't re-emit; we hold it in component
- *     state and lose it on navigation away. Dismissal clears it explicitly.
- *   - **Revoke**   — confirm modal then DELETE.
+ * Three operations on the hub-JWT surface:
+ *   - **List**   — accumulate ALL pages of `/api/auth/tokens`, then
+ *     client-filter to this vault's `vault:<name>:*` rows.
+ *   - **Mint**   — form for label + scope verb + optional tag-allowlist + TTL.
+ *     On 200 the one-time-reveal hub JWT renders in a banner (single-emit;
+ *     the server never re-emits it).
+ *   - **Revoke** — confirm modal then `POST /api/auth/revoke-token { jti }`.
  *
- * Mutate UI is gated on `hasAdminScope(name)`. The vault server requires
- * `vault:<name>:admin` for all three verbs (list, mint, revoke), so the
- * client-side gate is defense-in-depth: a read-scoped session sees a
- * banner directing them to re-auth instead of getting a 403 toast on
- * every interaction.
+ * Mutate UI is gated on `hasAdminScope(name)` (the vault-admin JWT the SPA
+ * already holds). The host-admin bearer is minted lazily by the token API
+ * calls; a friend account (signed in but not the hub admin) gets a 403 from
+ * the host-admin endpoint → we redirect to the issuer's `/account/` home.
+ *
+ * Two independent load states: the hub-JWT list (host-admin bearer) and the
+ * legacy `pvt_*` list (vault-admin bearer). They load + fail independently.
  */
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { HttpError } from "../lib/api.ts";
+import { HostAdminError, redirectToAccountHome } from "../lib/host-admin-auth.ts";
 import { hasAdminScope } from "../lib/scope.ts";
 import { SignInBanner } from "../lib/SignInBanner.tsx";
 import {
-  type MintTokenResult,
-  type TokenSummary,
-  listTokens,
+  DEFAULT_TTL_DAYS,
+  type HubTokenSummary,
+  type LegacyTokenSummary,
+  type MintHubTokenResult,
+  type ScopeVerb,
+  TTL_DAY_OPTIONS,
+  listHubTokens,
+  listLegacyTokens,
   listVaultTags,
-  mintToken,
-  revokeToken,
+  mintHubToken,
+  revokeHubToken,
+  revokeLegacyToken,
 } from "../lib/tokens-api.ts";
 
-type LoadState =
+type HubLoadState =
   | { kind: "loading" }
-  | { kind: "ok"; tokens: TokenSummary[] }
+  | { kind: "ok"; tokens: HubTokenSummary[] }
   | { kind: "auth-required"; status: number | null }
   | { kind: "error"; message: string };
 
-const KNOWN_SCOPE_VERBS = ["read", "write", "admin"] as const;
+type LegacyLoadState =
+  | { kind: "loading" }
+  | { kind: "ok"; tokens: LegacyTokenSummary[] }
+  // Legacy-list auth/error failures are non-fatal — the hub-JWT surface is
+  // the page's primary function. We collapse them to "hidden" so a vault
+  // whose legacy endpoint 401s/errors just doesn't render the section.
+  | { kind: "hidden" };
+
+const KNOWN_SCOPE_VERBS: ScopeVerb[] = ["read", "write", "admin"];
+
+const TTL_LABELS: Record<number, string> = {
+  30: "30 days",
+  90: "90 days",
+  180: "180 days",
+  365: "1 year (max)",
+};
+
+/** Branch a thrown error from a host-admin-backed call into the right load
+ *  disposition. `forbidden` triggers the friend-account redirect as a side
+ *  effect; the returned state is what the caller should set. */
+function dispositionForHubError(err: unknown): HubLoadState {
+  if (err instanceof HostAdminError) {
+    if (err.disposition === "forbidden") {
+      redirectToAccountHome();
+      return { kind: "auth-required", status: 403 };
+    }
+    if (err.disposition === "auth-required") {
+      return { kind: "auth-required", status: err.status };
+    }
+    return { kind: "error", message: err.message };
+  }
+  if (err instanceof HttpError && (err.status === 401 || err.status === 403)) {
+    return { kind: "auth-required", status: err.status };
+  }
+  return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+}
 
 export function VaultTokens({ vaultName }: { vaultName?: string } = {}) {
-  // Per-vault mount passes `vaultName` directly (no `:name` segment under
-  // `basename="/vault/<name>/admin"`); stand-alone `/vault/:name/tokens`
-  // reads it from useParams. The presence of the prop also picks the
-  // detail-link shape — `/` under per-vault, `/vault/<name>` stand-alone.
   const params = useParams<{ name: string }>();
   const name = vaultName ?? params.name;
   const isPerVaultMount = vaultName !== undefined;
   const detailHref = isPerVaultMount ? "/" : `/vault/${encodeURIComponent(name ?? "")}`;
-  const [state, setState] = useState<LoadState>({ kind: "loading" });
-  const [minted, setMinted] = useState<MintTokenResult | null>(null);
-  const [confirmingRevokeId, setConfirmingRevokeId] = useState<string | null>(null);
+
+  const [hubState, setHubState] = useState<HubLoadState>({ kind: "loading" });
+  const [legacyState, setLegacyState] = useState<LegacyLoadState>({ kind: "loading" });
+  const [minted, setMinted] = useState<MintHubTokenResult | null>(null);
+  const [confirmingRevokeJti, setConfirmingRevokeJti] = useState<string | null>(null);
+  const [confirmingLegacyId, setConfirmingLegacyId] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
 
+  // Hub-JWT list (host-admin bearer).
   useEffect(() => {
     let cancelled = false;
     if (!name) return;
-    setState({ kind: "loading" });
-    listTokens(name)
+    setHubState({ kind: "loading" });
+    listHubTokens(name)
       .then((tokens) => {
         if (cancelled) return;
-        setState({ kind: "ok", tokens });
+        setHubState({ kind: "ok", tokens });
       })
       .catch((err) => {
         if (cancelled) return;
-        if (err instanceof HttpError && (err.status === 401 || err.status === 403)) {
-          setState({ kind: "auth-required", status: err.status });
-          return;
-        }
-        const message = err instanceof Error ? err.message : String(err);
-        setState({ kind: "error", message });
+        setHubState(dispositionForHubError(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name, reloadTick]);
+
+  // Legacy pvt_* list (vault-admin bearer). Non-fatal — any failure (or an
+  // empty list) collapses to "hidden", so fresh installs and vaults whose
+  // legacy endpoint 401s simply don't render the section.
+  useEffect(() => {
+    let cancelled = false;
+    if (!name) return;
+    setLegacyState({ kind: "loading" });
+    listLegacyTokens(name)
+      .then((tokens) => {
+        if (cancelled) return;
+        setLegacyState(tokens.length > 0 ? { kind: "ok", tokens } : { kind: "hidden" });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLegacyState({ kind: "hidden" });
       });
     return () => {
       cancelled = true;
@@ -77,11 +143,9 @@ export function VaultTokens({ vaultName }: { vaultName?: string } = {}) {
 
   const onRecovered = useCallback(() => setReloadTick((n) => n + 1), []);
 
-  // Belt-and-suspenders for the single-emit contract: while the plaintext
-  // pvt_* is on screen, prompt the browser's "leave site?" confirm on tab
-  // close / refresh / back. Dismissing the banner (the explicit "I've
-  // saved it" path) detaches the listener. Doesn't cover in-SPA navigation
-  // — react-router blocking is a separate, larger surface.
+  // Belt-and-suspenders for the single-emit contract: while the just-minted
+  // token is on screen, prompt the browser's "leave site?" confirm on tab
+  // close / refresh / back. Dismissing the banner detaches the listener.
   useEffect(() => {
     if (!minted) return;
     const handler = (e: BeforeUnloadEvent) => {
@@ -126,14 +190,13 @@ export function VaultTokens({ vaultName }: { vaultName?: string } = {}) {
       {minted ? <MintBanner result={minted} onDismiss={() => setMinted(null)} /> : null}
 
       {/*
-       * MintForm is hidden while the just-minted banner is showing. The
+       * MintForm is hidden while the just-minted banner is showing — the
        * banner is the single point at which the operator copies the
-       * plaintext pvt_*; if a second mint happens before the first is
-       * saved, the first is gone forever (the server can't re-emit). The
-       * dismissal-then-mint sequence makes that loss impossible by
-       * construction. Keep the gate; don't "fix" it back to always-on.
+       * plaintext token; a second mint before the first is saved would lose
+       * the first forever (the server can't re-emit). The dismissal-then-mint
+       * sequence makes that loss impossible by construction.
        */}
-      {state.kind === "ok" && isAdmin && !minted ? (
+      {hubState.kind === "ok" && isAdmin && !minted ? (
         <MintForm
           vaultName={name}
           onMinted={(result) => {
@@ -145,34 +208,47 @@ export function VaultTokens({ vaultName }: { vaultName?: string } = {}) {
 
       <div className="section">
         <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>Existing tokens</h3>
-        {state.kind === "loading" ? <p className="muted">Loading…</p> : null}
-        {state.kind === "auth-required" ? (
-          <SignInBanner vaultName={name} status={state.status} onRecovered={onRecovered} />
+        {hubState.kind === "loading" ? <p className="muted">Loading…</p> : null}
+        {hubState.kind === "auth-required" ? (
+          <SignInBanner vaultName={name} status={hubState.status} onRecovered={onRecovered} />
         ) : null}
-        {state.kind === "error" ? (
+        {hubState.kind === "error" ? (
           <div className="error-banner">
-            <code>{state.message}</code>
+            <code>{hubState.message}</code>
           </div>
         ) : null}
-        {state.kind === "ok" ? (
-          <TokenList
-            vaultName={name}
-            tokens={state.tokens}
+        {hubState.kind === "ok" ? (
+          <HubTokenList
+            tokens={hubState.tokens}
             allowRevoke={isAdmin}
-            confirmingRevokeId={confirmingRevokeId}
-            onAskConfirm={setConfirmingRevokeId}
+            confirmingJti={confirmingRevokeJti}
+            onAskConfirm={setConfirmingRevokeJti}
             onRevoked={() => {
-              setConfirmingRevokeId(null);
+              setConfirmingRevokeJti(null);
               setReloadTick((n) => n + 1);
             }}
           />
         ) : null}
       </div>
+
+      {legacyState.kind === "ok" ? (
+        <LegacySection
+          vaultName={name}
+          tokens={legacyState.tokens}
+          allowRevoke={isAdmin}
+          confirmingId={confirmingLegacyId}
+          onAskConfirm={setConfirmingLegacyId}
+          onRevoked={() => {
+            setConfirmingLegacyId(null);
+            setReloadTick((n) => n + 1);
+          }}
+        />
+      ) : null}
     </div>
   );
 }
 
-function MintBanner({ result, onDismiss }: { result: MintTokenResult; onDismiss: () => void }) {
+function MintBanner({ result, onDismiss }: { result: MintHubTokenResult; onDismiss: () => void }) {
   const [copied, setCopied] = useState(false);
   const onCopy = async () => {
     try {
@@ -212,15 +288,13 @@ function MintForm({
   onMinted,
 }: {
   vaultName: string;
-  onMinted: (result: MintTokenResult) => void;
+  onMinted: (result: MintHubTokenResult) => void;
 }) {
   const [label, setLabel] = useState("");
-  const [verb, setVerb] = useState<(typeof KNOWN_SCOPE_VERBS)[number]>("admin");
+  const [verb, setVerb] = useState<ScopeVerb>("admin");
+  const [ttlDays, setTtlDays] = useState<number>(DEFAULT_TTL_DAYS);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Tag-allowlist (root tags only). Empty = unscoped (full vault). The
-  // server enforces (a) each tag exists, (b) subset of caller's allowlist,
-  // (c) no path separators — see patterns/tag-scoped-tokens.md.
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [tagsLoadError, setTagsLoadError] = useState<string | null>(null);
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
@@ -230,9 +304,9 @@ function MintForm({
     listVaultTags(vaultName)
       .then((rows) => {
         if (cancelled) return;
-        // Picker only offers root tags — sub-tags inherit at enforcement
-        // time via the `_tags/<name>` hierarchy. The server rejects any
-        // value containing `/`, so filtering here keeps the UI honest.
+        // Picker only offers root tags — sub-tags inherit at enforcement time
+        // via the `_tags/<name>` hierarchy. The server rejects any value with
+        // a `/`, so filtering here keeps the UI honest.
         const roots = rows.map((t) => t.name).filter((n) => !n.includes("/")).sort();
         setAvailableTags(roots);
       })
@@ -266,17 +340,22 @@ function MintForm({
     setSubmitting(true);
     setError(null);
     try {
-      const tagList = [...selectedTags];
-      const result = await mintToken(vaultName, {
+      const result = await mintHubToken(vaultName, {
+        verb,
         label: trimmedLabel,
-        scopes: [`vault:${vaultName}:${verb}`],
-        tags: tagList.length > 0 ? tagList : null,
+        scopedTags: [...selectedTags],
+        ttlDays,
       });
       onMinted(result);
       setLabel("");
       setVerb("admin");
+      setTtlDays(DEFAULT_TTL_DAYS);
       setSelectedTags(new Set());
     } catch (err) {
+      if (err instanceof HostAdminError && err.disposition === "forbidden") {
+        redirectToAccountHome();
+        return;
+      }
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setSubmitting(false);
@@ -286,6 +365,10 @@ function MintForm({
   return (
     <form onSubmit={onSubmit} className="section">
       <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>Mint a token</h3>
+      <p className="dim" style={{ margin: "0 0 0.85rem" }}>
+        Issues a hub-signed token (JWT) scoped to this vault. Store it like a password — it's shown
+        once and can't be re-displayed.
+      </p>
       {error ? (
         <div className="error-banner">
           <code>{error}</code>
@@ -307,17 +390,36 @@ function MintForm({
       </div>
       <div className="form-row">
         <label htmlFor="mint-scope">Scope</label>
-        <select
-          id="mint-scope"
-          value={verb}
-          onChange={(e) => setVerb(e.target.value as typeof verb)}
-        >
-          <option value="read">read — query notes only</option>
-          <option value="write">write — query + create/update notes</option>
-          <option value="admin">admin — full control (incl. token mgmt)</option>
+        <select id="mint-scope" value={verb} onChange={(e) => setVerb(e.target.value as ScopeVerb)}>
+          {KNOWN_SCOPE_VERBS.map((v) => (
+            <option key={v} value={v}>
+              {v === "read"
+                ? "read — query notes only"
+                : v === "write"
+                  ? "write — query + create/update notes"
+                  : "admin — full control (incl. token mgmt)"}
+            </option>
+          ))}
         </select>
         <p className="dim" style={{ margin: "0.35rem 0 0" }}>
           Issued as <code>vault:{vaultName}:{verb}</code>. Lower scopes inherit narrower powers.
+        </p>
+      </div>
+      <div className="form-row">
+        <label htmlFor="mint-ttl">Expires after</label>
+        <select
+          id="mint-ttl"
+          value={ttlDays}
+          onChange={(e) => setTtlDays(Number(e.target.value))}
+        >
+          {TTL_DAY_OPTIONS.map((days) => (
+            <option key={days} value={days}>
+              {TTL_LABELS[days] ?? `${days} days`}
+            </option>
+          ))}
+        </select>
+        <p className="dim" style={{ margin: "0.35rem 0 0" }}>
+          The token stops working after this. Rotate before it lapses.
         </p>
       </div>
       <div className="form-row">
@@ -363,19 +465,17 @@ function MintForm({
   );
 }
 
-function TokenList({
-  vaultName,
+function HubTokenList({
   tokens,
   allowRevoke,
-  confirmingRevokeId,
+  confirmingJti,
   onAskConfirm,
   onRevoked,
 }: {
-  vaultName: string;
-  tokens: TokenSummary[];
+  tokens: HubTokenSummary[];
   allowRevoke: boolean;
-  confirmingRevokeId: string | null;
-  onAskConfirm: (id: string | null) => void;
+  confirmingJti: string | null;
+  onAskConfirm: (jti: string | null) => void;
   onRevoked: () => void;
 }) {
   if (tokens.length === 0) {
@@ -384,12 +484,11 @@ function TokenList({
   return (
     <div className="token-list">
       {tokens.map((tok) => (
-        <TokenRow
-          key={tok.id}
-          vaultName={vaultName}
+        <HubTokenRow
+          key={tok.jti}
           token={tok}
           allowRevoke={allowRevoke}
-          confirming={confirmingRevokeId === tok.id}
+          confirming={confirmingJti === tok.jti}
           onAskConfirm={onAskConfirm}
           onRevoked={onRevoked}
         />
@@ -398,7 +497,173 @@ function TokenList({
   );
 }
 
-function TokenRow({
+function HubTokenRow({
+  token,
+  allowRevoke,
+  confirming,
+  onAskConfirm,
+  onRevoked,
+}: {
+  token: HubTokenSummary;
+  allowRevoke: boolean;
+  confirming: boolean;
+  onAskConfirm: (jti: string | null) => void;
+  onRevoked: () => void;
+}) {
+  const [revoking, setRevoking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isRevoked = token.revoked_at !== null;
+
+  const onConfirm = async () => {
+    setRevoking(true);
+    setError(null);
+    try {
+      await revokeHubToken(token.jti);
+      onRevoked();
+    } catch (err) {
+      if (err instanceof HostAdminError && err.disposition === "forbidden") {
+        redirectToAccountHome();
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
+      setRevoking(false);
+    }
+  };
+
+  return (
+    <div className="token-row">
+      <div className="body">
+        <div className="name">
+          <strong>{token.label ?? "(unlabeled)"}</strong>
+          <code className="dim">{token.jti}</code>
+          {isRevoked ? (
+            <code className="scope-tag" title="This token has been revoked and no longer works.">
+              revoked
+            </code>
+          ) : null}
+        </div>
+        <div className="meta">
+          <span className="dim">scopes:</span>{" "}
+          {token.scopes.length > 0 ? (
+            token.scopes.map((s) => (
+              <code key={s} className="scope-tag">
+                {s}
+              </code>
+            ))
+          ) : (
+            <span className="dim">(none)</span>
+          )}
+        </div>
+        {token.scoped_tags && token.scoped_tags.length > 0 ? (
+          <div className="meta">
+            <span className="dim">tags:</span>{" "}
+            {token.scoped_tags.map((t) => (
+              <code key={t} className="scope-tag tag-pill">
+                #{t}
+              </code>
+            ))}
+          </div>
+        ) : null}
+        <div className="meta dim">
+          created {fmtDate(token.created_at)}
+          {token.expires_at ? ` · expires ${fmtDate(token.expires_at)}` : ""}
+          {isRevoked && token.revoked_at ? ` · revoked ${fmtDate(token.revoked_at)}` : ""}
+        </div>
+        {error ? (
+          <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+            <code>{error}</code>
+          </div>
+        ) : null}
+      </div>
+      {allowRevoke && !isRevoked ? (
+        confirming ? (
+          <div className="actions">
+            <button type="button" onClick={onConfirm} disabled={revoking}>
+              {revoking ? "Revoking…" : "Confirm revoke"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => onAskConfirm(null)}
+              disabled={revoking}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button type="button" className="secondary" onClick={() => onAskConfirm(token.jti)}>
+            Revoke
+          </button>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Read-only + revoke-only section for the vault's legacy `pvt_*` tokens.
+ * Rendered only when the legacy list is non-empty (the parent collapses an
+ * empty / failed legacy load to "hidden"). Collapsible — defaults closed so
+ * a vault mid-migration shows it but doesn't lead with it.
+ */
+function LegacySection({
+  vaultName,
+  tokens,
+  allowRevoke,
+  confirmingId,
+  onAskConfirm,
+  onRevoked,
+}: {
+  vaultName: string;
+  tokens: LegacyTokenSummary[];
+  allowRevoke: boolean;
+  confirmingId: string | null;
+  onAskConfirm: (id: string | null) => void;
+  onRevoked: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="section">
+      <h3
+        style={{
+          margin: "0 0 0.5rem",
+          fontSize: "1rem",
+          fontWeight: 500,
+          cursor: "pointer",
+          userSelect: "none",
+        }}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? "▾" : "▸"} Legacy tokens (pre-0.6.0){" "}
+        <span className="dim" style={{ fontWeight: 400 }}>
+          ({tokens.length})
+        </span>
+      </h3>
+      <p className="dim" style={{ margin: "0 0 0.85rem" }}>
+        These <code>pvt_*</code> tokens predate the move to hub-signed tokens. They still work, but
+        the vault can no longer mint new ones — rotate each to a hub token above, then revoke the
+        legacy one here.
+      </p>
+      {open ? (
+        <div className="token-list">
+          {tokens.map((tok) => (
+            <LegacyTokenRow
+              key={tok.id}
+              vaultName={vaultName}
+              token={tok}
+              allowRevoke={allowRevoke}
+              confirming={confirmingId === tok.id}
+              onAskConfirm={onAskConfirm}
+              onRevoked={onRevoked}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function LegacyTokenRow({
   vaultName,
   token,
   allowRevoke,
@@ -407,7 +672,7 @@ function TokenRow({
   onRevoked,
 }: {
   vaultName: string;
-  token: TokenSummary;
+  token: LegacyTokenSummary;
   allowRevoke: boolean;
   confirming: boolean;
   onAskConfirm: (id: string | null) => void;
@@ -420,7 +685,7 @@ function TokenRow({
     setRevoking(true);
     setError(null);
     try {
-      await revokeToken(vaultName, token.id);
+      await revokeLegacyToken(vaultName, token.id);
       onRevoked();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -434,11 +699,6 @@ function TokenRow({
         <div className="name">
           <strong>{token.label}</strong>
           <code className="dim">{token.id}</code>
-          {token.vault_name === null ? (
-            <code className="scope-tag" title="Pre-v16 token, not bound to any vault. Usable across vaults this session can see.">
-              server-wide
-            </code>
-          ) : null}
         </div>
         <div className="meta">
           <span className="dim">scopes:</span>{" "}
@@ -464,7 +724,6 @@ function TokenRow({
         ) : null}
         <div className="meta dim">
           created {fmtDate(token.created_at)}
-          {token.last_used_at ? ` · last used ${fmtDate(token.last_used_at)}` : " · never used"}
           {token.expires_at ? ` · expires ${fmtDate(token.expires_at)}` : ""}
         </div>
         {error ? (
@@ -500,7 +759,6 @@ function TokenRow({
 
 function fmtDate(iso: string): string {
   // v1 shows ISO timestamps verbatim — exact wall-clock UTC is what an
-  // operator wants for incident triage. Phase C may add a relative +
-  // local-time formatting pass once the broader admin UI gets a date util.
+  // operator wants for incident triage.
   return iso;
 }

--- a/web/ui/src/test/setup.ts
+++ b/web/ui/src/test/setup.ts
@@ -5,4 +5,11 @@ import { afterEach, vi } from "vitest";
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  // `vi.stubGlobal("fetch", ...)` (used by tokens-api / host-admin-auth
+  // tests) is NOT undone by `restoreAllMocks` — it needs an explicit
+  // unstub. Without this, a stubbed `fetch` leaks into whichever file the
+  // worker schedules next; it surfaced as a flaky VaultMirror "Push now"
+  // failure (the leaked global perturbed the credential-load render timing).
+  // Unstubbing here keeps every suite's global surface clean between tests.
+  vi.unstubAllGlobals();
 });


### PR DESCRIPTION
## Auth-unification arc — SPA step

Migrates the vault admin SPA Tokens page off deprecated `pvt_*` vault-DB tokens to minting **hub JWTs** through hub's token registry (`/api/auth/*`). All enabling hub pieces were already on main (mint/revoke attenuation, `/admin/host-admin-token`, `/api/auth/tokens`, vault C0 tag-scoping).

### Host-admin auth chain
New `lib/host-admin-auth.ts` mints a **separate** host-admin bearer from `GET /admin/host-admin-token` (same-origin, `parachute_hub_session` cookie auto-attaches), parallel to — and never clobbering — the existing vault-admin token cache in `lib/auth.ts`. All three token ops (mint/list/revoke) use this one bearer because the LIST endpoint hard-requires `parachute:host:auth`, which the vault-admin token lacks; one bearer keeps the model simple. `hostAdminAuthedFetch` does a 401 silent-refresh + retry. A `403 not_admin` (friend account) → redirect to `<issuerOrigin>/account/`.

### Mint / list / revoke contracts (verified against hub + vault code)
- **Mint** — `POST /api/auth/mint-token`: body uses the SINGULAR space-joined `scope` string per verb (`vault:<name>:<verb>`), `expires_in` from a new TTL dropdown (30/90/180/365d, default 90), `subject` carries the operator label (the registry has no label column — round-trips via `subject`), `audience` omitted (auto-derives to `vault.<name>`). Tag-scoping adds `permissions.scoped_tags`; **`permissions` is OMITTED entirely when no tags** (vault C0 fail-closes on empty `scoped_tags`). Reveal field stays `token` so the banner is unchanged. 200, not 201.
- **List** — `GET /api/auth/tokens?revoked=all`: follows `next_cursor` and accumulates **all** pages, THEN client-filters to `vault:<name>:*` rows (single-page filtering would hide rows past 50). `permissions` is read as a parsed object (no `JSON.parse`). Maps revoke-key=`jti`, label=`subject`, scoped_tags=`permissions?.scoped_tags`, shows a "revoked" pill when `revoked_at != null`.
- **Revoke** — `POST /api/auth/revoke-token { jti }` (idempotent).

### Legacy `pvt_*` section
Read-only + revoke-only "Legacy tokens (pre-0.6.0)" collapsible section, rendered **only when the vault still has live `pvt_*` rows** (fresh installs never see it). Lists via `GET /vault/<name>/tokens` and revokes via `DELETE /vault/<name>/tokens/<id>`, both on the **vault-admin** bearer (`_authedFetch`). The two bearers coexist. The legacy **mint path is removed** — new tokens are hub JWTs only.

### Dropped
- `last_used_at` line (not tracked for stateless JWTs).
- The pre-v16 "server-wide" pill (hub JWTs are always vault-scoped).

### Deferred
`pvt_*` INFRA (`generateToken`/`createToken`/`tokens-routes`) stays — the DROP (vault#282) removes it later. This PR only stops the SPA from **minting** `pvt_*`.

## Tests / verify
- `cd web/ui && bunx vitest run` → **143 passed (9 files)**.
- `bun run typecheck` (tsc --noEmit) → clean.
- `bun run build` → built; post-build `verify-base.mjs` passes (relative `./assets/` URLs).
- New coverage: `ensureHostAdminToken` (200 cache / cached-no-refetch / 401-404 auth-required / 403 forbidden / 5xx / expiry re-mint), `hostAdminAuthedFetch` 401-retry + forbidden throw, 403→`/account/` redirect; `mintHubToken` (scope singular per verb, tag-scoped→permissions.scoped_tags, **empty→permissions omitted**, ttl→expires_in, reveal=token), `listHubTokens` (vault client-filter + **2-page cursor accumulation**, permissions-as-object, revoked mapping), `revokeHubToken` (body key `jti`, idempotent), legacy section (hidden when empty; shown + vault-admin path when non-empty).

## Risk note
While validating, found a **pre-existing** flaky VaultMirror "Push now" test (reproduces on `25f6cb4` and with this PR's test files excluded — ~1/15 full-suite runs). Two isolation leaks fed it: `vi.stubGlobal("fetch")` not undone by `restoreAllMocks` (added `vi.unstubAllGlobals()` to the shared test setup), and a `not.toBeDisabled()` asserted synchronously after only awaiting button presence (wrapped in `waitFor`). Suite is now 0 failures across 20 consecutive runs. Bundled into this PR since it lives in the same `web/ui` test suite. Version/rc intentionally not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)