### PR TITLE
fix(vault): enforce tag-scope on raw /api/storage attachment reads (close C0 bypass)

### DIFF
--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -773,6 +773,38 @@ export class BunSqliteStore implements Store {
   }
 
   /**
+   * Reverse-lookup: every attachment row whose `path` column equals the given
+   * vault-internal relative path (`<date>/<filename>`). A single on-disk asset
+   * can be referenced by more than one attachment row (the orphan check in
+   * `deleteAttachment` accounts for that), so this returns an array. Used by
+   * the raw `/api/storage/<date>/<file>` byte-serve path to map a requested
+   * file back to its owning note(s) for tag-scope enforcement — without this,
+   * a tag-scoped token could fetch an out-of-scope note's attachment bytes
+   * directly by path (the path-secrecy-only bypass; see the C0 adversarial
+   * audit finding).
+   */
+  async getAttachmentsByPath(path: string): Promise<Attachment[]> {
+    const rows = this.db.prepare(
+      "SELECT * FROM attachments WHERE path = ? ORDER BY created_at",
+    ).all(path) as { id: string; note_id: string; path: string; mime_type: string; metadata: string | null; created_at: string }[];
+
+    return rows.map((r) => {
+      let metadata: Record<string, unknown> | undefined;
+      if (r.metadata && r.metadata !== "{}") {
+        try { metadata = JSON.parse(r.metadata); } catch {}
+      }
+      return {
+        id: r.id,
+        noteId: r.note_id,
+        path: r.path,
+        mimeType: r.mime_type,
+        metadata,
+        createdAt: r.created_at,
+      };
+    });
+  }
+
+  /**
    * Replace the attachment's metadata JSON blob. The caller passes the full
    * merged object — this is a set, not a patch, so partial-field updates
    * don't silently drop other keys.

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -342,6 +342,14 @@ export interface Store {
   addAttachment(noteId: string, path: string, mimeType: string, metadata?: Record<string, unknown>): Promise<Attachment>;
   getAttachments(noteId: string): Promise<Attachment[]>;
   getAttachment(attachmentId: string): Promise<Attachment | null>;
+  /**
+   * Reverse-lookup attachment rows by their vault-internal relative `path`
+   * (`<date>/<filename>`). Returns every row sharing that path (a single
+   * on-disk asset can be referenced by >1 row). Used by the raw
+   * `/api/storage/<date>/<file>` serve path to map a requested file back to
+   * its owning note(s) for tag-scope enforcement.
+   */
+  getAttachmentsByPath(path: string): Promise<Attachment[]>;
   setAttachmentMetadata(attachmentId: string, metadata: Record<string, unknown>): Promise<void>;
   deleteAttachment(noteId: string, attachmentId: string): Promise<{ deleted: boolean; path: string | null; orphaned: boolean }>;
   listAttachmentsByTranscribeStatus(status: "pending" | "failed" | "done", limit?: number): Promise<Attachment[]>;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2077,7 +2077,13 @@ const MIME_TYPES: Record<string, string> = {
   ".mp4": "video/mp4",
 };
 
-export async function handleStorage(req: Request, path: string, vault: string): Promise<Response> {
+export async function handleStorage(
+  req: Request,
+  path: string,
+  vault: string,
+  store: Store,
+  tagScope: TagScopeCtx = NO_TAG_SCOPE,
+): Promise<Response> {
   const assets = assetsDir(vault);
 
   if (req.method === "POST" && path === "/upload") {
@@ -2119,6 +2125,37 @@ export async function handleStorage(req: Request, path: string, vault: string): 
     }
     if (!existsSync(filePath)) {
       return json({ error: "Not found" }, 404);
+    }
+
+    // Tag-scope gate (C0 adversarial-audit finding). The note-keyed
+    // attachment surfaces (GET /notes/:id?include_attachments, GET
+    // /notes/:id/attachments, query results) are all gated behind
+    // `noteWithinTagScope`, but this raw byte-serve endpoint historically
+    // shipped bytes purely by filesystem path with only a path-traversal
+    // guard — so a tag-scoped token (scoped to e.g. ["work"]) could fetch
+    // an out-of-scope note's attachment bytes directly if it learned the
+    // storage path. Path secrecy (the 122-bit UUID in the filename) is NOT
+    // an access control. When the token is tag-scoped, reverse-lookup the
+    // requested path → owning attachment row(s) → note_id, and serve only
+    // if at least one owning note is within scope. Unscoped tokens
+    // (tagScope.raw === null) keep the prior behavior verbatim.
+    //
+    // 404 (not 403) on out-of-scope / no-owning-row, matching the
+    // note-level surfaces — don't create an existence oracle that confirms
+    // "this path exists but you can't see it."
+    if (tagScope.raw !== null) {
+      const rows = await store.getAttachmentsByPath(reqPath);
+      let allowed = false;
+      for (const att of rows) {
+        const note = await store.getNote(att.noteId);
+        if (note && noteWithinTagScope(note, tagScope.allowed, tagScope.raw)) {
+          allowed = true;
+          break;
+        }
+      }
+      if (!allowed) {
+        return json({ error: "Not found" }, 404);
+      }
     }
 
     const stat = statSync(filePath);

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -730,7 +730,7 @@ export async function route(
     });
   }
   if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store);
-  if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), vaultName);
+  if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), vaultName, store, tagScope);
   if (apiPath === "/health") return Response.json({ status: "ok", vault: vaultName });
 
   return Response.json({ error: "Not found" }, { status: 404 });

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -8,9 +8,14 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { rmSync, existsSync, mkdirSync } from "fs";
+import { rmSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { Database } from "bun:sqlite";
+import { SqliteStore } from "../core/src/store.ts";
+import { initSchema } from "../core/src/schema.ts";
+import type { Store } from "../core/src/types.ts";
+import type { TagScopeCtx } from "./routes.ts";
 
 const testDir = join(
   tmpdir(),
@@ -20,6 +25,16 @@ process.env.PARACHUTE_HOME = testDir;
 process.env.ASSETS_DIR = join(testDir, "assets");
 
 const { handleStorage } = await import("./routes.ts");
+const { expandTokenTagScope } = await import("./tag-scope.ts");
+
+// The upload-allowlist tests never touch the store (POST /upload writes to
+// disk only); a fresh in-memory store satisfies the now-required param.
+function freshStore(): SqliteStore {
+  const db = new Database(":memory:");
+  initSchema(db);
+  return new SqliteStore(db);
+}
+const uploadStore = freshStore();
 
 function uploadRequest(filename: string, mimeType: string): Request {
   const form = new FormData();
@@ -33,6 +48,11 @@ function uploadRequest(filename: string, mimeType: string): Request {
   });
 }
 
+/** Build the per-request TagScopeCtx the dispatcher hands handlers. */
+async function tagScopeCtx(store: Store, scopedTags: string[] | null): Promise<TagScopeCtx> {
+  return { allowed: await expandTokenTagScope(store, scopedTags), raw: scopedTags };
+}
+
 beforeAll(() => {
   mkdirSync(testDir, { recursive: true });
   mkdirSync(join(testDir, "assets"), { recursive: true });
@@ -44,7 +64,7 @@ afterAll(() => {
 
 describe("storage upload allowlist", () => {
   test("accepts .pdf — knowledge-vault content (#127)", async () => {
-    const res = await handleStorage(uploadRequest("paper.pdf", "application/pdf"), "/upload", "default");
+    const res = await handleStorage(uploadRequest("paper.pdf", "application/pdf"), "/upload", "default", uploadStore);
     expect(res.status).toBe(201);
     const body = (await res.json()) as { mimeType: string; path: string };
     expect(body.mimeType).toBe("application/pdf");
@@ -52,7 +72,7 @@ describe("storage upload allowlist", () => {
   });
 
   test("accepts .mp4 — mobile capture default (#127)", async () => {
-    const res = await handleStorage(uploadRequest("clip.mp4", "video/mp4"), "/upload", "default");
+    const res = await handleStorage(uploadRequest("clip.mp4", "video/mp4"), "/upload", "default", uploadStore);
     expect(res.status).toBe(201);
     const body = (await res.json()) as { mimeType: string };
     expect(body.mimeType).toBe("video/mp4");
@@ -66,27 +86,132 @@ describe("storage upload allowlist", () => {
       ["photo.jpg", "image/jpeg"],
       ["clip.webm", "audio/webm"],
     ] as const) {
-      const res = await handleStorage(uploadRequest(name, mime), "/upload", "default");
+      const res = await handleStorage(uploadRequest(name, mime), "/upload", "default", uploadStore);
       expect(res.status).toBe(201);
     }
   });
 
   test("rejects .svg — XSS vector via inline <script> (#127)", async () => {
-    const res = await handleStorage(uploadRequest("evil.svg", "image/svg+xml"), "/upload", "default");
+    const res = await handleStorage(uploadRequest("evil.svg", "image/svg+xml"), "/upload", "default", uploadStore);
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain(".svg");
   });
 
   test("rejects .html — same XSS surface as SVG (#127)", async () => {
-    const res = await handleStorage(uploadRequest("evil.html", "text/html"), "/upload", "default");
+    const res = await handleStorage(uploadRequest("evil.html", "text/html"), "/upload", "default", uploadStore);
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain(".html");
   });
 
   test("rejects unknown extensions (default-deny)", async () => {
-    const res = await handleStorage(uploadRequest("payload.exe", "application/octet-stream"), "/upload", "default");
+    const res = await handleStorage(uploadRequest("payload.exe", "application/octet-stream"), "/upload", "default", uploadStore);
     expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET byte-serve tag-scope enforcement (C0 adversarial-audit finding).
+//
+// The raw `/api/storage/<date>/<file>` endpoint historically served bytes by
+// filesystem path with only a path-traversal guard — bypassing the tag-scope
+// enforcement that gates every note-keyed attachment surface. A tag-scoped
+// token could therefore fetch an out-of-scope note's attachment bytes
+// directly if it learned the (UUID-secret) storage path. These tests pin the
+// fix: in-scope → 200, out-of-scope → 404 (no existence oracle), unscoped →
+// 200 (regression), path-traversal guard intact (regression).
+// ---------------------------------------------------------------------------
+
+describe("storage GET tag-scope enforcement", () => {
+  // Each test builds its own vault assets dir + store so rows and on-disk
+  // files line up. `vault` names the assets subdir; ASSETS_DIR is global to
+  // the test process, so we point it at this vault's dir per test.
+  const VAULT = "scope-vault";
+
+  async function setup(): Promise<{
+    store: SqliteStore;
+    assets: string;
+    inScopePath: string;
+    outScopePath: string;
+  }> {
+    const store = freshStore();
+    const assets = join(testDir, "assets", VAULT, "data");
+    mkdirSync(join(assets, "2026-05-28"), { recursive: true });
+    process.env.ASSETS_DIR = assets;
+
+    // An in-scope (#work) note + attachment, and an out-of-scope (#health)
+    // note + attachment. Both files exist on disk.
+    const workNote = await store.createNote("work note", { tags: ["work"] });
+    const healthNote = await store.createNote("health note", { tags: ["health"] });
+
+    const inScopePath = "2026-05-28/work-asset.pdf";
+    const outScopePath = "2026-05-28/health-asset.pdf";
+    writeFileSync(join(assets, inScopePath), Buffer.from([0x25, 0x50, 0x44, 0x46])); // %PDF
+    writeFileSync(join(assets, outScopePath), Buffer.from([0x25, 0x50, 0x44, 0x46]));
+
+    await store.addAttachment(workNote.id, inScopePath, "application/pdf");
+    await store.addAttachment(healthNote.id, outScopePath, "application/pdf");
+
+    return { store, assets, inScopePath, outScopePath };
+  }
+
+  function getReq(reqPath: string): Request {
+    return new Request(`http://localhost:1940/storage/${reqPath}`, { method: "GET" });
+  }
+
+  test("tag-scoped token (work): GET in-scope attachment → 200 (bytes served)", async () => {
+    const { store, inScopePath } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    const res = await handleStorage(getReq(inScopePath), `/${inScopePath}`, VAULT, store, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/pdf");
+    expect((await res.arrayBuffer()).byteLength).toBe(4);
+  });
+
+  test("tag-scoped token (work): GET OUT-of-scope attachment → 404 (no existence oracle)", async () => {
+    const { store, outScopePath } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    const res = await handleStorage(getReq(outScopePath), `/${outScopePath}`, VAULT, store, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  test("tag-scoped token: GET path with NO owning attachment row → 404", async () => {
+    const { store, assets } = await setup();
+    // A real on-disk file that no attachment row references — must 404 for a
+    // scoped token (would-be existence oracle otherwise).
+    const orphanPath = "2026-05-28/orphan-on-disk.pdf";
+    writeFileSync(join(assets, orphanPath), Buffer.from([0x25, 0x50, 0x44, 0x46]));
+    const ctx = await tagScopeCtx(store, ["work"]);
+    const res = await handleStorage(getReq(orphanPath), `/${orphanPath}`, VAULT, store, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  test("unscoped token: GET any attachment → 200 (regression — no behavior change)", async () => {
+    const { store, outScopePath } = await setup();
+    const ctx = await tagScopeCtx(store, null); // unscoped
+    const res = await handleStorage(getReq(outScopePath), `/${outScopePath}`, VAULT, store, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  test("default ctx (no tagScope arg): unscoped behavior — 200 (regression)", async () => {
+    const { store, outScopePath } = await setup();
+    const res = await handleStorage(getReq(outScopePath), `/${outScopePath}`, VAULT, store);
+    expect(res.status).toBe(200);
+  });
+
+  test("path-traversal guard still blocks ../ escapes (regression)", async () => {
+    const { store } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    // `/a/../../../etc/passwd` resolves outside assetsDir → 403 Invalid path.
+    const evil = "/a/../../../../../../etc/passwd";
+    const res = await handleStorage(
+      new Request(`http://localhost:1940/storage${evil}`, { method: "GET" }),
+      evil,
+      VAULT,
+      store,
+      ctx,
+    );
+    expect(res.status).toBe(403);
   });
 });


### PR DESCRIPTION
## The bypass (C0, P2 — confirmed by adversarial audit)

The raw attachment-binary endpoint `GET /vault/<name>/api/storage/<date>/<file>` bypassed tag-scope enforcement.

Every **note-keyed** attachment surface is correctly gated behind `noteWithinTagScope`:
- `GET /notes/:id?include_attachments`
- `GET /notes/:id/attachments`
- query results

…but `handleStorage` was dispatched (`routing.ts`) **without** the tag-scope context, and its GET branch served bytes purely by filesystem path with only a path-traversal guard — no note/tag association check.

So a tag-scoped `vault:<name>:read` token (e.g. scoped to `["work"]`) could fetch the binary of an **out-of-scope** note's attachment (e.g. a `#health` note) directly via `/storage` if it learned the storage path. The only thing standing in the way today is the 122-bit random UUID baked into the upload filename — i.e. **path secrecy, which is not an access control.**

## The fix

Thread `store` + `tagScope` into `handleStorage` and enforce on the GET (byte-read) path:

- **Tag-scoped token** (`auth.scoped_tags !== null`): reverse-lookup the requested storage path → owning attachment row(s) → `note_id` → `noteWithinTagScope(note, allowed, raw)` (the same helper/semantics the note-level surfaces use). Serve only if at least one owning note is in scope.
  - New store method `Store.getAttachmentsByPath(path)` does the reverse lookup. It returns an array because a single on-disk asset can be referenced by more than one attachment row (the `orphaned` check in `deleteAttachment` already accounts for shared paths). The URL's `<date>/<file>` segment matches the stored `path` column verbatim (`addAttachment` stores `${date}/${filename}`).
- **Unscoped token** (`scoped_tags === null`): serve as before — no behavior change (`tagScope.raw === null` fast-path).
- Path-traversal guard left intact (orthogonal — still needed).

### 404, not 403

Out-of-scope — **or a path that maps to no attachment row** — returns **404**, matching the note-level surfaces' not-found behavior. A 403 would create an existence oracle confirming "this path exists but you can't see it"; 404 is indistinguishable from "no such file."

### Write-side handling

`/api/storage` exposes only `POST /upload` and `GET /<date>/<file>` — **no PUT/DELETE**. So there is no write-side analog on this endpoint to gate. Attachment deletion goes through `DELETE /notes/:id/attachments/:attId`, which is already behind `noteWithinTagScope` (`routes.ts`). Upload writes a brand-new UUID file and doesn't associate it with an existing note, so there's no cross-note write to scope there.

## Tests (`src/storage.test.ts`, new `storage GET tag-scope enforcement` block)

- tag-scoped (`work`) GET in-scope attachment → **200** (bytes served, correct Content-Type)
- tag-scoped (`work`) GET out-of-scope (`#health`) attachment → **404** (no existence oracle)
- tag-scoped GET path with no owning attachment row (real on-disk orphan) → **404**
- unscoped token GET any attachment → **200** (regression)
- default ctx (no tagScope arg) → **200** (regression)
- path-traversal `../` escape → **403** (regression)

Existing upload-allowlist tests updated for the new required `store` param.

Gates: `bun test ./src/` 1285 pass / 0 fail; `bun test ./core/src/` 610 pass / 0 fail; `bun run typecheck` clean. No version/rc bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)