### PR TITLE
fix(vault): per-vault mirror config + manager + routes (real multi-vault git remote, #400)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,8 +34,11 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync, renameSy
 import crypto from "node:crypto";
 
 import {
+  // vault#400: only the PARSE side is used here now — to detect a legacy
+  // server-wide `mirror:` block so the boot migration can relocate it to the
+  // owning vault's per-vault file. `writeGlobalConfig` no longer serializes a
+  // mirror block (per-vault writes live in `mirror-config.ts`).
   parseMirrorConfig as parseMirrorSectionFromYaml,
-  serializeMirrorConfig as serializeMirrorSection,
   type MirrorConfig as MirrorConfigType,
 } from "./mirror-config.ts";
 
@@ -1330,9 +1333,14 @@ export function writeGlobalConfig(config: GlobalConfig): void {
     lines.push(...serializeBackup(config.backup));
   }
 
-  if (config.mirror) {
-    lines.push(...serializeMirrorSection(config.mirror));
-  }
+  // vault#400: mirror config is now PER-VAULT (`data/<vault>/mirror-config.yaml`),
+  // not a server-wide block here. `writeGlobalConfig` deliberately does NOT
+  // re-emit a `mirror:` block — doing so would resurrect the legacy
+  // server-wide config the boot migration just commented out, re-introducing
+  // the "same remote on every vault page" bug. `readGlobalConfig` still parses
+  // a legacy block (below) so the one-time migration can detect + relocate it.
+  // `serializeMirrorSection` remains used by the per-vault writer in
+  // `mirror-config.ts`.
 
   if (config.auto_transcribe) {
     lines.push("auto_transcribe:");

--- a/src/mirror-config.test.ts
+++ b/src/mirror-config.test.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_SAFETY_NET_SECONDS,
   MAX_SAFETY_NET_SECONDS,
   MIN_SAFETY_NET_SECONDS,
+  commentOutMirrorBlock,
   defaultMirrorConfig,
   parseMirrorConfig,
   resolveMirrorPath,
@@ -494,5 +495,97 @@ describe("validateExternalPath", () => {
     const r = await validateExternalPath(dir);
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.resolved_path).toBe(dir);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commentOutMirrorBlock — vault#400 migration YAML rewrite (extracted from
+// server.ts per vault#408 review N3). Runs against the operator's real
+// config.yaml, so it gets direct coverage here.
+// ---------------------------------------------------------------------------
+
+describe("commentOutMirrorBlock", () => {
+  test("comments out a real serializer-shaped mirror block; leaves other keys intact", () => {
+    // Build the block exactly as serializeMirrorConfig emits it — pins the
+    // real production shape rather than a hand-written approximation.
+    const block = serializeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "external",
+      external_path: "/home/aaron/mirrors/brain",
+      auto_push: true,
+    }).join("\n");
+    const yaml = `port: 1940
+default_vault: brain
+${block}
+auto_transcribe:
+  enabled: true
+`;
+    const out = commentOutMirrorBlock(yaml);
+
+    // No LIVE mirror block survives (the parser anchor won't match).
+    expect(parseMirrorConfig(out)).toBeUndefined();
+    // Every mirror line is commented.
+    expect(out).toContain("# mirror:");
+    expect(out).toContain("#   enabled: true");
+    expect(out).toContain("#   external_path: /home/aaron/mirrors/brain");
+    expect(out).toContain("#   auto_push: true");
+    // Provenance marker added.
+    expect(out).toContain("# [vault#400] migrated to per-vault");
+    // Non-mirror top-level keys untouched (byte-for-byte).
+    expect(out).toContain("port: 1940");
+    expect(out).toContain("default_vault: brain");
+    expect(out).toContain("auto_transcribe:");
+    expect(out).toContain("  enabled: true");
+    // The mirror block must NOT have swallowed the auto_transcribe block —
+    // its child line stays a live (uncommented) 2-space-indent field.
+    expect(out).not.toContain("#   enabled: true\n# auto_transcribe");
+    const at = out.indexOf("auto_transcribe:");
+    expect(out.slice(at)).toContain("\n  enabled: true");
+  });
+
+  test("idempotent — running on already-commented output is a no-op", () => {
+    const block = serializeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: true,
+    }).join("\n");
+    const yaml = `port: 1940\n${block}\ndiscovery: enabled\n`;
+    const once = commentOutMirrorBlock(yaml);
+    const twice = commentOutMirrorBlock(once);
+    expect(twice).toBe(once); // second pass changes nothing
+  });
+
+  test("no mirror block → returns input unchanged", () => {
+    const yaml = `port: 1940
+default_vault: brain
+discovery: enabled
+`;
+    expect(commentOutMirrorBlock(yaml)).toBe(yaml);
+  });
+
+  test("mirror block at EOF (no trailing key) is fully commented", () => {
+    const block = serializeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: true,
+      auto_commit: false,
+    }).join("\n");
+    const yaml = `port: 1940\n${block}\n`;
+    const out = commentOutMirrorBlock(yaml);
+    expect(parseMirrorConfig(out)).toBeUndefined();
+    expect(out).toContain("#   auto_commit: false");
+    expect(out).toContain("port: 1940"); // live, untouched
+  });
+
+  test("preserves a blank line between the mirror block and the next key", () => {
+    const block = serializeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: true,
+    }).join("\n");
+    // Blank line separates the block from `discovery:` — must stay blank
+    // (not commented) and `discovery:` must stay live.
+    const yaml = `port: 1940\n${block}\n\ndiscovery: enabled\n`;
+    const out = commentOutMirrorBlock(yaml);
+    expect(out).toContain("\n\ndiscovery: enabled"); // blank line preserved, key live
+    expect(parseMirrorConfig(out)).toBeUndefined();
   });
 });

--- a/src/mirror-config.ts
+++ b/src/mirror-config.ts
@@ -4,11 +4,24 @@
  * Builds on the manual export primitives from vault#346 (`parachute-vault
  * export --watch --git-commit`). This module owns the *persistent* form:
  *
- *   - Schema for the `mirror:` block in `~/.parachute/vault/config.yaml`.
- *   - Parse + serialize that block alongside the existing global config.
+ *   - Schema for the per-vault mirror config block.
+ *   - Parse + serialize that block.
+ *   - Per-vault read/write of the config to `data/<vault>/mirror-config.yaml`
+ *     (vault#400 — see below).
  *   - Resolve the on-disk mirror path (internal vs external).
  *   - Validate the operator-supplied shape (location enum, external_path
  *     existence + git-repo-ness).
+ *
+ * **Per-vault config (vault#400).** Before vault#400, mirror config lived in a
+ * SINGLE server-wide `mirror:` block in `~/.parachute/vault/config.yaml`.
+ * That made every vault's mirror page show the same config + the same git
+ * remote, and configuring vault B clobbered vault A. vault#399 had already
+ * moved credential STORAGE per-vault; vault#400 completes the job by moving
+ * the CONFIG block to `data/<vault>/mirror-config.yaml` — alongside the
+ * per-vault credentials file + the SQLite DB. The legacy server-wide
+ * `mirror:` block is migrated to its owning vault on boot (default/first
+ * vault, matching how the single server-wide mirror was bound); other
+ * vaults start with no mirror config. See `migrateLegacyServerWideConfig`.
  *
  * The lifecycle wiring (boot-time bootstrap, watch loop start/stop/reload)
  * lives in `./mirror-manager.ts`; the HTTP surface lives in
@@ -19,8 +32,16 @@
  * `parachute.computer/design/2026-05-20-vault-as-git-projection.md`.
  */
 
-import { existsSync, statSync } from "fs";
-import { join } from "path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { dirname, join } from "path";
+import { homedir } from "os";
 
 import { DEFAULT_COMMIT_TEMPLATE, isGitRepo } from "./export-watch.ts";
 import { readCredentials, type MirrorCredentials } from "./mirror-credentials.ts";
@@ -65,9 +86,9 @@ export const MIN_SAFETY_NET_SECONDS = 60;
 export const MAX_SAFETY_NET_SECONDS = 86400;
 
 /**
- * The persistent mirror configuration block. Lives under the `mirror:` key
- * in the global config.yaml (one mirror per vault server today — multi-vault
- * mirroring is a future ripple, see open question 2 in the design doc).
+ * The persistent mirror configuration block. Per-vault since vault#400: each
+ * vault stores its own block in `data/<vault>/mirror-config.yaml` (real
+ * multi-vault mirroring — every vault can mirror to its own git remote).
  *
  * Field semantics:
  *   - `enabled` — master switch. When false (the default for upgrading
@@ -310,6 +331,165 @@ export function serializeMirrorConfig(config: MirrorConfig): string[] {
   lines.push(`  commit_template: "${config.commit_template.replace(/"/g, '\\"')}"`);
   lines.push(`  safety_net_seconds: ${config.safety_net_seconds}`);
   return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Per-vault config storage (vault#400)
+//
+// Each vault's mirror config lives in `data/<vault>/mirror-config.yaml`,
+// alongside its SQLite DB (`vault.db`), config (`vault.yaml`), and per-vault
+// credentials file (`.mirror-credentials.yaml`, vault#399). The file holds
+// the same `mirror:`-prefixed block `serializeMirrorConfig` already emits, so
+// `parseMirrorConfig`/`serializeMirrorConfig` are reused verbatim.
+//
+// Why a separate file from credentials (not folded in): config is
+// non-secret + hand-editable; credentials are 0o600 + token-bearing. Keeping
+// them separate avoids accidentally widening the credentials file's perms,
+// and keeps the credentials migration (vault#399) and config migration
+// (vault#400) cleanly independent.
+//
+// Path resolution mirrors `mirror-credentials.ts` rather than importing
+// `config.ts:vaultDir()` — config.ts imports this module, so importing it
+// back would close a cycle. We re-derive from `PARACHUTE_HOME` (the canonical
+// override the rest of vault honors) instead.
+// ---------------------------------------------------------------------------
+
+/** The vault home root — `<configDir>/vault`. Re-reads PARACHUTE_HOME per call. */
+function vaultHomeRoot(): string {
+  const root = process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
+  return join(root, "vault");
+}
+
+/**
+ * Path to a vault's per-vault mirror-config file (vault#400):
+ * `<configDir>/vault/data/<vaultName>/mirror-config.yaml`.
+ */
+export function mirrorConfigPath(vaultName: string): string {
+  return join(vaultHomeRoot(), "data", vaultName, "mirror-config.yaml");
+}
+
+/**
+ * Read a vault's mirror config from its per-vault file. Returns `undefined`
+ * when the file is absent (operator has never configured this vault's
+ * mirror) — distinct from "configured with enabled:false" so callers can
+ * tell "never touched" apart from "explicitly disabled" (same distinction
+ * `parseMirrorConfig` preserves). Callers that just want a usable config
+ * coalesce with `defaultMirrorConfig()`.
+ */
+export function readMirrorConfigForVault(vaultName: string): MirrorConfig | undefined {
+  const path = mirrorConfigPath(vaultName);
+  if (!existsSync(path)) return undefined;
+  try {
+    const raw = readFileSync(path, "utf8");
+    return parseMirrorConfig(raw);
+  } catch {
+    // Unreadable / malformed → treat as "no config" rather than crashing
+    // the boot path or a route. The operator can re-PUT to repair it.
+    return undefined;
+  }
+}
+
+/**
+ * Persist a vault's mirror config to its per-vault file, atomically
+ * (write-temp → rename). Creates the vault data dir if missing (fresh
+ * installs / tests). The file is NOT secret (no tokens — those live in
+ * `.mirror-credentials.yaml`), so default perms are fine.
+ */
+export function writeMirrorConfigForVault(
+  vaultName: string,
+  config: MirrorConfig,
+): void {
+  const path = mirrorConfigPath(vaultName);
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const body = serializeMirrorConfig(config).join("\n") + "\n";
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, body);
+  renameSync(tmp, path);
+}
+
+// ---------------------------------------------------------------------------
+// Migration — legacy server-wide `mirror:` config → per-vault (vault#400)
+// ---------------------------------------------------------------------------
+
+/**
+ * One-time migration of the legacy server-wide `mirror:` config block to the
+ * per-vault layout (vault#400). Symmetric counterpart to vault#399's
+ * `migrateLegacyServerWideCredentials`.
+ *
+ * The bug: pre-vault#400, mirror config lived in a single `mirror:` block in
+ * `<configDir>/vault/config.yaml`, shared across ALL vaults. Every vault's
+ * mirror page rendered that one config (+ the owning vault's git remote);
+ * configuring vault B clobbered vault A.
+ *
+ * Attribution: attribute the legacy block to the mirror-owning vault
+ * (`resolveMirrorVaultName` = default_vault → first listed) — the same vault
+ * the single server-wide mirror was actually bound to. Other vaults start
+ * with no mirror config (they read `undefined` → default disabled).
+ *
+ * Safety:
+ *   - No-op when no legacy block exists (fresh installs, already-migrated).
+ *   - No-op when the target vault already has a per-vault config file (don't
+ *     clobber config the operator set post-migration).
+ *   - The legacy block is preserved (commented out in place) rather than
+ *     silently dropped, so nothing is lost if attribution was wrong.
+ *   - Logs the attribution decision clearly.
+ *
+ * This function is intentionally I/O-light on the config.yaml side: it takes
+ * the raw config.yaml text + a rewriter callback so it doesn't import
+ * `config.ts` (which imports this module). server.ts supplies the read/write.
+ *
+ * @param legacyConfig the `mirror:` block parsed from config.yaml, or
+ *   undefined when there is none. server.ts passes `readGlobalConfig().mirror`.
+ * @param targetVaultName the vault to attribute the legacy config to
+ *   (caller passes `resolveMirrorVaultName()`).
+ * @param commentOutLegacyBlock callback that rewrites config.yaml to comment
+ *   out the `mirror:` block (so it isn't re-migrated + the operator can see
+ *   the old values). Best-effort; failure is non-fatal.
+ * @returns a struct describing what happened, for logging + tests.
+ */
+export function migrateLegacyServerWideConfig(
+  legacyConfig: MirrorConfig | undefined,
+  targetVaultName: string | null,
+  commentOutLegacyBlock: () => void,
+):
+  | { migrated: false; reason: "no_legacy_block" | "no_target_vault" | "target_already_configured" }
+  | { migrated: true; targetVaultName: string } {
+  if (!legacyConfig) {
+    return { migrated: false, reason: "no_legacy_block" };
+  }
+  if (!targetVaultName) {
+    // Legacy block present but no vault to attribute it to. Leave it in
+    // place — a future boot (once a vault exists) migrates it.
+    return { migrated: false, reason: "no_target_vault" };
+  }
+  const targetPath = mirrorConfigPath(targetVaultName);
+  if (existsSync(targetPath)) {
+    // Target vault already has per-vault config. Don't clobber. Still
+    // comment out the legacy block so we don't re-evaluate it every boot.
+    try {
+      commentOutLegacyBlock();
+    } catch {
+      // Non-fatal — worst case we re-check next boot and short-circuit here.
+    }
+    return { migrated: false, reason: "target_already_configured" };
+  }
+
+  writeMirrorConfigForVault(targetVaultName, legacyConfig);
+  try {
+    commentOutLegacyBlock();
+  } catch {
+    // Non-fatal — the config is now in the per-vault file; the legacy block
+    // staying live would just re-migrate to the same place idempotently
+    // (the target_already_configured branch short-circuits next boot).
+  }
+
+  console.log(
+    `[mirror] migrated legacy server-wide mirror config → vault "${targetVaultName}" ` +
+      `(per-vault, vault#400). Other vaults start with no mirror config (configure each ` +
+      `separately). Legacy config.yaml \`mirror:\` block commented out (preserved for reference).`,
+  );
+  return { migrated: true, targetVaultName };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mirror-config.ts
+++ b/src/mirror-config.ts
@@ -492,6 +492,66 @@ export function migrateLegacyServerWideConfig(
   return { migrated: true, targetVaultName };
 }
 
+/**
+ * Pure string transform: comment out the server-wide `mirror:` block in a
+ * config.yaml string (vault#400 migration). Prefixes each line of the block
+ * with `# ` so the operator can still see the migrated values + nothing is
+ * silently dropped, and a subsequent boot's `parseMirrorConfig` no longer
+ * sees a LIVE block (so no re-migration — `parseMirrorConfig`'s anchor regex
+ * `^mirror:\s*$` doesn't match `# mirror:`).
+ *
+ * Block boundaries match the parser's stop rule exactly: the block starts at
+ * a 0-indent `mirror:` line and runs until the next 0-indent non-blank line
+ * (the next top-level key). Other top-level keys (port, default_vault, …) are
+ * left byte-for-byte intact; blank lines are preserved verbatim (not
+ * commented). Idempotent: an already-commented config has no live `mirror:`
+ * line, so it passes through unchanged.
+ *
+ * Extracted from server.ts (vault#408 review N3) so the YAML rewriting — which
+ * runs against the operator's real config.yaml — is directly unit-tested.
+ */
+export function commentOutMirrorBlock(yaml: string): string {
+  const lines = yaml.split("\n");
+  const out: string[] = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (!inBlock && /^mirror:\s*$/.test(line)) {
+      inBlock = true;
+      out.push(`# [vault#400] migrated to per-vault data/<vault>/mirror-config.yaml`);
+      out.push(`# ${line}`);
+      continue;
+    }
+    if (inBlock) {
+      // The block runs until the next top-level (0-indent, non-blank) key.
+      if (/^\S/.test(line) && line.trim().length > 0) {
+        inBlock = false;
+        out.push(line);
+      } else if (line.trim().length === 0) {
+        // Preserve blank lines verbatim (don't comment them).
+        out.push(line);
+      } else {
+        out.push(`# ${line}`);
+      }
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+/**
+ * File-I/O wrapper around `commentOutMirrorBlock`: read config.yaml at
+ * `configPath`, comment out its `mirror:` block, write it back. No-op when
+ * the file is absent. server.ts passes this (bound to GLOBAL_CONFIG_PATH) as
+ * the migration's `commentOutLegacyBlock` callback. Best-effort — callers
+ * treat a throw as non-fatal.
+ */
+export function commentOutLegacyMirrorBlockFile(configPath: string): void {
+  if (!existsSync(configPath)) return;
+  const yaml = readFileSync(configPath, "utf8");
+  writeFileSync(configPath, commentOutMirrorBlock(yaml));
+}
+
 // ---------------------------------------------------------------------------
 // Path resolution
 // ---------------------------------------------------------------------------

--- a/src/mirror-deps.ts
+++ b/src/mirror-deps.ts
@@ -10,8 +10,13 @@
 import { exportVaultToDir, hasSchemaContent, pruneOrphans } from "../core/src/portable-md.ts";
 
 import { defaultHookRegistry } from "../core/src/hooks.ts";
-import { readGlobalConfig, writeGlobalConfig, readVaultConfig } from "./config.ts";
-import { defaultMirrorConfig, type MirrorConfig } from "./mirror-config.ts";
+import { readGlobalConfig, readVaultConfig } from "./config.ts";
+import {
+  defaultMirrorConfig,
+  readMirrorConfigForVault,
+  writeMirrorConfigForVault,
+  type MirrorConfig,
+} from "./mirror-config.ts";
 import type { MirrorDeps } from "./mirror-manager.ts";
 import { assetsDir } from "./routes.ts";
 import { getVaultStore } from "./vault-store.ts";
@@ -24,9 +29,9 @@ import { getVaultStore } from "./vault-store.ts";
  *     CLI mode exactly.
  *   - `firstChangedNoteTitle` → DB query for the most recent note with
  *     `updated_at >= cursor`. Identical to the CLI helper.
- *   - `readMirrorConfig` / `writeMirrorConfig` → round-trip through
- *     `readGlobalConfig` + `writeGlobalConfig`, preserving the rest of
- *     the global config file atomically.
+ *   - `readMirrorConfig` / `writeMirrorConfig` → per-vault config file at
+ *     `data/<vault>/mirror-config.yaml` (vault#400). Each vault carries its
+ *     own mirror config, so configuring vault B never touches vault A's.
  */
 export function buildMirrorDeps(vaultName: string): MirrorDeps {
   return {
@@ -92,11 +97,12 @@ export function buildMirrorDeps(vaultName: string): MirrorDeps {
         return "";
       }
     },
-    readMirrorConfig: () => readGlobalConfig().mirror,
+    // Per-vault (vault#400): read/write THIS vault's own config file, never
+    // a shared server-wide block. Configuring vault B's mirror leaves vault
+    // A's config untouched.
+    readMirrorConfig: () => readMirrorConfigForVault(vaultName),
     writeMirrorConfig: (config: MirrorConfig) => {
-      const global = readGlobalConfig();
-      global.mirror = config;
-      writeGlobalConfig(global);
+      writeMirrorConfigForVault(vaultName, config);
     },
     // Share the process-wide hook registry so mirror's subscriptions land
     // on the same event bus that `BunSqliteStore` dispatches on. This is
@@ -107,14 +113,17 @@ export function buildMirrorDeps(vaultName: string): MirrorDeps {
 }
 
 /**
- * Resolve the mirror's owning vault. Today the mirror is per-server
- * (single config block in `config.yaml`), and the natural binding is
- * `default_vault` (the same vault the CLI + MCP wire up by default).
- * If no default is set, fall back to the first listed vault.
+ * Resolve the mirror's "owning" vault — the one the LEGACY server-wide
+ * config + credentials are attributed to during migration.
  *
- * Multi-vault mirror routing is future work (open question 2 in the
- * design doc); this helper localizes the binding decision so a future
- * refactor only touches one site.
+ * Post-vault#400 every vault has its own mirror config + manager (real
+ * multi-vault mirroring), so this is no longer "the one vault that can
+ * mirror." It survives as the migration-attribution target: the legacy
+ * server-wide `mirror:` block (vault#400) and the legacy server-wide
+ * credentials file (vault#399) belong to the vault the single old mirror
+ * was bound to — `default_vault`, or the first listed vault when no default
+ * is set. Localizing the binding here keeps the migration attribution in one
+ * place.
  */
 export function resolveMirrorVaultName(
   listVaults: () => string[],

--- a/src/mirror-manager.ts
+++ b/src/mirror-manager.ts
@@ -26,17 +26,16 @@
  *     debounce timer, cancel safety-net poll, let an in-flight export
  *     finish via the soft settle window.
  *
- * Singleton per-process: one `MirrorManager` instance backs the vault
- * server's lifecycle. Tests instantiate `MirrorManager` directly with
- * fake deps to exercise lifecycle transitions without spawning a full
- * vault server.
+ * One `MirrorManager` instance PER VAULT (vault#400). The per-vault
+ * registry (`mirror-registry.ts`) holds them keyed by vault name; boot
+ * stands up a manager for each vault whose config is enabled, and the
+ * routes resolve a manager by the URL's vault name. Tests instantiate
+ * `MirrorManager` directly with fake deps to exercise lifecycle
+ * transitions without spawning a full vault server.
  *
- * Phase A1 deliberately surfaces ONE mirror per vault server (matching
- * the design doc's single-mirror-per-vault model). Multi-vault server
- * deployments today already pin one vault per server via
- * `PARACHUTE_VAULT_NAME` / `default_vault`; the mirror config follows
- * suit. Multi-vault mirror routing is a future ripple (open question 2
- * in the design doc).
+ * Each manager is bound to its vault via `deps.vaultName` — its config
+ * read/write, credential reads, and resolved mirror path are all
+ * scoped to that one vault, so vault A's mirror never touches vault B's.
  *
  * ## Race-condition contract
  *
@@ -424,6 +423,30 @@ export class MirrorManager {
    * accidentally mutate the manager's internal state.
    */
   getConfig(): MirrorConfig {
+    return { ...this.currentConfig };
+  }
+
+  /**
+   * The config the operator + SPA should SEE for this vault — distinct from
+   * the live in-memory `getConfig()` only before the manager has started.
+   *
+   * Why this exists (vault#400): routes resolve a per-vault manager via the
+   * registry, which can LAZILY build a manager for a vault that has config
+   * on disk but no running instance yet (e.g. a non-default vault the
+   * operator configured, or a runtime-enabled vault between PUT and the
+   * reload's start). A freshly-constructed-but-never-started manager has
+   * `currentConfig === defaultMirrorConfig()` (disabled), which would make
+   * `GET /vault/<name>/.parachute/mirror` show "disabled" for a vault whose
+   * file says `enabled: true`. Reading the persisted config when we haven't
+   * started yet returns the truth for that vault. Once `start()` has run,
+   * `currentConfig` is authoritative (it reflects the same persisted config
+   * plus any bootstrap outcome).
+   */
+  getEffectiveConfig(): MirrorConfig {
+    if (this.startCount === 0) {
+      const persisted = this.deps.readMirrorConfig();
+      if (persisted) return { ...persisted };
+    }
     return { ...this.currentConfig };
   }
 

--- a/src/mirror-per-vault.test.ts
+++ b/src/mirror-per-vault.test.ts
@@ -1,0 +1,512 @@
+/**
+ * vault#400 — per-vault mirror config + manager + routes.
+ *
+ * The bug this file pins: before vault#400, the vault admin SPA showed the
+ * SAME git remote (the default vault's) on EVERY vault's mirror page, because
+ * the server held a SINGLE MirrorManager bound to the default/first vault and
+ * every mirror route resolved to it — ignoring the URL's vault name. Config
+ * was a single server-wide `mirror:` block, so configuring vault B clobbered
+ * vault A. vault#399 fixed credential STORAGE per-vault; this completes the
+ * job with per-vault CONFIG + per-vault MANAGER + routes that resolve by URL
+ * vault name.
+ *
+ * These tests exercise the REAL production seams end-to-end — real per-vault
+ * config files, the real registry, the real route handlers, real per-vault
+ * SQLite stores via `buildMirrorDeps` — against a fresh PARACHUTE_HOME. Two
+ * vaults (A, B) with DIFFERENT configs prove no bleed + no clobber.
+ */
+
+import { describe, test, expect, afterEach, afterAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  defaultMirrorConfig,
+  mirrorConfigPath,
+  readMirrorConfigForVault,
+  writeMirrorConfigForVault,
+  migrateLegacyServerWideConfig,
+  type MirrorConfig,
+} from "./mirror-config.ts";
+import {
+  clearMirrorManagers,
+  getMirrorManager,
+  setMirrorManager,
+  setMirrorManagerFactory,
+} from "./mirror-registry.ts";
+import { MirrorManager } from "./mirror-manager.ts";
+import { buildMirrorDeps } from "./mirror-deps.ts";
+import {
+  handleMirrorGet,
+  handleMirrorPut,
+  handleAuthGet,
+} from "./mirror-routes.ts";
+import {
+  writeCredentials,
+  emptyCredentials,
+  mirrorCredentialsPath,
+  type MirrorCredentials,
+} from "./mirror-credentials.ts";
+import { writeVaultConfig } from "./config.ts";
+
+const ORIG_HOME = process.env.HOME;
+const ORIG_PARACHUTE_HOME = process.env.PARACHUTE_HOME;
+
+afterEach(() => {
+  clearMirrorManagers();
+  if (ORIG_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIG_HOME;
+  if (ORIG_PARACHUTE_HOME === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = ORIG_PARACHUTE_HOME;
+});
+afterAll(() => {
+  if (ORIG_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIG_HOME;
+});
+
+function tmpHome(prefix: string): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  process.env.PARACHUTE_HOME = home;
+  process.env.HOME = home;
+  return home;
+}
+
+/** Create a real vault on disk (data dir + vault.yaml + SQLite store). */
+function makeVault(name: string): void {
+  fs.mkdirSync(path.join(process.env.PARACHUTE_HOME!, "vault", "data", name), {
+    recursive: true,
+  });
+  writeVaultConfig({
+    name,
+    api_keys: [],
+    created_at: new Date().toISOString(),
+  });
+}
+
+/** A real, registered, started manager for `name` via production deps. */
+async function standUpVault(name: string): Promise<MirrorManager> {
+  const mgr = new MirrorManager(buildMirrorDeps(name));
+  setMirrorManager(name, mgr);
+  await mgr.start();
+  return mgr;
+}
+
+function patCredentials(remoteUrl: string): MirrorCredentials {
+  return {
+    ...emptyCredentials(),
+    active_method: "pat",
+    pat: { token: "ghp_faketoken1234567890", remote_url: remoteUrl, label: "test" },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-vault config storage (vault#400)
+// ---------------------------------------------------------------------------
+
+describe("per-vault config storage", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("writes to data/<vault>/mirror-config.yaml; reads back per-vault", () => {
+    home = tmpHome("pv-config-");
+    makeVault("alpha");
+    makeVault("beta");
+
+    const cfgA: MirrorConfig = {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "external",
+      external_path: "/tmp/alpha-mirror",
+      auto_commit: false,
+    };
+    writeMirrorConfigForVault("alpha", cfgA);
+
+    // File landed in alpha's data dir, not beta's, not server-wide.
+    expect(fs.existsSync(mirrorConfigPath("alpha"))).toBe(true);
+    expect(fs.existsSync(mirrorConfigPath("beta"))).toBe(false);
+    expect(mirrorConfigPath("alpha")).toContain(path.join("data", "alpha"));
+
+    // Read back is alpha's; beta is undefined (never configured).
+    const back = readMirrorConfigForVault("alpha");
+    expect(back?.enabled).toBe(true);
+    expect(back?.external_path).toBe("/tmp/alpha-mirror");
+    expect(back?.auto_commit).toBe(false);
+    expect(readMirrorConfigForVault("beta")).toBeUndefined();
+  });
+
+  test("writing beta does NOT mutate alpha's config file (no clobber)", () => {
+    home = tmpHome("pv-noclobber-");
+    makeVault("alpha");
+    makeVault("beta");
+
+    writeMirrorConfigForVault("alpha", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      external_path: "/tmp/alpha",
+    });
+    const alphaBefore = fs.readFileSync(mirrorConfigPath("alpha"), "utf8");
+
+    writeMirrorConfigForVault("beta", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "external",
+      external_path: "/tmp/beta",
+    });
+
+    const alphaAfter = fs.readFileSync(mirrorConfigPath("alpha"), "utf8");
+    expect(alphaAfter).toBe(alphaBefore); // byte-identical — untouched
+    expect(readMirrorConfigForVault("beta")?.external_path).toBe("/tmp/beta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-vault manager registry (vault#400)
+// ---------------------------------------------------------------------------
+
+describe("per-vault manager registry", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("get/set keyed by vault; distinct instances", () => {
+    home = tmpHome("pv-registry-");
+    makeVault("alpha");
+    makeVault("beta");
+    const a = new MirrorManager(buildMirrorDeps("alpha"));
+    const b = new MirrorManager(buildMirrorDeps("beta"));
+    setMirrorManager("alpha", a);
+    setMirrorManager("beta", b);
+    expect(getMirrorManager("alpha")).toBe(a);
+    expect(getMirrorManager("beta")).toBe(b);
+    expect(getMirrorManager("alpha")).not.toBe(getMirrorManager("beta"));
+    expect(getMirrorManager("alpha")!.getVaultName()).toBe("alpha");
+    expect(getMirrorManager("beta")!.getVaultName()).toBe("beta");
+  });
+
+  test("no factory + no entry → null; factory builds on demand + binds vault", () => {
+    home = tmpHome("pv-lazy-");
+    makeVault("gamma");
+    expect(getMirrorManager("gamma")).toBeNull(); // no factory installed yet
+
+    setMirrorManagerFactory((name) => new MirrorManager(buildMirrorDeps(name)));
+    const built = getMirrorManager("gamma");
+    expect(built).not.toBeNull();
+    expect(built!.getVaultName()).toBe("gamma");
+    // Cached — second get returns the same lazily-built instance.
+    expect(getMirrorManager("gamma")).toBe(built);
+  });
+
+  test("lazily-built manager reports THIS vault's persisted config (getEffectiveConfig)", () => {
+    home = tmpHome("pv-effective-");
+    makeVault("delta");
+    // delta has enabled config on disk but no live (started) manager.
+    writeMirrorConfigForVault("delta", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "external",
+      external_path: "/tmp/delta",
+    });
+    setMirrorManagerFactory((name) => new MirrorManager(buildMirrorDeps(name)));
+    const mgr = getMirrorManager("delta")!;
+    // Never started, so live getConfig() is still the default (disabled) —
+    // but getEffectiveConfig() reads the persisted truth.
+    expect(mgr.getConfig().enabled).toBe(false);
+    expect(mgr.getEffectiveConfig().enabled).toBe(true);
+    expect(mgr.getEffectiveConfig().external_path).toBe("/tmp/delta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THE BUG: routes resolve per-vault — GET A returns A's, GET B returns B's
+// ---------------------------------------------------------------------------
+
+describe("mirror routes resolve per-vault (the 'same remote on every page' bug)", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("GET A returns A's config; GET B returns B's — never A's on B's page", async () => {
+    home = tmpHome("pv-get-distinct-");
+    makeVault("alpha");
+    makeVault("beta");
+
+    // Two DIFFERENT configs persisted per-vault.
+    writeMirrorConfigForVault("alpha", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "external",
+      external_path: "/tmp/alpha-mirror",
+      auto_push: false,
+    });
+    writeMirrorConfigForVault("beta", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "external",
+      external_path: "/tmp/beta-mirror",
+      auto_push: false,
+    });
+
+    setMirrorManagerFactory((name) => new MirrorManager(buildMirrorDeps(name)));
+
+    // Resolve EACH vault's manager via the registry exactly as routing.ts does.
+    const resA = handleMirrorGet(getMirrorManager("alpha")!);
+    const resB = handleMirrorGet(getMirrorManager("beta")!);
+    const bodyA = (await resA.json()) as { config: MirrorConfig };
+    const bodyB = (await resB.json()) as { config: MirrorConfig };
+
+    expect(bodyA.config.external_path).toBe("/tmp/alpha-mirror");
+    expect(bodyB.config.external_path).toBe("/tmp/beta-mirror");
+    // The exact symptom: B's page must NOT show A's remote.
+    expect(bodyB.config.external_path).not.toBe(bodyA.config.external_path);
+  });
+
+  test("GET on an unconfigured vault returns 'not configured' (disabled), not the default vault's", async () => {
+    home = tmpHome("pv-get-unconfigured-");
+    makeVault("alpha"); // default/first — configured + enabled
+    makeVault("beta"); // never configured
+
+    writeMirrorConfigForVault("alpha", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "external",
+      external_path: "/tmp/alpha-mirror",
+    });
+    setMirrorManagerFactory((name) => new MirrorManager(buildMirrorDeps(name)));
+
+    const resB = handleMirrorGet(getMirrorManager("beta")!);
+    const bodyB = (await resB.json()) as { config: MirrorConfig; status: { enabled: boolean } };
+    // beta is disabled + has no external_path — NOT alpha's "/tmp/alpha-mirror".
+    expect(bodyB.config.enabled).toBe(false);
+    expect(bodyB.config.external_path).toBeNull();
+    expect(bodyB.status.enabled).toBe(false);
+  });
+
+  test("PUT B does not mutate A's persisted config (no clobber via route)", async () => {
+    home = tmpHome("pv-put-noclobber-");
+    makeVault("alpha");
+    makeVault("beta");
+
+    // A configured + persisted first.
+    writeMirrorConfigForVault("alpha", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "internal",
+      auto_commit: false,
+      sync_mode: "manual",
+    });
+    const alphaBefore = readMirrorConfigForVault("alpha")!;
+
+    setMirrorManagerFactory((name) => new MirrorManager(buildMirrorDeps(name)));
+
+    // PUT B's config via the real handler (resolved per-vault).
+    const req = new Request("http://x/vault/beta/.parachute/mirror", {
+      method: "PUT",
+      body: JSON.stringify({
+        enabled: true,
+        location: "internal",
+        sync_mode: "manual",
+        auto_commit: true, // DIFFERENT from A
+      }),
+    });
+    const res = await handleMirrorPut(req, getMirrorManager("beta")!);
+    expect(res.status).toBe(200);
+
+    // A's persisted config is unchanged.
+    const alphaAfter = readMirrorConfigForVault("alpha")!;
+    expect(alphaAfter).toEqual(alphaBefore);
+    expect(alphaAfter.auto_commit).toBe(false); // A still false
+    // B got its own config.
+    expect(readMirrorConfigForVault("beta")!.auto_commit).toBe(true);
+
+    await getMirrorManager("beta")!.stop();
+    await getMirrorManager("alpha")!.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-vault credentials surface (vault#399 storage, vault#400 routing)
+// ---------------------------------------------------------------------------
+
+describe("getMirrorAuth resolves per-vault (never bleeds A's creds onto B)", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("auth GET returns B's remote, or none — never A's", async () => {
+    home = tmpHome("pv-auth-");
+    makeVault("alpha");
+    makeVault("beta");
+
+    // A has a PAT pointing at A's repo. B has its OWN PAT at B's repo.
+    writeCredentials("alpha", patCredentials("https://x-access-token:tok@github.com/me/alpha.git"));
+    writeCredentials("beta", patCredentials("https://x-access-token:tok@github.com/me/beta.git"));
+
+    // Files are per-vault.
+    expect(mirrorCredentialsPath("alpha")).toContain(path.join("data", "alpha"));
+    expect(mirrorCredentialsPath("beta")).toContain(path.join("data", "beta"));
+
+    const a = new MirrorManager(buildMirrorDeps("alpha"));
+    const b = new MirrorManager(buildMirrorDeps("beta"));
+    setMirrorManager("alpha", a);
+    setMirrorManager("beta", b);
+
+    const bodyA = (await handleAuthGet(a).json()) as { pat: { remote_url: string } | null };
+    const bodyB = (await handleAuthGet(b).json()) as { pat: { remote_url: string } | null };
+    // Redacted, but host/path survive sanitization — assert the repo differs.
+    expect(bodyA.pat?.remote_url).toContain("alpha.git");
+    expect(bodyB.pat?.remote_url).toContain("beta.git");
+    expect(bodyB.pat?.remote_url).not.toContain("alpha.git");
+  });
+
+  test("B with no credentials returns none even when A has some", async () => {
+    home = tmpHome("pv-auth-none-");
+    makeVault("alpha");
+    makeVault("beta");
+    writeCredentials("alpha", patCredentials("https://x-access-token:tok@github.com/me/alpha.git"));
+    // beta: no credentials file written.
+
+    const b = new MirrorManager(buildMirrorDeps("beta"));
+    const bodyB = (await handleAuthGet(b).json()) as { active_method: string | null; pat: unknown };
+    expect(bodyB.active_method).toBeNull();
+    expect(bodyB.pat).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Both vaults enabled simultaneously — boot stands up both managers
+// ---------------------------------------------------------------------------
+
+describe("both vaults enabled simultaneously", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("two internal mirrors both bootstrap + run with independent paths", async () => {
+    home = tmpHome("pv-both-enabled-");
+    makeVault("alpha");
+    makeVault("beta");
+
+    writeMirrorConfigForVault("alpha", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "internal",
+      sync_mode: "manual",
+      auto_commit: false,
+    });
+    writeMirrorConfigForVault("beta", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "internal",
+      sync_mode: "manual",
+      auto_commit: false,
+    });
+
+    const a = await standUpVault("alpha");
+    const b = await standUpVault("beta");
+
+    const statusA = a.getStatus();
+    const statusB = b.getStatus();
+    expect(statusA.enabled).toBe(true);
+    expect(statusB.enabled).toBe(true);
+    // Independent on-disk mirror paths under each vault's own data dir.
+    expect(statusA.mirror_path).toContain(path.join("data", "alpha", "mirror"));
+    expect(statusB.mirror_path).toContain(path.join("data", "beta", "mirror"));
+    expect(statusA.mirror_path).not.toBe(statusB.mirror_path);
+    // Both are real git repos.
+    expect(fs.existsSync(path.join(statusA.mirror_path!, ".git"))).toBe(true);
+    expect(fs.existsSync(path.join(statusB.mirror_path!, ".git"))).toBe(true);
+
+    await a.stop();
+    await b.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config migration — legacy server-wide `mirror:` block → owning vault
+// ---------------------------------------------------------------------------
+
+describe("legacy server-wide config migration (vault#400)", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("migrates the legacy block to the owning vault; others unaffected", () => {
+    home = tmpHome("pv-migrate-");
+    makeVault("first"); // owning vault (default/first)
+    makeVault("second");
+
+    const legacy: MirrorConfig = {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "external",
+      external_path: "/tmp/legacy-mirror",
+      auto_push: true,
+    };
+    let commented = false;
+    const result = migrateLegacyServerWideConfig(legacy, "first", () => {
+      commented = true;
+    });
+
+    expect(result.migrated).toBe(true);
+    if (result.migrated) expect(result.targetVaultName).toBe("first");
+    expect(commented).toBe(true);
+
+    // first got the legacy config; second got nothing.
+    const firstCfg = readMirrorConfigForVault("first");
+    expect(firstCfg?.enabled).toBe(true);
+    expect(firstCfg?.external_path).toBe("/tmp/legacy-mirror");
+    expect(firstCfg?.auto_push).toBe(true);
+    expect(readMirrorConfigForVault("second")).toBeUndefined();
+  });
+
+  test("idempotent — second run is a no-op when target already configured", () => {
+    home = tmpHome("pv-migrate-idem-");
+    makeVault("first");
+
+    const legacy: MirrorConfig = {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      external_path: "/tmp/legacy",
+      location: "external",
+    };
+    const first = migrateLegacyServerWideConfig(legacy, "first", () => {});
+    expect(first.migrated).toBe(true);
+    const afterFirst = readMirrorConfigForVault("first");
+
+    // Operator then edits first's config; a second migration must NOT clobber.
+    writeMirrorConfigForVault("first", {
+      ...afterFirst!,
+      external_path: "/tmp/operator-edited",
+    });
+    const second = migrateLegacyServerWideConfig(legacy, "first", () => {});
+    expect(second.migrated).toBe(false);
+    if (!second.migrated) expect(second.reason).toBe("target_already_configured");
+    // Operator's edit survives.
+    expect(readMirrorConfigForVault("first")?.external_path).toBe("/tmp/operator-edited");
+  });
+
+  test("no legacy block → no-op", () => {
+    home = tmpHome("pv-migrate-noblock-");
+    makeVault("first");
+    const result = migrateLegacyServerWideConfig(undefined, "first", () => {});
+    expect(result.migrated).toBe(false);
+    if (!result.migrated) expect(result.reason).toBe("no_legacy_block");
+    expect(readMirrorConfigForVault("first")).toBeUndefined();
+  });
+
+  test("no target vault → no-op (leaves block for a future boot)", () => {
+    home = tmpHome("pv-migrate-notarget-");
+    const legacy: MirrorConfig = { ...defaultMirrorConfig(), enabled: true };
+    const result = migrateLegacyServerWideConfig(legacy, null, () => {});
+    expect(result.migrated).toBe(false);
+    if (!result.migrated) expect(result.reason).toBe("no_target_vault");
+  });
+});

--- a/src/mirror-per-vault.test.ts
+++ b/src/mirror-per-vault.test.ts
@@ -49,12 +49,19 @@ import {
   type MirrorCredentials,
 } from "./mirror-credentials.ts";
 import { writeVaultConfig } from "./config.ts";
+import { clearVaultStoreCache } from "./vault-store.ts";
 
 const ORIG_HOME = process.env.HOME;
 const ORIG_PARACHUTE_HOME = process.env.PARACHUTE_HOME;
 
 afterEach(() => {
   clearMirrorManagers();
+  // `getVaultStore` caches SqliteStore handles in a process-wide Map keyed by
+  // vault name. Tests reuse vault names ("alpha"/"beta") across cases in fresh
+  // tempdirs, so without clearing the cache a later case picks up a handle
+  // pointing at a DELETED tempdir → SQLite "disk I/O error" on export. Clear
+  // it every test (matches auth.test.ts / routing.test.ts / export-watch.test.ts).
+  clearVaultStoreCache();
   if (ORIG_HOME === undefined) delete process.env.HOME;
   else process.env.HOME = ORIG_HOME;
   if (ORIG_PARACHUTE_HOME === undefined) delete process.env.PARACHUTE_HOME;

--- a/src/mirror-registry.ts
+++ b/src/mirror-registry.ts
@@ -1,26 +1,108 @@
 /**
- * Process-singleton holder for the active MirrorManager.
+ * Per-vault holder for MirrorManager instances.
  *
  * Why a registry module: `server.ts` owns the lifecycle (constructs + starts
- * on boot, drains on shutdown), but `routing.ts` needs to hand the same
- * instance to the `/admin/mirror` HTTP handlers. A shared module with a
- * setter + getter is the lightest seam — no top-level circular import,
- * no globals on `process`, no DI framework.
+ * each enabled vault's manager on boot, drains on shutdown), but `routing.ts`
+ * needs to hand the SAME instance to the `/.parachute/mirror[/*]` HTTP
+ * handlers for the vault named in the URL. A shared module with per-vault
+ * get/set is the lightest seam — no top-level circular import, no globals on
+ * `process`, no DI framework.
  *
- * Tests instantiate their own manager + call `setMirrorManager` to inject
- * it before exercising the route handlers.
+ * ## Why per-vault (vault#400)
+ *
+ * Before vault#400 this module held a SINGLE `activeManager` bound to the
+ * mirror-owning vault (`resolveMirrorVaultName` = default/first). Every
+ * mirror route — for EVERY vault in the URL — resolved to that one manager,
+ * so `GET /vault/gitcoin/.parachute/mirror` returned the DEFAULT vault's
+ * config + status + git remote. The admin SPA showed the same remote on
+ * every vault's mirror page. vault#399 fixed credential STORAGE to be
+ * per-vault; vault#400 completes the job: per-vault config + per-vault
+ * manager + routes that resolve by the URL vault name.
+ *
+ * Now the registry is a `Map<vaultName, MirrorManager>`. A vault that has
+ * config but no manager yet (runtime-enabled without a restart) is built
+ * lazily on first `getMirrorManager(vaultName)` via the installed factory.
+ *
+ * Tests instantiate their own manager + call `setMirrorManager(name, mgr)`
+ * to inject it before exercising the route handlers, OR install a fake
+ * factory via `setMirrorManagerFactory`. `clearMirrorManagers()` resets
+ * the map between tests.
  */
 
 import type { MirrorManager } from "./mirror-manager.ts";
 
-let activeManager: MirrorManager | null = null;
+/**
+ * Factory that builds a fresh MirrorManager for a vault. Installed by
+ * production wiring (server.ts) so the registry can lazily stand up a
+ * manager for a vault that has config but no live instance yet — without
+ * the registry importing the heavy production deps (mirror-deps → config,
+ * vault-store, routes) at module load. Tests install a fake factory or
+ * skip lazy-build entirely by pre-seeding the map.
+ */
+export type MirrorManagerFactory = (vaultName: string) => MirrorManager;
 
-/** Install (or replace) the process-wide mirror manager. */
-export function setMirrorManager(manager: MirrorManager | null): void {
-  activeManager = manager;
+const managers = new Map<string, MirrorManager>();
+let factory: MirrorManagerFactory | null = null;
+
+/**
+ * Install (or replace) the lazy-build factory. server.ts wires this once at
+ * boot to `(name) => new MirrorManager(buildMirrorDeps(name))`. Until it's
+ * set, `getMirrorManager` won't lazily build — it returns whatever's already
+ * in the map (or null).
+ */
+export function setMirrorManagerFactory(f: MirrorManagerFactory | null): void {
+  factory = f;
 }
 
-/** Retrieve the current mirror manager. Null when boot hasn't wired one yet. */
-export function getMirrorManager(): MirrorManager | null {
-  return activeManager;
+/** Install (or replace) the manager for a vault. Pass null to evict. */
+export function setMirrorManager(
+  vaultName: string,
+  manager: MirrorManager | null,
+): void {
+  if (manager === null) {
+    managers.delete(vaultName);
+  } else {
+    managers.set(vaultName, manager);
+  }
+}
+
+/**
+ * Retrieve the manager for `vaultName`. If none is registered and a factory
+ * is installed, build one lazily, register it, and return it — so a vault
+ * whose mirror config was flipped on at runtime works without a restart.
+ *
+ * The lazily-built manager is NOT auto-started here (start() is async + does
+ * filesystem work); callers that need it running call `manager.start()`.
+ * Route handlers read `getConfig()`/`getStatus()` which reflect "disabled /
+ * not configured" until a start happens — exactly the right answer for a
+ * vault the operator hasn't enabled. The PUT handler's `reload()` is what
+ * stands it up when the operator enables it.
+ *
+ * Returns null only when no manager exists AND no factory is installed
+ * (e.g. tests that pre-seed the map deliberately, or a boot that hasn't
+ * wired the factory yet).
+ */
+export function getMirrorManager(vaultName: string): MirrorManager | null {
+  const existing = managers.get(vaultName);
+  if (existing) return existing;
+  if (!factory) return null;
+  const built = factory(vaultName);
+  managers.set(vaultName, built);
+  return built;
+}
+
+/** True iff a manager is currently registered for `vaultName` (no lazy build). */
+export function hasMirrorManager(vaultName: string): boolean {
+  return managers.has(vaultName);
+}
+
+/** Snapshot of vault names with a live manager. Used by shutdown drain. */
+export function listMirrorManagers(): MirrorManager[] {
+  return Array.from(managers.values());
+}
+
+/** Reset the registry (drops all managers + the factory). Test seam. */
+export function clearMirrorManagers(): void {
+  managers.clear();
+  factory = null;
 }

--- a/src/mirror-registry.ts
+++ b/src/mirror-registry.ts
@@ -91,11 +91,6 @@ export function getMirrorManager(vaultName: string): MirrorManager | null {
   return built;
 }
 
-/** True iff a manager is currently registered for `vaultName` (no lazy build). */
-export function hasMirrorManager(vaultName: string): boolean {
-  return managers.has(vaultName);
-}
-
 /** Snapshot of vault names with a live manager. Used by shutdown drain. */
 export function listMirrorManagers(): MirrorManager[] {
   return Array.from(managers.values());

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -75,7 +75,11 @@ import { assetsDir } from "./routes.ts";
  * any persistence has happened yet.
  */
 export function handleMirrorGet(manager: MirrorManager): Response {
-  const config = manager.getConfig();
+  // Per-vault (vault#400): `getEffectiveConfig()` returns THIS vault's
+  // persisted config even when the lazily-built manager hasn't started yet,
+  // so a non-default vault's page shows ITS config — never the default
+  // vault's. That's the exact "same remote on every vault page" symptom.
+  const config = manager.getEffectiveConfig();
   const status = manager.getStatus();
   return Response.json(
     {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -489,15 +489,13 @@ export async function route(
     return handleTokens(req, store, vaultName, auth.scopes, auth.scoped_tags, tokensMatch[1] ?? "");
   }
 
-  // /.parachute/mirror — vault-sync Phase A1. Admin-gated read+write of
-  // the persistent mirror config + runtime status. Lives under
-  // `.parachute/` (alongside info/icon/config) rather than `admin/`
-  // because `/vault/<name>/admin/*` is reserved for the admin SPA's
-  // static-file mount; the API surface goes under `.parachute/` by the
-  // module-protocol convention. Per the design doc, the hub admin SPA
-  // (Phase A2 — future PR) is the eventual primary consumer; for Phase
-  // A1 these endpoints unblock direct API callers and the by-hand
-  // config workflow.
+  // /.parachute/mirror — Admin-gated read+write of THIS vault's persistent
+  // mirror config + runtime status. Per-vault (vault#400): the manager is
+  // resolved by the URL's vault name, so each vault's mirror page reflects
+  // its own config + git remote. Lives under `.parachute/` (alongside
+  // info/icon/config) rather than `admin/` because `/vault/<name>/admin/*`
+  // is reserved for the admin SPA's static-file mount; the API surface goes
+  // under `.parachute/` by the module-protocol convention.
   if (subpath === "/.parachute/mirror") {
     if (!hasScopeForVault(auth.scopes, vaultName, "admin")) {
       return Response.json(
@@ -511,19 +509,22 @@ export async function route(
         { status: 403 },
       );
     }
-    const manager = getMirrorManager();
+    // vault#400: resolve the manager for THIS vault (from the URL). The
+    // registry lazily builds one (via the boot-installed factory) for any
+    // existing vault — including a non-default vault or one configured at
+    // runtime — so the handler operates on the right vault's config + status
+    // + git remote, never the default vault's.
+    const manager = getMirrorManager(vaultName);
     if (!manager) {
-      // The boot path constructs a manager when at least one vault
-      // exists; a missing manager here means either a startup error or
-      // a brand-new deploy that hasn't finished first-boot. Surface a
-      // clear 503 rather than a JSON null so the operator + the hub
-      // SPA know it's a service-state issue, not a misconfig on their
-      // end.
+      // Null only when boot hasn't installed the factory yet (startup race
+      // or boot failure). Surface a clear 503 rather than a JSON null so the
+      // operator + the hub SPA know it's a service-state issue, not a
+      // misconfig on their end.
       return Response.json(
         {
           error: "Mirror manager not initialized",
           message:
-            "The vault server hasn't wired a mirror manager yet (no vaults exist, or boot failed). Check logs for [mirror] entries.",
+            "The vault server hasn't wired the mirror manager registry yet (boot hasn't finished, or it failed). Check logs for [mirror] entries.",
         },
         { status: 503 },
       );
@@ -551,13 +552,13 @@ export async function route(
         { status: 403 },
       );
     }
-    const manager = getMirrorManager();
+    const manager = getMirrorManager(vaultName);
     if (!manager) {
       return Response.json(
         {
           error: "Mirror manager not initialized",
           message:
-            "The vault server hasn't wired a mirror manager yet (no vaults exist, or boot failed). Check logs for [mirror] entries.",
+            "The vault server hasn't wired the mirror manager registry yet (boot hasn't finished, or it failed). Check logs for [mirror] entries.",
         },
         { status: 503 },
       );
@@ -583,13 +584,13 @@ export async function route(
         { status: 403 },
       );
     }
-    const manager = getMirrorManager();
+    const manager = getMirrorManager(vaultName);
     if (!manager) {
       return Response.json(
         {
           error: "Mirror manager not initialized",
           message:
-            "The vault server hasn't wired a mirror manager yet (no vaults exist, or boot failed). Check logs for [mirror] entries.",
+            "The vault server hasn't wired the mirror manager registry yet (boot hasn't finished, or it failed). Check logs for [mirror] entries.",
         },
         { status: 503 },
       );
@@ -639,13 +640,13 @@ export async function route(
         { status: 403 },
       );
     }
-    const manager = getMirrorManager();
+    const manager = getMirrorManager(vaultName);
     if (!manager) {
       return Response.json(
         {
           error: "Mirror manager not initialized",
           message:
-            "The vault server hasn't wired a mirror manager yet (no vaults exist, or boot failed). Check logs for [mirror] entries.",
+            "The vault server hasn't wired the mirror manager registry yet (boot hasn't finished, or it failed). Check logs for [mirror] entries.",
         },
         { status: 503 },
       );

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@
  */
 
 import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile, generateApiKey, hashKey, stopSignalPath } from "./config.ts";
-import { existsSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, rmSync } from "fs";
 import { migrateVaultKeys } from "./token-store.ts";
 import { resolveFirstBootVaultName } from "./vault-name.ts";
 import { getVaultStore, getVaultNameForStore } from "./vault-store.ts";
@@ -39,6 +39,7 @@ import {
 import { buildMirrorDeps, resolveMirrorVaultName } from "./mirror-deps.ts";
 import { migrateLegacyServerWideCredentials } from "./mirror-credentials.ts";
 import {
+  commentOutLegacyMirrorBlockFile,
   migrateLegacyServerWideConfig,
   readMirrorConfigForVault,
 } from "./mirror-config.ts";
@@ -287,7 +288,7 @@ const hostname = resolveBindHostname();
     migrateLegacyServerWideConfig(
       readGlobalConfig().mirror,
       mirrorVaultName,
-      commentOutLegacyMirrorBlock,
+      () => commentOutLegacyMirrorBlockFile(GLOBAL_CONFIG_PATH),
     );
   } catch (err) {
     console.warn(
@@ -332,45 +333,6 @@ const hostname = resolveBindHostname();
       console.warn(`[mirror] vault "${name}" manager construction failed: ${(err as Error).message ?? err}`);
     }
   }
-}
-
-/**
- * Comment out the legacy server-wide `mirror:` block in config.yaml after
- * its values have been migrated to a per-vault file (vault#400). Prefixes
- * each line of the block with `# ` so the operator can still see the old
- * values + nothing is silently dropped, and a subsequent boot's
- * `parseMirrorConfig` no longer sees a live block (so no re-migration).
- * Best-effort; callers treat a throw as non-fatal.
- */
-function commentOutLegacyMirrorBlock(): void {
-  if (!existsSync(GLOBAL_CONFIG_PATH)) return;
-  const yaml = readFileSync(GLOBAL_CONFIG_PATH, "utf-8");
-  const lines = yaml.split("\n");
-  const out: string[] = [];
-  let inBlock = false;
-  for (const line of lines) {
-    if (!inBlock && /^mirror:\s*$/.test(line)) {
-      inBlock = true;
-      out.push(`# [vault#400] migrated to per-vault data/<vault>/mirror-config.yaml`);
-      out.push(`# ${line}`);
-      continue;
-    }
-    if (inBlock) {
-      // The block runs until the next top-level (0-indent, non-blank) key.
-      if (/^\S/.test(line) && line.trim().length > 0) {
-        inBlock = false;
-        out.push(line);
-      } else if (line.trim().length === 0) {
-        // Preserve blank lines verbatim (don't comment them).
-        out.push(line);
-      } else {
-        out.push(`# ${line}`);
-      }
-      continue;
-    }
-    out.push(line);
-  }
-  writeFileSync(GLOBAL_CONFIG_PATH, out.join("\n"));
 }
 
 const server = Bun.serve({

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@
  */
 
 import { readVaultConfig, readGlobalConfig, writeGlobalConfig, writeVaultConfig, listVaults, DEFAULT_PORT, ensureConfigDirSync, loadEnvFile, generateApiKey, hashKey, stopSignalPath } from "./config.ts";
-import { existsSync, rmSync } from "fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { migrateVaultKeys } from "./token-store.ts";
 import { resolveFirstBootVaultName } from "./vault-name.ts";
 import { getVaultStore, getVaultNameForStore } from "./vault-store.ts";
@@ -31,9 +31,18 @@ import { getCachedScribeUrl } from "./scribe-discovery.ts";
 import { readEnvFile, setEnvVar } from "./config.ts";
 import { resolveBindHostname } from "./bind.ts";
 import { MirrorManager } from "./mirror-manager.ts";
-import { setMirrorManager } from "./mirror-registry.ts";
+import {
+  setMirrorManager,
+  setMirrorManagerFactory,
+  listMirrorManagers,
+} from "./mirror-registry.ts";
 import { buildMirrorDeps, resolveMirrorVaultName } from "./mirror-deps.ts";
 import { migrateLegacyServerWideCredentials } from "./mirror-credentials.ts";
+import {
+  migrateLegacyServerWideConfig,
+  readMirrorConfigForVault,
+} from "./mirror-config.ts";
+import { GLOBAL_CONFIG_PATH } from "./config.ts";
 import { selfRegister } from "./self-register.ts";
 import pkg from "../package.json" with { type: "json" };
 
@@ -232,33 +241,35 @@ const port = parseInt(process.env.PORT ?? "") || globalConfig.port || DEFAULT_PO
 const hostname = resolveBindHostname();
 
 // ---------------------------------------------------------------------------
-// Mirror lifecycle (vault-sync Phase A1).
+// Mirror lifecycle — per-vault (vault#400).
 //
-// Boot-time bootstrap of the persistent mirror manager. Only stands up an
-// active mirror when global config carries `mirror.enabled: true`; otherwise
-// the manager construct + status reflects "disabled" but no filesystem work
-// happens. The HTTP `/admin/mirror` routes can still flip it on at runtime
-// without a vault restart — see routing.ts + mirror-routes.ts.
+// Before vault#400 the server stood up a SINGLE mirror manager bound to the
+// mirror-owning vault (default/first), and every mirror route resolved to it
+// — so every vault's mirror page showed the default vault's config + git
+// remote. Now each vault gets its OWN config (`data/<vault>/mirror-config.yaml`)
+// + its OWN manager. Boot:
 //
-// Failure here is logged and ignored; vault keeps serving. The operator
-// sees the error via `GET /admin/mirror` + the log line.
+//   1. Migrate the legacy SERVER-WIDE credentials file (vault#399) + the
+//      legacy server-wide `mirror:` config block (vault#400) to the
+//      mirror-owning vault (default/first). Other vaults start unconfigured.
+//   2. Install the lazy-build factory so routes can stand up a manager for
+//      any vault on first request (handles a vault configured at runtime
+//      without a restart).
+//   3. Iterate ALL vaults; for each whose per-vault config has
+//      `enabled: true`, build + register + start its manager. Per-vault
+//      failure is logged + isolated — one vault's mirror error never breaks
+//      another vault's mirror or the vault server's serving path.
 // ---------------------------------------------------------------------------
-let mirrorManager: MirrorManager | null = null;
 {
-  // Canonicalized in `mirror-deps.ts:resolveMirrorVaultName` so the
-  // binding rule (default_vault → first listed vault → null) lives in
-  // exactly one place; multi-vault-mirror work (design-doc open
-  // question 2) only has to touch one site.
+  // Canonicalized in `mirror-deps.ts:resolveMirrorVaultName` — the binding
+  // rule (default_vault → first listed vault → null) lives in exactly one
+  // place. Post-vault#400 it's only used for migration attribution.
   const mirrorVaultName = resolveMirrorVaultName(listVaults);
-  // vault#399: migrate the legacy SERVER-WIDE credentials file
-  // (`<configDir>/vault/.mirror-credentials.yaml`) to the per-vault layout.
-  // Attribute to the mirror-owning vault (default_vault → first listed) —
-  // the same vault the single server-wide mirror was bound to, so the
-  // legacy remote/PAT lands on the vault it actually corresponds to. Other
-  // vaults start with no mirror credentials (configure each separately).
-  // Idempotent + safe: no-op when no legacy file / already migrated, and the
-  // legacy file is renamed `.bak` rather than deleted. Runs even when no
-  // vault exists yet (no-op) so we don't gate the migration on enabled state.
+
+  // vault#399: migrate the legacy SERVER-WIDE credentials file to the
+  // per-vault layout, attributed to the mirror-owning vault. Idempotent +
+  // safe (no-op when no legacy file / already migrated; legacy file renamed
+  // `.bak`, never deleted). Runs even with no vaults (no-op).
   try {
     migrateLegacyServerWideCredentials(mirrorVaultName);
   } catch (err) {
@@ -266,30 +277,100 @@ let mirrorManager: MirrorManager | null = null;
       `[mirror] legacy credential migration failed (non-fatal): ${(err as Error).message ?? err}`,
     );
   }
-  if (mirrorVaultName) {
+
+  // vault#400: migrate the legacy server-wide `mirror:` CONFIG block from
+  // config.yaml to the mirror-owning vault's per-vault config file. The
+  // legacy block is commented out in place (preserved for reference), never
+  // silently dropped. Idempotent: no-op when no block / target already
+  // configured. (#399 already moved credentials — we do NOT re-migrate them.)
+  try {
+    migrateLegacyServerWideConfig(
+      readGlobalConfig().mirror,
+      mirrorVaultName,
+      commentOutLegacyMirrorBlock,
+    );
+  } catch (err) {
+    console.warn(
+      `[mirror] legacy config migration failed (non-fatal): ${(err as Error).message ?? err}`,
+    );
+  }
+
+  // Install the lazy-build factory so routes can stand up a per-vault manager
+  // on demand (a vault configured at runtime works without a restart).
+  setMirrorManagerFactory((name) => new MirrorManager(buildMirrorDeps(name)));
+
+  // Stand up every vault whose per-vault config is enabled. Don't block
+  // server startup on slow initial exports — kick each off in the background.
+  const vaults = listVaults();
+  if (vaults.length === 0) {
+    console.log("[mirror] no vaults yet — managers stand up on next restart after a vault exists");
+  }
+  for (const name of vaults) {
+    let cfg;
     try {
-      mirrorManager = new MirrorManager(buildMirrorDeps(mirrorVaultName));
-      setMirrorManager(mirrorManager);
-      // Don't block server startup on a slow initial export — kick it off
-      // in the background, log the outcome. The HTTP server comes up
-      // immediately so OAuth + REST aren't blocked behind a multi-second
-      // export pass.
-      void mirrorManager
+      cfg = readMirrorConfigForVault(name);
+    } catch (err) {
+      console.warn(`[mirror] could not read config for vault "${name}" (skipping): ${(err as Error).message ?? err}`);
+      continue;
+    }
+    if (!cfg?.enabled) continue; // unconfigured / disabled → no manager work
+    try {
+      const mgr = new MirrorManager(buildMirrorDeps(name));
+      setMirrorManager(name, mgr);
+      void mgr
         .start()
         .then((status) => {
           if (!status.enabled && status.last_error) {
-            console.warn(`[mirror] startup error: ${status.last_error}`);
+            console.warn(`[mirror] vault "${name}" startup error: ${status.last_error}`);
           }
         })
         .catch((err) => {
-          console.warn(`[mirror] startup threw: ${(err as Error).message ?? err}`);
+          console.warn(`[mirror] vault "${name}" startup threw: ${(err as Error).message ?? err}`);
         });
     } catch (err) {
-      console.warn(`[mirror] manager construction failed: ${(err as Error).message ?? err}`);
+      // Isolated per-vault: one vault's failure never touches others.
+      console.warn(`[mirror] vault "${name}" manager construction failed: ${(err as Error).message ?? err}`);
     }
-  } else {
-    console.log("[mirror] no vaults yet — manager will be initialized on next restart after a vault exists");
   }
+}
+
+/**
+ * Comment out the legacy server-wide `mirror:` block in config.yaml after
+ * its values have been migrated to a per-vault file (vault#400). Prefixes
+ * each line of the block with `# ` so the operator can still see the old
+ * values + nothing is silently dropped, and a subsequent boot's
+ * `parseMirrorConfig` no longer sees a live block (so no re-migration).
+ * Best-effort; callers treat a throw as non-fatal.
+ */
+function commentOutLegacyMirrorBlock(): void {
+  if (!existsSync(GLOBAL_CONFIG_PATH)) return;
+  const yaml = readFileSync(GLOBAL_CONFIG_PATH, "utf-8");
+  const lines = yaml.split("\n");
+  const out: string[] = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (!inBlock && /^mirror:\s*$/.test(line)) {
+      inBlock = true;
+      out.push(`# [vault#400] migrated to per-vault data/<vault>/mirror-config.yaml`);
+      out.push(`# ${line}`);
+      continue;
+    }
+    if (inBlock) {
+      // The block runs until the next top-level (0-indent, non-blank) key.
+      if (/^\S/.test(line) && line.trim().length > 0) {
+        inBlock = false;
+        out.push(line);
+      } else if (line.trim().length === 0) {
+        // Preserve blank lines verbatim (don't comment them).
+        out.push(line);
+      } else {
+        out.push(`# ${line}`);
+      }
+      continue;
+    }
+    out.push(line);
+  }
+  writeFileSync(GLOBAL_CONFIG_PATH, out.join("\n"));
 }
 
 const server = Bun.serve({
@@ -334,10 +415,11 @@ console.log(`Parachute Vault server listening on http://${hostname}:${server.por
 // Graceful shutdown — best-effort drain of in-flight note-mutation hooks.
 //
 // Order matters under the event-driven mirror shape (vault#382):
-//   1. MirrorManager.stop() runs FIRST so it can unsubscribe from hooks
-//      cleanly + cancel its debounce timer. Otherwise the registry drain
-//      below would wait on the manager's hook handler that just queued
-//      itself after a final mutation.
+//   1. Every MirrorManager.stop() runs FIRST (vault#400: drain ALL per-vault
+//      managers, not just one) so they unsubscribe from hooks cleanly +
+//      cancel their debounce timers. Otherwise the registry drain below
+//      would wait on a manager's hook handler that just queued itself after
+//      a final mutation.
 //   2. Then drain hooks + stop the transcription worker in parallel —
 //      neither depends on the other.
 //
@@ -348,9 +430,16 @@ async function shutdown(signal: string): Promise<void> {
   try {
     await Promise.race([
       (async () => {
-        // Mirror stop first — unsubscribes + cancels its debounce. Its
-        // internal soft-settle timeout (250ms) bounds the wait.
-        await (mirrorManager?.stop() ?? Promise.resolve());
+        // Mirror stop first — unsubscribes + cancels each debounce. Each
+        // manager's internal soft-settle timeout (250ms) bounds the wait;
+        // drain them in parallel so total shutdown stays bounded.
+        await Promise.all(
+          listMirrorManagers().map((m) =>
+            m.stop().catch((err) =>
+              console.warn(`[mirror] stop threw during shutdown (non-fatal): ${(err as Error).message ?? err}`),
+            ),
+          ),
+        );
         // Then drain hooks + stop the transcription worker in parallel.
         await Promise.all([
           defaultHookRegistry.drain(),


### PR DESCRIPTION
Closes the **"same git remote on every vault's mirror page"** symptom Aaron is hitting live, and completes the per-vault isolation vault#399 began. vault#399 made credential STORAGE per-vault; this PR finishes the job with per-vault **config** + per-vault **manager** + routes that resolve by the URL vault name.

## The bug

`mirror-registry.ts` held a SINGLE `activeManager` (a `MirrorManager` bound to the default/first vault via `resolveMirrorVaultName`). Every mirror route handler operated on that one injected manager, ignoring the URL's vault — so `GET /vault/<any>/.parachute/mirror` returned the DEFAULT vault's config/status/credentials. Mirror config also lived in a single server-wide `mirror:` block in `config.yaml`, so configuring vault B clobbered vault A. The admin SPA already threaded `vaultName` through every API call (`/vault/${vaultName}/.parachute/mirror`), so the bug was entirely server-side — **no SPA changes needed**.

## Step-1 map (precise)

- `src/mirror-registry.ts` — single `activeManager`; `getMirrorManager()` took no vault arg (the single holder).
- `src/mirror-manager.ts` — `MirrorManager` is per-vault-capable (`deps.vaultName`, `getVaultName`/`getConfig`/`getStatus`/`reload`/`runNow`/`pushNow`); it was just only ever instantiated once.
- `src/mirror-deps.ts` — `buildMirrorDeps(vaultName)` wired `readMirrorConfig`/`writeMirrorConfig` to the **server-wide** `readGlobalConfig().mirror` / `writeGlobalConfig`. `resolveMirrorVaultName` = default_vault → first listed.
- `src/mirror-config.ts` — server-wide `mirror:` block parse/serialize (`parseMirrorConfig`/`serializeMirrorConfig`); `resolveMirrorPath` was already per-vault (`<vaultDataDir>/mirror`).
- `src/server.ts` (~246–301) — built ONE manager for `resolveMirrorVaultName` and `setMirrorManager(mgr)`; ran the vault#399 credential migration.
- `src/routing.ts` (~492+) — dispatched mirror routes; had `vaultName` in scope (from the `/vault/<name>/...` match) but called `getMirrorManager()` with no arg and passed that single manager to every handler.

## What changed

**Per-vault config storage (commit 1).** Mirror config moved out of the server-wide `mirror:` block into a per-vault file `data/<vault>/mirror-config.yaml` — same per-vault-state pattern as vault#399's `.mirror-credentials.yaml`. *Chosen over folding into the credentials file:* config is non-secret + hand-editable; credentials are `0o600` + token-bearing — keeping them separate avoids widening the credentials file's perms and keeps the two migrations independent. New `readMirrorConfigForVault`/`writeMirrorConfigForVault` (atomic write-temp → rename); `buildMirrorDeps` now reads/writes THIS vault's file.

**Per-vault manager registry (commit 2).** `mirror-registry.ts` is now a `Map<vaultName, MirrorManager>`: `getMirrorManager(vaultName)`/`setMirrorManager(vaultName, mgr)`, a lazy-build factory (`setMirrorManagerFactory`) so a vault configured at runtime works without a restart, `listMirrorManagers()` for shutdown drain, and `clearMirrorManagers()` for tests. Added `MirrorManager.getEffectiveConfig()` — returns the vault's persisted config even for a lazily-built-but-not-started manager, so a non-default vault's GET shows its own config, never the default's.

**Routes resolve per-vault.** `routing.ts` resolves the manager via `getMirrorManager(vaultName)` at every mirror dispatch site (vault existence is verified upstream → 404). A vault with no config returns disabled/not-configured status for THAT vault.

**Boot bootstrap.** `server.ts` now iterates ALL vaults and stands up + starts a manager for each whose per-vault config is enabled; per-vault failure is logged + isolated (one vault's mirror error never breaks others or vault serving). Shutdown drains ALL managers in parallel.

**Config migration (coexists with #399).** On boot, the legacy server-wide `mirror:` CONFIG block migrates to the mirror-owning vault's per-vault file (`migrateLegacyServerWideConfig`), attributed to default/first (same vault the single old mirror was bound to). Idempotent; the legacy block is **commented out** in `config.yaml` (preserved for reference), never dropped. Other vaults start unconfigured. Credentials are NOT re-migrated (#399 did that). `writeGlobalConfig` no longer emits a `mirror:` block (would resurrect the migrated legacy block); `readGlobalConfig` still parses one so the migration can detect it.

## Tests + gates

- New `src/mirror-per-vault.test.ts` — **15 tests**: per-vault storage + no-clobber; registry get/set + lazy-build + `getEffectiveConfig`; **GET A returns A's, GET B returns B's, never A's on B's page**; unconfigured vault → disabled (not the default's); PUT B doesn't mutate A; `getMirrorAuth` per-vault (never bleeds A's creds onto B); both vaults enabled boot to independent paths; config migration correct + idempotent + no-op cases.
- `bun test ./src/` → **1300 pass / 0 fail** (49 files).
- `bun test ./core/src/` → **610 pass / 0 fail** (9 files).
- `bun run typecheck` → clean.
- No vitest run — SPA untouched (it already passes `vaultName` to every helper).

## Sandbox E2E (fresh `PARACHUTE_HOME`, never Aaron's `~/.parachute`)

Real HTTP server + routing + auth + per-vault storage, two vaults (alpha, beta) + two external git repos:

```
STEP 1: PUT alpha → alpha-repo   → alpha config.external_path = .../alpha-repo
STEP 2: PUT beta  → beta-repo    → beta  config.external_path = .../beta-repo
STEP 3: GET alpha → .../alpha-repo ; GET beta → .../beta-repo
STEP 4: PASS: alpha shows alpha repo, beta shows beta repo, no bleed
        (on-disk: data/alpha/mirror-config.yaml ≠ data/beta/mirror-config.yaml)
STEP 5: re-PUT alpha (auto_commit true) → beta config byte-unchanged (no clobber)
```

Migration E2E: injected a legacy server-wide `mirror:` block into `config.yaml`; on boot it migrated to gamma (default), the block was commented out, delta was unaffected (no per-vault config), and a reboot was idempotent (no re-migration log, no errors).

## Notes

- Closes the "same remote on every vault page" symptom; completes vault#399.
- No version/rc bump.
- Do not merge — reviewer dispatch pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)