### PR TITLE
chore(release): 0.4.9-rc.11 — hub-JWT auth arc + per-vault mirror + bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.10",
+  "version": "0.4.9-rc.11",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Bumps `0.4.9-rc.10` → `0.4.9-rc.11`, bundling the work merged since rc.10: hub-JWT auth arc (#397/#403/#405/#406/#407), gitcoin indexed-field fix (#398), per-vault mirror (#399/#408). Adversarially audited (0 P0/P1), live-verified on the dev deploy. Non-breaking — pvt_* still accepted (DROP = separate breaking 0.6.0, vault#282). Depends on hub 0.5.14-rc.9 + scope-guard 0.4.0-rc.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)