### PR TITLE
feat(vault): pvt_* deprecation warning + migration guide (vault#282 Stage 1, non-breaking)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,110 @@ Operator-facing migration guidance. For the full chronological CHANGELOG,
 see [CHANGELOG.md](./CHANGELOG.md) — note the meta-note at the top about
 what's actually been published to npm.
 
+## pvt_* token deprecation — will be rejected at 0.6.0
+
+**TL;DR:** `pvt_*` tokens (the opaque `pvt_…` bearers vault mints into its own
+SQLite `tokens` table) are **deprecated**. They still work today — every
+upgrade up to and including the last 0.5.x release keeps authenticating them
+unchanged. At **vault 0.6.0** they will be **rejected with a 401**. Migrate
+each client to a **hub-issued JWT** before you upgrade to 0.6.0.
+
+This is the safe on-ramp: nothing breaks now. Starting with the release that
+ships this notice, every successful `pvt_*` authentication logs a one-time
+warning naming the token's display id and pointing here, so you can find which
+clients still need migrating before the cutover.
+
+### Why this is happening
+
+Vault is becoming a **pure OAuth resource-server**. Granular, revocable,
+audience-bound auth is a hub-minted capability — the hub is the single token
+issuer for the ecosystem (it already mints the JWTs that browser-based clients
+use today). `pvt_*` was vault's own pre-hub token type; it predates the hub and
+duplicates a capability that now lives entirely on the hub. Keeping two parallel
+auth surfaces (vault-local `pvt_*` + hub JWTs) is the thing 0.6.0 retires. After
+0.6.0, vault validates hub-issued JWTs (and the coarse `VAULT_AUTH_TOKEN` /
+`vault.yaml` operator secrets for the no-granular-auth path) and nothing else.
+
+Every capability `pvt_*` provided has a hub-minted equivalent already shipped:
+read/write/admin scopes, per-vault binding, tag-scoped tokens, and
+session-managed mint/revoke via the `manage-token` MCP tool. Nothing is
+stranded by the removal.
+
+### Who this affects
+
+If you came up on **vault 0.2.4-era** (vault standalone, no hub) you are
+**100% on `pvt_*`** — every MCP client and script you wired authenticates with
+a `pvt_…` bearer. You are the operator this notice is for. You need to install
+the hub and re-mint each client's token before upgrading to 0.6.0.
+
+If you are **already running vault behind the hub** and your clients connect
+via OAuth (Claude Desktop, claude.ai, Parachute Daily, etc.), those clients
+already use hub JWTs — they need no change. You only need to migrate any
+**scripts or CLI-wired tokens** that still present a `pvt_…` bearer (check your
+logs for the `[deprecation] pvt_* token …` lines).
+
+### Upgrading to the CURRENT release is safe
+
+You do **not** have to migrate before upgrading to the current (pre-0.6.0)
+release. `pvt_*` keeps authenticating exactly as before — same permission, same
+scopes, same vault binding — and just emits the one-time deprecation warning.
+Use the window between this release and 0.6.0 to migrate at your own pace. The
+deprecation is **non-breaking** until 0.6.0.
+
+### Migration path (no-hub operator)
+
+1. **Install the hub.** It's the OAuth issuer — vault delegates the whole
+   authorization flow to it.
+
+   ```bash
+   bun add -g @openparachute/hub
+   parachute init
+   ```
+
+   `parachute init` sets up the hub on `127.0.0.1:1939` and wires the JWT mint
+   path. (If vault must reach the hub on a non-default origin, set
+   `PARACHUTE_HUB_ORIGIN` in `~/.parachute/vault/.env`.)
+
+2. **Re-mint each client's token as a hub JWT.**
+
+   - **MCP clients** (Claude Code, Claude Desktop, Daily) — re-run the install
+     helper; it now writes a hub-minted JWT into the client config instead of a
+     `pvt_*`:
+
+     ```bash
+     parachute vault mcp-install
+     ```
+
+   - **Scripts / headless callers** — mint a scoped JWT directly and use it as
+     the bearer:
+
+     ```bash
+     parachute auth mint-token --scope vault:<name>:<verb>
+     ```
+
+     where `<name>` is the vault and `<verb>` is `read`, `write`, or `admin`.
+
+3. **Swap the configs.** Replace the old `pvt_…` value anywhere you hard-coded
+   it (`~/.claude.json` MCP entries, script env vars, `Authorization: Bearer`
+   headers) with the freshly-minted JWT. `mcp-install` does this for the MCP
+   clients automatically; scripts you wired by hand you update by hand.
+
+4. **Confirm, then cut over.** Watch your vault logs — once no
+   `[deprecation] pvt_* token …` lines appear for a full cycle of your clients'
+   activity, every caller is on a hub JWT. Then upgrade vault to 0.6.0:
+
+   ```bash
+   parachute upgrade vault
+   ```
+
+   At 0.6.0 any remaining `pvt_*` bearer starts returning 401, so finish the
+   re-mint before this step.
+
+Reference: pvt_* retirement arc tracked at
+[vault#282](https://github.com/ParachuteComputer/parachute-vault/issues/282);
+propagation tracker at
+[parachute-patterns/migrations/2026-05-28-operator-mintable-vault-admin.md](https://github.com/ParachuteComputer/parachute-patterns/blob/main/migrations/2026-05-28-operator-mintable-vault-admin.md).
+
 ## Mirror event-driven exports + `sync_mode` schema (0.4.9-rc.5 → 0.4.9-rc.6)
 
 The git-mirror feature flipped from polling to event-driven. The watch

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -30,6 +30,7 @@ import { writeVaultConfig, readVaultConfig } from "./config.ts";
 import { getVaultStore, clearVaultStoreCache } from "./vault-store.ts";
 import { authenticateVaultRequest, authenticateGlobalRequest } from "./auth.ts";
 import { resetJwksCache, resetRevocationCache } from "./hub-jwt.ts";
+import { generateToken, createToken } from "./token-store.ts";
 
 interface Keypair {
   privateKey: CryptoKey;
@@ -664,4 +665,118 @@ describe("authenticateVaultRequest — hub JWT tag-scoping (auth-unification C0)
       }
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// pvt_* deprecation warning (vault#282 Stage 1 — soft deprecation, NON-BREAKING)
+//
+// Every successful pvt_* (vault-DB token-store) authentication emits a
+// one-time-per-token deprecation warning signalling that pvt_* tokens will be
+// REJECTED at vault 0.6.0. Auth OUTCOMES are unchanged: the token still
+// validates + authorizes exactly as before. Hub-issued JWTs — the migration
+// target — never trigger the pvt_* warning.
+//
+// The `warnPvtDeprecationOnce` cache is process-global and keyed on the
+// token's display id (`t_<hashprefix>`). Each test mints a fresh random pvt_*,
+// so display ids never collide across tests; the "warns once" assertion holds
+// within a single test by making two requests with the same token.
+// ---------------------------------------------------------------------------
+
+/** Mint a fresh pvt_* token directly into a vault's DB and return it. */
+function mintPvtToken(vaultName: string): string {
+  const store = getVaultStore(vaultName);
+  const { fullToken } = generateToken();
+  createToken(store.db, fullToken, { label: "deprecation-test", permission: "full" });
+  return fullToken;
+}
+
+describe("pvt_* deprecation warning (vault#282 Stage 1)", () => {
+  test("pvt_* auth still SUCCEEDS and emits the deprecation warning once", async () => {
+    seedVault("journal");
+    const token = mintPvtToken("journal");
+    const config = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // First request: auth outcome unchanged (full permission), warning fires.
+      const r1 = await authenticateVaultRequest(bearer(token), config, store.db);
+      expect("error" in r1).toBe(false);
+      if (!("error" in r1)) {
+        expect(r1.permission).toBe("full");
+        expect(r1.scopes).toContain("vault:admin");
+      }
+
+      const deprecationCalls = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("[deprecation]"),
+      );
+      expect(deprecationCalls.length).toBe(1);
+      const msg = String(deprecationCalls[0]![0]);
+      // Shape: names pvt_*, the 0.6.0 rejection, the issue, the mint paths, the guide.
+      expect(msg).toContain("pvt_* token");
+      expect(msg).toContain("DEPRECATED");
+      expect(msg).toContain("REJECTED at vault 0.6.0");
+      expect(msg).toContain("vault#282");
+      expect(msg).toContain("parachute vault mcp-install");
+      expect(msg).toContain("parachute auth mint-token");
+      expect(msg).toContain("UPGRADING.md");
+      // The display id of the presented token appears in the message.
+      expect(msg).toMatch(/pvt_\* token t_[0-9a-f]+ authenticated/);
+
+      // Second request with the SAME token: still authorizes, no second warn.
+      const r2 = await authenticateVaultRequest(bearer(token), config, store.db);
+      expect("error" in r2).toBe(false);
+      const stillOne = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("[deprecation]"),
+      );
+      expect(stillOne.length).toBe(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("pvt_* auth on the global (unified) surface also SUCCEEDS and warns once", async () => {
+    seedVault("journal");
+    const token = mintPvtToken("journal");
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await authenticateGlobalRequest(bearer(token));
+      expect("error" in result).toBe(false);
+      if (!("error" in result)) expect(result.permission).toBe("full");
+
+      const deprecationCalls = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("[deprecation]"),
+      );
+      expect(deprecationCalls.length).toBe(1);
+      expect(String(deprecationCalls[0]![0])).toContain("vault#282");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("hub-JWT auth does NOT emit the pvt_* deprecation warning", async () => {
+    seedVault("journal");
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: "vault.journal",
+      scope: "vault:journal:write",
+    });
+    const config = readVaultConfig("journal")!;
+    const store = getVaultStore("journal");
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await authenticateVaultRequest(bearer(token), config, store.db);
+      // Auth succeeds (the migration target works) ...
+      expect("error" in result).toBe(false);
+      // ... and no pvt_* deprecation warning is emitted for a hub JWT.
+      const deprecationCalls = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("[deprecation]"),
+      );
+      expect(deprecationCalls.length).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -169,6 +169,40 @@ export function warnLegacyOnce(cacheKey: string, context: string): void {
   );
 }
 
+/**
+ * Doc link operators are sent to when a `pvt_*` token authenticates. Points
+ * at the pvt_* → hub-JWT migration section of vault's UPGRADING.md.
+ */
+const PVT_MIGRATION_DOC =
+  "https://github.com/ParachuteComputer/parachute-vault/blob/main/UPGRADING.md#pvt_-token-deprecation--will-be-rejected-at-060";
+
+// One-shot pvt_* deprecation warning tracker, keyed by the token's display id
+// (`t_<hashprefix>`) so each distinct token warns exactly once per process.
+const warnedPvtTokens = new Set<string>();
+
+/**
+ * Log a one-time (per token-hash) deprecation warning for a successfully-
+ * authenticated `pvt_*` vault-DB token. Stage 1 of vault#282: pvt_* still
+ * AUTHENTICATES and AUTHORIZES exactly as before — this only signals that the
+ * credential is on a deprecation clock and will be REJECTED at vault 0.6.0.
+ *
+ * Keyed on the token's display id (`t_<hashprefix>` — the `jti` ResolvedToken
+ * surfaces) so a given token logs once per process regardless of how many
+ * requests it makes or whether it carries explicit scopes. Folds in the
+ * narrower pre-existing "vault token without scopes column" warning — a legacy-
+ * derived pvt_* gets THIS warning, not both, so we never double-warn one token.
+ */
+export function warnPvtDeprecationOnce(displayId: string): void {
+  if (warnedPvtTokens.has(displayId)) return;
+  warnedPvtTokens.add(displayId);
+  console.warn(
+    `[deprecation] pvt_* token ${displayId} authenticated — pvt_* tokens are DEPRECATED and will be REJECTED at vault 0.6.0 (vault#282). ` +
+      "Migrate to a hub-issued JWT: run `parachute vault mcp-install` (MCP clients) or " +
+      "`parachute auth mint-token --scope vault:<name>:<verb>` (scripts). " +
+      `Guide: ${PVT_MIGRATION_DOC}.`,
+  );
+}
+
 /** Read-only tools (the only tools allowed for "read" permission). */
 const READ_TOOLS = new Set([
   "query-notes",
@@ -292,9 +326,12 @@ export async function authenticateVaultRequest(
             ),
           };
         }
-        if (resolved.legacyDerived) {
-          warnLegacyOnce(`vault-token:${vaultConfig.name ?? ""}`, "vault token without scopes column");
-        }
+        // vault#282 Stage 1: every successful pvt_* (vault-DB token-store)
+        // authentication is on a deprecation clock. One-time per token-hash
+        // (keyed on the display id). Folds in the old narrower "vault token
+        // without scopes column" warning — a legacy-derived pvt_* gets THIS
+        // warning, not both. Auth OUTCOME is unchanged; this only signals.
+        warnPvtDeprecationOnce(resolved.jti);
         return {
           permission: resolved.permission,
           scopes: resolved.scopes,
@@ -621,9 +658,10 @@ export async function authenticateGlobalRequest(
       const store = getVaultStore(vaultName);
       const resolved = resolveToken(store.db, key);
       if (resolved) {
-        if (resolved.legacyDerived) {
-          warnLegacyOnce(`vault-token:${vaultName}`, "vault token without scopes column");
-        }
+        // vault#282 Stage 1: pvt_* resolved on the unified surface is on the
+        // same deprecation clock. One-time per token-hash; folds in the old
+        // narrower legacy-scopes warning. Auth OUTCOME unchanged.
+        warnPvtDeprecationOnce(resolved.jti);
         return {
           permission: resolved.permission,
           scopes: resolved.scopes,


### PR DESCRIPTION
Stage 1 of the pvt_* retirement (**vault#282**) — the safe soft-deprecation on-ramp **before** the breaking pvt_* DROP at 0.6.0. **Auth OUTCOMES are unchanged**: pvt_* tokens still validate + authorize exactly as before. This just makes the deprecation loud and ships the operator migration path. Context: vault 0.2.4-era operators are 100% pvt_* (no hub) — they need a clear warning + a path before the DROP.

## 1. Broadened + sharpened pvt_* deprecation warning (`src/auth.ts`)

Previously a deprecation warning fired only for narrow cases (a vault token whose `scopes` column was still NULL, plus the YAML-key paths). Now **every successful pvt_* authentication** — any token resolved via the vault-DB token-store `resolveToken` path, scoped or not, on **both** `authenticateVaultRequest` (per-vault) and `authenticateGlobalRequest` (unified `/mcp`) — emits a one-time-per-token-hash warning:

```
[deprecation] pvt_* token t_<id> authenticated — pvt_* tokens are DEPRECATED and will be REJECTED at vault 0.6.0 (vault#282). Migrate to a hub-issued JWT: run `parachute vault mcp-install` (MCP clients) or `parachute auth mint-token --scope vault:<name>:<verb>` (scripts). Guide: <UPGRADING.md link>.
```

- Keyed on the token's **display id** (`t_<hashprefix>`, the `jti` `ResolvedToken` already surfaces) via a dedicated `warnedPvtTokens` set — one warning per distinct token per process, no per-request spam.
- **Folds in** the old narrower `"vault token without scopes column"` warning, so a legacy-derived pvt_* gets THIS warning, not both — no double-warn on one token.
- Legacy **YAML-key** warnings (`vault.yaml` / `config.yaml` api_keys) are a *separate* auth method and keep their own `[scopes]` warning, unchanged.
- **No change to auth outcomes** — permission, scopes, scoped_tags, vault binding all resolve as before.

## 2. Deprecation / Sunset HTTP headers (RFC 8594) — **SKIPPED** (assessed invasive)

Assessment: the `AuthResult` flows into **many distinct response-builders** — `handleConfig`, the streaming `handleScopedMcp` path, `handleTokens`, the REST API dispatch, the mirror handlers, the bare-vault JSON response, the `/api/storage` path — with **no single response chokepoint** in `routing.ts`. Threading a `deprecated: true`/`authMethod` flag onto pvt_*-authed responses would require wrapping dozens of `Response` returns across multiple handlers plus the MCP streaming response. Per the task's own guidance ("if threading it cleanly is invasive, SKIP"), the headers are skipped. The **log warning + migration doc are the required, sufficient minimum** for Stage 1; headers can ride the 0.6.0 DROP work if still wanted.

## 3. Operator migration doc (`UPGRADING.md`)

New top section **"pvt_* token deprecation — will be rejected at 0.6.0"** covering:
- **Why** — vault becomes a pure hub OAuth resource-server; granular auth is a hub-minted capability; every pvt_* capability already has a hub-minted equivalent.
- **Who** — no-hub (0.2.4-era) operators are 100% pvt_*; hub-fronted operators only need to migrate scripts/CLI-wired tokens.
- **Upgrading to CURRENT is safe** — pvt_* keeps working with the warning until 0.6.0; non-breaking.
- **Migration path** — install hub (`bun add -g @openparachute/hub`), `parachute init`, re-mint each client (`mcp-install` for MCP, `parachute auth mint-token --scope vault:<name>:<verb>` for scripts), swap configs, then `parachute upgrade vault` to 0.6.0.

## Tests

In `src/auth-hub-jwt.test.ts` (has both the pvt_* mint helpers and the live hub-JWT signing fixture):
- pvt_* auth still **SUCCEEDS** (full permission, vault:admin scopes) AND emits the warning **exactly once**; a second request with the same token re-authorizes with **no** second warning.
- pvt_* on the **global/unified** surface also succeeds + warns once.
- a **hub-JWT** auth succeeds and emits **NO** pvt_* deprecation warning.

## Gates

- `bun test ./src/` — **1308 pass / 0 fail** (49 files)
- `bun test ./core/src/` — **610 pass / 0 fail** (9 files)
- `bun run typecheck` — clean

## Versioning

No version/rc bump (per governance — orchestrator cuts the rc when shipping).

Refs vault#282 (Stage 1, soft deprecation, non-breaking). The breaking pvt_* DROP (vault rejects with 401, validation path deleted) is a separate 0.6.0 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)