### PR TITLE
chore(release): 0.4.9-rc.12 — pvt_* deprecation warning + migration guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.4.9-rc.11",
+  "version": "0.4.9-rc.12",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Bumps `0.4.9-rc.11` → `0.4.9-rc.12`, shipping vault#282 Stage 1 (#410, reviewed LGTM): non-breaking pvt_* deprecation warning + UPGRADING.md migration guide. Auth outcomes unchanged. Published before the 0.6.0 DROP to give operators a migration window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)