### PR TITLE
feat(vault): auto-enable sync to the imported repo (default-on, opt-out) (+ rc.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.0-rc.2",
+  "version": "0.5.0-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/mirror-import.test.ts
+++ b/src/mirror-import.test.ts
@@ -297,6 +297,10 @@ describe("cloneAndImport — success", () => {
     expect(result.notes_imported).toBe(2); // alpha + beta
     expect(result.notes_deleted).toBeUndefined();
     expect(result.warnings).toEqual([]);
+    // vault#416: cloneAndImport stays focused on content — sync-enabling is
+    // the route's job. The worker always returns sync_enabled: false.
+    expect(result.sync_enabled).toBe(false);
+    expect(result.sync_warning).toBeUndefined();
 
     const restored = await store.getNote("n-alpha");
     expect(restored).toBeTruthy();

--- a/src/mirror-import.ts
+++ b/src/mirror-import.ts
@@ -154,6 +154,29 @@ export interface ImportResult {
    * etc.). The HTTP handler returns these so the operator can audit.
    */
   warnings: string[];
+  /**
+   * vault#416 — whether sync (mirror push-back to the imported repo) ended
+   * up enabled as part of this import. Default-on UX: the import request
+   * carries `enable_sync` (default true), and the route turns the imported
+   * repo into a configured, credential-backed, auto-pushing mirror after a
+   * successful import. `true` when sync is now wired (or was already wired
+   * to this same remote); `false` when sync was opted out, couldn't be
+   * enabled (no push-capable credentials), was skipped to avoid clobbering
+   * a different existing mirror, or threw during setup (import already
+   * succeeded — never lost to a sync error).
+   *
+   * `cloneAndImport` itself never sets these — the field is populated by the
+   * route (`handleMirrorImport`) after a successful import. `importResultFromStats`
+   * defaults `sync_enabled` to false; the route overwrites it.
+   */
+  sync_enabled: boolean;
+  /**
+   * Human-readable reason sync wasn't enabled (no creds / conflicting
+   * existing mirror / setup error). Only set when `sync_enabled` is false
+   * AND the caller asked for sync (`enable_sync !== false`). Absent when
+   * sync succeeded or the operator opted out.
+   */
+  sync_warning?: string;
 }
 
 /**
@@ -500,6 +523,10 @@ function importResultFromStats(
     tags_imported: stats.schemas_restored,
     attachments_imported: stats.attachments_restored,
     warnings,
+    // Default false; the route flips it true after wiring sync. Keeping the
+    // default here means a caller that bypasses the route (CLI, tests of
+    // cloneAndImport directly) gets a well-typed, conservative result.
+    sync_enabled: false,
   };
   if (mode === "replace") {
     result.notes_deleted = stats.notes_wiped;

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -11,7 +11,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { defaultMirrorConfig, type MirrorConfig } from "./mirror-config.ts";
+import {
+  defaultMirrorConfig,
+  readMirrorConfigForVault,
+  writeMirrorConfigForVault,
+  type MirrorConfig,
+} from "./mirror-config.ts";
 import {
   MirrorManager,
   type MirrorDeps,
@@ -1112,6 +1117,28 @@ const spawnCloneFail: GitSpawn = async () => ({
   timedOut: false,
 });
 
+/**
+ * vault#416 — a MirrorManager wired to the REAL per-vault config file (so
+ * `handleMirrorImport`'s `readMirrorConfigForVault` agrees with what
+ * `manager.reload()` wrote) + a no-op export. Passed to `handleMirrorImport`
+ * as the `managerOverride` so the sync-enable step has a live manager without
+ * standing up the registry factory. Bootstrap (git init of the internal
+ * mirror) runs for real; push to a fake remote fails non-fatally (we assert
+ * on persisted config + credentials, not on a landed push).
+ */
+function makeSyncManager(home: string): MirrorManager {
+  process.env.PARACHUTE_HOME = home;
+  process.env.HOME = home;
+  const deps: MirrorDeps = {
+    vaultName: "default",
+    runExport: async () => ({ notes: 0 }),
+    firstChangedNoteTitle: async () => "",
+    readMirrorConfig: () => readMirrorConfigForVault("default"),
+    writeMirrorConfig: (c) => writeMirrorConfigForVault("default", c),
+  };
+  return new MirrorManager(deps);
+}
+
 describe("handleMirrorImport", () => {
   let home: string;
   let fixture: string;
@@ -1391,6 +1418,381 @@ describe("handleMirrorImport", () => {
     const joined = observedArgv!.join(" ");
     expect(joined).toContain("ghp_per_call_only");
     expect(joined).not.toContain("ghp_stored_xyz");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// vault#416 — auto-enable sync to the imported repo (default-on, opt-out).
+// ---------------------------------------------------------------------------
+
+describe("handleMirrorImport — auto-enable sync (vault#416)", () => {
+  let home: string;
+  let fixture: string;
+  let manager: MirrorManager;
+
+  afterEach(async () => {
+    if (manager) await manager.stop();
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    if (fixture) fs.rmSync(fixture, { recursive: true, force: true });
+    _resetImportInFlightForTest();
+    clearVaultStoreCache();
+  });
+
+  test("enable_sync true + PAT auth → mirror configured, creds persisted, auto_push on, sync_enabled true", async () => {
+    home = tmp("import-sync-pat-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    manager = makeSyncManager(home);
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_import_token_abc" },
+        enable_sync: true,
+      }),
+    });
+    const res = await handleMirrorImport(
+      req,
+      "default",
+      spawnCloneSuccess(fixture),
+      undefined,
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      notes_imported: number;
+      sync_enabled: boolean;
+      sync_warning?: string;
+    };
+    expect(body.notes_imported).toBe(2);
+    expect(body.sync_enabled).toBe(true);
+    expect(body.sync_warning).toBeUndefined();
+
+    // Mirror config persisted with auto_push + enabled.
+    const cfg = readMirrorConfigForVault("default");
+    expect(cfg?.enabled).toBe(true);
+    expect(cfg?.auto_push).toBe(true);
+
+    // Credentials persisted, pointing at the imported remote.
+    const creds = readCredentials("default");
+    expect(creds?.active_method).toBe("pat");
+    expect(creds?.pat?.token).toBe("ghp_import_token_abc");
+    expect(creds?.pat?.remote_url).toContain("github.com/aaron/my-vault.git");
+  });
+
+  test("enable_sync false → no mirror configured, sync_enabled false, no warning", async () => {
+    home = tmp("import-sync-optout-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    manager = makeSyncManager(home);
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_import_token_abc" },
+        enable_sync: false,
+      }),
+    });
+    const res = await handleMirrorImport(
+      req,
+      "default",
+      spawnCloneSuccess(fixture),
+      undefined,
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sync_enabled: boolean;
+      sync_warning?: string;
+    };
+    expect(body.sync_enabled).toBe(false);
+    expect(body.sync_warning).toBeUndefined();
+
+    // Nothing configured.
+    expect(readMirrorConfigForVault("default")).toBeUndefined();
+    expect(readCredentials("default")).toBeNull();
+  });
+
+  test("enable_sync true + auth none → sync_enabled false + needs-write-creds warning; no broken mirror", async () => {
+    home = tmp("import-sync-nocreds-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    manager = makeSyncManager(home);
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "none" },
+        enable_sync: true,
+      }),
+    });
+    const res = await handleMirrorImport(
+      req,
+      "default",
+      spawnCloneSuccess(fixture),
+      undefined,
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      notes_imported: number;
+      sync_enabled: boolean;
+      sync_warning?: string;
+    };
+    // Import still succeeded.
+    expect(body.notes_imported).toBe(2);
+    expect(body.sync_enabled).toBe(false);
+    expect(body.sync_warning).toContain("write credentials");
+
+    // No mirror left configured, no credentials written.
+    expect(readMirrorConfigForVault("default")).toBeUndefined();
+    expect(readCredentials("default")).toBeNull();
+  });
+
+  test("enable_sync defaults to true when omitted", async () => {
+    home = tmp("import-sync-default-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    manager = makeSyncManager(home);
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_default_on_token" },
+        // enable_sync omitted — should default ON.
+      }),
+    });
+    const res = await handleMirrorImport(
+      req,
+      "default",
+      spawnCloneSuccess(fixture),
+      undefined,
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sync_enabled: boolean };
+    expect(body.sync_enabled).toBe(true);
+    expect(readMirrorConfigForVault("default")?.auto_push).toBe(true);
+  });
+
+  test("existing mirror to a DIFFERENT remote → not clobbered, sync_enabled false + conflict warning", async () => {
+    home = tmp("import-sync-conflict-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    manager = makeSyncManager(home);
+
+    // Pre-existing mirror config (enabled) + credential pointing elsewhere.
+    writeMirrorConfigForVault("default", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      auto_push: true,
+    });
+    writeCredentials("default", {
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        token: "ghp_existing_other",
+        remote_url:
+          "https://x-access-token:ghp_existing_other@github.com/aaron/OTHER-repo.git",
+        label: "existing backup",
+      },
+    });
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_import_token_abc" },
+        enable_sync: true,
+      }),
+    });
+    const res = await handleMirrorImport(
+      req,
+      "default",
+      spawnCloneSuccess(fixture),
+      undefined,
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sync_enabled: boolean;
+      sync_warning?: string;
+    };
+    expect(body.sync_enabled).toBe(false);
+    expect(body.sync_warning).toContain("already syncs to a different repo");
+
+    // The existing credential was NOT clobbered.
+    const creds = readCredentials("default");
+    expect(creds?.pat?.token).toBe("ghp_existing_other");
+    expect(creds?.pat?.remote_url).toContain("OTHER-repo.git");
+  });
+
+  test("existing mirror to the SAME remote → no-op success (sync_enabled true)", async () => {
+    home = tmp("import-sync-same-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    manager = makeSyncManager(home);
+
+    writeMirrorConfigForVault("default", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      auto_push: true,
+    });
+    writeCredentials("default", {
+      active_method: "pat",
+      github_oauth: null,
+      pat: {
+        token: "ghp_same_token",
+        remote_url:
+          "https://x-access-token:ghp_same_token@github.com/aaron/my-vault.git",
+        label: "existing same",
+      },
+    });
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_same_token" },
+        enable_sync: true,
+      }),
+    });
+    const res = await handleMirrorImport(
+      req,
+      "default",
+      spawnCloneSuccess(fixture),
+      undefined,
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sync_enabled: boolean;
+      sync_warning?: string;
+    };
+    expect(body.sync_enabled).toBe(true);
+    expect(body.sync_warning).toBeUndefined();
+  });
+
+  test("existing GitHub-connected mirror → PAT import doesn't clobber it (sync_enabled false + warning)", async () => {
+    home = tmp("import-sync-oauth-conflict-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    manager = makeSyncManager(home);
+
+    writeMirrorConfigForVault("default", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      auto_push: true,
+    });
+    writeCredentials("default", {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_existing_oauth",
+        scope: "repo",
+        authorized_at: "2026-05-28T00:00:00.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_import_token_abc" },
+        enable_sync: true,
+      }),
+    });
+    const res = await handleMirrorImport(
+      req,
+      "default",
+      spawnCloneSuccess(fixture),
+      undefined,
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sync_enabled: boolean;
+      sync_warning?: string;
+    };
+    expect(body.sync_enabled).toBe(false);
+    expect(body.sync_warning).toContain("connected GitHub account");
+
+    // The existing OAuth credential is untouched (not switched to a PAT).
+    const creds = readCredentials("default");
+    expect(creds?.active_method).toBe("github_oauth");
+    expect(creds?.pat).toBeNull();
+  });
+
+  test("sync-setup failure after a successful import → import result still returned, sync_enabled false + warning", async () => {
+    home = tmp("import-sync-setupfail-");
+    await bootstrapVault(home);
+    fixture = await buildExportFixture();
+    manager = makeSyncManager(home);
+
+    // Force the sync-enable step to throw by stubbing the manager's reload.
+    // The import itself has already succeeded by the time reload runs, so the
+    // request must still return a 200 with the import counts intact.
+    manager.reload = async () => {
+      throw new Error("boom: simulated reload failure");
+    };
+
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "pat", token: "ghp_import_token_abc" },
+        enable_sync: true,
+      }),
+    });
+    const res = await handleMirrorImport(
+      req,
+      "default",
+      spawnCloneSuccess(fixture),
+      undefined,
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      notes_imported: number;
+      sync_enabled: boolean;
+      sync_warning?: string;
+    };
+    // Import NOT lost.
+    expect(body.notes_imported).toBe(2);
+    expect(body.sync_enabled).toBe(false);
+    expect(body.sync_warning).toContain("enabling Sync failed");
+  });
+
+  test("invalid enable_sync type → 400 validation error", async () => {
+    home = tmp("import-sync-badtype-");
+    await bootstrapVault(home);
+    const req = new Request("http://x/import", {
+      method: "POST",
+      body: JSON.stringify({
+        remote_url: "https://github.com/aaron/my-vault.git",
+        mode: "merge",
+        credentials: { kind: "none" },
+        enable_sync: "yes",
+      }),
+    });
+    const res = await handleMirrorImport(req, "default");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { field: string };
+    expect(body.field).toBe("enable_sync");
   });
 });
 

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -26,16 +26,20 @@
 
 import {
   defaultMirrorConfig,
+  readMirrorConfigForVault,
   validateExternalPath,
   validateMirrorConfigShape,
   type MirrorConfig,
 } from "./mirror-config.ts";
 import type { MirrorManager } from "./mirror-manager.ts";
+import { getMirrorManager } from "./mirror-registry.ts";
 import {
   applyToGitRemote,
   deleteCredentials,
   emptyCredentials,
+  githubAuthedRemoteUrl,
   readCredentials,
+  redactRemoteUrl,
   sanitizeCredentials,
   unsetGitRemote,
   writeCredentials,
@@ -1106,15 +1110,32 @@ export async function applyCredentialsToMirror(
 //     "mode": "merge" | "replace",
 //     "credentials": null
 //       | { "kind": "pat", "token": "ghp_..." }
-//       | { "kind": "none" }
+//       | { "kind": "none" },
+//     "enable_sync": true   // optional, DEFAULT TRUE
 //   }
 //
 // `credentials: null` means "use the stored mirror credentials." Passing
-// `{kind: "pat", token}` is the one-shot path — token doesn't get persisted.
+// `{kind: "pat", token}` is the one-shot path — token doesn't get persisted
+// for the CLONE, but IS persisted when sync is enabled (it's the push
+// credential for the now-configured mirror).
+//
+// `enable_sync` (vault#416) — DEFAULT TRUE when omitted. After a successful
+// import, auto-enable mirror push-back to the SAME repo, reusing the import's
+// credentials. Makes "import a repo" and "back up to that repo going forward"
+// one fluid flow. The UI ships a checked-by-default checkbox the operator can
+// uncheck. Edge cases (handled in `enableSyncToImportedRepo`, never fail the
+// whole import):
+//   - `auth: none` (public repo, no push creds) → skip + warn (can't push
+//     without a credential).
+//   - A mirror already points at a DIFFERENT remote → skip + warn (don't
+//     clobber the operator's existing backup target).
+//   - A mirror already points at the SAME remote → no-op success.
+//   - Sync setup throws → import result still returned (success);
+//     `sync_enabled: false` + a warning. Import success is never lost.
 //
 // Response:
 //   200 { notes_imported, tags_imported, attachments_imported,
-//         notes_deleted?, warnings }
+//         notes_deleted?, warnings, sync_enabled, sync_warning? }
 //   400 { error, error_type, message }  — validation / not-a-vault-export
 //   409 { error, error_type, message }  — concurrent import for this vault
 //   502 { error, message }              — clone failed (auth, network, …)
@@ -1136,17 +1157,25 @@ export async function applyCredentialsToMirror(
  * `whichOverride` is a test seam for the git-presence preflight (default
  * `Bun.which` inside `cloneAndImport`). Inject a fn returning `null` to
  * exercise the git_not_installed 503 path without uninstalling git.
+ *
+ * `managerOverride` is a test seam for the post-import sync-enable step
+ * (vault#416). Production callers omit it; the route resolves the per-vault
+ * manager via `getMirrorManager(vaultName)` (same registry the auth /
+ * run-now / push-now routes use). Tests inject a manager so they can assert
+ * on the config it ends up with without standing up the full registry.
  */
 export async function handleMirrorImport(
   req: Request,
   vaultName: string,
   spawnOverride?: GitSpawn,
   whichOverride?: (cmd: string) => string | null,
+  managerOverride?: MirrorManager,
 ): Promise<Response> {
   let body: {
     remote_url?: unknown;
     mode?: unknown;
     credentials?: unknown;
+    enable_sync?: unknown;
   };
   try {
     body = (await req.json()) as Record<string, unknown>;
@@ -1239,6 +1268,25 @@ export async function handleMirrorImport(
     );
   }
 
+  // vault#416: `enable_sync` defaults TRUE when omitted — the default-on UX.
+  // Only a literal `false` opts out; any other type is a validation error so
+  // a malformed body never silently flips the default.
+  let enableSync = true;
+  if ("enable_sync" in body && body.enable_sync !== undefined) {
+    if (typeof body.enable_sync !== "boolean") {
+      return Response.json(
+        {
+          error: "enable_sync invalid",
+          error_type: "validation",
+          field: "enable_sync",
+          message: "enable_sync must be a boolean (defaults to true when omitted).",
+        },
+        { status: 400 },
+      );
+    }
+    enableSync = body.enable_sync;
+  }
+
   // Resolve the target vault's store + assets dir. The route is gated on
   // `vault:<name>:admin`, so we trust vaultName is real by the time we
   // reach this code path; defensively re-resolve in case the vault was
@@ -1311,7 +1359,368 @@ export async function handleMirrorImport(
     );
   }
 
+  // ---- vault#416: auto-enable sync to the imported repo (default-on) -------
+  //
+  // The import SUCCEEDED above. From here on, every failure is non-fatal —
+  // we never lose a successful import to a sync-setup error. `result` already
+  // carries `sync_enabled: false` (set by importResultFromStats); we flip it
+  // true only when sync is actually wired (or already wired to this remote).
+  if (enableSync) {
+    try {
+      const manager =
+        managerOverride ?? getMirrorManager(vaultName) ?? undefined;
+      const outcome = await enableSyncToImportedRepo({
+        vaultName,
+        remoteUrl: remote_url,
+        auth,
+        manager,
+      });
+      result.sync_enabled = outcome.sync_enabled;
+      if (outcome.warning) result.sync_warning = outcome.warning;
+    } catch (err) {
+      // Defense-in-depth: enableSyncToImportedRepo is written to not throw
+      // (it catches its own write/credential/reload errors), but a future
+      // edit or an unexpected throw must NOT take down a successful import.
+      const msg = redactToken((err as Error).message ?? String(err));
+      console.warn(
+        `[mirror-import] sync-enable threw after a successful import (non-fatal): ${msg}`,
+      );
+      result.sync_enabled = false;
+      result.sync_warning =
+        "Import succeeded, but enabling Sync failed. Set up Sync separately from the Git remote section.";
+    }
+  }
+
   return Response.json(result, {
     headers: { "Access-Control-Allow-Origin": "*" },
   });
+}
+
+// ---------------------------------------------------------------------------
+// vault#416 — sync-enable after a successful import.
+// ---------------------------------------------------------------------------
+
+/**
+ * After a successful import, turn the imported-from repo into a configured,
+ * credential-backed, auto-pushing mirror — reusing the import's credentials.
+ * This is the back half of the default-on "import → also sync back" flow.
+ *
+ * Reuses the SAME machinery the manual mirror-setup flow uses:
+ *   - `writeCredentials` to persist the push credential (per-vault, vault#399).
+ *   - `MirrorConfig` + `manager.reload()` to enable `auto_push` and restart
+ *     the lifecycle — which calls `applyCredentialsToRemote` to set `origin`
+ *     from the stored credentials (exactly like handleAuthPat /
+ *     handleAuthGithubSelectRepo do).
+ *
+ * Mirror location is left `internal` (vault-managed dir under the vault's
+ * data dir) — the import didn't ask the operator to pick an external path,
+ * and `auto_push + internal + credentials` is the supported "push to a
+ * GitHub/GitLab remote" shape (see mirror-config.ts validation note). The
+ * remote lives in credentials, not the config; that's why we persist
+ * credentials AND flip auto_push.
+ *
+ * Never throws — every failure path returns `{ sync_enabled: false, warning }`.
+ * The import already succeeded by the time this runs; a sync-setup error must
+ * not be surfaced as an import failure.
+ *
+ * Edge cases (returns `sync_enabled: false` + a warning, no broken mirror
+ * left behind):
+ *   - **No push-capable credential** — `auth: none`, OR `credentialsFile`
+ *     with no stored credential that covers this remote's host. Can't push
+ *     without a credential; skip rather than configure a mirror that would
+ *     just fail every push.
+ *   - **A mirror already targets a DIFFERENT remote** — don't clobber the
+ *     operator's existing backup target. Detected by comparing the existing
+ *     stored credential's remote host/path against the import remote.
+ *   - **A mirror already targets the SAME remote** — no-op success.
+ */
+export async function enableSyncToImportedRepo(opts: {
+  vaultName: string;
+  remoteUrl: string;
+  auth: ImportAuth;
+  /**
+   * The per-vault mirror manager. Undefined only in the boot-race window
+   * where the registry factory hasn't been installed; we then skip (warn)
+   * rather than persisting a half-configured mirror with no live manager.
+   */
+  manager: MirrorManager | undefined;
+}): Promise<{ sync_enabled: boolean; warning?: string }> {
+  const { vaultName, remoteUrl, auth, manager } = opts;
+
+  if (!manager) {
+    return {
+      sync_enabled: false,
+      warning:
+        "Sync not enabled — the vault's mirror manager wasn't ready. Set up Sync from the Git remote section.",
+    };
+  }
+
+  // --- Resolve the push credential we'll persist for this remote. ----------
+  // We need a credential that can PUSH to `remoteUrl`. The clone-time auth
+  // shapes map onto push credentials as follows:
+  //   - pat            → persist the supplied PAT against this remote.
+  //   - none           → no push credential; cannot enable a working sync.
+  //   - credentialsFile → reuse the already-stored credential, but only if it
+  //                       actually covers this remote's host (a stored PAT for
+  //                       a different host can't push here).
+  let credentialToWrite: MirrorCredentials | null = null;
+
+  if (auth.kind === "none") {
+    return {
+      sync_enabled: false,
+      warning:
+        "Sync not enabled — pushing changes back needs write credentials (a PAT or GitHub sign-in). Set up Sync separately to enable it.",
+    };
+  }
+
+  if (auth.kind === "pat") {
+    // Persist the supplied PAT against this remote — the same x-access-token
+    // embedding the manual PAT route stores, so bare `git push` works.
+    const embedded = embedTokenInRemoteUrl(remoteUrl, auth.token);
+    if (!embedded) {
+      return {
+        sync_enabled: false,
+        warning:
+          "Sync not enabled — the remote URL couldn't be parsed to embed the access token. Set up Sync separately from the Git remote section.",
+      };
+    }
+    credentialToWrite = {
+      ...(readCredentials(vaultName) ?? emptyCredentials()),
+      active_method: "pat",
+      pat: {
+        token: auth.token,
+        remote_url: embedded,
+        label: "Imported-repo sync",
+      },
+    };
+  }
+
+  // For credentialsFile we DON'T overwrite — we reuse what's already stored,
+  // but must verify it covers this remote (host match). Resolve the existing
+  // credential's effective remote so the conflict check below has something
+  // to compare against.
+  const existing = readCredentials(vaultName);
+
+  // --- Conflict / idempotency check against any already-configured mirror. --
+  // The mirror's remote lives in credentials, not in MirrorConfig. Compare
+  // the existing stored credential's remote against the import remote.
+  const persistedConfig = readMirrorConfigForVault(vaultName);
+  const mirrorAlreadyConfigured = !!persistedConfig && persistedConfig.enabled;
+  const existingRemote = existing ? effectiveRemoteOf(existing) : null;
+
+  if (mirrorAlreadyConfigured && existingRemote) {
+    if (sameRemote(existingRemote, remoteUrl)) {
+      // Same remote — make sure auto_push is on, then no-op success. We don't
+      // need to rewrite credentials (credentialsFile) or can refresh the PAT
+      // (pat path) — either way the mirror already points here.
+      if (auth.kind === "pat" && credentialToWrite) {
+        try {
+          writeCredentials(vaultName, credentialToWrite);
+        } catch (err) {
+          return {
+            sync_enabled: false,
+            warning: `Import succeeded; mirror already targets this repo but the credential refresh failed: ${redactToken((err as Error).message ?? String(err))}`,
+          };
+        }
+      }
+      return await applyEnabledAutoPush(manager);
+    }
+    // Different remote — don't clobber the operator's existing backup target.
+    return {
+      sync_enabled: false,
+      warning: `Sync not enabled — this vault already syncs to a different repo (${redactRemoteUrl(existingRemote)}). Leaving your existing backup target untouched. Change it from the Git remote section if you want to switch.`,
+    };
+  }
+
+  // A mirror is already configured + enabled with an active credential, but we
+  // couldn't read its remote to compare (github_oauth stores no owner/repo at
+  // the credential level — its remote lives on the mirror dir's `origin`). To
+  // avoid clobbering an existing GitHub-connected backup target by switching
+  // `active_method` to a PAT, refuse unless the existing credential is OAuth
+  // and this is the same GitHub host (then the manual select-repo flow already
+  // points origin where it should; we treat that as "already set up — leave
+  // it"). Conservative: don't auto-switch an existing connected mirror.
+  if (
+    mirrorAlreadyConfigured &&
+    existing?.active_method === "github_oauth" &&
+    existing.github_oauth
+  ) {
+    return {
+      sync_enabled: false,
+      warning:
+        "Sync not enabled — this vault already syncs via a connected GitHub account. Leaving your existing backup target untouched. Switch it from the Git remote section if you want to point sync at this repo instead.",
+    };
+  }
+
+  // --- No conflicting mirror. Wire it up. ----------------------------------
+  if (auth.kind === "credentialsFile") {
+    // Reuse the stored credential — but only if it can push to this remote.
+    const covers = existing && existingRemote && sameRemote(existingRemote, remoteUrl);
+    const hasOauthForGithub =
+      existing?.active_method === "github_oauth" &&
+      !!existing.github_oauth &&
+      isGithubRemote(remoteUrl);
+    if (!covers && !hasOauthForGithub) {
+      return {
+        sync_enabled: false,
+        warning:
+          "Sync not enabled — no saved credential can push to this repo. Connect GitHub or paste a Personal Access Token in the Git remote section to enable Sync.",
+      };
+    }
+    if (existing?.active_method === "github_oauth" && hasOauthForGithub) {
+      // OAuth path: persist origin via the github authed URL, same as the
+      // select-repo flow. Parse owner/repo from the import remote.
+      const ownerRepo = parseGithubOwnerRepo(remoteUrl);
+      if (!ownerRepo) {
+        return {
+          sync_enabled: false,
+          warning:
+            "Sync not enabled — couldn't parse owner/repo from the GitHub URL. Pick the repo from the Git remote section to enable Sync.",
+        };
+      }
+      const status = manager.getStatus();
+      const authedUrl = githubAuthedRemoteUrl(
+        existing.github_oauth!.access_token,
+        ownerRepo.owner,
+        ownerRepo.repo,
+      );
+      if (status.mirror_path) {
+        await applyToGitRemote(status.mirror_path, authedUrl);
+      }
+      // Stash a PAT-shaped credential so a restart re-applies the right
+      // origin without needing the operator to re-pick the repo. (The OAuth
+      // token works through the same x-access-token shape.) This mirrors how
+      // applyCredentialsToRemote refreshes github origins on restart.
+      credentialToWrite = {
+        ...existing,
+        active_method: "github_oauth",
+      };
+    }
+    // covers === true → existing PAT already targets this remote; nothing to
+    // re-persist. Fall through to enabling auto_push.
+  }
+
+  if (credentialToWrite) {
+    try {
+      writeCredentials(vaultName, credentialToWrite);
+    } catch (err) {
+      return {
+        sync_enabled: false,
+        warning: `Import succeeded, but saving the sync credential failed: ${redactToken((err as Error).message ?? String(err))}. Set up Sync separately from the Git remote section.`,
+      };
+    }
+  }
+
+  return await applyEnabledAutoPush(manager);
+}
+
+/**
+ * Flip the mirror config to `enabled: true, auto_push: true` (internal
+ * location) and reload the manager — which applies the just-persisted
+ * credentials to `origin` and starts the event-driven export loop. Returns
+ * the sync outcome; reload failures are non-fatal (import already succeeded).
+ */
+async function applyEnabledAutoPush(
+  manager: MirrorManager,
+): Promise<{ sync_enabled: boolean; warning?: string }> {
+  const current = manager.getEffectiveConfig();
+  const next: MirrorConfig = {
+    ...current,
+    enabled: true,
+    // Keep the operator's existing location if they'd set external; default
+    // internal for the fresh case. Internal + credentials is the supported
+    // "push to a hosted remote" shape.
+    location: current.location,
+    auto_push: true,
+  };
+  try {
+    await manager.reload(next);
+  } catch (err) {
+    return {
+      sync_enabled: false,
+      warning: `Import succeeded, but enabling Sync failed: ${redactToken((err as Error).message ?? String(err))}. Set up Sync separately from the Git remote section.`,
+    };
+  }
+  // reload → start sets status.enabled iff bootstrap succeeded. If bootstrap
+  // failed (e.g. git-less host, though import would've 503'd earlier), surface
+  // that rather than claiming sync is on.
+  const status = manager.getStatus();
+  if (!status.enabled) {
+    return {
+      sync_enabled: false,
+      warning: status.last_error
+        ? `Import succeeded, but the mirror couldn't start: ${redactToken(status.last_error)}`
+        : "Import succeeded, but the mirror couldn't start. Check the Git remote section.",
+    };
+  }
+  return { sync_enabled: true };
+}
+
+/**
+ * Embed an x-access-token credential into an HTTPS remote URL, the same shape
+ * the manual PAT route persists. Returns null when the URL can't be parsed or
+ * isn't http(s) (SSH / local-path remotes can't carry a token in userinfo —
+ * those rely on the operator's ssh-agent, so there's no push credential for
+ * us to embed). When the URL already carries userinfo, trust it verbatim.
+ */
+function embedTokenInRemoteUrl(remoteUrl: string, token: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(remoteUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  if (parsed.username || parsed.password) return remoteUrl;
+  parsed.username = "x-access-token";
+  parsed.password = token;
+  return parsed.toString();
+}
+
+/**
+ * The remote a stored credential effectively pushes to:
+ *   - pat → its `remote_url` (userinfo-embedded; comparison strips userinfo).
+ *   - github_oauth → null here (no owner/repo stored at the credential level;
+ *     the origin is set when a repo is picked). Callers treat null as "no
+ *     known remote to conflict with."
+ */
+function effectiveRemoteOf(creds: MirrorCredentials): string | null {
+  if (creds.active_method === "pat" && creds.pat) return creds.pat.remote_url;
+  return null;
+}
+
+/**
+ * Compare two remote URLs ignoring userinfo (embedded tokens) + a trailing
+ * `.git` + a trailing slash, case-insensitively on host. "Same repo" for the
+ * clobber check. Falls back to a trimmed string compare for non-URL remotes
+ * (SSH shorthand, local paths).
+ */
+function sameRemote(a: string, b: string): boolean {
+  const norm = (u: string): string => {
+    try {
+      const url = new URL(u);
+      const host = url.host.toLowerCase();
+      const path = url.pathname.replace(/\.git$/, "").replace(/\/+$/, "");
+      return `${url.protocol}//${host}${path}`;
+    } catch {
+      return u.trim().replace(/\.git$/, "").replace(/\/+$/, "");
+    }
+  };
+  return norm(a) === norm(b);
+}
+
+/** True when a remote URL is on github.com (host-exact, case-insensitive). */
+function isGithubRemote(remoteUrl: string): boolean {
+  try {
+    return new URL(remoteUrl).host.toLowerCase() === "github.com";
+  } catch {
+    return false;
+  }
+}
+
+/** Parse `owner` + `repo` out of a github.com HTTPS URL. Null when it doesn't match. */
+function parseGithubOwnerRepo(remoteUrl: string): { owner: string; repo: string } | null {
+  const match = remoteUrl.match(/github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?(?:\/)?$/i);
+  if (!match) return null;
+  return { owner: match[1]!, repo: match[2]! };
 }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -522,6 +522,12 @@ export interface MirrorImportRequest {
   remote_url: string;
   mode: "merge" | "replace";
   credentials: MirrorImportCredentials;
+  /**
+   * vault#416 — also enable sync (mirror push-back) to the imported repo,
+   * reusing the import credentials. DEFAULT TRUE on the server when omitted;
+   * the UI sends the checkbox state explicitly.
+   */
+  enable_sync?: boolean;
 }
 
 export interface MirrorImportResult {
@@ -531,6 +537,19 @@ export interface MirrorImportResult {
   /** Only set when `mode === "replace"`. */
   notes_deleted?: number;
   warnings: string[];
+  /**
+   * vault#416 — whether sync to the imported repo ended up enabled. True
+   * when push-back is now wired; false when opted out, blocked (no push
+   * credentials / a different mirror already configured), or sync-setup
+   * failed (the import still succeeded).
+   */
+  sync_enabled: boolean;
+  /**
+   * Human-readable reason sync wasn't enabled. Present only when
+   * `sync_enabled` is false and the caller asked for sync. Shown as an
+   * info/warning, NOT an error — the import succeeded regardless.
+   */
+  sync_warning?: string;
 }
 
 /**

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -934,12 +934,24 @@ describe("VaultMirror — Import from git section", () => {
     expect(startBtn).not.toBeDisabled();
   });
 
-  it("Start import fires postMirrorImport + shows success summary on resolve", async () => {
+  it("the 'Also sync changes back' checkbox is checked by default", async () => {
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
+    );
+    const syncCheckbox = screen.getByLabelText(
+      /Also sync changes back to this repo/i,
+    ) as HTMLInputElement;
+    expect(syncCheckbox.checked).toBe(true);
+  });
+
+  it("Start import fires postMirrorImport (enable_sync true) + shows sync-enabled confirmation", async () => {
     vi.mocked(api.postMirrorImport).mockResolvedValue({
       notes_imported: 42,
       tags_imported: 3,
       attachments_imported: 5,
       warnings: [],
+      sync_enabled: true,
     });
     renderRoute();
     await waitFor(() =>
@@ -952,23 +964,91 @@ describe("VaultMirror — Import from git section", () => {
     await waitFor(() =>
       expect(screen.getByText(/Import succeeded/i)).toBeInTheDocument(),
     );
+    // enable_sync defaults ON and is sent in the POST body.
     expect(api.postMirrorImport).toHaveBeenCalledWith("work", {
       remote_url: "https://github.com/aaron/vault.git",
       mode: "merge",
       credentials: { kind: "none" },
+      enable_sync: true,
     });
     // The success summary mentions the counts.
     expect(screen.getByText(/Imported 42 notes/i)).toBeInTheDocument();
-    // Auto-wire offer surfaces.
-    expect(screen.getByText(/Set this repo as the active mirror remote/i)).toBeInTheDocument();
+    // Sync-enabled confirmation surfaces (not the old auto-wire offer).
+    expect(screen.getByText(/Sync enabled/i)).toBeInTheDocument();
   });
 
-  it("one-time PAT credential is sent on Start", async () => {
+  it("unchecking the sync checkbox sends enable_sync false", async () => {
+    vi.mocked(api.postMirrorImport).mockResolvedValue({
+      notes_imported: 4,
+      tags_imported: 0,
+      attachments_imported: 0,
+      warnings: [],
+      sync_enabled: false,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText(/Remote URL/i),
+      "https://github.com/aaron/vault.git",
+    );
+    await user.click(screen.getByLabelText(/Also sync changes back to this repo/i));
+    await user.click(screen.getByRole("button", { name: /Start import/i }));
+    await waitFor(() =>
+      expect(api.postMirrorImport).toHaveBeenCalledWith("work", {
+        remote_url: "https://github.com/aaron/vault.git",
+        mode: "merge",
+        credentials: { kind: "none" },
+        enable_sync: false,
+      }),
+    );
+    // No sync confirmation, no warning — opted out cleanly.
+    await waitFor(() =>
+      expect(screen.getByText(/Import succeeded/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/Sync enabled/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Sync not enabled/i)).not.toBeInTheDocument();
+  });
+
+  it("renders sync_warning as an info/warning (not error) when sync wasn't enabled", async () => {
+    vi.mocked(api.postMirrorImport).mockResolvedValue({
+      notes_imported: 9,
+      tags_imported: 0,
+      attachments_imported: 0,
+      warnings: [],
+      sync_enabled: false,
+      sync_warning:
+        "Sync not enabled — pushing changes back needs write credentials (a PAT or GitHub sign-in).",
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText(/Remote URL/i),
+      "https://github.com/aaron/public.git",
+    );
+    await user.click(screen.getByRole("button", { name: /Start import/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/Import succeeded/i)).toBeInTheDocument(),
+    );
+    // Warning surfaces as info, not an error-banner/alert. ("Sync not
+    // enabled" appears in both the <strong> lead-in and the warning copy,
+    // so assert at-least-one match + the credential-specific phrase.)
+    expect(screen.getAllByText(/Sync not enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/needs write credentials/i)).toBeInTheDocument();
+  });
+
+  it("one-time PAT credential is sent on Start (with enable_sync)", async () => {
     vi.mocked(api.postMirrorImport).mockResolvedValue({
       notes_imported: 1,
       tags_imported: 0,
       attachments_imported: 0,
       warnings: [],
+      sync_enabled: true,
     });
     renderRoute();
     await waitFor(() =>
@@ -988,6 +1068,7 @@ describe("VaultMirror — Import from git section", () => {
         remote_url: "https://github.com/aaron/private.git",
         mode: "merge",
         credentials: { kind: "pat", token: "ghp_oneshot_xyz" },
+        enable_sync: true,
       }),
     );
   });
@@ -1007,6 +1088,7 @@ describe("VaultMirror — Import from git section", () => {
       tags_imported: 1,
       attachments_imported: 0,
       warnings: [],
+      sync_enabled: true,
     });
     renderRoute();
     await waitFor(() =>
@@ -1023,6 +1105,7 @@ describe("VaultMirror — Import from git section", () => {
         remote_url: "https://github.com/aaron/saved.git",
         mode: "merge",
         credentials: null,
+        enable_sync: true,
       }),
     );
   });

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -1664,6 +1664,9 @@ function ImportFromGitSection({
   const [mode, setMode] = useState<ImportMode>("merge");
   const [usePerCallPat, setUsePerCallPat] = useState(false);
   const [perCallPat, setPerCallPat] = useState("");
+  // vault#416 — default-on: also sync changes back to this repo. The operator
+  // can uncheck before importing.
+  const [enableSync, setEnableSync] = useState(true);
   const [phase, setPhase] = useState<ImportPhase>({ kind: "idle" });
   // Typed-name confirmation for replace mode. The operator types the
   // literal vault name to unlock the Start button.
@@ -1705,6 +1708,7 @@ function ImportFromGitSection({
         remote_url: remoteUrl.trim(),
         mode,
         credentials,
+        enable_sync: enableSync,
       });
       window.clearTimeout(stageTimer);
       setPhase({ kind: "success", result, remoteUrl: remoteUrl.trim(), mode });
@@ -1891,6 +1895,28 @@ function ImportFromGitSection({
             ) : null}
           </div>
 
+          {/*
+            vault#416 — default-on "also sync back to this repo" checkbox.
+            Reuses the access entered above (stored creds or the one-time PAT).
+            Unchecking imports as a one-time snapshot with no push-back.
+          */}
+          <div className="form-row">
+            <label>
+              <input
+                type="checkbox"
+                checked={enableSync}
+                onChange={(e) => setEnableSync(e.target.checked)}
+                disabled={phase.kind === "running"}
+                style={{ width: "auto", marginRight: "0.5rem" }}
+              />
+              Also sync changes back to this repo
+            </label>
+            <p className="dim" style={{ margin: "0.35rem 0 0", fontSize: "0.85em" }}>
+              Pushes future changes to this repo automatically. Uses the access
+              you provide above.
+            </p>
+          </div>
+
           {phase.kind === "error" ? (
             <div className="error-banner" role="alert">
               <code>{phase.message}</code>
@@ -1937,18 +1963,18 @@ function ImportFromGitSection({
 }
 
 /**
- * After-success panel. Shows the import counts + warnings, and offers
- * to set the imported-from repo as the active mirror remote (auto-wire).
+ * After-success panel. Shows the import counts + warnings, and reflects the
+ * sync-back outcome (vault#416).
  *
- * The auto-wire offer is the symmetric move: if the operator just
- * imported FROM a repo, they almost certainly want exports going BACK
- * to the same repo. Yes triggers select-repo (for github-OAuth case)
- * or guides the operator to the PAT save flow.
- *
- * Aaron's directive: "if there are multiple things pushing to the same
- * git repository … important to think about" — the offer is opt-in
- * precisely because mindlessly chaining import → push back risks the
- * multi-pusher footgun. Operator opts in deliberately.
+ * Sync is now enabled BY DEFAULT during the import (the checked-by-default
+ * "Also sync changes back to this repo" checkbox). This panel just reports
+ * what happened:
+ *   - `sync_enabled` → confirm push-back is on.
+ *   - `sync_warning` (and not enabled) → show it as an info/warning, NOT an
+ *     error — the import still succeeded. Covers "no push credentials" and
+ *     "a different mirror is already configured" (the multi-pusher footgun
+ *     Aaron flagged — the server refuses to clobber an existing target).
+ *   - opted out (no warning, not enabled) → nothing extra to say.
  */
 function ImportSuccessPanel({
   vaultName,
@@ -1963,7 +1989,6 @@ function ImportSuccessPanel({
   mode: ImportMode;
   onReset: () => void;
 }) {
-  const [wireOffered, setWireOffered] = useState(true);
   return (
     <>
       <div className="mint-banner" role="status" style={{ marginBottom: "0.75rem" }}>
@@ -1993,42 +2018,39 @@ function ImportSuccessPanel({
         </details>
       ) : null}
 
-      {wireOffered ? (
+      {result.sync_enabled ? (
+        <div className="mint-banner" style={{ marginBottom: "0.75rem" }} role="status">
+          <strong>Sync enabled.</strong> Changes to vault <code>{vaultName}</code>{" "}
+          now push back to <code>{remoteUrl}</code> automatically.
+        </div>
+      ) : result.sync_warning ? (
         <div className="info-banner" style={{ marginBottom: "0.75rem" }} role="status">
           <p style={{ marginTop: 0 }}>
-            <strong>Set this repo as the active mirror remote?</strong> Future
-            exports from vault <code>{vaultName}</code> would push back to{" "}
-            <code>{remoteUrl}</code>. Skip if you'd rather keep them separate —
-            see the "one vault per remote" note above.
+            <strong>Sync not enabled.</strong> {result.sync_warning}
           </p>
-          <div className="actions">
+          <p className="dim" style={{ marginBottom: 0, fontSize: "0.9em" }}>
+            You can still set up Sync from the{" "}
             <button
               type="button"
-              onClick={() => {
-                // We don't auto-wire from here today (the existing
-                // GitRemoteSection above handles credential flow + repo
-                // selection). Closing the offer + scrolling the operator
-                // to the GitRemoteSection is the right next step.
-                // Reviewer-flagged on #390: was selecting `.section h3`
-                // (the FIRST `.section` on the page — the StatusCard's
-                // heading near the top), so the scroll landed nowhere
-                // useful. Pinned to the id we added on GitRemoteSection.
-                setWireOffered(false);
+              onClick={() =>
                 document
                   .getElementById("git-remote-section")
-                  ?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  ?.scrollIntoView({ behavior: "smooth", block: "start" })
+              }
+              style={{
+                background: "none",
+                border: "none",
+                padding: 0,
+                color: "var(--accent)",
+                textDecoration: "underline",
+                cursor: "pointer",
+                fontSize: "inherit",
               }}
             >
-              Yes — configure mirror push above
-            </button>
-            <button
-              type="button"
-              className="secondary"
-              onClick={() => setWireOffered(false)}
-            >
-              No, keep import-only
-            </button>
-          </div>
+              Git remote section
+            </button>{" "}
+            above.
+          </p>
         </div>
       ) : null}
 


### PR DESCRIPTION
## What

When a user imports a vault from a git repo, **auto-enable sync (mirror push-back) to that same repo BY DEFAULT**, reusing the credentials they entered for the import. "Import a repo" and "back up to that repo going forward" become one fluid flow. A **checked-by-default** checkbox lets the operator opt out before importing.

Builds on #415 — a git-less host still 503s before any of this runs.

## UX

- New checkbox **"Also sync changes back to this repo"** in the import form, **checked by default**, with helper text *"Pushes future changes to this repo automatically. Uses the access you provide above."*
- On success the panel reflects the outcome:
  - sync enabled → *"Sync enabled — changes now push back to this repo."*
  - a `sync_warning` came back → shown as an **info/warning, not an error** (the import succeeded regardless).
- Replaces the old manual after-the-fact "auto-wire offer" with this default-on flow.

## Reuse-import-credentials flow

After a SUCCESSFUL import, the route (`enableSyncToImportedRepo`) reuses the **same machinery the manual mirror-setup route uses**:
1. Persists the push credential via the per-vault `mirror-credentials` path (PAT embedded x-access-token; or the existing stored credential for the `credentialsFile` path).
2. Flips the per-vault `MirrorConfig` to `enabled: true, auto_push: true` (location stays internal — the supported "push to a hosted remote" shape).
3. `manager.reload()` → `start()` applies credentials to `origin` and starts the event-driven export loop.

The mirror's remote lives in **credentials**, not in `MirrorConfig` — that's why we persist credentials AND flip `auto_push`.

`ImportResult` gains `sync_enabled: boolean` (+ optional `sync_warning`). `cloneAndImport` stays content-focused and always returns `sync_enabled: false`; the route flips it. Sync-enabling happens in the route **after** a successful import (not in `cloneAndImport`).

## Edge cases (never fail the whole import)

- **`auth: none`** (public repo, no push creds) → skip + `sync_warning: "…needs write credentials (a PAT or GitHub sign-in)…"`. No broken auto-push left behind.
- **A mirror already targets a DIFFERENT remote** (PAT to another repo, or an existing GitHub-connected mirror) → **skip + warn, don't clobber** the operator's backup target. (Chose no-clobber over silent-overwrite — multi-pusher footgun Aaron flagged.)
- **A mirror already targets the SAME remote** → no-op success (`sync_enabled: true`).
- **Sync-setup throws after a successful import** → import result still returned (200), `sync_enabled: false` + warning. **Import success is never lost to a sync error.**

## Design judgments for the reviewer

- **Where sync-enabling lives**: in the route after a successful `cloneAndImport`, not inside the worker — keeps `cloneAndImport` focused on content (per the brief's "cleaner" option).
- **Manager resolution**: production resolves the per-vault manager via `getMirrorManager(vaultName)` (same registry the auth / run-now / push-now routes use); a `managerOverride` test seam injects one in tests. If the registry factory isn't ready (boot race), sync is skipped with a warning rather than persisting a half-configured mirror.
- **github_oauth conflict guard**: `effectiveRemoteOf` returns null for OAuth creds (no owner/repo stored at credential level), so a PAT import while an OAuth mirror is already configured-and-enabled is treated as a conflict and refused — avoids silently switching `active_method` from OAuth to PAT and clobbering a connected backup.
- **Location**: left `internal` (vault-managed dir); the import never asked the operator to pick an external path. `auto_push + internal + credentials` is the supported hosted-remote shape per the mirror-config validation.

## Gates

- `bun test ./src`: **1274 pass / 0 fail**
- `bun test ./core/src`: **610 pass / 0 fail**
- `bun run typecheck`: clean
- `web/ui` vitest: **142 pass / 0 fail**
- `biome check`: clean on changed files

New tests cover: PAT import enables sync (config + creds + auto_push); opt-out leaves nothing configured; `auth: none` warns + no broken mirror; existing-different-remote not clobbered; existing GitHub-OAuth mirror not clobbered by a PAT import; same-remote no-op success; default-on when omitted; sync-setup failure preserves import success; invalid `enable_sync` type → 400. Frontend: checkbox checked by default, `enable_sync` sent, success-confirmation + warning rendering, opt-out sends `enable_sync: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)