### PR TITLE
fix(vault): per-vault OAuth discovery advertises resource-narrowed scopes — fixes Claude MCP auth (+ rc.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.0-rc.3",
+  "version": "0.5.0-rc.4",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/oauth-discovery.test.ts
+++ b/src/oauth-discovery.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { handleAuthorizationServer, handleProtectedResource } from "./oauth-discovery.ts";
+
+/**
+ * Regression: the per-vault discovery documents MUST advertise resource-narrowed
+ * `vault:<name>:<verb>` scopes, never broad `vault:<verb>`. A broad scope makes a
+ * spec-following MCP client (Claude) request `vault:read`, which the hub stamps
+ * `aud=vault`, which the per-vault MCP endpoint rejects ("audience mismatch:
+ * expected vault.<name>, got vault") — the live "Authorization with the MCP
+ * server failed" bug. See oauth-discovery.ts + auth.ts findBroadVaultScopes.
+ */
+describe("oauth-discovery per-vault scopes_supported is resource-narrowed", () => {
+  const req = new Request("https://hub.example.com/vault/default/.well-known/oauth-protected-resource");
+
+  test("protected-resource metadata advertises vault:<name>:<verb>, never broad", async () => {
+    const body = (await handleProtectedResource(req, "default").json()) as {
+      resource: string;
+      scopes_supported: string[];
+    };
+    expect(body.scopes_supported).toEqual([
+      "vault:default:read",
+      "vault:default:write",
+      "vault:default:admin",
+    ]);
+    // No broad scope leaks through — vault rejects those on audience mismatch.
+    for (const s of body.scopes_supported) {
+      expect(s).not.toBe("vault:read");
+      expect(s).not.toBe("vault:write");
+      expect(s).not.toBe("vault:admin");
+    }
+    expect(body.resource).toContain("/vault/default/mcp");
+  });
+
+  test("scopes are narrowed to the specific vault name", async () => {
+    const body = (await handleProtectedResource(req, "work-notes").json()) as {
+      scopes_supported: string[];
+    };
+    expect(body.scopes_supported).toEqual([
+      "vault:work-notes:read",
+      "vault:work-notes:write",
+      "vault:work-notes:admin",
+    ]);
+  });
+
+  test("authorization-server forwarding doc also advertises narrowed scopes", async () => {
+    const body = (await handleAuthorizationServer(req, "default").json()) as {
+      scopes_supported: string[];
+    };
+    expect(body.scopes_supported).toEqual([
+      "vault:default:read",
+      "vault:default:write",
+      "vault:default:admin",
+    ]);
+  });
+});

--- a/src/oauth-discovery.ts
+++ b/src/oauth-discovery.ts
@@ -28,8 +28,27 @@
 
 import { getHubOrigin } from "./hub-jwt.ts";
 
-/** OAuth scopes vault publishes through discovery; see scopes.ts for enforcement. */
-const SCOPES_SUPPORTED = ["vault:read", "vault:write", "vault:admin"];
+/**
+ * OAuth scopes vault publishes through discovery, RESOURCE-NARROWED to the
+ * specific vault instance the metadata document describes.
+ *
+ * This MUST be narrowed (`vault:<name>:<verb>`), not broad (`vault:<verb>`).
+ * Post auth-unification (vault#282/#412), vault is a pure hub resource server
+ * that REJECTS broad `vault:<verb>` tokens (`findBroadVaultScopes` → 401) and
+ * requires `vault:<name>:<verb>` scopes carrying `aud=vault.<name>`. A
+ * spec-following MCP client (e.g. Claude) reads `scopes_supported` from this
+ * PRM and requests exactly those scopes; if we advertise broad `vault:read`
+ * the client gets a token stamped `aud=vault` and the per-vault MCP endpoint
+ * rejects it ("audience mismatch: expected vault.<name>, got vault") — the
+ * "Authorization with the MCP server failed" symptom. Advertising the narrowed
+ * shape makes the client request the scope vault will actually accept. The
+ * hub's RFC 8707 resource-binding narrows too, but only when the client echoes
+ * the `resource` param — advertising narrowed scopes here is the belt that
+ * works regardless. See scopes.ts for enforcement.
+ */
+function scopesSupportedFor(vaultName: string): string[] {
+  return [`vault:${vaultName}:read`, `vault:${vaultName}:write`, `vault:${vaultName}:admin`];
+}
 
 /**
  * Public-facing base URL of the server. Honors `x-forwarded-*` headers so a
@@ -63,7 +82,7 @@ export function handleProtectedResource(req: Request, vaultName: string): Respon
   return Response.json({
     resource: `${base}${prefix}/mcp`,
     authorization_servers: [getHubOrigin()],
-    scopes_supported: SCOPES_SUPPORTED,
+    scopes_supported: scopesSupportedFor(vaultName),
     bearer_methods_supported: ["header"],
   });
 }
@@ -78,7 +97,7 @@ export function handleProtectedResource(req: Request, vaultName: string): Respon
  * land here and discover the hub's actual endpoints; conformant clients that
  * probe AS metadata directly at the vault path get the same answer.
  */
-export function handleAuthorizationServer(_req: Request, _vaultName: string): Response {
+export function handleAuthorizationServer(_req: Request, vaultName: string): Response {
   const hub = getHubOrigin();
   return Response.json({
     issuer: hub,
@@ -90,6 +109,6 @@ export function handleAuthorizationServer(_req: Request, _vaultName: string): Re
     code_challenge_methods_supported: ["S256"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
-    scopes_supported: SCOPES_SUPPORTED,
+    scopes_supported: scopesSupportedFor(vaultName),
   });
 }


### PR DESCRIPTION
## The bug (found live)
Connecting **Claude via MCP** to a vault fails with *"Authorization with the MCP server failed"* even though Notes + the admin SPA work.

**Root cause:** the per-vault Protected Resource Metadata (`/vault/<name>/.well-known/oauth-protected-resource`) and the AS-metadata forwarding doc advertised **broad** `scopes_supported: ["vault:read","vault:write","vault:admin"]`. Post auth-unification DROP (vault#282/#412), vault is a pure hub resource server that **rejects broad `vault:<verb>` scopes** (`findBroadVaultScopes` → 401) and requires resource-narrowed `vault:<name>:<verb>` carrying `aud=vault.<name>`. A spec-following MCP client reads the PRM, requests `vault:read`, the hub mints a token stamped `aud=vault`, and the per-vault MCP endpoint rejects it: `audience mismatch: expected "vault.default", got "vault"`. Notes/SPA mint narrowed `vault:<name>:*` directly, so they were unaffected.

**Confirmed live** on gitcoin-parachute: narrowed `vault:default:read` token → MCP `initialize` **200**; broad `vault:read` token → **401 audience mismatch**.

## Fix
`oauth-discovery.ts` now derives `scopes_supported` from the `vaultName` both handlers already receive: `["vault:<name>:read","vault:<name>:write","vault:<name>:admin"]`. This is the scope shape vault accepts → correct `aud=vault.<name>`. It's a belt to the hub's existing RFC 8707 resource-binding (which only narrows when the client echoes `resource`); advertising narrowed scopes works regardless of whether the client sends the resource indicator.

## Tests / gates
- New `oauth-discovery.test.ts` (3 tests): PRM + AS-forwarding docs advertise narrowed scopes, narrowed to the specific vault name, never broad.
- `bun test ./src` 1277 pass / 0 fail · `bun run typecheck` clean.

rc.3 → rc.4. Release-relevant: this is a core flow (connect Claude to a vault) broken by the DROP's discovery-reconciliation gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)