### PR TITLE
fix(vault): allow PUT in CORS methods — unblocks Notes tag/schema setup (+ rc.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.0-rc.4",
+  "version": "0.5.0-rc.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/server.ts
+++ b/src/server.ts
@@ -345,7 +345,7 @@ const server = Bun.serve({
 
     const corsHeaders = {
       "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
       "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-Key, Mcp-Session-Id",
     };
 


### PR DESCRIPTION
## Bug (live, on Aaron's test run)
In Notes, running the vault schema setup fails: `PUT /api/tags/capture failed: Failed to fetch`.

**Root cause:** vault's CORS preflight (`src/server.ts`) returned `Access-Control-Allow-Methods: GET, POST, PATCH, DELETE, OPTIONS` — **`PUT` was missing**. The tags REST API creates/upserts tags via `PUT /api/tags/:name` (`routes.ts`: GET/PUT/DELETE /api/tags[/:name]). A cross-origin `PUT` (Notes → vault) is preflighted; the browser sees PUT isn't allowed → blocks it → "Failed to fetch" (a network-level failure, not an HTTP error).

**Confirmed live** on gitcoin-parachute: `OPTIONS` preflight for `PUT /vault/default/api/tags/capture` returned `access-control-allow-methods: GET, POST, PATCH, DELETE, OPTIONS` (no PUT).

## Fix
Add `PUT` to the allowed methods. One line. `bun test ./src` 1277/0, typecheck clean.

(No unit test added — the CORS headers live inline in the `Bun.serve` fetch handler, not unit-testable without extracting it; verified live instead, and will re-verify the preflight after deploy. A CORS regression test is a clean 0.5.1 nice-to-have.)

rc.4 → rc.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)