### PR TITLE
fix(vault): expose WWW-Authenticate via CORS — unblocks browser MCP (claude.ai) (+ rc.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",

--- a/src/server.ts
+++ b/src/server.ts
@@ -347,6 +347,15 @@ const server = Bun.serve({
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
       "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-Key, Mcp-Session-Id",
+      // Expose response headers a BROWSER-based MCP client (e.g. claude.ai) must
+      // read cross-origin: `WWW-Authenticate` carries the RFC 9728 auth challenge
+      // (the `resource_metadata` PRM URL) the client follows to discover the auth
+      // server — without exposing it, the browser's fetch() can't see it and the
+      // OAuth flow never starts ("Couldn't register with the sign-in service").
+      // `Mcp-Session-Id` is the streamable-HTTP MCP session the client echoes
+      // back. (Claude Code is a CLI → no CORS → unaffected. The hub already
+      // exposes WWW-Authenticate; this matches it on the resource server.)
+      "Access-Control-Expose-Headers": "WWW-Authenticate, Mcp-Session-Id",
     };
 
     if (req.method === "OPTIONS") {


### PR DESCRIPTION
claude.ai (browser MCP) fails at registration: the vault MCP 401's WWW-Authenticate (RFC 9728 challenge) wasn't CORS-exposed, so the browser cannot read it. Claude Code (CLI) works. Fix: Access-Control-Expose-Headers WWW-Authenticate, Mcp-Session-Id. Confirmed live. rc only; @latest stays 0.5.0.