### PR TITLE
feat(mcp): point the connect-time brief at the scripting guide

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -5609,6 +5609,12 @@ describe("vault projection (vault#271)", async () => {
     expect(md).toContain("#person");
     expect(md).toContain("vault-info");
     expect(md).toContain("list-tags { include_schema: true }");
+    // Scripting pointer (closes the "points nowhere" gap): the brief routes an
+    // agent to the HTTP API + the public guide, with the vault name baked into
+    // the copy-paste mint command.
+    expect(md).toContain("## Scripting & automation");
+    expect(md).toContain("https://parachute.computer/scripting/");
+    expect(md).toContain("parachute auth mint-token --scope vault:test:read --ephemeral");
   });
 
   it("markdown brief degrades gracefully when no schemas declared", async () => {

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -5612,9 +5612,10 @@ describe("vault projection (vault#271)", async () => {
     // Scripting pointer (closes the "points nowhere" gap): the brief routes an
     // agent to the HTTP API + the public guide, with the vault name baked into
     // the copy-paste mint command.
-    expect(md).toContain("## Scripting & automation");
+    expect(md).toContain("## Scripting & automation (beyond this session)");
     expect(md).toContain("https://parachute.computer/scripting/");
     expect(md).toContain("parachute auth mint-token --scope vault:test:read --ephemeral");
+    expect(md).toContain("vault/test/api");
   });
 
   it("markdown brief degrades gracefully when no schemas declared", async () => {

--- a/core/src/vault-projection.ts
+++ b/core/src/vault-projection.ts
@@ -305,7 +305,7 @@ export function projectionToMarkdown(args: {
   lines.push("");
   lines.push("If schema or tags change during this session, call `vault-info` to refresh the full projection. Call `list-tags { include_schema: true }` for tag-only details.");
 
-  // Pointer block (vault#…): the connect-time brief used to dead-end on
+  // Scripting pointer block: the connect-time brief used to dead-end on
   // querying — an agent had no path to "how do I script/automate against this
   // vault." Point at the guide rather than inlining it, to keep this brief
   // lean (token-budget note above). Uses the concrete vault name so the mint
@@ -319,7 +319,7 @@ export function projectionToMarkdown(args: {
   lines.push(
     `- Mint a scoped credential: \`parachute auth mint-token --scope vault:${vaultName}:read --ephemeral\` (\`--ephemeral\` = short-lived, ideal for scripts; use \`:write\` to create/edit).`,
   );
-  lines.push("- Call the REST API at `<hub-origin>/vault/" + vaultName + "/api/...`.");
+  lines.push(`- Call the REST API at \`<hub-origin>/vault/${vaultName}/api/...\`.`);
   lines.push(
     "- Full guide — copy-paste bash/Python/JS examples, plus how to design tags vs paths vs schemas: https://parachute.computer/scripting/",
   );

--- a/core/src/vault-projection.ts
+++ b/core/src/vault-projection.ts
@@ -305,5 +305,25 @@ export function projectionToMarkdown(args: {
   lines.push("");
   lines.push("If schema or tags change during this session, call `vault-info` to refresh the full projection. Call `list-tags { include_schema: true }` for tag-only details.");
 
+  // Pointer block (vault#…): the connect-time brief used to dead-end on
+  // querying — an agent had no path to "how do I script/automate against this
+  // vault." Point at the guide rather than inlining it, to keep this brief
+  // lean (token-budget note above). Uses the concrete vault name so the mint
+  // command is copy-paste ready.
+  lines.push("");
+  lines.push("## Scripting & automation (beyond this session)");
+  lines.push("");
+  lines.push(
+    "This vault is also a plain HTTP API — reach for it when the user wants a script, cron job, or CI step rather than an interactive session:",
+  );
+  lines.push(
+    `- Mint a scoped credential: \`parachute auth mint-token --scope vault:${vaultName}:read --ephemeral\` (\`--ephemeral\` = short-lived, ideal for scripts; use \`:write\` to create/edit).`,
+  );
+  lines.push("- Call the REST API at `<hub-origin>/vault/" + vaultName + "/api/...`.");
+  lines.push(
+    "- Full guide — copy-paste bash/Python/JS examples, plus how to design tags vs paths vs schemas: https://parachute.computer/scripting/",
+  );
+  lines.push("- For a prompt on a schedule with no code, see Parachute Runner.");
+
   return lines.join("\n");
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.1-rc.1",
+  "version": "0.5.1-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
## What

The vault's MCP **connect-time brief** (`projectionToMarkdown`) oriented an agent on *querying* but dead-ended there — nothing routed it to "how do I script or automate against this vault." An audit of the onboarding/scripting story flagged this as the core gap: the HTTP API, `mint-token`, and the runner all exist, but were **undiscoverable from the brief** (it pointed nowhere).

Adds a terse **"Scripting & automation"** section to the brief:
- Mint a scoped credential — `parachute auth mint-token --scope vault:<name>:read --ephemeral`, with the **concrete vault name interpolated** so it's copy-paste ready, and the new `--ephemeral` flag as the scripting default.
- Call the REST API at `<hub-origin>/vault/<name>/api/...`.
- Link to the full guide at **https://parachute.computer/scripting/** (copy-paste bash/Python/JS + the tags-vs-paths-vs-schemas design strategy).
- The runner for no-code automation.

**Points rather than inlines**, to hold the brief's token budget — ~80 tokens added; the existing "~5K tokens at 50 tags-with-schemas" budget test still passes.

## Tests
The markdown-brief test now asserts the pointer section + the vault-name-interpolated mint command. **core: 610 pass / 0 fail; server: 1277 pass / 0 fail; typecheck clean.**

Companion to the scripting guide (parachute.computer#84, merged) — together they close the "points nowhere" gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)