### PR TITLE
release: vault 0.5.1 (stable @latest cut)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.1-rc.2",
+  "version": "0.5.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Drop the `-rc` suffix (was 0.5.1-rc.2) to cut the stable `@latest` release. Carries the auth work + the Obsidian CLI-importer alignment (#424). Pushing tag `v0.5.1` after merge triggers the CI publish to `@latest`. No code change — version field only.