### PR TITLE
fix(rest): accept `?metadata=<json>` filter alias on GET /api/notes (silent-drop fix)

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -459,11 +459,6 @@ Query params:
     alias does compose with bracket *date* filters (`meta[created_at][gte]=…`),
     which are a separate axis.
 
-> **Percent-encode slashes in path filters.** Single-note routes and
-> path-valued params resolve a note by id-or-path; a literal `/` in the path
-> must be percent-encoded as `%2F` (e.g. `GET .../api/notes/Projects%2FFoo`,
-> `?path=Projects%2FFoo`) so it isn't parsed as a route separator.
-
 - **Full-text search**
   - `search=query` — switches to FTS mode. Returns `Note[]` (full shape),
     not `NoteIndex[]`. Optional `tag=` filters compose. `limit` defaults to
@@ -544,6 +539,12 @@ Error shapes:
 #### `GET /vault/{name}/api/notes/{idOrPath}` — `vault:read`
 Returns the full `Note` (defaults to `include_content=true` for point
 reads). `?include_content=false` returns a `NoteIndex`.
+
+> **Percent-encode slashes in `{idOrPath}`.** This route (and the `PATCH` /
+> `DELETE` siblings below) resolves a note by id-or-path; a literal `/` in a
+> path must be percent-encoded as `%2F` (e.g.
+> `GET .../api/notes/Projects%2FFoo`) so it isn't parsed as a route separator.
+> The same applies to path-valued query params like `?path=Projects%2FFoo`.
 
 Folding options:
 

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -445,6 +445,25 @@ Query params:
 
   Mixing shorthand and operator form on the same field is rejected.
 
+- **Metadata filters (JSON alias)**
+  - `metadata=<json>` — the JSON-object form of the same filter, e.g.
+    `metadata={"status":{"eq":"open"},"priority":{"gte":3}}`. This is
+    **symmetric with the nested `metadata` object the MCP `query-notes` tool
+    takes** — paste the same object you'd send over MCP, URL-encoded.
+    Shorthand equality works too: `metadata={"status":"open"}` lowers through
+    the `json_extract` fallback. JSON preserves real number/boolean types, so
+    `{"priority":{"gte":3}}` compares numerically.
+  - **Not both.** Pass metadata filters as *either* the JSON `metadata=` param
+    *or* the bracket `meta[field][op]=` form, not both — supplying both is a
+    `400 INVALID_QUERY` (we won't silently pick a winner). The `metadata=`
+    alias does compose with bracket *date* filters (`meta[created_at][gte]=…`),
+    which are a separate axis.
+
+> **Percent-encode slashes in path filters.** Single-note routes and
+> path-valued params resolve a note by id-or-path; a literal `/` in the path
+> must be percent-encoded as `%2F` (e.g. `GET .../api/notes/Projects%2FFoo`,
+> `?path=Projects%2FFoo`) so it isn't parsed as a route separator.
+
 - **Full-text search**
   - `search=query` — switches to FTS mode. Returns `Note[]` (full shape),
     not `NoteIndex[]`. Optional `tag=` filters compose. `limit` defaults to
@@ -473,7 +492,9 @@ Query params:
 Error shapes notable to callers:
 
 - `400 INVALID_QUERY` — non-indexed `order_by`, unknown operator, cursor +
-  incompatible param, etc.
+  incompatible param, a malformed `metadata=` JSON alias (parse failure, or a
+  non-object value), or supplying both the `metadata=` alias and bracket
+  `meta[...]` forms, etc.
 - `400 cursor_invalid` / `400 cursor_query_mismatch` — see cursor section.
 - `409 ambiguous_path` — `id=<path>` resolved to more than one note. Body
   carries `path` + `candidates: NoteIndex[]`. Re-issue with the exact id of

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -354,6 +354,55 @@ function parseMetaBrackets(url: URL): {
 }
 
 /**
+ * Parse the `?metadata=<json>` alias on GET /api/notes — the JSON-object form
+ * of the metadata filter, symmetric with the nested `metadata` object MCP
+ * forwards verbatim (`core/src/mcp.ts`). The value is a JSON object of the form
+ * `{"field":{"op":value}}` (operator query) or `{"field":value}` (shorthand
+ * equality via the engine's json_extract fallback).
+ *
+ * This exists because the bracket grammar (`?meta[field][op]=value`) couldn't
+ * see a `metadata=` param at all — it was silently dropped, and the query
+ * returned ALL tag-matching notes (a silent wrong result, not an error).
+ *
+ * We do NOT validate operators here — the parsed object lowers straight into
+ * `queryNotes`, where `validateOperatorObject` raises a loud 400 on unknown
+ * operators (caught by the QueryError handler in handleNotes). We only enforce
+ * that the param parses and is a non-null, non-array plain object; anything
+ * else is a malformed filter the engine can't consume.
+ *
+ * Returns `{ metadata?, error? }`. When `error` is set the caller returns it
+ * directly (already shaped as a 400 with `error` + `code`).
+ */
+function parseMetadataJsonAlias(url: URL): {
+  metadata?: Record<string, unknown>;
+  error?: Response;
+} {
+  const raw = parseQuery(url, "metadata");
+  if (raw === null) return {};
+
+  const malformed = (detail: string): Response =>
+    json(
+      {
+        error: `metadata query param must be a JSON object of the form {"field":{"op":value}} — ${detail}`,
+        code: "INVALID_QUERY",
+      },
+      400,
+    );
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e: any) {
+    return { error: malformed(`failed to parse: ${e?.message ?? String(e)}`) };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    const got = Array.isArray(parsed) ? "array" : parsed === null ? "null" : typeof parsed;
+    return { error: malformed(`got ${got}`) };
+  }
+  return { metadata: parsed as Record<string, unknown> };
+}
+
+/**
  * Parse include_metadata query param.
  * - absent/null → undefined (all metadata, default)
  * - "true"/"1" → true (all metadata)
@@ -580,6 +629,27 @@ async function handleNotesInner(
       const tags = parseQueryList(url, "tag");
       const bracket = parseMetaBrackets(url);
       if (bracket.error) return bracket.error;
+      // `?metadata=<json>` alias — the JSON-object form of the metadata
+      // filter, symmetric with the nested object MCP forwards. Before this,
+      // a `metadata=` param was silently dropped (the bracket grammar never
+      // matched it), so the query returned ALL tag-matching notes.
+      const metadataAlias = parseMetadataJsonAlias(url);
+      if (metadataAlias.error) return metadataAlias.error;
+      // Reject "both forms" loudly. If a caller passes BOTH the JSON
+      // `metadata=` param AND any `meta[...]` bracket param, there's no
+      // well-defined merge and silently picking a winner is exactly the
+      // class of bug we're fixing. Symmetric with the mixed shorthand/
+      // operator rejection inside parseMetaBrackets. Guard stays narrow —
+      // only the named `metadata` param triggers it.
+      if (metadataAlias.metadata && bracket.metadata) {
+        return json(
+          {
+            error: "pass metadata filters as either the JSON `metadata=` param or bracket `meta[field][op]=` form, not both.",
+            code: "INVALID_QUERY",
+          },
+          400,
+        );
+      }
       // Opaque cursor for "since last checked" agent loops (vault#313).
       // When present, switches the response shape to {notes, next_cursor}
       // and routes through queryNotesPaged for keyset pagination. Mutually
@@ -612,7 +682,9 @@ async function handleNotesInner(
         // are present, so the filter is silently skipped on a plain
         // GET without the extension query.
         extension: parseExtensionFilter(url),
-        metadata: bracket.metadata,
+        // Bracket form and JSON-alias form are mutually exclusive (guarded
+        // above), so at most one of these is set.
+        metadata: bracket.metadata ?? metadataAlias.metadata,
         // Date-range precedence chain (highest to lowest):
         //   1. Bracket-style `meta[created_at][gte]=…` (canonical).
         //   2. Flat `date_field=…&date_from=…&date_to=…` (deprecated).

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -370,6 +370,10 @@ function parseMetaBrackets(url: URL): {
  * that the param parses and is a non-null, non-array plain object; anything
  * else is a malformed filter the engine can't consume.
  *
+ * An empty object (`metadata={}`) carries no filter intent, so it's treated as
+ * absent: it sets no metadata filter AND doesn't trip the both-forms guard, so
+ * it composes harmlessly with bracket params.
+ *
  * Returns `{ metadata?, error? }`. When `error` is set the caller returns it
  * directly (already shaped as a 400 with `error` + `code`).
  */
@@ -392,13 +396,16 @@ function parseMetadataJsonAlias(url: URL): {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch (e: any) {
-    return { error: malformed(`failed to parse: ${e?.message ?? String(e)}`) };
+  } catch (e) {
+    return { error: malformed(`failed to parse: ${e instanceof Error ? e.message : String(e)}`) };
   }
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     const got = Array.isArray(parsed) ? "array" : parsed === null ? "null" : typeof parsed;
     return { error: malformed(`got ${got}`) };
   }
+  // Empty object → no filter intent. Return absent so it neither sets a
+  // metadata filter nor trips the both-forms guard in the handler.
+  if (Object.keys(parsed).length === 0) return {};
   return { metadata: parsed as Record<string, unknown> };
 }
 

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2810,6 +2810,38 @@ describe("HTTP /notes", async () => {
       expect(body.code).toBe("INVALID_QUERY");
     });
 
+    test("primitive-scalar `metadata=` JSON (number / bare string) rejects with 400 INVALID_QUERY", async () => {
+      // `metadata=42` and `metadata="open"` are valid JSON but not objects —
+      // both fall through the non-object branch.
+      for (const raw of ["42", JSON.stringify("open")]) {
+        const res = await handleNotes(
+          mkReq("GET", "/notes?metadata=" + encodeURIComponent(raw)),
+          store,
+          "",
+        );
+        expect(res.status).toBe(400);
+        const body = await res.json() as any;
+        expect(body.code).toBe("INVALID_QUERY");
+      }
+    });
+
+    test("empty-object alias `metadata={}` is treated as absent and composes with a bracket filter", async () => {
+      // `{}` carries no filter intent — it must neither set a metadata filter
+      // NOR trip the both-forms 400 guard. So `metadata={}` + a bracket
+      // metadata filter is a 200 filtered by the bracket form only.
+      await declareIndexed();
+      await store.createNote("hi", { metadata: { priority: 5 } });
+      await store.createNote("lo", { metadata: { priority: 1 } });
+      const res = await handleNotes(
+        mkReq("GET", "/notes?metadata=" + encodeURIComponent("{}") + "&meta[priority][gte]=3&include_content=true"),
+        store,
+        "",
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["hi"]);
+    });
+
     test("both `metadata=` alias AND `meta[...]` bracket params present rejects with 400 INVALID_QUERY", async () => {
       await declareIndexed();
       const q = encodeURIComponent(JSON.stringify({ status: { eq: "open" } }));

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2721,6 +2721,139 @@ describe("HTTP /notes", async () => {
       const body = await res.json() as any[];
       expect(body.map((n) => n.content)).toEqual(["new"]);
     });
+
+    // ---- JSON `metadata=<json>` alias (symmetric with the MCP nested obj) ----
+    //
+    // Before this alias, a `?metadata={...}` param was silently dropped: the
+    // bracket grammar never matched it, `queryOpts.metadata` stayed undefined,
+    // and the query returned ALL tag-matching notes — a silent wrong result.
+
+    test("alias `metadata={field:{op:value}}` filters on an indexed field", async () => {
+      await declareIndexed();
+      await store.createNote("open-1", { metadata: { status: "open" } });
+      await store.createNote("open-2", { metadata: { status: "open" } });
+      await store.createNote("closed", { metadata: { status: "closed" } });
+      const q = encodeURIComponent(JSON.stringify({ status: { eq: "open" } }));
+      const res = await handleNotes(
+        mkReq("GET", `/notes?metadata=${q}&include_content=true`),
+        store,
+        "",
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content).sort()).toEqual(["open-1", "open-2"]);
+    });
+
+    test("alias shorthand equality `metadata={field:value}` works via json_extract fallback", async () => {
+      // No declareIndexed — shorthand routes through the engine's json_extract
+      // exact-match path, no indexed declaration required.
+      await store.createNote("matches", { metadata: { status: "open" } });
+      await store.createNote("other", { metadata: { status: "closed" } });
+      const q = encodeURIComponent(JSON.stringify({ status: "open" }));
+      const res = await handleNotes(
+        mkReq("GET", `/notes?metadata=${q}&include_content=true`),
+        store,
+        "",
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any[];
+      expect(body.map((n) => n.content)).toEqual(["matches"]);
+    });
+
+    test("alias and bracket form return identical results for the same indexed-field operator query", async () => {
+      await declareIndexed();
+      for (const p of [1, 2, 3, 4, 5]) {
+        await store.createNote(`p${p}`, { metadata: { priority: p } });
+      }
+      // JSON preserves the real number type 3; bracket form passes "3" as a
+      // string. Both must coerce to the same range result against the INTEGER
+      // indexed column — this guards the type-coercion edge.
+      const aliasQ = encodeURIComponent(JSON.stringify({ priority: { gte: 3 } }));
+      const aliasRes = await handleNotes(
+        mkReq("GET", `/notes?metadata=${aliasQ}&include_content=true`),
+        store,
+        "",
+      );
+      const bracketRes = await handleNotes(
+        mkReq("GET", "/notes?meta[priority][gte]=3&include_content=true"),
+        store,
+        "",
+      );
+      const aliasBody = await aliasRes.json() as any[];
+      const bracketBody = await bracketRes.json() as any[];
+      expect(aliasBody.map((n) => n.content).sort()).toEqual(["p3", "p4", "p5"]);
+      expect(aliasBody.map((n) => n.content).sort()).toEqual(
+        bracketBody.map((n) => n.content).sort(),
+      );
+    });
+
+    test("malformed JSON in `metadata=` rejects with 400 INVALID_QUERY", async () => {
+      const res = await handleNotes(
+        mkReq("GET", "/notes?metadata=" + encodeURIComponent("{not json")),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_QUERY");
+      expect(body.error).toContain("JSON object");
+    });
+
+    test("non-object `metadata=` JSON (array) rejects with 400 INVALID_QUERY", async () => {
+      const res = await handleNotes(
+        mkReq("GET", "/notes?metadata=" + encodeURIComponent(JSON.stringify(["status"]))),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_QUERY");
+    });
+
+    test("both `metadata=` alias AND `meta[...]` bracket params present rejects with 400 INVALID_QUERY", async () => {
+      await declareIndexed();
+      const q = encodeURIComponent(JSON.stringify({ status: { eq: "open" } }));
+      const res = await handleNotes(
+        mkReq("GET", `/notes?metadata=${q}&meta[priority][gte]=3`),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("INVALID_QUERY");
+      expect(body.error).toContain("not both");
+    });
+
+    test("regression: previously-silently-dropped `?metadata={status:{eq:pending}}` now actually filters", async () => {
+      await declareIndexed();
+      await store.createNote("pending-1", { metadata: { status: "pending" } });
+      await store.createNote("pending-2", { metadata: { status: "pending" } });
+      await store.createNote("done", { metadata: { status: "done" } });
+      const q = encodeURIComponent(JSON.stringify({ status: { eq: "pending" } }));
+      const res = await handleNotes(
+        mkReq("GET", `/notes?metadata=${q}&include_content=true`),
+        store,
+        "",
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any[];
+      // Before the fix this returned ALL three notes (filter dropped). Now it
+      // returns only the two pending ones.
+      expect(body.map((n) => n.content).sort()).toEqual(["pending-1", "pending-2"]);
+    });
+
+    test("alias with an unknown operator surfaces the engine's 400 UNKNOWN_OPERATOR", async () => {
+      await declareIndexed();
+      const q = encodeURIComponent(JSON.stringify({ priority: { bogus: 5 } }));
+      const res = await handleNotes(
+        mkReq("GET", `/notes?metadata=${q}`),
+        store,
+        "",
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.code).toBe("UNKNOWN_OPERATOR");
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## The bug (confirmed)

REST `GET /api/notes` only parsed bracket-style metadata filters
(`?meta[field][op]=value`) via `parseMetaBrackets`. A client sending the
MCP-style `?metadata={"status":{"eq":"pending"}}` JSON param had it
**silently dropped** — `parseMetaBrackets`'s regex never matched `metadata=`,
so `queryOpts.metadata` stayed `undefined` and the query returned **ALL
tag-matching notes** (a silent wrong result, not an error). The engine itself
filters indexed metadata operators correctly; the defect was purely at the
REST surface.

## The fix

**Accept a `?metadata=<json>` alias.** New helper `parseMetadataJsonAlias(url)`
in `src/routes.ts` (next to `parseMetaBrackets`):
- reads the `metadata=` param via the existing `parseQuery` helper (no-op if absent);
- `JSON.parse` inside try/catch → malformed JSON returns
  `400 { code: "INVALID_QUERY" }`;
- validates the parsed value is a **non-null, non-array plain object** → else the
  same 400 shape;
- does **not** hand-roll operator validation — the parsed object lowers straight
  into `queryNotes`, where `validateOperatorObject` raises a loud
  `400 UNKNOWN_OPERATOR` (caught by the existing QueryError handler).

In the GET handler, `queryOpts.metadata` is now `bracket.metadata ?? metadataAlias.metadata`.
Shorthand equality (`metadata={"status":"open"}`) lowers through the engine's
`json_extract` fallback; JSON preserves real number/boolean types so
`{"priority":{"gte":3}}` compares numerically.

**Reject "both forms" loudly.** Passing BOTH a `metadata=` param AND any
`meta[...]` bracket metadata param → `400 INVALID_QUERY` ("…not both."),
symmetric with the existing mixed shorthand/operator rejection. No silent
winner — the silent-drop is the class of bug we're fixing. The guard is keyed
on `bracket.metadata` only, so the alias still composes with bracket **date**
filters (`meta[created_at][gte]=…`), which are a separate axis.

**No MCP change** — `core/src/mcp.ts` already forwards `params.metadata`
verbatim as the same nested object.

## Docs (`docs/HTTP_API.md`)

- New "Metadata filters (JSON alias)" subsection documenting `metadata=<json>`
  (symmetric with the MCP nested object) + the not-both rule.
- A note that single-note routes / path filters need `/` percent-encoded as
  `%2F` (closes a separate reported sharp edge).
- The new malformed-JSON / both-forms 400s in the error-shapes section.

## Tests (`src/vault.test.ts`, inside the existing bracket-style `describe`)

- alias operator query on the indexed `status` field returns the right rows;
- alias shorthand equality via the `json_extract` fallback;
- **agreement test**: alias vs bracket form return identical results for the
  same indexed-field operator query (guards the JSON-real-number vs
  bracket-string type-coercion edge);
- malformed JSON → `400 INVALID_QUERY`;
- non-object (array) JSON → `400 INVALID_QUERY`;
- both `metadata=` and `meta[...]` present → `400 INVALID_QUERY`;
- **regression**: the previously-silently-dropped
  `?metadata={"status":{"eq":"pending"}}` now actually filters (would have
  returned all rows before);
- alias unknown-operator surfaces the engine's `400 UNKNOWN_OPERATOR`.

## Gates

- `bun test ./src/` → **1285 pass, 0 fail**
- `bun test ./core/src/` → **639 pass, 0 fail**
- `bun run typecheck` → clean

No version bump (RC versioning — the bump + tag happen at release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)