### PR TITLE
docs: clarify force/if_updated_at precedence, tag relationships shape, storage statuses

### DIFF
--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -543,7 +543,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
 - \`links: { add: [{ target, relationship }], remove: [{ target, relationship }] }\` — add/remove links
 - When removing a wikilink-type link, \`[[brackets]]\` are also removed from content.
 - For batch: pass a \`notes\` array, each with an \`id\` field.
-- **Optimistic concurrency is required by default.** Pass \`if_updated_at\` with the \`updated_at\` value you last read — the update is rejected with a conflict error if the note has changed since. Re-read, reconcile, and retry. To skip the safety check (e.g. bulk migration), pass \`force: true\` instead; the update then runs unconditionally. \`append\` / \`prepend\` only updates are exempt from the precondition (no-conflict-by-design).
+- **Optimistic concurrency is required by default.** Pass \`if_updated_at\` with the \`updated_at\` value you last read — the update is rejected with a conflict error if the note has changed since. Re-read, reconcile, and retry. To skip the safety check (e.g. bulk migration), pass \`force: true\` instead; the update then runs unconditionally. \`force\` only waives the *requirement to supply* \`if_updated_at\` — if you pass both, the precondition you supplied still applies and a mismatch returns a conflict error. \`append\` / \`prepend\` only updates are exempt from the precondition (no-conflict-by-design).
 - **Idempotent upsert via \`if_missing: "create"\`** — when the note doesn't exist, create it from this same payload (content/path/tags/metadata become the create fields; OC precondition skipped — nothing to conflict with). Response carries \`created: true\`. Useful for nightly sync loops that don't know ahead of time whether the note exists. Default \`"fail"\` (current behavior — missing note errors). See vault#309.
 - \`include_content\` (default \`true\`) — set \`false\` to receive a lean index shape (\`id\`, \`path\`, \`createdAt\`, \`updatedAt\`, \`tags\`, \`metadata\`, \`byteSize\`, \`preview\`) instead of full content. Useful for agents making frequent small edits to large notes (e.g. via \`append\` or \`content_edit\`) where re-receiving the body is the dominant cost. \`validation_status\` is preserved on the lean shape when present.`,
       inputSchema: {
@@ -567,7 +567,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           metadata: { type: "object", description: "Metadata to merge (keys are merged, not replaced wholesale)" },
           created_at: { type: "string", description: "New created_at timestamp" },
           if_updated_at: { type: "string", description: "Optimistic concurrency check: the updated_at value you last read. Rejects with a conflict error if the note has been modified since. Required unless `force: true` is set or the call is `append`/`prepend`-only." },
-          force: { type: "boolean", description: "Override the required `if_updated_at` check and run the update unconditionally. Use only for bulk migrations or scripted writes where concurrency is known-safe." },
+          force: { type: "boolean", description: "Waive the *requirement to supply* `if_updated_at` and run the update unconditionally. Use only for bulk migrations or scripted writes where concurrency is known-safe. Note: this does not override an `if_updated_at` you actually pass — if you supply both, the precondition still applies and a mismatch returns a conflict error." },
           if_missing: { type: "string", enum: ["fail", "create"], description: "What to do when the note (by `id`/path) doesn't exist. `\"fail\"` (default) — error, current behavior. `\"create\"` — create the note from this same payload (content/path/tags/metadata become the create fields; the response carries `created: true`). Skips the `if_updated_at` precondition on the create branch (nothing to conflict with). Idempotent for sync loops that don't know ahead of time whether the note exists. See vault#309." },
           tags: {
             type: "object",
@@ -632,7 +632,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
                 metadata: { type: "object" },
                 created_at: { type: "string" },
                 if_updated_at: { type: "string", description: "Optimistic concurrency check for this item; rejects with a conflict error if the note has been modified since. Required unless `force: true` is set on this item or the item is `append`/`prepend`-only." },
-                force: { type: "boolean", description: "Override the required `if_updated_at` check for this item." },
+                force: { type: "boolean", description: "Waive the *requirement to supply* `if_updated_at` for this item. Does not override an `if_updated_at` you actually pass — a supplied precondition still applies and a mismatch conflicts." },
                 if_missing: { type: "string", enum: ["fail", "create"], description: "Per-item: see top-level `if_missing` docs. Each batch item carries its own setting." },
                 tags: { type: "object" },
                 links: { type: "object" },

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -575,7 +575,7 @@ supports three mutually-exclusive content modes:
   },
 
   "if_updated_at": "2026-05-20T...",                 // optimistic concurrency
-  "force": true,                                     // bypass if_updated_at
+  "force": true,                                     // bypass the *requirement* for if_updated_at
   "if_missing": "create",                            // vault#309 — upsert
   "include_content": false                           // optional lean response
 }
@@ -586,6 +586,12 @@ supports three mutually-exclusive content modes:
 returns `428 Precondition Required`. Pure append/prepend updates (no
 content/metadata/path/tags/links) are exempt — concatenation is
 no-conflict-by-design.
+
+If you supply both `if_updated_at` and `force: true`, the precondition
+still applies — `if_updated_at` wins and a mismatch returns `409 conflict`.
+`force` only waives the requirement to supply `if_updated_at`; it does not
+override one you actually passed. To update unconditionally, omit
+`if_updated_at` and send `force: true` alone.
 
 **`if_missing: "create"` (vault#309 — shipped 0.4.5).** When the target
 note doesn't exist, treat the PATCH body as a create. Useful for sync
@@ -768,13 +774,41 @@ Upsert a tag's identity row. Body accepts any combination of:
 {
   "description": "string | null",
   "fields": { "<field>": { "type": "string", "enum": [...], ... } } | null,
-  "relationships": { "<name>": { "cardinality": "one|many", "target_tags": [...] } } | null,
+  "relationships": {
+    "<relName>": {
+      "target_tag": "<tag>",
+      "cardinality": "one" | "optional" | "many" | "many-required",
+      "description": "<optional string>"
+    }
+  } | null,
   "parent_names": ["parent-tag", ...] | null
 }
 ```
 
 Omitted keys are preserved; explicit `null` clears. `fields` merges into
 the existing schema (mirrors MCP `update-tag`).
+
+**`relationships` shape.** An **object-of-objects**, never an array. Each
+key is a relationship name; each value MUST carry both `target_tag` (a
+non-empty string) and `cardinality` (one of `one`, `optional`, `many`,
+`many-required`). `description` is optional. A malformed payload — an
+array, a value missing `target_tag` or `cardinality`, or a `cardinality`
+outside the vocabulary — is **rejected with `400` and
+`error_type: invalid_relationships`** (the `error` field carries the
+specific violation); it is never silently dropped or nulled. Concrete
+example:
+
+```json
+{
+  "relationships": {
+    "works-on": {
+      "target_tag": "project",
+      "cardinality": "many",
+      "description": "projects this person contributes to"
+    }
+  }
+}
+```
 
 #### `DELETE /vault/{name}/api/tags/{name}` — `vault:write`
 Removes the tag, its identity row, and untags every note. Returns the
@@ -952,11 +986,20 @@ Multipart form upload.
 - Allowed extensions: `.wav .mp3 .m4a .ogg .webm .png .jpg .jpeg .gif
   .webp .pdf .mp4`. `.svg` and `.html` are explicitly disallowed (XSS).
 
-Returns `{path, size, mimeType}` (201).
+Returns `{path, size, mimeType}` with status `201` on success. A file
+larger than the 100MB limit is rejected with `413`.
 
 #### `GET /vault/{name}/api/storage/{date}/{filename}` — `vault:read`
 Serves the uploaded file bytes with the matching `Content-Type`. Path is
 sandboxed under the vault's assets dir; traversal attempts return `403`.
+
+With a **tag-scoped** token, the serve is additionally gated by the owning
+note's tag scope: the requested storage path is reverse-looked-up to its
+owning attachment row(s) → note(s), and the bytes are served only if at
+least one owning note is in scope. An out-of-scope (or owner-less) path
+returns `404` — matching the note-level attachment surfaces, so the
+endpoint can't act as an existence oracle. Unscoped tokens keep the
+path-only behavior.
 
 ### MCP
 

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -774,13 +774,13 @@ Upsert a tag's identity row. Body accepts any combination of:
 {
   "description": "string | null",
   "fields": { "<field>": { "type": "string", "enum": [...], ... } } | null,
-  "relationships": {
+  "relationships": {                                 // object-of-objects, never an array; | null clears
     "<relName>": {
       "target_tag": "<tag>",
       "cardinality": "one" | "optional" | "many" | "many-required",
       "description": "<optional string>"
     }
-  } | null,
+  },
   "parent_names": ["parent-tag", ...] | null
 }
 ```
@@ -996,10 +996,11 @@ sandboxed under the vault's assets dir; traversal attempts return `403`.
 With a **tag-scoped** token, the serve is additionally gated by the owning
 note's tag scope: the requested storage path is reverse-looked-up to its
 owning attachment row(s) → note(s), and the bytes are served only if at
-least one owning note is in scope. An out-of-scope (or owner-less) path
-returns `404` — matching the note-level attachment surfaces, so the
-endpoint can't act as an existence oracle. Unscoped tokens keep the
-path-only behavior.
+least one owning note is in scope. The serve returns `404` in **both**
+failure cases — when no attachment row owns the path (owner-less) and when
+an owning note exists but falls outside the token's scope. The same `404`
+either way keeps the endpoint from acting as an existence oracle. Unscoped
+tokens keep the path-only behavior.
 
 ### MCP
 


### PR DESCRIPTION
Doc-only PR folding three triaged feedback items into documentation. **All three were verified against the code** — this documents accurate behavior; **no behavior change, no version bump** (doc-only exemption). The only non-doc edits are user-facing docstring strings in `core/src/mcp.ts` (no logic change).

## 1. `force` vs `if_updated_at` precedence on PATCH (feedback #7)

`force` only waives the *requirement to supply* `if_updated_at`; it is **never passed to the store**, so a *supplied* `if_updated_at` is always enforced and a mismatch returns `409 conflict`. To update unconditionally, omit `if_updated_at` and send `force: true` alone. REST and MCP gate the requirement identically (`force !== true`).

- `docs/HTTP_API.md` — added a precedence paragraph to "Optimistic concurrency"; tightened the inline comment (`bypass if_updated_at` → `bypass the *requirement* for if_updated_at`).
- `core/src/mcp.ts` — updated the three `force` descriptions (prose + single-call field + batch-item field) to say it overrides the *requirement to supply*, not a supplied value. Docstring-only.

Verified at `src/routes.ts:1209` (requirement gate) + `:1298-1300` (if_updated_at always forwarded), and `core/src/mcp.ts:788` + `:871`.

## 2. Tag `relationships` accepted shape + the 400 (feedback #2)

`relationships` **does** persist; a malformed shape is rejected with `400 error_type: invalid_relationships`, **not** silently nulled. Confirmed against `core/src/tag-schemas.ts:242-279` (`validateRelationships`) and `src/routes.ts:1588-1612` (`PUT /api/tags/:name`).

- Accepted shape: an **object-of-objects** (never an array); every value MUST carry `target_tag` (non-empty string) + `cardinality` (one of `one`, `optional`, `many`, `many-required`); `description` optional.
- `docs/HTTP_API.md` — documented the shape with a concrete example and the `400 / invalid_relationships` rejection in the existing `PUT .../api/tags/{name}` section.

**Discrepancy fixed:** the section already had a `relationships` line that was **wrong** — it showed `{ "cardinality": "one|many", "target_tags": [...] }` (an array field `target_tags`, and a narrowed two-value vocabulary). Corrected to the verified `target_tag` (single string) + the full four-value cardinality vocabulary.

## 3. Storage doc polish (feedback #5)

Routes already documented; added only the two missing details, verified against `src/routes.ts`:

- `POST .../api/storage/upload` — `201` on success; `413` when the file exceeds the 100MB limit (`MAX_UPLOAD_BYTES`, `src/routes.ts:2129/2174/2194`).
- `GET .../api/storage/{date}/{filename}` — tag-scoped tokens are additionally gated by the owning note's tag scope and get a **404** (not just the 403 traversal guard) when the path's note is out of scope (`src/routes.ts:2225-2238`).

## Gates

- `bun test ./src/` — **1287 pass, 0 fail**
- `bun test ./core/src/` — **639 pass, 0 fail**
- `bun run typecheck` (`tsc --noEmit`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)