### PR TITLE
feat(update): echo hydrated links on the update response (REST + MCP)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2219,6 +2219,25 @@ describe("MCP tools", async () => {
     expect(result[1]).not.toHaveProperty("links");
   });
 
+  it("update-note if_missing=create with include_links echoes links (no link mutation)", async () => {
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    // The created note has no links yet and the payload declares none, so the
+    // echo is driven purely by the explicit `include_links` flag — closing the
+    // create-on-missing × flag-only matrix gap. Hydrated `links` key is present
+    // (empty array), not absent.
+    const result = await updateNote.execute({
+      id: "fresh-note",
+      content: "brand new",
+      if_missing: "create",
+      include_links: true,
+    }) as any;
+    expect(result.created).toBe(true);
+    expect(result.content).toBe("brand new");
+    expect(Array.isArray(result.links)).toBe(true);
+    expect(result.links).toHaveLength(0);
+  });
+
   it("update-note removes wikilink brackets when removing wikilink-type link", async () => {
     await store.createNote("Target", { id: "target", path: "People/Alice" });
     const source = await store.createNote("See [[People/Alice]] for details", { id: "source" });

--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2131,6 +2131,94 @@ describe("MCP tools", async () => {
     expect(await store.getLinks("a", { direction: "outbound" })).toHaveLength(0);
   });
 
+  // vault feedback #8 — echo hydrated links on the update response when the
+  // request mutated links OR `include_links` is set, so callers don't re-query.
+  it("update-note echoes hydrated links when the update mutates links", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b", path: "beta", tags: ["t"] });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = await updateNote.execute({
+      id: "a",
+      links: { add: [{ target: "b", relationship: "mentions" }] },
+      force: true,
+    }) as any;
+    expect(Array.isArray(result.links)).toBe(true);
+    expect(result.links).toHaveLength(1);
+    // Hydrated shape matches query-notes' include_links output.
+    const link = result.links[0];
+    expect(link.sourceId).toBe("a");
+    expect(link.targetId).toBe("b");
+    expect(link.relationship).toBe("mentions");
+    expect(link.targetNote.path).toBe("beta");
+    expect(link.targetNote.tags).toEqual(["t"]);
+  });
+
+  it("update-note echoes links on removal (post-removal set)", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createNote("C", { id: "c" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("a", "c", "mentions");
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = await updateNote.execute({
+      id: "a",
+      links: { remove: [{ target: "b", relationship: "mentions" }] },
+      force: true,
+    }) as any;
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].targetId).toBe("c");
+  });
+
+  it("update-note with include_links echoes links even without a mutation", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions");
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = await updateNote.execute({
+      id: "a",
+      content: "updated",
+      include_links: true,
+      force: true,
+    }) as any;
+    expect(result.content).toBe("updated");
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].targetId).toBe("b");
+  });
+
+  it("update-note without a link mutation or flag does NOT echo links", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions");
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = await updateNote.execute({ id: "a", content: "updated", force: true }) as any;
+    expect(result.content).toBe("updated");
+    expect(result).not.toHaveProperty("links");
+  });
+
+  it("update-note batch echoes links per-item (only on the mutated/flagged item)", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createNote("C", { id: "c" });
+    const tools = generateMcpTools(store);
+    const updateNote = tools.find((t) => t.name === "update-note")!;
+    const result = await updateNote.execute({
+      notes: [
+        // Item 0 mutates links → echoes.
+        { id: "a", links: { add: [{ target: "b", relationship: "mentions" }] }, force: true },
+        // Item 1 only edits content, no flag → no links key.
+        { id: "c", content: "C updated", force: true },
+      ],
+    }) as any[];
+    expect(result).toHaveLength(2);
+    expect(result[0].links).toHaveLength(1);
+    expect(result[0].links[0].targetId).toBe("b");
+    expect(result[1]).not.toHaveProperty("links");
+  });
+
   it("update-note removes wikilink brackets when removing wikilink-type link", async () => {
     await store.createNote("Target", { id: "target", path: "People/Alice" });
     const source = await store.createNote("See [[People/Alice]] for details", { id: "source" });

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -611,7 +611,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           },
           include_links: {
             type: "boolean",
-            description: "Echo the note's hydrated inbound + outbound links on the response (vault feedback #8). Links are *also* echoed automatically whenever the update itself mutated links (`links.add`/`links.remove`), so you rarely need to set this — its purpose is to fetch the current link set on an update that didn't touch links. Default: `false` (and absent from the response unless mutated or requested). Mirrors `query-notes`'s `include_links`. Applies per-item on batch.",
+            description: "Echo the note's hydrated inbound + outbound links on the response (vault feedback #8). Links are *also* echoed automatically whenever the update itself mutated links (`links.add`/`links.remove`), so you rarely need to set this — its purpose is to fetch the current link set on an update that didn't touch links. Default: `false` (and absent from the response unless mutated or requested). Mirrors `query-notes`'s `include_links`. This top-level flag applies to the single-note form only; for a batch, set `include_links` on each note object in `notes` (a top-level `include_links` is ignored when `notes` is present).",
           },
           // Batch
           notes: {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -609,6 +609,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             type: "boolean",
             description: "Response shape opt-out. Default `true` (returns the full Note with content). Set `false` to receive the lean index shape (drops `content`, adds `byteSize` and a whitespace-collapsed `preview`). `validation_status` is preserved on the lean shape when present. Applies uniformly to single and batch responses.",
           },
+          include_links: {
+            type: "boolean",
+            description: "Echo the note's hydrated inbound + outbound links on the response (vault feedback #8). Links are *also* echoed automatically whenever the update itself mutated links (`links.add`/`links.remove`), so you rarely need to set this — its purpose is to fetch the current link set on an update that didn't touch links. Default: `false` (and absent from the response unless mutated or requested). Mirrors `query-notes`'s `include_links`. Applies per-item on batch.",
+          },
           // Batch
           notes: {
             type: "array",
@@ -636,6 +640,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
                 if_missing: { type: "string", enum: ["fail", "create"], description: "Per-item: see top-level `if_missing` docs. Each batch item carries its own setting." },
                 tags: { type: "object" },
                 links: { type: "object" },
+                include_links: { type: "boolean", description: "Per-item: echo hydrated links on this item's response (vault feedback #8). Also implied when this item mutates links." },
               },
               required: ["id"],
             },
@@ -657,6 +662,15 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         // sync-loop caller (Gitcoin Brain et al) reads this to know which
         // path fired without doing a separate query. vault#309.
         const createdIds = new Set<string>();
+        // Track which note IDs should echo hydrated links on the response.
+        // A note qualifies when this request mutated its links
+        // (`links.add`/`links.remove`) OR the caller set `include_links`.
+        // vault feedback #8 — previously the update response omitted links
+        // entirely, forcing a re-query just to confirm a link the caller had
+        // just added/removed. Per-item on batch. Note IDs (not item indices)
+        // key this so the create-on-missing branch, which assigns the id
+        // late, can register correctly.
+        const echoLinkIds = new Set<string>();
         // Wrap multi-item batches in a SQLite transaction so any mid-batch
         // failure (precondition error, content_edit miss, ConflictError, …)
         // rolls back every prior mutation in the batch — see #236.
@@ -745,6 +759,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               const fresh = noteOps.getNote(db, created.id) ?? created;
               updated.push(fresh);
               createdIds.add(fresh.id);
+              // Echo links if this create-on-missing declared `links.add`
+              // (the only link op honored on create) or asked explicitly.
+              if (linksAdd !== undefined || item.include_links === true) {
+                echoLinkIds.add(fresh.id);
+              }
               continue;
             }
             // Fallthrough: not-found + no if_missing → existing error
@@ -907,6 +926,13 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             }
           }
 
+          // Echo links if this update mutated them (`links.add`/`links.remove`)
+          // or the caller asked explicitly. vault feedback #8.
+          const linkMutated = (item.links as any)?.add !== undefined || (item.links as any)?.remove !== undefined;
+          if (linkMutated || item.include_links === true) {
+            echoLinkIds.add(note.id);
+          }
+
           // Re-read for final state
           updated.push(noteOps.getNote(db, note.id) ?? result);
         }
@@ -929,11 +955,23 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         const final = updated.map((n) => {
           const validated = attachValidationStatus(store, db, n);
           const created = createdIds.has(n.id);
-          if (includeContent) return { ...validated, created } as Note & { created: boolean };
+          // Echo hydrated links when this note was flagged for it (mutated
+          // its links or `include_links` was set). Additive key, present only
+          // when triggered — mirrors the GET / query-notes shape exactly via
+          // the shared `linkOps.getLinksHydrated` call. vault feedback #8.
+          const echoLinks = echoLinkIds.has(n.id);
+          if (includeContent) {
+            const full: any = { ...validated, created };
+            if (echoLinks) full.links = linkOps.getLinksHydrated(db, n.id);
+            return full as Note & { created: boolean };
+          }
           const lean: any = noteOps.toNoteIndex(validated);
           const vs = (validated as any).validation_status;
           if (vs !== undefined) lean.validation_status = vs;
           lean.created = created;
+          // Carry the link echo across the lean conversion — `toNoteIndex`
+          // drops unknown fields.
+          if (echoLinks) lean.links = linkOps.getLinksHydrated(db, n.id);
           return lean;
         });
         return batch ? final : final[0];

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1335,7 +1335,20 @@ async function handleNotesInner(
       // `toNoteIndex` drops unknown fields).
       const updatedNote = await store.getNote(note.id);
       if (updatedNote === null) return json({ error: "Note disappeared" }, 404);
-      const validated = attachValidationStatus(store, db, updatedNote);
+      const validated: any = attachValidationStatus(store, db, updatedNote);
+      // Echo hydrated links when a link mutation was part of this request,
+      // OR the caller explicitly asked for them via `?include_links=true`
+      // (vault feedback #8). Previously the update response omitted links
+      // entirely (`getNote` populates tags but not links), forcing callers
+      // to re-GET with `?include_links=true` just to confirm a link they
+      // had just added/removed. Additive field, scoped to UPDATE: present
+      // only when mutated or requested. Mirrors the GET / query-notes
+      // hydration call form exactly (`linkOps.getLinksHydrated`).
+      const linkMutated = body.links?.add !== undefined || body.links?.remove !== undefined;
+      const includeLinksResp = linkMutated || parseBool(parseQuery(url, "include_links"), false);
+      if (includeLinksResp) {
+        validated.links = linkOps.getLinksHydrated(db, note.id);
+      }
       const includeContentResp = body.include_content !== false;
       // `created: false` is appended to every update-path response so
       // sync-loop callers using `if_missing: "create"` can distinguish
@@ -1345,6 +1358,9 @@ async function handleNotesInner(
       const lean: any = toNoteIndex(validated);
       const vs = (validated as any).validation_status;
       if (vs !== undefined) lean.validation_status = vs;
+      // Carry the link echo across the lean conversion — `toNoteIndex`
+      // drops unknown fields, same as the `validation_status` recipe above.
+      if (validated.links !== undefined) lean.links = validated.links;
       lean.created = false;
       return json(lean);
     } catch (e: any) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1347,7 +1347,7 @@ async function handleNotesInner(
       const linkMutated = body.links?.add !== undefined || body.links?.remove !== undefined;
       const includeLinksResp = linkMutated || parseBool(parseQuery(url, "include_links"), false);
       if (includeLinksResp) {
-        validated.links = linkOps.getLinksHydrated(db, note.id);
+        validated.links = linkOps.getLinksHydrated(db, updatedNote.id);
       }
       const includeContentResp = body.include_content !== false;
       // `created: false` is appended to every update-path response so

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -3191,6 +3191,78 @@ describe("HTTP PATCH /notes/:idOrPath (update)", async () => {
     expect(await store.getLinks("a", { direction: "outbound" })).toHaveLength(0);
   });
 
+  // vault feedback #8 — the update response now echoes hydrated links when
+  // the request mutated links OR `?include_links=true` is passed, so callers
+  // no longer have to re-GET to confirm a link they just added/removed.
+  test("PATCH links.add echoes hydrated links on the response", async () => {
+    await store.createNote("a", { id: "a" });
+    await store.createNote("b", { id: "b", path: "People/Bob", tags: ["person"] });
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/a", { links: { add: [{ target: "b", relationship: "mentions" }] }, force: true }),
+      store,
+      "/a",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(Array.isArray(body.links)).toBe(true);
+    expect(body.links).toHaveLength(1);
+    const link = body.links[0];
+    expect(link.sourceId).toBe("a");
+    expect(link.targetId).toBe("b");
+    expect(link.relationship).toBe("mentions");
+    // Hydrated shape matches GET / query-notes: targetNote summary present.
+    expect(link.targetNote.id).toBe("b");
+    expect(link.targetNote.path).toBe("People/Bob");
+    expect(link.targetNote.tags).toEqual(["person"]);
+  });
+
+  test("PATCH links.remove echoes the post-removal link set", async () => {
+    await store.createNote("a", { id: "a" });
+    await store.createNote("b", { id: "b" });
+    await store.createNote("c", { id: "c" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("a", "c", "mentions");
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/a", { links: { remove: [{ target: "b", relationship: "mentions" }] }, force: true }),
+      store,
+      "/a",
+    );
+    const body = await res.json() as any;
+    expect(Array.isArray(body.links)).toBe(true);
+    expect(body.links).toHaveLength(1);
+    expect(body.links[0].targetId).toBe("c");
+  });
+
+  test("PATCH without a link mutation or flag does NOT include links", async () => {
+    await store.createNote("a", { id: "a" });
+    await store.createNote("b", { id: "b" });
+    await store.createLink("a", "b", "mentions");
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/a", { content: "updated", force: true }),
+      store,
+      "/a",
+    );
+    const body = await res.json() as any;
+    expect(body.content).toBe("updated");
+    expect(body).not.toHaveProperty("links");
+  });
+
+  test("PATCH ?include_links=true echoes current links even without a mutation", async () => {
+    await store.createNote("a", { id: "a" });
+    await store.createNote("b", { id: "b" });
+    await store.createLink("a", "b", "mentions");
+    const res = await handleNotes(
+      mkReq("PATCH", "/notes/a?include_links=true", { content: "updated", force: true }),
+      store,
+      "/a",
+    );
+    const body = await res.json() as any;
+    expect(body.content).toBe("updated");
+    expect(Array.isArray(body.links)).toBe(true);
+    expect(body.links).toHaveLength(1);
+    expect(body.links[0].targetId).toBe("b");
+  });
+
   test("PATCH resolves note by path", async () => {
     await store.createNote("x", { path: "Projects/README" });
     const res = await handleNotes(


### PR DESCRIPTION
## Friction (feedback #8)

After a `links.add` / `links.remove` on an update, the response omitted the new links — callers had to **re-GET with `?include_links=true`** just to confirm a link they had just mutated. The root cause: `core/src/notes.ts` `getNote` populates `tags` but never `links`, so the assembled update response simply never carried them.

## Fix

Echo the hydrated links on the update response, on **both update surfaces**:

1. **Echo-on-mutation** — whenever the request mutated links (`links.add` / `links.remove`), the response now includes the hydrated link set.
2. **`include_links` flag** — an explicit flag (REST `?include_links=true`, MCP `include_links: true`) also echoes the *current* link set on a non-link update. This mirrors the existing GET / `query-notes` `include_links` convention.

Both reuse the exact GET / query-notes hydration call (`linkOps.getLinksHydrated(db, id)` — `getLinks` + one batched note-summary fetch, no extra round-trip), so the echoed shape (`sourceId`/`targetId`/`relationship`/`metadata` + `sourceNote`/`targetNote` summaries) is byte-consistent with what reads already return.

### Where the echo is injected

- **REST** (`src/routes.ts`, PATCH handler): after the final `getNote` + validation, before `json(...)`. Trigger: `body.links?.add`/`remove` present **OR** `?include_links=true`. Carried across the lean (`include_content: false`) conversion the same way `validation_status` is.
- **MCP** (`core/src/mcp.ts` update-note): added `include_links` to the single + batch `inputSchema` (mirrors query-notes' param). A per-note `echoLinkIds` set is populated during item processing — **per-item on batch**, and covering the create-on-missing branch (`links.add` only, since remove is a no-op on a fresh note). The response mapping attaches `links` on both the full and lean shapes when the note is flagged.

## Scope & backwards-compat

- **Scoped to UPDATE only.** Create-symmetry (echoing links on create) is a possible follow-up — tracked separately if wanted.
- **Additive response key.** `links` is present *only* when mutated or requested. The common no-link-edit path is byte-identical to before — no existing test asserted the absence of `links` on a mutation response, so nothing's shape changed unexpectedly.

## Tests

- **REST** (`src/vault.test.ts`): `links.add` → echo; `links.remove` → post-removal set; no mutation/no flag → no `links` key; `?include_links=true` with no mutation → echo current.
- **MCP** (`core/src/core.test.ts`): mutation → echo; removal → post-removal set; `include_links: true` no-mutation → echo; no mutation/flag → no `links`; **batch** per-item (mutated item echoes, content-only item doesn't).
- Both assert the hydrated shape matches GET / query-notes (`targetNote` summary with path + tags).

## Gates

- `bun test ./src/` — **1291 pass, 0 fail**
- `bun test ./core/src/` — **644 pass, 0 fail**
- `bun run typecheck` — clean

Resolves feedback #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)