### PR TITLE
feat(query): opt-in link_count field + order_by=link_count (feedback #4)

### DIFF
--- a/core/src/link-count.test.ts
+++ b/core/src/link-count.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { SqliteStore } from "./store.js";
+import { generateMcpTools } from "./mcp.js";
+import { getLinkCounts } from "./links.js";
+
+// Feature: link-count field (`include_link_count` / `linkCount`) +
+// `order_by=link_count` (vault feedback #4).
+//
+// LOCKED SEMANTICS exercised here:
+//   - degree = row count = (#rows source_id=id) + (#rows target_id=id)
+//   - both directions by default; outbound/inbound variants
+//   - self-loop (source_id==target_id) counts as degree 2 under `both`
+//   - the order_by sort key uses the SAME directional-sum definition, so
+//     field value == sort key for EVERY note, self-loops included
+//   - two typed links between the same pair count as 2 (row count)
+
+let store: SqliteStore;
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  store = new SqliteStore(db);
+});
+
+describe("getLinkCounts (core helper)", () => {
+  it("counts both directions as a row sum", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createNote("C", { id: "c" });
+    // a → b, a → c  (a outbound 2)
+    // c → a          (a inbound 1)  => a degree 3
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("a", "c", "mentions");
+    await store.createLink("c", "a", "mentions");
+
+    const both = getLinkCounts(db, ["a", "b", "c"]);
+    expect(both.get("a")).toBe(3); // 2 outbound + 1 inbound
+    expect(both.get("b")).toBe(1); // 1 inbound
+    expect(both.get("c")).toBe(2); // 1 outbound (c→a) + 1 inbound (a→c)
+  });
+
+  it("outbound and inbound variants count only one direction", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions"); // a outbound, b inbound
+
+    expect(getLinkCounts(db, ["a"], "outbound").get("a")).toBe(1);
+    expect(getLinkCounts(db, ["a"], "inbound").get("a")).toBe(0);
+    expect(getLinkCounts(db, ["b"], "outbound").get("b")).toBe(0);
+    expect(getLinkCounts(db, ["b"], "inbound").get("b")).toBe(1);
+  });
+
+  it("returns 0 for ids with no links (id always present in map)", async () => {
+    await store.createNote("Lonely", { id: "lonely" });
+    const counts = getLinkCounts(db, ["lonely"]);
+    expect(counts.get("lonely")).toBe(0);
+  });
+
+  it("empty id list → empty map (no query)", () => {
+    expect(getLinkCounts(db, []).size).toBe(0);
+  });
+
+  it("self-loop counts as degree 2 under both (outbound + inbound)", async () => {
+    await store.createNote("S", { id: "s" });
+    await store.createLink("s", "s", "relates"); // self-loop
+
+    expect(getLinkCounts(db, ["s"], "both").get("s")).toBe(2);
+    expect(getLinkCounts(db, ["s"], "outbound").get("s")).toBe(1);
+    expect(getLinkCounts(db, ["s"], "inbound").get("s")).toBe(1);
+  });
+
+  it("two typed links between the same pair count as 2 (row count)", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions");
+    await store.createLink("a", "b", "cites"); // same pair, different relationship
+
+    expect(getLinkCounts(db, ["a"], "both").get("a")).toBe(2);
+    expect(getLinkCounts(db, ["b"], "both").get("b")).toBe(2);
+  });
+
+  it("dedupes repeated ids in the request (no double-count)", async () => {
+    await store.createNote("A", { id: "a" });
+    await store.createNote("B", { id: "b" });
+    await store.createLink("a", "b", "mentions");
+    const counts = getLinkCounts(db, ["a", "a", "a"]);
+    expect(counts.get("a")).toBe(1);
+  });
+
+  it("batch correctness over a large page (exceeds the chunk size)", async () => {
+    // 1000 notes > the 900-id chunk boundary; each note i links to note 0,
+    // so note 0 has inbound degree 999 and every other note has outbound 1.
+    for (let i = 0; i < 1000; i++) {
+      await store.createNote(`n${i}`, { id: `n${i}` });
+    }
+    for (let i = 1; i < 1000; i++) {
+      await store.createLink(`n${i}`, "n0", "mentions");
+    }
+    const ids = Array.from({ length: 1000 }, (_, i) => `n${i}`);
+    const counts = getLinkCounts(db, ids);
+    expect(counts.size).toBe(1000); // every id present even across chunks
+    expect(counts.get("n0")).toBe(999); // all inbound
+    expect(counts.get("n1")).toBe(1); // one outbound
+    expect(counts.get("n999")).toBe(1);
+  });
+});
+
+describe("order_by=link_count (engine)", () => {
+  // Helper: assert the field value (via getLinkCounts, both) equals the
+  // sort-key ordering produced by order_by=link_count for EVERY note.
+  async function assertFieldEqualsSortOrder(sort: "asc" | "desc") {
+    const ordered = await store.queryNotes({ orderBy: "link_count", sort });
+    const degrees = getLinkCounts(
+      db,
+      ordered.map((n) => n.id),
+      "both",
+    );
+    const seq = ordered.map((n) => degrees.get(n.id) ?? 0);
+    // The emitted SQL sorts by the same directional-sum degree, so the
+    // degree sequence must already be monotonic in the requested direction.
+    const sorted = [...seq].sort((a, b) => (sort === "desc" ? b - a : a - b));
+    expect(seq).toEqual(sorted);
+    return { ordered, degrees };
+  }
+
+  it("sorts by degree descending and the field matches the sort key", async () => {
+    await store.createNote("Hub", { id: "hub" });
+    await store.createNote("Mid", { id: "mid" });
+    await store.createNote("Leaf", { id: "leaf" });
+    // hub degree 3, mid degree 1, leaf degree 0
+    await store.createLink("hub", "mid", "a");
+    await store.createLink("hub", "leaf", "b");
+    await store.createLink("mid", "hub", "c"); // hub inbound +1 => 3, mid outbound +1 => 2? recount below
+
+    // Recount precisely: hub source: hub→mid, hub→leaf (2); hub target: mid→hub (1) = 3
+    // mid source: mid→hub (1); mid target: hub→mid (1) = 2
+    // leaf target: hub→leaf (1) = 1
+    const { ordered } = await assertFieldEqualsSortOrder("desc");
+    expect(ordered.map((n) => n.id)).toEqual(["hub", "mid", "leaf"]);
+  });
+
+  it("sorts ascending too", async () => {
+    await store.createNote("Hub", { id: "hub" });
+    await store.createNote("Leaf", { id: "leaf" });
+    await store.createLink("hub", "leaf", "a");
+    const { ordered } = await assertFieldEqualsSortOrder("asc");
+    // leaf degree 1, hub degree 1 — both 1 here; just assert monotonic + the
+    // tiebreaker keeps a deterministic order (created_at asc => hub first).
+    expect(ordered.length).toBe(2);
+  });
+
+  it("self-loop: linkCount==2 AND its order_by position matches that 2", async () => {
+    // selfy has a self-loop (degree 2), plain has one inbound (degree 1),
+    // zero has none (degree 0). Descending order must place selfy first,
+    // and selfy's field value must be exactly 2 (not 1).
+    await store.createNote("Selfy", { id: "selfy" });
+    await store.createNote("Plain", { id: "plain" });
+    await store.createNote("Zero", { id: "zero" });
+    await store.createLink("selfy", "selfy", "loop"); // degree 2
+    await store.createLink("zero", "plain", "ref"); // plain inbound 1, zero outbound 1
+
+    const { ordered, degrees } = await assertFieldEqualsSortOrder("desc");
+    // selfy degree 2 is the max → first.
+    expect(ordered[0]!.id).toBe("selfy");
+    expect(degrees.get("selfy")).toBe(2);
+    // The field value (2) equals the sort key — selfy outranks plain/zero
+    // (both degree 1) precisely because the order_by subquery also counts
+    // the self-loop twice. A single OR-COUNT would have made it 1 and tied.
+    expect(degrees.get("plain")).toBe(1);
+    expect(degrees.get("zero")).toBe(1);
+  });
+
+  it("created_at is the stable tiebreaker among equal degrees", async () => {
+    // Three zero-degree notes; descending order falls back to created_at
+    // descending (the tiebreaker honors direction).
+    await store.createNote("First", { id: "first", created_at: "2026-01-01T00:00:00.000Z" });
+    await store.createNote("Second", { id: "second", created_at: "2026-01-02T00:00:00.000Z" });
+    await store.createNote("Third", { id: "third", created_at: "2026-01-03T00:00:00.000Z" });
+    const desc = await store.queryNotes({ orderBy: "link_count", sort: "desc" });
+    expect(desc.map((n) => n.id)).toEqual(["third", "second", "first"]);
+    const asc = await store.queryNotes({ orderBy: "link_count", sort: "asc" });
+    expect(asc.map((n) => n.id)).toEqual(["first", "second", "third"]);
+  });
+
+  it("does NOT require the field to be indexed (pseudo-field bypass)", async () => {
+    await store.createNote("A", { id: "a" });
+    // Would throw FIELD_NOT_INDEXED if it routed through requireIndexedField.
+    const results = await store.queryNotes({ orderBy: "link_count" });
+    expect(results.length).toBe(1);
+  });
+});
+
+describe("query-notes MCP surface: include_link_count", () => {
+  async function seed() {
+    await store.createNote("Hub", { id: "hub" });
+    await store.createNote("Leaf", { id: "leaf" });
+    await store.createNote("Self", { id: "self" });
+    await store.createLink("hub", "leaf", "a"); // hub out 1, leaf in 1
+    await store.createLink("leaf", "hub", "b"); // hub in 1, leaf out 1 => both degree 2
+    await store.createLink("self", "self", "loop"); // self degree 2
+  }
+
+  it("list mode: include_link_count injects linkCount; absent flag → no key", async () => {
+    await seed();
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+
+    const withCount = (await query.execute({ include_link_count: true })) as any[];
+    const hub = withCount.find((n) => n.id === "hub");
+    expect(hub.linkCount).toBe(2);
+    const self = withCount.find((n) => n.id === "self");
+    expect(self.linkCount).toBe(2); // self-loop = 2
+
+    const without = (await query.execute({})) as any[];
+    expect(without.every((n) => !("linkCount" in n))).toBe(true);
+  });
+
+  it("single-note mode: include_link_count → correct degree", async () => {
+    await seed();
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = (await query.execute({ id: "self", include_link_count: true })) as any;
+    expect(result.linkCount).toBe(2);
+  });
+
+  it("direction variants on the MCP surface", async () => {
+    await seed();
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const out = (await query.execute({
+      id: "hub",
+      include_link_count: true,
+      link_count_direction: "outbound",
+    })) as any;
+    expect(out.linkCount).toBe(1); // hub→leaf only
+    const inb = (await query.execute({
+      id: "hub",
+      include_link_count: true,
+      link_count_direction: "inbound",
+    })) as any;
+    expect(inb.linkCount).toBe(1); // leaf→hub only
+  });
+
+  it("note with 0 links → linkCount: 0", async () => {
+    await store.createNote("Lonely", { id: "lonely" });
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = (await query.execute({ id: "lonely", include_link_count: true })) as any;
+    expect(result.linkCount).toBe(0);
+  });
+
+  it("order_by=link_count over MCP: field value == sort key for every note", async () => {
+    await seed();
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const ordered = (await query.execute({
+      order_by: "link_count",
+      sort: "desc",
+      include_link_count: true,
+    })) as any[];
+    // Every note carries linkCount, and the sequence is non-increasing.
+    const seq = ordered.map((n) => n.linkCount as number);
+    expect(seq).toEqual([...seq].sort((a, b) => b - a));
+    // hub (2), leaf (2), self (2) all degree 2 here.
+    for (const n of ordered) expect(typeof n.linkCount).toBe("number");
+  });
+});

--- a/core/src/link-count.test.ts
+++ b/core/src/link-count.test.ts
@@ -140,14 +140,33 @@ describe("order_by=link_count (engine)", () => {
     expect(ordered.map((n) => n.id)).toEqual(["hub", "mid", "leaf"]);
   });
 
-  it("sorts ascending too", async () => {
-    await store.createNote("Hub", { id: "hub" });
-    await store.createNote("Leaf", { id: "leaf" });
-    await store.createLink("hub", "leaf", "a");
-    const { ordered } = await assertFieldEqualsSortOrder("asc");
-    // leaf degree 1, hub degree 1 — both 1 here; just assert monotonic + the
-    // tiebreaker keeps a deterministic order (created_at asc => hub first).
-    expect(ordered.length).toBe(2);
+  it("sorts ascending with DISTINCT degrees: non-decreasing sequence, pinned IDs", async () => {
+    // Distinct degrees so ascending order is unambiguous (not just the
+    // tiebreaker case): low=0, mid=1, high=2. This genuinely pins
+    // field==sort-key for the ascending path.
+    await store.createNote("Low", { id: "low" }); // degree 0
+    await store.createNote("Mid", { id: "mid" }); // degree 1
+    await store.createNote("High", { id: "high" }); // degree 2
+    await store.createNote("Other", { id: "other" }); // link partner
+    await store.createLink("mid", "other", "a"); // mid out 1 => degree 1
+    await store.createLink("high", "other", "b"); // high out 1
+    await store.createLink("other", "high", "c"); // high in 1 => degree 2
+    // (other: out 1 + in 1 + in 1 = degree 3, sits above all — fine, we
+    // assert the low/mid/high prefix explicitly below.)
+
+    const { ordered, degrees } = await assertFieldEqualsSortOrder("asc");
+    const seq = ordered.map((n) => degrees.get(n.id) ?? 0);
+    // Non-decreasing (assertFieldEqualsSortOrder already checks this; assert
+    // explicitly here too for the distinct-degree case).
+    for (let i = 1; i < seq.length; i++) {
+      expect(seq[i]!).toBeGreaterThanOrEqual(seq[i - 1]!);
+    }
+    // Ascending: the three distinct-degree notes appear in 0,1,2 order.
+    expect(ordered.map((n) => n.id)).toEqual(["low", "mid", "high", "other"]);
+    expect(degrees.get("low")).toBe(0);
+    expect(degrees.get("mid")).toBe(1);
+    expect(degrees.get("high")).toBe(2);
+    expect(degrees.get("other")).toBe(3);
   });
 
   it("self-loop: linkCount==2 AND its order_by position matches that 2", async () => {
@@ -240,6 +259,20 @@ describe("query-notes MCP surface: include_link_count", () => {
       link_count_direction: "inbound",
     })) as any;
     expect(inb.linkCount).toBe(1); // leaf→hub only
+  });
+
+  it("unrecognized link_count_direction falls back to both (MCP normalizeLinkCountDirection)", async () => {
+    await seed();
+    const tools = generateMcpTools(store);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    // hub: both=2, outbound=1, inbound=1. A bogus value must degrade to
+    // `both` (2), distinct from either directional value (1).
+    const result = (await query.execute({
+      id: "hub",
+      include_link_count: true,
+      link_count_direction: "sideways",
+    })) as any;
+    expect(result.linkCount).toBe(2);
   });
 
   it("note with 0 links → linkCount: 0", async () => {

--- a/core/src/links.ts
+++ b/core/src/links.ts
@@ -165,6 +165,83 @@ export function getLinksHydrated(
   }));
 }
 
+/**
+ * Batch link-degree counter (vault feedback #4).
+ *
+ * Returns the link **degree** (raw row count) for each requested note id,
+ * never materializing link rows. Degree is defined as a sum of two
+ * directional row counts:
+ *
+ *   - `outbound` = `COUNT(*) FROM links WHERE source_id = id`
+ *   - `inbound`  = `COUNT(*) FROM links WHERE target_id = id`
+ *   - `both`     = outbound + inbound   (default)
+ *
+ * It is a **row count**, matching `getVaultStats.linkCount` (notes.ts):
+ * two typed links A→B (different `relationship`) count as 2, and a
+ * **self-loop** (source_id == target_id) counts as **degree 2** under
+ * `both` — once via the outbound query, once via the inbound query.
+ *
+ * ⚠️ This directional-sum definition MUST stay identical to the
+ * `order_by=link_count` sort key in `queryNotes` (notes.ts), which uses
+ * `(SELECT COUNT(*) ... source_id=n.id) + (SELECT COUNT(*) ... target_id=n.id)`.
+ * A single `COUNT(*) ... WHERE source_id=id OR target_id=id` would count a
+ * self-loop ONCE and diverge — do NOT use that shape here.
+ *
+ * Each direction is one grouped query over an existing B-tree index
+ * (`idx_links_source` / `idx_links_target`), so the whole page costs at
+ * most two index scans regardless of page size. The IN-list is chunked to
+ * stay under SQLite's bound-variable limit on very large pages.
+ *
+ * Returns 0 for ids with no links (every requested id is present in the map).
+ */
+export function getLinkCounts(
+  db: Database,
+  noteIds: string[],
+  direction: "both" | "outbound" | "inbound" = "both",
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  if (noteIds.length === 0) return counts;
+
+  // Dedupe so a repeated id doesn't inflate the IN-list or get summed twice
+  // when the same chunk runs the outbound + inbound grouped queries.
+  const ids = [...new Set(noteIds)];
+  for (const id of ids) counts.set(id, 0);
+
+  const wantOutbound = direction === "outbound" || direction === "both";
+  const wantInbound = direction === "inbound" || direction === "both";
+
+  // SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999 on older builds and
+  // 32766 on newer ones; chunk well under the conservative floor so the
+  // IN-list never trips the bind limit on a large page.
+  const CHUNK = 900;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const chunk = ids.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(", ");
+
+    if (wantOutbound) {
+      const rows = db.prepare(
+        `SELECT source_id AS id, COUNT(*) AS c FROM links
+         WHERE source_id IN (${placeholders}) GROUP BY source_id`,
+      ).all(...chunk) as { id: string; c: number }[];
+      for (const row of rows) {
+        counts.set(row.id, (counts.get(row.id) ?? 0) + row.c);
+      }
+    }
+
+    if (wantInbound) {
+      const rows = db.prepare(
+        `SELECT target_id AS id, COUNT(*) AS c FROM links
+         WHERE target_id IN (${placeholders}) GROUP BY target_id`,
+      ).all(...chunk) as { id: string; c: number }[];
+      for (const row of rows) {
+        counts.set(row.id, (counts.get(row.id) ?? 0) + row.c);
+      }
+    }
+  }
+
+  return counts;
+}
+
 // ---- Deeper Link Queries ----
 
 export interface TraversalNode {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -178,7 +178,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             type: "object",
             description: "Filter by metadata values. Each value is either a primitive (exact match, scans JSON) or an operator object: `{eq|ne|gt|gte|lt|lte|in|not_in|exists: value}`. Operator objects require the field to be declared `indexed: true` in a tag schema — they route through the backing B-tree index. Multiple operators on one field AND together (e.g. `{gt: 5, lt: 10}`). `in`/`not_in` take arrays; `exists` takes a boolean.",
           },
-          order_by: { type: "string", description: "Sort by an indexed metadata field instead of `created_at`. Field must be declared `indexed: true`; errors otherwise. Direction is taken from `sort` (default 'asc'); `created_at` is appended as a stable tiebreaker." },
+          order_by: { type: "string", description: "Sort by an indexed metadata field instead of `created_at`. Field must be declared `indexed: true`; errors otherwise. The special value `link_count` sorts by link DEGREE (both-directions raw row count) — no declaration needed — matching the `include_link_count` field for every note. Direction is taken from `sort` (default 'asc'); `created_at` is appended as a stable tiebreaker." },
           date_from: { type: "string", description: "Start date (ISO, inclusive). Filters on `created_at` (vault ingestion time). Shorthand for `date_filter: { field: 'created_at', from }`." },
           date_to: { type: "string", description: "End date (ISO, exclusive). Filters on `created_at` (vault ingestion time). Shorthand for `date_filter: { field: 'created_at', to }`." },
           date_filter: {
@@ -217,6 +217,17 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             description: "Control metadata in response: true (all, default), false (none), or array of field names to include",
           },
           include_links: { type: "boolean", description: "Include inbound + outbound links per note (default: false)" },
+          include_link_count: {
+            type: "boolean",
+            description:
+              "Include the note's link DEGREE as a `linkCount` field, without hauling the link objects (default: false). Degree is a raw row count: outbound (source) + inbound (target). A self-loop counts as 2. Cheap COUNT over indexes; batched once per request. For a tag-scoped token, `linkCount` is the raw degree and MAY include edges to notes the token can't see — only the number leaks, not the neighbor.",
+          },
+          link_count_direction: {
+            type: "string",
+            enum: ["both", "outbound", "inbound"],
+            description:
+              "Which edges `include_link_count` counts: both (default), outbound only (source_id), or inbound only (target_id). order_by=link_count always uses the both-directions degree.",
+          },
           include_attachments: { type: "boolean", description: "Include attachment records (default: false)" },
           expand_links: { type: "boolean", description: "Inline [[wikilinks]] in returned content (default: false). Has no effect if content is not included (e.g., default list mode with include_content=false); wikilinks inside fenced or inline code are not expanded." },
           expand_depth: { type: "number", description: "Recursion depth for link expansion (default 1, max 3). Only meaningful in 'full' mode — 'summary' mode does not recurse." },
@@ -255,6 +266,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           }
           if (params.include_attachments) {
             result.attachments = await store.getAttachments(note.id);
+          }
+          if (params.include_link_count) {
+            const dir = normalizeLinkCountDirection(params.link_count_direction);
+            result.linkCount = linkOps.getLinkCounts(db, [note.id], dir).get(note.id) ?? 0;
           }
           return result;
         }
@@ -388,6 +403,16 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         // --- Apply metadata filtering ---
         if (includeMetadata !== undefined && includeMetadata !== true) {
           output = output.map((n: any) => filterMetadata(n, includeMetadata));
+        }
+
+        // --- Opt-in link degree (vault feedback #4) ---
+        // ONE batch count over all result ids (NOT per-note), so the field
+        // stays O(2 index scans) per request regardless of page size.
+        // Injected on the same objects the enrichment loop copies below.
+        if (params.include_link_count) {
+          const dir = normalizeLinkCountDirection(params.link_count_direction);
+          const counts = linkOps.getLinkCounts(db, output.map((n: any) => n.id), dir);
+          for (const n of output) n.linkCount = counts.get(n.id) ?? 0;
         }
 
         // --- Hydrate links/attachments per note if requested ---
@@ -1418,6 +1443,16 @@ function normalizeTags(tag: unknown): string[] | undefined {
   // the original `params` object untouched.
   if (Array.isArray(tag)) return [...tag];
   return [tag as string];
+}
+
+/**
+ * Coerce the `link_count_direction` MCP param to a known value, defaulting
+ * to "both" (matches the REST `parseLinkCountDirection` fallback). A typo
+ * silently degrades to the documented default rather than erroring.
+ */
+function normalizeLinkCountDirection(v: unknown): "both" | "outbound" | "inbound" {
+  if (v === "outbound" || v === "inbound") return v;
+  return "both";
 }
 
 // Re-exported for backward compat; defined in notes.ts alongside the

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -267,6 +267,8 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           if (params.include_attachments) {
             result.attachments = await store.getAttachments(note.id);
           }
+          // linkCount injected after filterMetadata on purpose — same as
+          // links/attachments above; filterMetadata only touches `metadata`.
           if (params.include_link_count) {
             const dir = normalizeLinkCountDirection(params.link_count_direction);
             result.linkCount = linkOps.getLinkCounts(db, [note.id], dir).get(note.id) ?? 0;
@@ -409,6 +411,9 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         // ONE batch count over all result ids (NOT per-note), so the field
         // stays O(2 index scans) per request regardless of page size.
         // Injected on the same objects the enrichment loop copies below.
+        // Ordering: runs AFTER the filterMetadata pass above on purpose —
+        // filterMetadata only touches the `metadata` key, so linkCount
+        // survives. Don't casually swap the order.
         if (params.include_link_count) {
           const dir = normalizeLinkCountDirection(params.link_count_direction);
           const counts = linkOps.getLinkCounts(db, output.map((n: any) => n.id), dir);

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -736,6 +736,32 @@ export function queryNotes(db: Database, opts: QueryOpts): Note[] {
     // be at the mercy of SQLite's row order and the next page could
     // miss or duplicate one.
     orderBy = "n.updated_at ASC, n.id ASC";
+  } else if (opts.orderBy === "link_count") {
+    // `link_count` is a pseudo-field — like `created_at`/`updated_at` in the
+    // dateFilter block above, it bypasses `requireIndexedField` (it's not a
+    // metadata column). Sort by link DEGREE using the SAME directional-sum
+    // definition as the `linkCount` response field (see `getLinkCounts` in
+    // links.ts): two correlated COUNT subqueries summed. This MUST stay a
+    // sum of two directional counts — a single
+    // `COUNT(*) ... WHERE source_id=n.id OR target_id=n.id` would count a
+    // self-loop ONCE (degree 1) and DIVERGE from the field's degree-2. Both
+    // subqueries ride the existing `idx_links_source` / `idx_links_target`
+    // B-trees. `created_at` stays the stable tiebreaker.
+    //
+    // Always the both-directions degree — inbound-only ordering is a future
+    // extension and is not built here.
+    //
+    // Perf caveat: these are correlated subqueries, evaluated once per
+    // candidate row. At small-to-moderate vault sizes (tens of thousands of
+    // notes) that's fine — each subquery is an O(log n) index probe. At very
+    // large vault sizes the per-row scan cost grows; the upgrade path is a
+    // maintained `link_count` counter column on `notes`, incremented in
+    // `createLink` and decremented in `deleteLink`, then ordered directly.
+    // NOT built now — flagged so a future contributor sees the lever.
+    orderBy =
+      `((SELECT COUNT(*) FROM links WHERE source_id = n.id) ` +
+      `+ (SELECT COUNT(*) FROM links WHERE target_id = n.id)) ${direction}, ` +
+      `n.created_at ${direction}`;
   } else if (opts.orderBy) {
     requireIndexedField(db, opts.orderBy);
     // `orderBy` came from indexed_fields (validated on declaration), so

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -25,6 +25,14 @@ export interface Note {
   updatedAt?: string;
   tags?: string[];
   links?: Link[];
+  /**
+   * Opt-in link degree (raw row count, both directions by default). Present
+   * only when the caller requests it via `include_link_count` (REST/MCP).
+   * Surfaced the same way `links`/`attachments` are — an extra key injected
+   * onto the response after the base shape. See `getLinkCounts` in links.ts
+   * for the exact degree semantics (self-loop = 2 under `both`).
+   */
+  linkCount?: number;
 }
 
 // ---- Link ----
@@ -115,6 +123,12 @@ export interface QueryOpts {
   // declared `indexed: true`; errors loudly otherwise. Direction is taken
   // from `sort` (default "asc") and `created_at` is appended as a stable
   // tiebreaker.
+  //
+  // The pseudo-field `link_count` is special-cased (no indexed-field
+  // declaration needed): it sorts by link DEGREE — the both-directions
+  // raw row count — using the same directional-sum definition as the
+  // `linkCount` response field, so the sort key equals the field value for
+  // every note (self-loops included). See `queryNotes`/`getLinkCounts`.
   orderBy?: string;
   limit?: number;
   offset?: number;
@@ -153,6 +167,8 @@ export interface NoteSummary {
   createdAt: string;
   updatedAt?: string;
   tags?: string[];
+  /** Opt-in link degree (see `Note.linkCount`). */
+  linkCount?: number;
 }
 
 /**
@@ -169,6 +185,8 @@ export interface NoteIndex {
   metadata?: Record<string, unknown>;
   byteSize: number;
   preview: string;
+  /** Opt-in link degree (see `Note.linkCount`). */
+  linkCount?: number;
 }
 
 /** Link with hydrated note summaries. */

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -75,6 +75,11 @@ function parseQuery(url: URL, key: string): string | null {
  * Parse `link_count_direction` (vault feedback #4). Defaults to "both";
  * anything other than the three known values falls back to "both" so a
  * typo silently degrades to the documented default rather than erroring.
+ *
+ * Tag-scope note (symmetric with the MCP param description): `linkCount`
+ * is a raw degree that MAY include edges to notes a tag-scoped token can't
+ * see — the tag-scope filter runs post-query, over the result notes, not
+ * their neighbors. Only the number leaks, not the neighbor.
  */
 function parseLinkCountDirection(url: URL): "both" | "outbound" | "inbound" {
   const v = url.searchParams.get("link_count_direction");
@@ -574,6 +579,8 @@ async function handleNotesInner(
         if (parseBool(parseQuery(url, "include_attachments"), false)) {
           result.attachments = await store.getAttachments(note.id);
         }
+        // linkCount injected after filterMetadata on purpose — same as
+        // links/attachments above; filterMetadata only touches `metadata`.
         if (parseBool(parseQuery(url, "include_link_count"), false)) {
           result.linkCount = linkOps.getLinkCounts(db, [note.id], parseLinkCountDirection(url)).get(note.id) ?? 0;
         }
@@ -620,7 +627,9 @@ async function handleNotesInner(
           output = output.map((n: any) => filterMetadata(n, inclMeta));
         }
         // Opt-in link degree (vault feedback #4) — one batch count, same as
-        // the structured-query path.
+        // the structured-query path. Runs AFTER filterMetadata on purpose
+        // (filterMetadata only touches `metadata`, so linkCount survives —
+        // don't casually swap the order).
         if (parseBool(parseQuery(url, "include_link_count"), false)) {
           const counts = linkOps.getLinkCounts(
             db,
@@ -813,6 +822,11 @@ async function handleNotesInner(
       // scans) per request regardless of page size. Mutates `output` in
       // place; injected on the same objects the enrichment loop below
       // touches, the same way `links`/`attachments` are surfaced.
+      // Ordering: this runs AFTER the filterMetadata pass above on purpose —
+      // filterMetadata only touches the `metadata` key, so a linkCount
+      // injected here survives. Don't casually swap the order; injecting
+      // before filterMetadata would still survive today but couples the two
+      // to filterMetadata's current narrow behavior.
       if (includeLinkCount) {
         const counts = linkOps.getLinkCounts(
           db,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -71,6 +71,17 @@ function parseQuery(url: URL, key: string): string | null {
   return url.searchParams.get(key);
 }
 
+/**
+ * Parse `link_count_direction` (vault feedback #4). Defaults to "both";
+ * anything other than the three known values falls back to "both" so a
+ * typo silently degrades to the documented default rather than erroring.
+ */
+function parseLinkCountDirection(url: URL): "both" | "outbound" | "inbound" {
+  const v = url.searchParams.get("link_count_direction");
+  if (v === "outbound" || v === "inbound") return v;
+  return "both";
+}
+
 function parseQueryList(url: URL, key: string): string[] | undefined {
   const val = url.searchParams.get(key);
   return val ? val.split(",") : undefined;
@@ -563,6 +574,9 @@ async function handleNotesInner(
         if (parseBool(parseQuery(url, "include_attachments"), false)) {
           result.attachments = await store.getAttachments(note.id);
         }
+        if (parseBool(parseQuery(url, "include_link_count"), false)) {
+          result.linkCount = linkOps.getLinkCounts(db, [note.id], parseLinkCountDirection(url)).get(note.id) ?? 0;
+        }
         return json(result);
       }
 
@@ -604,6 +618,16 @@ async function handleNotesInner(
         }
         if (inclMeta !== undefined && inclMeta !== true) {
           output = output.map((n: any) => filterMetadata(n, inclMeta));
+        }
+        // Opt-in link degree (vault feedback #4) — one batch count, same as
+        // the structured-query path.
+        if (parseBool(parseQuery(url, "include_link_count"), false)) {
+          const counts = linkOps.getLinkCounts(
+            db,
+            output.map((n: any) => n.id),
+            parseLinkCountDirection(url),
+          );
+          for (const n of output) n.linkCount = counts.get(n.id) ?? 0;
         }
         return json(output);
       }
@@ -769,6 +793,7 @@ async function handleNotesInner(
       const includeContent = parseBool(parseQuery(url, "include_content"), false);
       const includeLinks = parseBool(parseQuery(url, "include_links"), false);
       const includeAttachments = parseBool(parseQuery(url, "include_attachments"), false);
+      const includeLinkCount = parseBool(parseQuery(url, "include_link_count"), false);
       const inclMeta = parseIncludeMetadata(url);
       let output: any[] = includeContent ? results.map((n) => ({ ...n })) : results.map(toNoteIndex);
       const expand = parseExpandParams(url, db);
@@ -782,6 +807,19 @@ async function handleNotesInner(
       }
       if (inclMeta !== undefined && inclMeta !== true) {
         output = output.map((n: any) => filterMetadata(n, inclMeta));
+      }
+      // Opt-in link degree (vault feedback #4). ONE batch count over all
+      // result ids — NOT a per-note query — so the field stays O(2 index
+      // scans) per request regardless of page size. Mutates `output` in
+      // place; injected on the same objects the enrichment loop below
+      // touches, the same way `links`/`attachments` are surfaced.
+      if (includeLinkCount) {
+        const counts = linkOps.getLinkCounts(
+          db,
+          output.map((n: any) => n.id),
+          parseLinkCountDirection(url),
+        );
+        for (const n of output) n.linkCount = counts.get(n.id) ?? 0;
       }
 
       // Graph format — reshape into { nodes, edges }
@@ -1070,6 +1108,9 @@ async function handleNotesInner(
     }
     if (parseBool(parseQuery(url, "include_attachments"), false)) {
       result.attachments = await store.getAttachments(note.id);
+    }
+    if (parseBool(parseQuery(url, "include_link_count"), false)) {
+      result.linkCount = linkOps.getLinkCounts(db, [note.id], parseLinkCountDirection(url)).get(note.id) ?? 0;
     }
     return json(result);
   }

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -3131,6 +3131,44 @@ describe("HTTP /notes include_link_count + order_by=link_count (vault feedback #
     expect(((await inb.json()) as any).linkCount).toBe(1); // leaf→hub
   });
 
+  test("unrecognized link_count_direction falls back to both (REST parseLinkCountDirection)", async () => {
+    await seed();
+    // hub: both=2, outbound=1, inbound=1. A bogus value must degrade to
+    // `both` (2), distinct from either directional value (1).
+    const res = await handleNotes(
+      mkReq("GET", "/notes?id=hub&include_link_count=true&link_count_direction=sideways"),
+      store,
+      "",
+    );
+    expect(((await res.json()) as any).linkCount).toBe(2);
+  });
+
+  test("FTS branch: search + include_link_count → results carry linkCount", async () => {
+    // The full-text-search branch is a separate return path from the
+    // structured query; exercise the flag there explicitly.
+    await store.createNote("quokka sighting near the hub", { id: "fts-hub", path: "fts-hub" });
+    await store.createNote("a quokka friend", { id: "fts-friend", path: "fts-friend" });
+    await store.createLink("fts-hub", "fts-friend", "a"); // hub out1, friend in1
+    await store.createLink("fts-friend", "fts-hub", "b"); // hub in1 => hub degree 2
+    const res = await handleNotes(
+      mkReq("GET", "/notes?search=quokka&include_link_count=true"),
+      store,
+      "",
+    );
+    const body = (await res.json()) as any[];
+    const byId = Object.fromEntries(body.map((n) => [n.id, n]));
+    expect(byId["fts-hub"].linkCount).toBe(2);
+    expect(byId["fts-friend"].linkCount).toBe(2);
+  });
+
+  test("FTS branch: absent flag → no linkCount key", async () => {
+    await store.createNote("quokka sighting near the hub", { id: "fts-hub", path: "fts-hub" });
+    await store.createLink("fts-hub", "fts-hub", "loop");
+    const res = await handleNotes(mkReq("GET", "/notes?search=quokka"), store, "");
+    const body = (await res.json()) as any[];
+    expect(body.every((n) => !("linkCount" in n))).toBe(true);
+  });
+
   test("order_by=link_count desc: field value == sort key for every note", async () => {
     // Distinct degrees so the ordering is unambiguous: big=3, mid=2, small=0.
     await store.createNote("Big", { id: "big", path: "big" });

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -3065,6 +3065,117 @@ describe("HTTP /notes", async () => {
   });
 });
 
+describe("HTTP /notes include_link_count + order_by=link_count (vault feedback #4)", async () => {
+  // Mirrors the MCP-surface tests in core/src/link-count.test.ts on the
+  // same fixtures so REST and MCP agree on the degree semantics.
+  async function seed() {
+    await store.createNote("Hub", { id: "hub", path: "hub", tags: ["t"] });
+    await store.createNote("Leaf", { id: "leaf", path: "leaf", tags: ["t"] });
+    await store.createNote("Self", { id: "self", path: "self", tags: ["t"] });
+    await store.createLink("hub", "leaf", "a"); // hub out 1, leaf in 1
+    await store.createLink("leaf", "hub", "b"); // hub in 1, leaf out 1 => both degree 2
+    await store.createLink("self", "self", "loop"); // self-loop => degree 2
+  }
+
+  test("list mode: include_link_count injects linkCount (both directions)", async () => {
+    await seed();
+    const res = await handleNotes(mkReq("GET", "/notes?include_link_count=true"), store, "");
+    const body = (await res.json()) as any[];
+    const byId = Object.fromEntries(body.map((n) => [n.id, n]));
+    expect(byId.hub.linkCount).toBe(2);
+    expect(byId.leaf.linkCount).toBe(2);
+    expect(byId.self.linkCount).toBe(2); // self-loop = 2
+  });
+
+  test("absent flag → no linkCount key (no behavior change)", async () => {
+    await seed();
+    const res = await handleNotes(mkReq("GET", "/notes"), store, "");
+    const body = (await res.json()) as any[];
+    expect(body.every((n) => !("linkCount" in n))).toBe(true);
+  });
+
+  test("note with 0 links → linkCount: 0", async () => {
+    await store.createNote("Lonely", { id: "lonely", path: "lonely" });
+    const res = await handleNotes(mkReq("GET", "/notes?include_link_count=true"), store, "");
+    const body = (await res.json()) as any[];
+    expect(body.find((n) => n.id === "lonely").linkCount).toBe(0);
+  });
+
+  test("single-note (?id=) mode: include_link_count → correct degree", async () => {
+    await seed();
+    const res = await handleNotes(mkReq("GET", "/notes?id=self&include_link_count=true"), store, "");
+    const body = (await res.json()) as any;
+    expect(body.linkCount).toBe(2);
+  });
+
+  test("single-note (/notes/:id) mode: include_link_count → correct degree", async () => {
+    await seed();
+    const res = await handleNotes(mkReq("GET", "/notes/self?include_link_count=true"), store, "/self");
+    const body = (await res.json()) as any;
+    expect(body.linkCount).toBe(2);
+  });
+
+  test("link_count_direction outbound / inbound variants", async () => {
+    await seed();
+    const out = await handleNotes(
+      mkReq("GET", "/notes?id=hub&include_link_count=true&link_count_direction=outbound"),
+      store,
+      "",
+    );
+    expect(((await out.json()) as any).linkCount).toBe(1); // hub→leaf
+    const inb = await handleNotes(
+      mkReq("GET", "/notes?id=hub&include_link_count=true&link_count_direction=inbound"),
+      store,
+      "",
+    );
+    expect(((await inb.json()) as any).linkCount).toBe(1); // leaf→hub
+  });
+
+  test("order_by=link_count desc: field value == sort key for every note", async () => {
+    // Distinct degrees so the ordering is unambiguous: big=3, mid=2, small=0.
+    await store.createNote("Big", { id: "big", path: "big" });
+    await store.createNote("Mid", { id: "mid", path: "mid" });
+    await store.createNote("Small", { id: "small", path: "small" });
+    await store.createLink("big", "mid", "a"); // big out1, mid in1
+    await store.createLink("big", "small", "b"); // big out2, small in1
+    await store.createLink("mid", "big", "c"); // big in1 => big degree 3; mid out1 => mid degree 2
+    // small degree 1 (in from big). Adjust: make small degree 0 by removing
+    // — instead assert monotonic + field==sortkey, which is the real invariant.
+
+    const res = await handleNotes(
+      mkReq("GET", "/notes?order_by=link_count&sort=desc&include_link_count=true"),
+      store,
+      "",
+    );
+    const body = (await res.json()) as any[];
+    const seq = body.map((n) => n.linkCount as number);
+    // The injected field equals the sort key, so the sequence is non-increasing.
+    expect(seq).toEqual([...seq].sort((a, b) => b - a));
+    expect(body[0].id).toBe("big"); // degree 3 — the most-connected note
+    expect(body[0].linkCount).toBe(3);
+  });
+
+  test("order_by=link_count: self-loop note ranks by its degree-2 field value", async () => {
+    await store.createNote("Selfy", { id: "selfy", path: "selfy" });
+    await store.createNote("Plain", { id: "plain", path: "plain" });
+    await store.createNote("Zero", { id: "zero", path: "zero" });
+    await store.createLink("selfy", "selfy", "loop"); // degree 2
+    await store.createLink("zero", "plain", "ref"); // plain in1, zero out1
+
+    const res = await handleNotes(
+      mkReq("GET", "/notes?order_by=link_count&sort=desc&include_link_count=true"),
+      store,
+      "",
+    );
+    const body = (await res.json()) as any[];
+    expect(body[0].id).toBe("selfy"); // degree 2 outranks the degree-1 notes
+    expect(body[0].linkCount).toBe(2); // field == the sort key that put it first
+    const byId = Object.fromEntries(body.map((n) => [n.id, n]));
+    expect(byId.plain.linkCount).toBe(1);
+    expect(byId.zero.linkCount).toBe(1);
+  });
+});
+
 describe("HTTP GET /notes?format=graph", async () => {
   test("returns nodes and edges for linked notes", async () => {
     const a = await store.createNote("A", { id: "a", path: "People/Alice", tags: ["person"] });


### PR DESCRIPTION
## What

Gives callers a cheap way to read a note's link **degree** without hauling every link object, plus a "most-connected" sort. Resolves feedback #4.

- **A. opt-in `linkCount` field** on note responses (REST `include_link_count`, MCP `include_link_count`).
- **B. `order_by=link_count`** for degree-sorted ("most-connected") queries.

Degree is a cheap COUNT over the existing `idx_links_source` / `idx_links_target` B-trees — link rows are never materialized.

## Locked degree semantics

- **Degree = row count** = `(#rows where source_id = id) + (#rows where target_id = id)`. Matches `getVaultStats.linkCount` (`COUNT(*) FROM links`): two typed links A→B (different `relationship`) count as **2**.
- **Both directions by default.** `direction` (`link_count_direction` on both surfaces) is `both` (default) | `outbound` | `inbound`.
- **Self-loop = degree 2.** A row with `source_id == target_id` counts once as outbound and once as inbound, because the field is two directional counts summed.
- `order_by=link_count` always uses the **both-directions** degree (inbound-only ordering is a future extension; not built).

## field == order_by consistency guarantee

The field helper (`getLinkCounts`) and the `order_by=link_count` sort key use the **identical** directional-sum definition:

```sql
-- field (getLinkCounts, per direction, grouped + summed):
SELECT source_id AS id, COUNT(*) FROM links WHERE source_id IN (...) GROUP BY source_id   -- outbound
SELECT target_id AS id, COUNT(*) FROM links WHERE target_id IN (...) GROUP BY target_id   -- inbound

-- order_by (correlated subqueries, summed):
ORDER BY ((SELECT COUNT(*) FROM links WHERE source_id = n.id)
        + (SELECT COUNT(*) FROM links WHERE target_id = n.id)) <dir>, n.created_at <dir>
```

So the sort key equals the field value for **every** note — self-loops included. A single `COUNT(*) ... WHERE source_id=id OR target_id=id` would count a self-loop **once** (degree 1) and **diverge** from the field's degree-2; we deliberately do NOT use that shape. Pinned by self-loop fixture tests on both surfaces asserting field == sort order. `created_at` stays the stable tiebreaker and honors the sort direction.

## Batched-count perf design

The field does **ONE batch `getLinkCounts` call over all result ids per request** (not per-note N+1) — two grouped index scans regardless of page size. The IN-list is chunked at 900/chunk to stay under SQLite's bound-variable limit on very large pages. Verified by a >chunk-size (1000-note) batch-correctness test.

## Correlated-subquery caveat + upgrade path

`order_by=link_count` uses correlated subqueries evaluated once per candidate row — O(log n) index probes each, fine at tens of thousands of notes. At very large vault sizes the per-row scan cost grows. A code comment flags the upgrade path: a maintained `link_count` counter column on `notes`, incremented in `createLink` / decremented in `deleteLink`, then ordered directly. **Not built now** — flagged so a future contributor sees the lever.

## Tag-scope note

`link_count` is a **raw degree** that MAY include edges to notes a tag-scoped token can't see (the tag-scope filter runs post-query). Only the **number** leaks, not the neighbor. Documented on the MCP param description.

## Surface wiring

- **REST** (`src/routes.ts`): `include_link_count` + `link_count_direction` parsed; `linkCount` injected at the list loop, the full-text-search branch, and both single-note blocks (`?id=` and `/notes/:idOrPath`). One batch call per request.
- **MCP** (`core/src/mcp.ts`): `include_link_count` + `link_count_direction` added to the `query-notes` inputSchema and injected in the list loop + single-note block. One batch call per request.
- **Types** (`core/src/types.ts`): `linkCount?: number` on `Note`, `NoteSummary`, `NoteIndex`.

## Tests

- **core helper:** both/outbound/inbound, 0-link, empty list, self-loop=2, relationship multiplicity, dedupe, >chunk-size batch correctness.
- **engine order_by:** asc/desc, **field value == sort key for every note**, self-loop ranks by its degree-2 value, `created_at` tiebreaker, pseudo-field bypass (no indexed-field declaration needed).
- **REST + MCP surfaces** on the same fixtures (so they agree): list + single-note injection, absent-flag → no `linkCount` key, direction variants, order_by + self-loop ranking.

## Gates

- `bun run typecheck` — clean
- `bun test ./core/src/` — 663 pass / 0 fail
- `bun test ./src/` — 1299 pass / 0 fail

No version bump (per RC-when-ready policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)