### PR TITLE
feat(tags): relationships is an opaque vocabulary map (vault#428)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -5039,43 +5039,65 @@ describe("tag record API (patterns/tag-data-model.md)", async () => {
     expect(idxZebra).toBeGreaterThan(idxAlpha);
   });
 
-  it("update-tag MCP rejects an invalid cardinality", async () => {
+  // ---- relationships is an opaque vocabulary map (vault#428) ----
+  // Vault no longer enforces the historical { target_tag, cardinality }
+  // shape. Apps (the Weaver / structural-link picker) declare a freeform
+  // vocabulary; vault stores + returns it verbatim. The old typed shape is
+  // still a valid value, so the loosening is a backwards-compatible superset.
+
+  it("update-tag MCP persists the opaque relationship-vocabulary map verbatim (vault#428)", async () => {
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-tag")!;
+    const vocab = {
+      "works-on": { from: "person", to: "project" },
+      "member-of": { from: "person", to: "organization" },
+      "partner-of": { from: "person", to: "person" },
+      "based-at": { from: "project", to: "place" },
+    };
+    await update.execute({ tag: "person", relationships: vocab });
+    const r = await store.getTagRecord("person");
+    expect(r?.relationships).toEqual(vocab);
+  });
+
+  it("update-tag MCP round-trips nested arbitrary relationship values verbatim", async () => {
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-tag")!;
+    const vocab = {
+      rel: { from: "a", to: "b", note: "freeform", weight: 3, optional: true, tags: ["x", "y"] },
+    };
+    await update.execute({ tag: "thing", relationships: vocab });
+    const r = await store.getTagRecord("thing");
+    expect(r?.relationships).toEqual(vocab);
+  });
+
+  it("update-tag MCP still accepts the historical typed shape (backwards-compat)", async () => {
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-tag")!;
+    const typed = { owned_by: { target_tag: "person", cardinality: "one", description: "DRI" } };
+    await update.execute({ tag: "project", relationships: typed });
+    const r = await store.getTagRecord("project");
+    expect(r?.relationships).toEqual(typed);
+  });
+
+  it("update-tag MCP accepts what used to be rejected (no inner-shape enforcement)", async () => {
+    const tools = generateMcpTools(store);
+    const update = tools.find((t) => t.name === "update-tag")!;
+    // Formerly rejected: non-vocabulary cardinality + missing target_tag.
+    const formerlyInvalid = {
+      a: { target_tag: "person", cardinality: "bogus" },
+      b: { cardinality: "one" },
+    };
+    await update.execute({ tag: "loose", relationships: formerlyInvalid });
+    const r = await store.getTagRecord("loose");
+    expect(r?.relationships).toEqual(formerlyInvalid);
+  });
+
+  it("update-tag MCP rejects a top-level array for relationships (must be a map)", async () => {
     const tools = generateMcpTools(store);
     const update = tools.find((t) => t.name === "update-tag")!;
     await expect(
-      update.execute({
-        tag: "project",
-        relationships: {
-          owned_by: { target_tag: "person", cardinality: "bogus" },
-        },
-      }),
-    ).rejects.toThrow(/cardinality/);
-  });
-
-  it("update-tag MCP accepts every cardinality in the named vocabulary", async () => {
-    const tools = generateMcpTools(store);
-    const update = tools.find((t) => t.name === "update-tag")!;
-    for (const card of ["one", "optional", "many", "many-required"]) {
-      await update.execute({
-        tag: `tag-${card}`,
-        relationships: {
-          rel: { target_tag: "other", cardinality: card },
-        },
-      });
-      const r = await store.getTagRecord(`tag-${card}`);
-      expect(r?.relationships?.rel?.cardinality).toBe(card);
-    }
-  });
-
-  it("update-tag MCP rejects a relationship missing target_tag", async () => {
-    const tools = generateMcpTools(store);
-    const update = tools.find((t) => t.name === "update-tag")!;
-    await expect(
-      update.execute({
-        tag: "project",
-        relationships: { owned_by: { cardinality: "one" } },
-      }),
-    ).rejects.toThrow(/target_tag/);
+      update.execute({ tag: "project", relationships: ["not", "a", "map"] as unknown as Record<string, unknown> }),
+    ).rejects.toThrow();
   });
 
   it("update-tag MCP sets parent_names and the hierarchy invalidates", async () => {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1097,7 +1097,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
     {
       name: "update-tag",
       requiredVerb: "write",
-      description: "Create or update a tag's identity row: description, indexed-field schemas, typed-link relationships, and hierarchy parents. If the tag doesn't exist, it's created. Fields are merged (new keys added, existing keys replaced); relationships and parent_names are replaced wholesale when provided. Pass null for fields/relationships/parent_names to clear that column. See parachute-patterns/patterns/tag-data-model.md.",
+      description: "Create or update a tag's identity row: description, indexed-field schemas, relationship-vocabulary map, and hierarchy parents. If the tag doesn't exist, it's created. Fields are merged (new keys added, existing keys replaced); relationships and parent_names are replaced wholesale when provided. Pass null for fields/relationships/parent_names to clear that column. See parachute-patterns/patterns/tag-data-model.md.",
       inputSchema: {
         type: "object",
         properties: {

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -1119,16 +1119,8 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           },
           relationships: {
             type: "object",
-            description: 'Typed-link declarations. Each value declares { target_tag, cardinality, description? }. Cardinality is one of: one | optional | many | many-required. Phase 1: informational, not enforced at write time. E.g., { "lives_in": { "target_tag": "place", "cardinality": "one" } }',
-            additionalProperties: {
-              type: "object",
-              properties: {
-                target_tag: { type: "string", description: "Tag the relationship points at" },
-                cardinality: { type: "string", enum: ["one", "optional", "many", "many-required"], description: "How many targets this relationship may have" },
-                description: { type: "string", description: "Why this relationship exists; surfaced to AI clients" },
-              },
-              required: ["target_tag", "cardinality"],
-            },
+            description: 'Opaque relationship-vocabulary map: keys are relationship names, values are arbitrary JSON the declaring app interprets. Vault stores and returns the values verbatim and does NOT enforce any inner shape — only that this is a JSON object (a map), not an array or primitive. Replaces any prior map wholesale when provided; pass null to clear. The historical typed shape { "lives_in": { "target_tag": "place", "cardinality": "one" } } is still a valid value, as is any app-defined shape e.g. { "works-on": { "from": "person", "to": "project" } }.',
+            additionalProperties: true,
           },
           parent_names: {
             type: "array",
@@ -1192,10 +1184,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           }
         }
 
-        // ---- relationships: replace wholesale when provided. Validate
-        // shape + cardinality vocabulary before persisting so a malformed
-        // payload can't leave the row in an inconsistent state.
-        let relationshipsPatch: Record<string, tagSchemaOps.TagRelationship> | null | undefined;
+        // ---- relationships: replace wholesale when provided. `relationships`
+        // is an opaque vocabulary map (relationship-name → arbitrary JSON the
+        // app interprets). Validate only that it's a JSON object (a map), then
+        // persist verbatim — no inner-shape enforcement.
+        let relationshipsPatch: tagSchemaOps.TagRelationshipMap | null | undefined;
         if (params.relationships === null) {
           relationshipsPatch = null;
         } else if (params.relationships !== undefined) {

--- a/core/src/portable-md.test.ts
+++ b/core/src/portable-md.test.ts
@@ -794,6 +794,37 @@ describe("importPortableVault", async () => {
     expect(typed!.metadata).toEqual({ source: "git://x" });
   });
 
+  it("preserves an opaque relationship-vocabulary map across export → import → re-export (vault#428)", async () => {
+    const vocab = {
+      "works-on": { from: "person", to: "project" },
+      "member-of": { from: "person", to: "organization" },
+      "partner-of": { from: "person", to: "person" },
+      "based-at": { from: "project", to: "place", note: "freeform" },
+    };
+    await store.upsertTagRecord("person", {
+      description: "a human",
+      relationships: vocab,
+    });
+    const outDir = join(tmpBase, "out");
+    await exportVaultToDir(store, { outDir, exportedAt: "2026-05-13T00:00:00.000Z" });
+
+    const target = new SqliteStore(new Database(":memory:"));
+    const stats = await importPortableVault(target, { inDir: outDir });
+    expect(stats.schemas_restored).toBe(1);
+
+    // Imported value matches the original verbatim.
+    const restored = await target.getTagRecord("person");
+    expect(restored?.relationships).toEqual(vocab);
+
+    // Re-export from the restored store and confirm the schema file is
+    // byte-identical to the first export (deep round-trip stability).
+    const outDir2 = join(tmpBase, "out2");
+    await exportVaultToDir(target, { outDir: outDir2, exportedAt: "2026-05-13T00:00:00.000Z" });
+    const schemaA = readFileSync(join(outDir, SIDECAR_DIR, "schemas", "person.yaml"), "utf-8");
+    const schemaB = readFileSync(join(outDir2, SIDECAR_DIR, "schemas", "person.yaml"), "utf-8");
+    expect(schemaB).toBe(schemaA);
+  });
+
   it("skips typed links whose target is missing from the import set", async () => {
     // Source note has a typed link to a target we don't include in
     // the export (synthetic — write the .md file by hand).
@@ -861,6 +892,15 @@ describe("portable-md round-trip — byte-equivalent re-export after blow-away i
     await store.upsertTagSchema("project", {
       description: "A long-running effort",
       fields: { status: { type: "string", enum: ["active", "done"] } },
+    });
+    // Opaque relationship-vocabulary map (vault#428) — exercises that the
+    // round-trip preserves an arbitrary app-defined relationships shape,
+    // not just the historical { target_tag, cardinality } one.
+    await store.upsertTagRecord("project", {
+      relationships: {
+        "works-on": { from: "person", to: "project" },
+        "based-at": { from: "project", to: "place", note: "freeform" },
+      },
     });
     const n1 = await store.createNote("alpha body", {
       id: "01HX001",

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -30,10 +30,13 @@ CREATE TABLE IF NOT EXISTS notes (
 -- description    — human-readable blurb (markdown).
 -- fields         — JSON: indexed metadata field declarations per
 --                  query-operators.md. Replaces v6-era tag_schemas.fields.
--- relationships  — JSON: typed-link declarations
---                  ({ "rel": { target_tag, cardinality, description? } }).
---                  Cardinality vocabulary: one | optional | many | many-required.
---                  Phase 1 informational — declared but not enforced at write.
+-- relationships  — JSON: opaque relationship-vocabulary map. Keys are
+--                  relationship names; values are arbitrary JSON the declaring
+--                  app interprets (e.g. the Weaver's { "works-on": { from, to } }).
+--                  Stored + returned verbatim; only the top level is validated
+--                  (must be a JSON object/map). The historical typed shape
+--                  { "rel": { target_tag, cardinality, description? } } remains a
+--                  valid value. Not enforced at write time. See vault#428.
 -- parent_names   — JSON array of parent tag names. Replaces the v6-era
 --                  _tags/NAME config-note hierarchy.
 CREATE TABLE IF NOT EXISTS tags (

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -572,7 +572,7 @@ export class BunSqliteStore implements Store {
     patch: {
       description?: string | null;
       fields?: Record<string, tagSchemaOps.TagFieldSchema> | null;
-      relationships?: Record<string, tagSchemaOps.TagRelationship> | null;
+      relationships?: tagSchemaOps.TagRelationshipMap | null;
       parent_names?: string[] | null;
     },
   ) {

--- a/core/src/tag-schemas.ts
+++ b/core/src/tag-schemas.ts
@@ -33,10 +33,13 @@ export interface TagFieldSchema {
 }
 
 /**
- * Cardinality vocabulary for typed relationships. Names rather than
- * algebra so AI clients reading `list-tags` can reason about intent
- * directly. Phase 1 is informational — declarations are not enforced
- * at write time. See patterns/tag-data-model.md §Typed relationships.
+ * Cardinality vocabulary for the historical typed-relationship shape.
+ * Names rather than algebra so AI clients reading `list-tags` can reason
+ * about intent directly. Retained for callers that still want the typed
+ * `{ target_tag, cardinality }` declaration — but `relationships` is now an
+ * opaque vocabulary map (see `TagRelationshipMap` / `validateRelationships`),
+ * so this is one valid value shape among many, not a required one.
+ * See patterns/tag-data-model.md §Typed relationships.
  */
 export type TagRelCardinality = "one" | "optional" | "many" | "many-required";
 
@@ -47,11 +50,23 @@ export const TAG_REL_CARDINALITIES: readonly TagRelCardinality[] = [
   "many-required",
 ] as const;
 
+/**
+ * The historical typed-relationship declaration. Still a valid opaque-map
+ * value — vault no longer enforces it. New apps (the Weaver / structural-link
+ * picker) declare their own freeform vocabulary instead.
+ */
 export interface TagRelationship {
   target_tag: string;
   cardinality: TagRelCardinality;
   description?: string;
 }
+
+/**
+ * `relationships` is an opaque vocabulary map: relationship-name → arbitrary
+ * JSON value the declaring app interprets. Vault stores and returns the values
+ * verbatim and enforces only that the top-level value is a JSON object (a map).
+ */
+export type TagRelationshipMap = Record<string, unknown>;
 
 /**
  * Schema-only view of a tag — the historical shape. Backwards-compatible
@@ -67,7 +82,7 @@ export interface TagSchema {
  * Full tag record — schema + typed relationships + hierarchy parents.
  */
 export interface TagRecord extends TagSchema {
-  relationships?: Record<string, TagRelationship>;
+  relationships?: TagRelationshipMap;
   parent_names?: string[];
   created_at?: string;
   updated_at?: string;
@@ -115,7 +130,7 @@ export function upsertTagRecord(
   patch: {
     description?: string | null;
     fields?: Record<string, TagFieldSchema> | null;
-    relationships?: Record<string, TagRelationship> | null;
+    relationships?: TagRelationshipMap | null;
     parent_names?: string[] | null;
   },
 ): TagRecord {
@@ -226,56 +241,56 @@ export function deleteTagSchema(db: Database, tag: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Validation — typed relationships
+// Validation — relationships (opaque vocabulary map)
 // ---------------------------------------------------------------------------
 
 /**
- * Validate a `relationships` payload before persisting. Returns the
- * canonicalized object on success; throws Error with a user-readable
- * message on the first violation. Rules:
+ * Validate a `relationships` payload before persisting. `relationships` is
+ * an **opaque vocabulary map**: a JSON object whose keys are relationship
+ * names and whose values are arbitrary JSON the declaring app interprets
+ * (e.g. the Weaver / structural-link picker's `{ "works-on": { from, to } }`
+ * shape). Vault does not enforce any inner structure — it stores and returns
+ * the values verbatim.
  *
- *   - Each value must declare `target_tag` (non-empty string) and
- *     `cardinality` from the named vocabulary.
- *   - `description` is optional, must be a string when present.
- *   - Relationship keys must be non-empty strings.
+ * Rules (the only ones):
+ *   - The top-level value must be a plain JSON object (a map). A top-level
+ *     array or primitive is rejected — relationships is a map, not a list.
+ *   - The payload must be JSON-serializable (no circular refs / functions /
+ *     bigints), since it's persisted as a JSON column.
+ *
+ * Returns the value verbatim (round-trips through JSON.parse(JSON.stringify)
+ * to both prove serializability and strip anything non-serializable). The
+ * historical typed shape `{ target_tag, cardinality }` is a valid opaque map,
+ * so this is a backwards-compatible superset — existing typed declarations
+ * and callers keep working unchanged.
+ *
+ * Phase 1 was already informational ("declarations are not enforced at write
+ * time"); dropping the inner-shape gate is consistent with that intent.
  */
-export function validateRelationships(
-  raw: unknown,
-): Record<string, TagRelationship> {
+export function validateRelationships(raw: unknown): Record<string, unknown> {
   if (raw === null || raw === undefined) {
     throw new Error("relationships: expected an object, got null/undefined");
   }
   if (typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("relationships: expected an object mapping rel name → declaration");
+    throw new Error(
+      "relationships: expected an object mapping relationship name → value (got an array or primitive)",
+    );
   }
-  const out: Record<string, TagRelationship> = {};
-  for (const [rel, decl] of Object.entries(raw as Record<string, unknown>)) {
+  for (const rel of Object.keys(raw as Record<string, unknown>)) {
     if (!rel || typeof rel !== "string") {
       throw new Error("relationships: keys must be non-empty strings");
     }
-    if (!decl || typeof decl !== "object" || Array.isArray(decl)) {
-      throw new Error(`relationships["${rel}"]: declaration must be an object`);
-    }
-    const d = decl as Record<string, unknown>;
-    if (typeof d.target_tag !== "string" || d.target_tag.length === 0) {
-      throw new Error(`relationships["${rel}"]: target_tag must be a non-empty string`);
-    }
-    const card = d.cardinality;
-    if (typeof card !== "string" || !TAG_REL_CARDINALITIES.includes(card as TagRelCardinality)) {
-      throw new Error(
-        `relationships["${rel}"]: cardinality must be one of ${TAG_REL_CARDINALITIES.join(" | ")}; got ${JSON.stringify(card)}`,
-      );
-    }
-    if (d.description !== undefined && typeof d.description !== "string") {
-      throw new Error(`relationships["${rel}"]: description must be a string when set`);
-    }
-    out[rel] = {
-      target_tag: d.target_tag,
-      cardinality: card as TagRelCardinality,
-      ...(d.description !== undefined ? { description: d.description as string } : {}),
-    };
   }
-  return out;
+  // Round-trip through JSON to (a) confirm the payload is serializable —
+  // the column is stored as JSON — and (b) return a clean, owned copy with
+  // no non-JSON values lingering. Throws on circular refs / bigint / etc.
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(raw);
+  } catch (err) {
+    throw new Error(`relationships: value must be JSON-serializable (${(err as Error).message})`);
+  }
+  return JSON.parse(serialized) as Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -287,7 +302,7 @@ function rowToRecord(row: TagRow): TagRecord {
     tag: row.name,
     description: row.description ?? undefined,
     fields: parseJson<Record<string, TagFieldSchema>>(row.fields),
-    relationships: parseJson<Record<string, TagRelationship>>(row.relationships),
+    relationships: parseJson<TagRelationshipMap>(row.relationships),
     parent_names: parseJson<string[]>(row.parent_names),
     created_at: row.created_at ?? undefined,
     updated_at: row.updated_at ?? undefined,

--- a/core/src/tag-schemas.ts
+++ b/core/src/tag-schemas.ts
@@ -277,7 +277,7 @@ export function validateRelationships(raw: unknown): Record<string, unknown> {
     );
   }
   for (const rel of Object.keys(raw as Record<string, unknown>)) {
-    if (!rel || typeof rel !== "string") {
+    if (!rel) {
       throw new Error("relationships: keys must be non-empty strings");
     }
   }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,9 +1,9 @@
-import type { TagFieldSchema, TagRelationship, TagRecord } from "./tag-schemas.js";
+import type { TagFieldSchema, TagRelationship, TagRelationshipMap, TagRecord } from "./tag-schemas.js";
 import type { PrunedField } from "./indexed-fields.js";
 
 // ---- Re-exports ----
 
-export type { TagFieldSchema, TagRelationship, TagRecord } from "./tag-schemas.js";
+export type { TagFieldSchema, TagRelationship, TagRelationshipMap, TagRecord } from "./tag-schemas.js";
 export type { PrunedField } from "./indexed-fields.js";
 
 // ---- Note ----
@@ -331,7 +331,7 @@ export interface Store {
     patch: {
       description?: string | null;
       fields?: Record<string, TagFieldSchema> | null;
-      relationships?: Record<string, TagRelationship> | null;
+      relationships?: TagRelationshipMap | null;
       parent_names?: string[] | null;
     },
   ): Promise<TagRecord>;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1663,10 +1663,12 @@ export async function handleTags(
       parent_names?: unknown;
     };
 
-    // Validate relationships shape + cardinality vocabulary up front so
-    // a bad payload returns 400, not a thrown 500.
+    // Validate the relationships payload up front so a bad payload returns
+    // 400, not a thrown 500. `relationships` is an opaque vocabulary map
+    // (relationship-name → arbitrary JSON the app interprets); we only check
+    // that it's a JSON object (a map), then persist verbatim.
     let relationshipsPatch:
-      | Record<string, tagSchemaOps.TagRelationship>
+      | tagSchemaOps.TagRelationshipMap
       | null
       | undefined;
     if (body.relationships === null) {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -4165,6 +4165,19 @@ describe("HTTP /tags", async () => {
     expect(body.error_type).toBe("invalid_relationships");
   });
 
+  test("PUT /tags/:name returns 400 invalid_relationships for an empty relationship key", async () => {
+    const res = await handleTags(
+      mkReq("PUT", "/tags/person", { relationships: { "": { from: "a", to: "b" } } }),
+      store,
+      "/person",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("invalid_relationships");
+    expect(typeof body.error).toBe("string");
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+
   test("DELETE /tags/:name removes tag and schema", async () => {
     await store.createNote("A", { tags: ["doomed"] });
     await store.upsertTagSchema("doomed", { description: "will be deleted" });

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -4088,11 +4088,62 @@ describe("HTTP /tags", async () => {
     expect(buildVaultProjection(db).indexed_fields.map((f) => f.name)).toContain("aspect_ratio");
   });
 
-  test("PUT /tags/:name returns 400 with error_type: invalid_relationships on bad shape", async () => {
+  // ---- relationships is an opaque vocabulary map (vault#428) ----
+  // PUT persists the value verbatim with no inner-shape enforcement; GET
+  // returns it byte-for-byte. Only a top-level non-map (array/primitive)
+  // or non-serializable input is rejected with invalid_relationships.
+
+  test("PUT /tags/:name persists the opaque vocabulary map; GET returns it verbatim (vault#428)", async () => {
+    const vocab = {
+      "works-on": { from: "person", to: "project" },
+      "member-of": { from: "person", to: "organization" },
+      "partner-of": { from: "person", to: "person" },
+      "based-at": { from: "project", to: "place" },
+    };
+    const put = await handleTags(
+      mkReq("PUT", "/tags/person", { relationships: vocab }),
+      store,
+      "/person",
+    );
+    expect(put.status).toBe(200);
+
+    const get = await handleTags(mkReq("GET", "/tags/person"), store, "/person");
+    expect(get.status).toBe(200);
+    const body = await get.json() as any;
+    // Byte-for-byte: serialize both sides and compare exactly.
+    expect(JSON.stringify(body.relationships)).toBe(JSON.stringify(vocab));
+    expect(body.relationships).toEqual(vocab);
+  });
+
+  test("PUT /tags/:name still accepts the historical typed relationships shape (backwards-compat)", async () => {
+    const typed = { owned_by: { target_tag: "person", cardinality: "one", description: "DRI" } };
+    const put = await handleTags(
+      mkReq("PUT", "/tags/project", { relationships: typed }),
+      store,
+      "/project",
+    );
+    expect(put.status).toBe(200);
+    const get = await handleTags(mkReq("GET", "/tags/project"), store, "/project");
+    const body = await get.json() as any;
+    expect(body.relationships).toEqual(typed);
+  });
+
+  test("PUT /tags/:name round-trips nested arbitrary relationship values verbatim", async () => {
+    const vocab = { rel: { from: "a", to: "b", note: "freeform", weight: 3, tags: ["x", "y"] } };
+    const put = await handleTags(
+      mkReq("PUT", "/tags/thing", { relationships: vocab }),
+      store,
+      "/thing",
+    );
+    expect(put.status).toBe(200);
+    const get = await handleTags(mkReq("GET", "/tags/thing"), store, "/thing");
+    const body = await get.json() as any;
+    expect(body.relationships).toEqual(vocab);
+  });
+
+  test("PUT /tags/:name returns 400 invalid_relationships for a top-level array", async () => {
     const res = await handleTags(
-      mkReq("PUT", "/tags/person", {
-        relationships: { mentions: { target_tag: "topic", cardinality: "infinite" } },
-      }),
+      mkReq("PUT", "/tags/person", { relationships: ["not", "a", "map"] }),
       store,
       "/person",
     );
@@ -4101,6 +4152,17 @@ describe("HTTP /tags", async () => {
     expect(body.error_type).toBe("invalid_relationships");
     expect(typeof body.error).toBe("string");
     expect(body.error.length).toBeGreaterThan(0);
+  });
+
+  test("PUT /tags/:name returns 400 invalid_relationships for a top-level primitive", async () => {
+    const res = await handleTags(
+      mkReq("PUT", "/tags/person", { relationships: "just-a-string" as unknown as Record<string, unknown> }),
+      store,
+      "/person",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error_type).toBe("invalid_relationships");
   });
 
   test("DELETE /tags/:name removes tag and schema", async () => {


### PR DESCRIPTION
## What

Loosen tag-schema `relationships` from the strictly-typed `{ target_tag, cardinality }` shape to an **opaque vocabulary map**: keys are relationship names, values are arbitrary JSON the declaring app (the Weaver / structural-link picker) interprets. Vault stores and returns the values **verbatim** and validates ONLY that the top-level value is a JSON object (a map) — no inner-shape enforcement.

Resolves **feedback #2** (tracked at **vault#428**) and supersedes the prior strict-shape behavior.

## Why this is needed

The UI's desired shape round-trips verbatim now:

```json
{"works-on":{"from":"person","to":"project"},
 "member-of":{"from":"person","to":"organization"},
 "partner-of":{"from":"person","to":"person"},
 "based-at":{"from":"project","to":"place"}}
```

Before, `validateRelationships` required each value to be `{ target_tag, cardinality }` and rejected the above with `400 invalid_relationships`. The UI explicitly said opaque persistence is enough — no enforcement needed.

## The contract (new)

`validateRelationships` now:
- **Accepts** any plain JSON object (a map of relationship-name → arbitrary JSON-serializable value), stored and returned verbatim.
- **Rejects** a top-level array or primitive (relationships must be a map), and non-JSON-serializable input. Empty keys still rejected.
- Returns the value via a `JSON.parse(JSON.stringify(...))` round-trip (proves serializability + returns a clean owned copy).

## Backwards-compatible superset

The new contract is a strict superset of the old typed shape — the old `{ target_tag, cardinality }` objects are still valid opaque maps, so existing typed `relationships` data and callers keep working unchanged. The repo already documented Phase 1 as informational ("declarations are not enforced at write time"), so dropping the inner-shape gate is consistent with intent.

## Verification

- **Consumer grep** — nothing reads `relationships.*.target_tag`/`.cardinality` as load-bearing. Every consumer (`list-tags`, `GET /tags/:name`, export/import, `renameTag`, `vault-projection`) just serializes / passes the whole map through. So loosening can't silently break a reader.
- **Export → import → re-export** preserves opaque shapes verbatim. `portable-md.ts` already serializes/deserializes `relationships` as an arbitrary object (no inner-shape coupling); extended the realistic round-trip fixture with an opaque map + added a focused round-trip test asserting the imported value matches verbatim and the re-exported schema file is byte-identical.
- **`list-tags` / GET** return the opaque map verbatim (REST tests assert byte-for-byte).

## Surfaces touched

- Engine: `core/src/tag-schemas.ts` — `validateRelationships` rewrite; new `TagRelationshipMap` type; `TagRelationship` retained as the documented typed shape; `rowToRecord`/`upsertTagRecord` typing.
- Storage types: `core/src/store.ts`, `core/src/types.ts` widened to `TagRelationshipMap`.
- MCP: `core/src/mcp.ts` `update-tag` inputSchema — `relationships` description rewritten to the opaque contract, `additionalProperties: true`.
- REST: `src/routes.ts` `PUT /api/tags/:name` — same flow, looser type.
- `core/src/schema.ts` column comment updated.

## Tests added / updated

- PUT opaque shape → 200; GET returns it byte-for-byte (the feedback #2 regression).
- Old typed shape still accepted (backwards-compat).
- Top-level array → 400; top-level primitive → 400.
- MCP `update-tag` opaque shape persists + reads back; nested arbitrary values round-trip; formerly-rejected shapes (`cardinality: bogus`, missing `target_tag`) now persist verbatim.
- portable-md round-trip preserves an opaque relationships map.

Replaced the two now-obsolete strict-rejection tests (invalid-cardinality, missing-target_tag) with their loosened-contract equivalents.

## Gates

- `bun test ./core/src/` — 667 pass, 0 fail
- `bun test ./src/` — 1306 pass, 0 fail
- `bun run typecheck` — clean

No version bump (per instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)