### PR TITLE
docs(http-api): relationships is an opaque vocabulary map

### DIFF
--- a/core/src/tag-schemas.ts
+++ b/core/src/tag-schemas.ts
@@ -39,7 +39,7 @@ export interface TagFieldSchema {
  * `{ target_tag, cardinality }` declaration — but `relationships` is now an
  * opaque vocabulary map (see `TagRelationshipMap` / `validateRelationships`),
  * so this is one valid value shape among many, not a required one.
- * See patterns/tag-data-model.md §Typed relationships.
+ * See patterns/tag-data-model.md §Relationships.
  */
 export type TagRelCardinality = "one" | "optional" | "many" | "many-required";
 

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -818,10 +818,10 @@ existing typed declarations keep working:
 Only the top-level shape is validated. A payload is **rejected with `400`
 and `error_type: invalid_relationships`** (the `error` field carries the
 specific violation) when it is a top-level array, a top-level primitive,
-`null`/absent-where-an-object-is-expected, has an empty-string key, or is
-not JSON-serializable. Inner values — including ones missing `target_tag`
-or `cardinality`, or with a `cardinality` outside the old vocabulary — are
-**no longer** rejected; they persist verbatim.
+has an empty-string key, or is not JSON-serializable. Explicit `null`
+**clears** the field (it is not rejected). Inner values — including ones
+missing `target_tag` or `cardinality`, or with a `cardinality` outside the
+old vocabulary — are **no longer** rejected; they persist verbatim.
 
 #### `DELETE /vault/{name}/api/tags/{name}` — `vault:write`
 Removes the tag, its identity row, and untags every note. Returns the

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -774,12 +774,8 @@ Upsert a tag's identity row. Body accepts any combination of:
 {
   "description": "string | null",
   "fields": { "<field>": { "type": "string", "enum": [...], ... } } | null,
-  "relationships": {                                 // object-of-objects, never an array; | null clears
-    "<relName>": {
-      "target_tag": "<tag>",
-      "cardinality": "one" | "optional" | "many" | "many-required",
-      "description": "<optional string>"
-    }
+  "relationships": {                                 // opaque map (relName → arbitrary JSON); never a top-level array; | null clears
+    "<relName>": <any JSON-serializable value>
   },
   "parent_names": ["parent-tag", ...] | null
 }
@@ -788,15 +784,24 @@ Upsert a tag's identity row. Body accepts any combination of:
 Omitted keys are preserved; explicit `null` clears. `fields` merges into
 the existing schema (mirrors MCP `update-tag`).
 
-**`relationships` shape.** An **object-of-objects**, never an array. Each
-key is a relationship name; each value MUST carry both `target_tag` (a
-non-empty string) and `cardinality` (one of `one`, `optional`, `many`,
-`many-required`). `description` is optional. A malformed payload — an
-array, a value missing `target_tag` or `cardinality`, or a `cardinality`
-outside the vocabulary — is **rejected with `400` and
-`error_type: invalid_relationships`** (the `error` field carries the
-specific violation); it is never silently dropped or nulled. Concrete
-example:
+**`relationships` shape.** An **opaque vocabulary map** (vault#431): a JSON
+object whose keys are relationship names and whose values are arbitrary
+JSON the declaring app interprets. Vault does **not** enforce any inner
+structure — it stores and returns the values verbatim. Any
+JSON-serializable value is accepted, e.g. the Weaver-style structural-link
+shape:
+
+```json
+{
+  "relationships": {
+    "works-on": { "from": "person", "to": "project" }
+  }
+}
+```
+
+The older typed `{ target_tag, cardinality }` shape is a **recommended
+convention** that's still accepted (it's just a valid opaque value), so
+existing typed declarations keep working:
 
 ```json
 {
@@ -809,6 +814,14 @@ example:
   }
 }
 ```
+
+Only the top-level shape is validated. A payload is **rejected with `400`
+and `error_type: invalid_relationships`** (the `error` field carries the
+specific violation) when it is a top-level array, a top-level primitive,
+`null`/absent-where-an-object-is-expected, has an empty-string key, or is
+not JSON-serializable. Inner values — including ones missing `target_tag`
+or `cardinality`, or with a `cardinality` outside the old vocabulary — are
+**no longer** rejected; they persist verbatim.
 
 #### `DELETE /vault/{name}/api/tags/{name}` — `vault:write`
 Removes the tag, its identity row, and untags every note. Returns the


### PR DESCRIPTION
## What

Fix the stale `relationships` documentation in `docs/HTTP_API.md` (the `PUT .../api/tags/{name}` tag-upsert section).

## Why

**vault#431** (merged, `bda0bd6`) loosened tag-schema `relationships` from the strictly-typed `{ target_tag, cardinality }` shape to an **opaque vocabulary map** — keys are relationship names, values are arbitrary JSON the declaring app (Weaver / structural-link picker) interprets, stored and returned verbatim, with only the top-level shape validated.

But an earlier docs PR (**vault#427**) documented `relationships` in `docs/HTTP_API.md` as the strict typed shape — saying each value MUST carry `target_tag` + `cardinality` and that a value missing either is rejected. After #431 that doc is over-strict: opaque maps are now accepted, and the typed shape is only a recommended convention. This brings the doc back in line with shipped behavior.

## Changes

Rewrote the `relationships` block to match `core/src/tag-schemas.ts` `validateRelationships` on current `main`:
- `relationships` is an **opaque JSON map** — keys = relationship names, values = arbitrary JSON the app interprets, stored/returned verbatim, not enforced.
- Shows the Weaver-style `{"works-on":{"from":"person","to":"project"}}` value as valid.
- Notes the `{ target_tag, cardinality }` shape is a **recommended convention** that's still accepted (a valid opaque value), with the example retained.
- Keeps the `400 invalid_relationships` documentation but corrects WHAT triggers it: top-level array / primitive / null, empty-string key, or non-JSON-serializable — **not** a value missing `target_tag`/`cardinality`.

## Verification against source

Cross-checked every clause against `validateRelationships` on current `main` (`core/src/tag-schemas.ts`): rejects null/undefined, top-level array/primitive, empty-string keys, non-serializable; accepts any plain JSON object verbatim; the typed shape is a valid opaque value (backwards-compatible superset). The canonical pattern home is `parachute-patterns/patterns/tag-data-model.md §Typed relationships` (cited in the source); no separate parachute-patterns migration file was shipped for vault#431.

## Gates

- `bun test ./core/src/` — 667 pass, 0 fail
- `bun test ./src/` — 1307 pass, 0 fail
- `bun run typecheck` — clean

Doc-only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)