### PR TITLE
fix(storage): accept %2F-encoded slash in GET serve path (finding D)

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1005,6 +1005,10 @@ larger than the 100MB limit is rejected with `413`.
 #### `GET /vault/{name}/api/storage/{date}/{filename}` — `vault:read`
 Serves the uploaded file bytes with the matching `Content-Type`. Path is
 sandboxed under the vault's assets dir; traversal attempts return `403`.
+The `{date}/{filename}` slash may be sent either literally or
+`%2F`-encoded — both forms resolve to the same file. (Note the contrast
+with the single-note routes, which **require** `%2F` for a slash inside an
+id/path segment.)
 
 With a **tag-scoped** token, the serve is additionally gated by the owning
 note's tag scope: the requested storage path is reverse-looked-up to its

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2278,7 +2278,7 @@ export async function handleStorage(
   // REQUIRE `%2F` for slashes-in-an-id — a trap-grade asymmetry we accept here
   // because storage paths are always multi-segment date/file pairs.
   //
-  // Guard-safety (verified): the traversal guard at ~2275 operates on the
+  // Guard-safety (verified): the traversal guard below operates on the
   // post-`normalize(join())` filesystem path, so a decoded `..` is still
   // caught → 403. Decode is idempotent for today's unencoded callers
   // (filenames are `<Date.now()>-<uuid>.<ext>` — no stray `%`). A malformed

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2267,7 +2267,31 @@ export async function handleStorage(
     return json({ path: relativePath, size: buffer.length, mimeType }, 201);
   }
 
-  const fileMatch = path.match(/^\/([^/]+)\/(.+)$/);
+  // Decode percent-encoding BEFORE matching. `path` arrives from
+  // `url.pathname`, which (per WHATWG) keeps an encoded `%2F` slash literal —
+  // so a caller requesting `/api/storage/<date>%2F<file>` would never satisfy
+  // the literal-slash match below and would fall through to the 404. Decoding
+  // first accepts both the literal-slash and `%2F`-encoded forms, and yields
+  // the literal-slash path that the DB stores (`${date}/${filename}`) so the
+  // tag-scope reverse-lookup matches. This intentionally diverges from the
+  // single-note routes, which decode their *first* segment only and therefore
+  // REQUIRE `%2F` for slashes-in-an-id — a trap-grade asymmetry we accept here
+  // because storage paths are always multi-segment date/file pairs.
+  //
+  // Guard-safety (verified): the traversal guard at ~2275 operates on the
+  // post-`normalize(join())` filesystem path, so a decoded `..` is still
+  // caught → 403. Decode is idempotent for today's unencoded callers
+  // (filenames are `<Date.now()>-<uuid>.<ext>` — no stray `%`). A malformed
+  // `%` (e.g. `2026%2`) throws → 404, consistent with the no-existence-oracle
+  // stance (and an improvement over the prior catch-all 500).
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(path);
+  } catch {
+    return json({ error: "Not found" }, 404);
+  }
+
+  const fileMatch = decodedPath.match(/^\/([^/]+)\/(.+)$/);
   if (req.method === "GET" && fileMatch) {
     const reqPath = `${fileMatch[1]}/${fileMatch[2]}`;
     const filePath = normalize(join(assets, reqPath));

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -333,4 +333,47 @@ describe("storage GET percent-encoded slash (finding D)", () => {
     );
     expect(res.status).toBe(404);
   });
+
+  test("double-encoded %252F → 404 (decodes ONCE to literal %2F, no slash, no second decode)", async () => {
+    const { store } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    // `%252F` → decodeURIComponent once → `%2F` (a literal `%2F`, NOT a slash).
+    // The single decode is deliberate: a second decode would turn this into a
+    // real slash and risk serving / re-looping. With one decode the path has
+    // no `/` separator, so the date/file match fails → 404.
+    const doubleEncoded = "/2026-05-28%252Ffile.bin";
+    expect(decodeURIComponent(doubleEncoded)).toBe("/2026-05-28%2Ffile.bin");
+    const res = await handleStorage(
+      new Request(`http://localhost:1940/storage${doubleEncoded}`, { method: "GET" }),
+      doubleEncoded,
+      VAULT,
+      store,
+      ctx,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST parity (finding D — decode block must not change upload behavior).
+//
+// The `POST /upload` branch returns BEFORE the decode block, so a real upload
+// is untouched. A POST to a non-`/upload` storage path with a malformed `%`
+// falls past the upload branch into the decode (the `try/catch` is not method-
+// gated), where the throw → 404 — the same status the pre-fix unconditional
+// final 404 produced for this request. Pins that the decode doesn't turn a
+// malformed-`%` POST into a 500 and keeps POST behavior at parity.
+// ---------------------------------------------------------------------------
+
+describe("storage POST parity (finding D)", () => {
+  test("POST to a malformed-`%` storage path → 404, unchanged by the GET-side decode", async () => {
+    const bad = "/2026%2";
+    const res = await handleStorage(
+      new Request(`http://localhost:1940/storage${bad}`, { method: "POST" }),
+      bad,
+      "default",
+      uploadStore,
+    );
+    expect(res.status).toBe(404);
+  });
 });

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -215,3 +215,122 @@ describe("storage GET tag-scope enforcement", () => {
     expect(res.status).toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GET percent-encoded-slash handling (feedback finding D).
+//
+// `path` reaches handleStorage from `url.pathname`, which keeps an encoded
+// `%2F` slash LITERAL (WHATWG). The old `path.match(/^\/([^/]+)\/(.+)$/)`
+// required a literal slash, so `/api/storage/<date>%2F<file>` fell to the
+// unconditional 404 — a trap-grade asymmetry with the single-note routes,
+// which decode their first segment and therefore REQUIRE `%2F`. The fix
+// decodes `path` before matching, accepting BOTH forms; the decoded path is
+// also what the DB stores (`${date}/${filename}`), so tag-scope lookup and
+// the traversal guard keep working. These tests pin both forms + the
+// guard-safety of the decode.
+// ---------------------------------------------------------------------------
+
+describe("storage GET percent-encoded slash (finding D)", () => {
+  const VAULT = "encode-vault";
+
+  async function setup(): Promise<{
+    store: SqliteStore;
+    assets: string;
+    inScopePath: string;
+    outScopePath: string;
+  }> {
+    const store = freshStore();
+    const assets = join(testDir, "assets", VAULT, "data");
+    mkdirSync(join(assets, "2026-05-28"), { recursive: true });
+    process.env.ASSETS_DIR = assets;
+
+    const workNote = await store.createNote("work note", { tags: ["work"] });
+    const healthNote = await store.createNote("health note", { tags: ["health"] });
+
+    const inScopePath = "2026-05-28/work-asset.pdf";
+    const outScopePath = "2026-05-28/health-asset.pdf";
+    writeFileSync(join(assets, inScopePath), Buffer.from([0x25, 0x50, 0x44, 0x46])); // %PDF
+    writeFileSync(join(assets, outScopePath), Buffer.from([0x25, 0x50, 0x44, 0x46]));
+
+    await store.addAttachment(workNote.id, inScopePath, "application/pdf");
+    await store.addAttachment(healthNote.id, outScopePath, "application/pdf");
+
+    return { store, assets, inScopePath, outScopePath };
+  }
+
+  // The request URL carries the encoded form; the `path` arg mirrors what the
+  // dispatcher hands the handler (derived from url.pathname, %2F kept literal).
+  function getReqEncoded(reqPath: string): { req: Request; path: string } {
+    const encoded = reqPath.replace(/\//g, "%2F");
+    return {
+      req: new Request(`http://localhost:1940/storage/${encoded}`, { method: "GET" }),
+      path: `/${encoded}`,
+    };
+  }
+
+  test("encoded %2F path serves the same bytes as the literal form (200)", async () => {
+    const { store, inScopePath } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    const { req, path } = getReqEncoded(inScopePath);
+    const res = await handleStorage(req, path, VAULT, store, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/pdf");
+    expect((await res.arrayBuffer()).byteLength).toBe(4);
+  });
+
+  test("literal-slash path still serves (regression)", async () => {
+    const { store, inScopePath } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    const res = await handleStorage(
+      new Request(`http://localhost:1940/storage/${inScopePath}`, { method: "GET" }),
+      `/${inScopePath}`,
+      VAULT,
+      store,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    expect((await res.arrayBuffer()).byteLength).toBe(4);
+  });
+
+  test("encoded traversal %2E%2E%2F… → 403 (decoded `..` hits the traversal guard)", async () => {
+    const { store } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    // Fully percent-encoded `/a/../../../../../../etc/passwd`. Decode yields
+    // the literal traversal, which resolves outside assetsDir → 403.
+    const evilDecoded = "/a/../../../../../../etc/passwd";
+    const evilEncoded = "/a%2F%2E%2E%2F%2E%2E%2F%2E%2E%2F%2E%2E%2F%2E%2E%2F%2E%2E%2Fetc%2Fpasswd";
+    expect(decodeURIComponent(evilEncoded)).toBe(evilDecoded);
+    const res = await handleStorage(
+      new Request(`http://localhost:1940/storage${evilEncoded}`, { method: "GET" }),
+      evilEncoded,
+      VAULT,
+      store,
+      ctx,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("tag-scoped token + out-of-scope owning note → still 404 with an encoded path", async () => {
+    const { store, outScopePath } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    const { req, path } = getReqEncoded(outScopePath);
+    const res = await handleStorage(req, path, VAULT, store, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  test("malformed `%` (e.g. /api/storage/2026%2) → 404, not 500", async () => {
+    const { store } = await setup();
+    const ctx = await tagScopeCtx(store, ["work"]);
+    // `%2` is not a valid percent-escape → decodeURIComponent throws → 404.
+    const bad = "/2026%2";
+    expect(() => decodeURIComponent(bad)).toThrow();
+    const res = await handleStorage(
+      new Request(`http://localhost:1940/storage${bad}`, { method: "GET" }),
+      bad,
+      VAULT,
+      store,
+      ctx,
+    );
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## The asymmetry trap (feedback finding D)

`GET /vault/{name}/api/storage/<date>%2F<file>` returned **404**.

`path` reaches `handleStorage` from `url.pathname`, which — per WHATWG —
keeps an encoded `%2F` slash **literal**. The GET match at `routes.ts:2270`,
`path.match(/^\/([^/]+)\/(.+)$/)`, requires a **literal** slash, so the
encoded form never matched and fell through to the unconditional 404 at
~2326 (or 500'd via the catch-all on a malformed `%`).

This was a **trap-grade asymmetry** between the two route families:
- **Single-note routes** `decodeURIComponent` their first id/path segment
  (`routes.ts:987`) and therefore **REQUIRE** `%2F` for a slash inside an id.
- **Storage GET** required a **literal** slash.

The two families demanded opposite encodings of the same character — a caller
that learned the encoding for one route would break on the other.

## The fix

Decode `path` once, **immediately before** the GET match, and match on the
decoded form:

```ts
let decodedPath: string;
try { decodedPath = decodeURIComponent(path); } catch { return json({ error: "Not found" }, 404); }
```

This accepts **both** the literal and `%2F`-encoded forms. The decoded path is
also the form the DB stores (`${date}/${filename}`), so the tag-scope
reverse-lookup (`getAttachmentsByPath`) matches its rows without further
transformation.

## Guard-safety (verified — order/logic untouched)

The guard chain order is **unchanged**: 403 traversal → 404 existsSync →
tag-scope 404 → serve.

- **Traversal guard**: operates on the post-`normalize(join(assets, reqPath))`
  *filesystem* path, so a decoded `..` still resolves outside `assetsDir`
  → **403**. Pinned by the encoded-traversal test (`%2E%2E%2F…` → 403).
- **Tag-scope gate**: now receives the literal-slash path that matches DB rows;
  an out-of-scope owning note still → **404**. Pinned by the encoded
  out-of-scope test.
- **Idempotent** for today's callers (filenames are `<Date.now()>-<uuid>.<ext>`
  — no stray `%`); literal-form regression test confirms.
- **Malformed `%`** (e.g. `2026%2`) now → **404**, consistent with the
  endpoint's no-existence-oracle stance and an improvement over the prior
  catch-all 500.

The **upload POST branch is not touched**.

## Tests (`src/storage.test.ts`)

- `%2F`-encoded path serves the same bytes as the literal form (200)
- literal form still serves (regression)
- encoded traversal `%2E%2E%2F…` → 403 (decoded `..` hits the traversal guard)
- tag-scoped token + out-of-scope owning note → still 404 with an encoded path
- malformed `%` → 404, not 500

## Docs

One line in `docs/HTTP_API.md` storage section: the serve path accepts both
literal and `%2F`-encoded slashes (contrasted with single-note routes that
require `%2F`).

## Gates (literal counts)

- `bun test ./src/` — **1312 pass / 0 fail** (3599 expect)
- `bun test ./core/src/` — **667 pass / 0 fail** (1949 expect)
- `bun run typecheck` — clean (`tsc --noEmit`)

No version bump (per RC-versioning discipline — bump + tag happen at ship time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)