### PR TITLE
fix(transcription): never destroy memo content + retry legacy in-body memos (finding F)

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -633,9 +633,16 @@ used by the Notes voice-memo client. Server queues a transcription job:
 `note.metadata.transcribe_stub = true` is written as the opt-in to
 overwrite content when the transcript lands. On success the worker
 replaces the literal `_Transcript pending._` placeholder in the note
-body with the transcript (or the whole body if the placeholder is
-absent). A user edit clearing `transcribe_stub` before the transcript
-arrives opts out of the overwrite.
+body with the transcript (or, on a retry, the `_Transcription
+unavailable._` failure marker). If neither marker is present — the user
+edited the note while transcription was pending — the worker **appends**
+the transcript rather than overwriting the body, so the user's edits and
+the `![[<audio>]]` embed are never destroyed. A user edit clearing
+`transcribe_stub` before the transcript arrives opts out of the overwrite
+entirely. On terminal failure the worker writes `_Transcription
+unavailable._` the same way (surgical replace of the placeholder, or
+append if it's gone — never a full-body replace); a failed legacy memo can
+be retried via `/retry-transcription` (legacy in-body form) below.
 
 **Path B — auto-transcribe (vault#353, shipped 0.4.8-rc.1).** When
 `mimeType` starts with `audio/` AND `autoTranscribe.enabled === true` AND
@@ -680,9 +687,9 @@ doesn't exist or belongs to a different note. Idempotent: a second delete
 of the same id returns `404`.
 
 #### `POST /vault/{name}/api/notes/{idOrPath}/retry-transcription` — `vault:write`
-Re-enqueues the original audio attachment for a transcript note whose
-`transcript_status` is `failed`. Shipped in 0.4.8-rc.1 (vault#353,
-design Q5). Returns 202 on success:
+Re-enqueues the original audio attachment for a failed transcription. Two
+target shapes are accepted, distinguished by whether the target note carries
+`transcript_status` frontmatter. Returns 202 on success:
 
 ```json
 {
@@ -698,10 +705,14 @@ design Q5). Returns 202 on success:
 means no worker is registered this boot and the 30s sweep will pick up
 the row. Either way the row is updated.
 
-Error branches:
+**Auto-flow form (Path B, vault#353).** The target is a
+`<audio>.transcript.md` note with `transcript_status: failed` frontmatter.
+The audio is located via `transcript_attachment_id`; `transcribe_origin:
+"auto"` is preserved so a retried success overwrites the transcript note in
+place (note id preserved across retries). Shipped in 0.4.8-rc.1 (design Q5).
 
-- `400 invalid_target` — target note has no `transcript_status` frontmatter
-  (not a transcript note).
+Auto-flow error branches:
+
 - `400 not_failed` — transcript already succeeded; nothing to retry.
 - `400 missing_attachment_id` — transcript note lacks
   `transcript_attachment_id` (likely written by an older vault version).
@@ -710,8 +721,28 @@ Error branches:
 - `404 audio_missing` — original audio file no longer exists on disk
   (e.g. `audio_retention: never` already unlinked it).
 
-The same transcript note is overwritten in place; the note id is preserved
-across retries.
+**Legacy in-body form (Path A).** The target is the voice-memo note itself
+— no `transcript_status` frontmatter. The note directly owns the audio
+attachment whose transcription failed; on failure the worker had replaced
+the `_Transcript pending._` placeholder with a `_Transcription unavailable._`
+marker (leaving the `![[<audio>]]` embed intact). This form finds the note's
+own attachment with `transcribe_status: failed`, resets it to `pending`
+**preserving `transcribe_origin: "legacy"`** (forcing `"auto"` would switch
+to the sibling-transcript-note shape and orphan the in-body embed), and
+**re-stamps `transcribe_stub: true`** on the note. The stub re-arm is
+required: the worker's legacy success path only writes the transcript back
+into the body when the note carries `transcribe_stub`, and that flag was
+cleared when the failure marker was written. On a successful retry the
+transcript replaces the `_Transcription unavailable._` marker in place,
+yielding the same body a first-try success would have produced.
+
+Legacy-form error branch:
+
+- `400 no_failed_attachment` — the target note has no `transcript_status`
+  frontmatter and owns no audio attachment with a failed transcription, so
+  there's nothing to retry.
+- `404 audio_missing` — the failed attachment's audio file no longer exists
+  on disk.
 
 ### Graph queries
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1073,22 +1073,26 @@ async function handleNotesInner(
     return json({ error: "Method not allowed" }, 405);
   }
 
-  // POST /notes/:idOrPath/retry-transcription — vault#353 design Q5.
+  // POST /notes/:idOrPath/retry-transcription — vault#353 design Q5 + finding F.
   //
-  // Re-runs the auto-transcribe pipeline against the original audio
-  // attachment recorded in the transcript note's `transcript_attachment_id`
-  // frontmatter. Only valid on transcript notes (the target idOrPath must
-  // be a transcript note with `transcript_status: "failed"`); calling on
-  // anything else returns 400 with a clear reason.
+  // Re-runs transcription against a failed audio attachment. Two target
+  // shapes, dispatched in handleRetryTranscription by whether the note carries
+  // `transcript_status` frontmatter:
+  //   - Auto-flow (vault#353): target is a `<audio>.transcript.md` note with
+  //     `transcript_status: "failed"`; audio located via
+  //     `transcript_attachment_id`, origin preserved as "auto".
+  //   - Legacy in-body memo (finding F): target is the memo note itself (no
+  //     `transcript_status`); finds its own failed attachment, resets it
+  //     preserving `transcribe_origin: "legacy"`, and re-arms `transcribe_stub`.
   //
   // Wire shape:
   //   POST .../notes/<idOrPath>/retry-transcription
-  //   →  202 { attachment_id, transcript_path } when re-enqueued
-  //      400 invalid_target          (not a transcript note)
-  //      400 not_failed              (transcript already succeeded; nothing to retry)
-  //      404 attachment_missing      (transcript_attachment_id row deleted)
+  //   →  202 { attachment_id, attachment_path, transcript_note_id, worker }
+  //      400 not_failed              (auto-flow: transcript already succeeded)
+  //      400 missing_attachment_id   (auto-flow: transcript_attachment_id absent)
+  //      400 no_failed_attachment    (legacy: no failed audio attachment to retry)
+  //      404 attachment_missing      (auto-flow: transcript_attachment_id row deleted)
   //      404 audio_missing           (audio file unlinked from disk)
-  //      503 scribe_unavailable      (no worker configured this boot)
   if (sub === "/retry-transcription") {
     if (method !== "POST") return json({ error: "Method not allowed" }, 405);
     if (!vault) return json({ error: "Vault context required" }, 400);
@@ -2075,21 +2079,35 @@ ${rendered}
 // ---------------------------------------------------------------------------
 
 /**
- * Re-enqueue the original audio attachment for a `transcript_status: failed`
- * transcript note. Steps:
+ * Re-enqueue the original audio attachment for a failed transcription.
  *
- *   1. Validate target is a transcript note (`transcript_status` set in
- *      metadata) AND that status is `failed`.
- *   2. Find the original audio attachment by id from
- *      `transcript_attachment_id` frontmatter. 404 if the row's gone.
- *   3. Validate the audio file still exists on disk (retention=keep is
- *      assumed by the retry contract; retention=until_transcribed unlinks
- *      only on success, retention=never unlinks on failure — that last one
- *      explicitly breaks retry, by design).
- *   4. Reset `transcribe_status = "pending"`, clear backoff + error fields.
- *      The auto-origin marker is preserved so the worker writes a transcript
- *      note (overwriting this one in place).
- *   5. Kick the worker if registered; otherwise the sweep picks it up.
+ * Two target shapes are accepted:
+ *
+ *   - **Auto-flow (vault#353):** the target is a `<audio>.transcript.md` note
+ *     carrying `transcript_status` frontmatter. Requires that status be
+ *     `failed`; locates the audio via `transcript_attachment_id`; preserves
+ *     `transcribe_origin: "auto"` so a retried success overwrites this
+ *     transcript note in place. Behavior is byte-identical to the original
+ *     vault#353 contract.
+ *
+ *   - **Legacy in-body memo (finding F):** the target is the memo note
+ *     itself — no `transcript_status` frontmatter. The original capture body
+ *     holds `![[<audio>]]` + a `_Transcription unavailable._` marker (written
+ *     by the worker on terminal failure). We find the note's own failed audio
+ *     attachment, reset it to pending **preserving `transcribe_origin:
+ *     "legacy"`** (forcing "auto" would switch to the sibling-transcript-note
+ *     shape and orphan the in-body embed), and **re-stamp `transcribe_stub:
+ *     true`** on the note. The stub re-arm is load-bearing: the legacy success
+ *     path early-returns unless `transcribe_stub === true`, so without it the
+ *     retried success would never write the transcript back into the body.
+ *     On success the worker replaces the `_Transcription unavailable._` marker
+ *     with the transcript in place, yielding the same final shape a first-try
+ *     success would.
+ *
+ * Common steps for both: validate the audio attachment row exists (404 if
+ * gone) and its file is still on disk (404 if unlinked — e.g. retention=never
+ * already dropped it), reset the transcribe_status fields, then kick the
+ * worker if registered (otherwise the sweep picks it up).
  */
 async function handleRetryTranscription(
   store: Store,
@@ -2097,15 +2115,13 @@ async function handleRetryTranscription(
   vault: string,
 ): Promise<Response> {
   const meta = (note.metadata as Record<string, unknown> | undefined) ?? {};
+
+  // Legacy in-body memo: no `transcript_status` frontmatter. The note owns
+  // the failed audio attachment directly; there's no sibling transcript note.
   if (typeof meta.transcript_status !== "string") {
-    return json(
-      {
-        error: "invalid_target",
-        message: "Target note is not a transcript note (no transcript_status frontmatter).",
-      },
-      400,
-    );
+    return handleRetryLegacyInBody(store, note, vault);
   }
+
   if (meta.transcript_status !== "failed") {
     return json(
       {
@@ -2185,6 +2201,108 @@ async function handleRetryTranscription(
       status: "queued",
       attachment_id: attachment.id,
       attachment_path: attachment.path,
+      transcript_note_id: note.id,
+      worker: worker ? "kicked" : "sweep-only",
+    },
+    202,
+  );
+}
+
+/**
+ * Retry path for a legacy in-body voice memo (finding F). The target note is
+ * the memo itself (no `transcript_status` frontmatter); it directly owns the
+ * audio attachment whose transcription failed.
+ *
+ * Steps:
+ *   1. Find the note's own audio attachment with `transcribe_status ===
+ *      "failed"`. 400 `no_failed_attachment` if none — there's nothing to
+ *      retry.
+ *   2. Validate the audio file is still on disk (404 `audio_missing`).
+ *   3. Reset the attachment to pending, **preserving `transcribe_origin:
+ *      "legacy"`** (never force "auto" — that switches to the sibling-
+ *      transcript-note shape and orphans the in-body `![[memo]]` embed).
+ *   4. **Re-stamp `transcribe_stub: true`** on the note. The legacy worker
+ *      success path early-returns unless the note carries this flag (it was
+ *      cleared when the failure marker was written), so re-arming it is what
+ *      lets the retried success replace the `_Transcription unavailable._`
+ *      marker with the transcript.
+ *   5. Kick the worker if registered; otherwise the sweep picks it up.
+ */
+async function handleRetryLegacyInBody(
+  store: Store,
+  note: Note,
+  vault: string,
+): Promise<Response> {
+  const attachments = await store.getAttachments(note.id);
+  const failed = attachments.find((a) => {
+    const m = (a.metadata as Record<string, unknown> | undefined) ?? {};
+    return m.transcribe_status === "failed";
+  });
+  if (!failed) {
+    return json(
+      {
+        error: "no_failed_attachment",
+        message:
+          "Target note is not a transcript note and has no audio attachment with a failed transcription to retry.",
+      },
+      400,
+    );
+  }
+
+  // Audio file existence + safety: defense-in-depth against a bad attachment
+  // row pointing outside the vault assets dir. Same guard as the worker.
+  const assetsRoot = assetsDir(vault);
+  const audioFilePath = normalize(join(assetsRoot, failed.path));
+  if (!audioFilePath.startsWith(normalize(assetsRoot)) || !existsSync(audioFilePath)) {
+    return json(
+      {
+        error: "audio_missing",
+        message: `Original audio file at "${failed.path}" no longer exists on disk.`,
+      },
+      404,
+    );
+  }
+
+  // Reset the attachment back to pending. Preserve `transcribe_origin:
+  // "legacy"` (a default of `undefined` is also legacy, but make it explicit
+  // so a retried row reads unambiguously) — forcing "auto" here would make
+  // the worker materialize a sibling transcript note instead of patching the
+  // in-body embed, orphaning the memo.
+  const attMeta = { ...(failed.metadata ?? {}) } as Record<string, unknown>;
+  attMeta.transcribe_status = "pending";
+  attMeta.transcribe_requested_at = new Date().toISOString();
+  attMeta.transcribe_origin = "legacy";
+  delete attMeta.transcribe_backoff_until;
+  delete attMeta.transcribe_error;
+  delete attMeta.transcribe_error_code;
+  delete attMeta.transcribe_attempts;
+  await store.setAttachmentMetadata(failed.id, attMeta);
+
+  // Re-arm the stub on the note. The worker's legacy success path gates on
+  // `transcribe_stub === true` and CLEARED it when it wrote the failure
+  // marker; without re-stamping it the retried success early-returns and
+  // never writes the transcript back into the body. Use skipUpdatedAt so the
+  // note's modification time still reflects user intent, matching the
+  // worker's own note writes.
+  const noteMeta = { ...((note.metadata as Record<string, unknown> | undefined) ?? {}) };
+  noteMeta.transcribe_stub = true;
+  await store.updateNote(note.id, {
+    metadata: noteMeta,
+    skipUpdatedAt: true,
+  });
+
+  const { getTranscriptionWorker } = await import("./transcription-registry.ts");
+  const worker = getTranscriptionWorker();
+  if (worker) {
+    const fresh = await store.getAttachment(failed.id) ?? failed;
+    void worker.kick(vault, fresh);
+  }
+
+  return json(
+    {
+      status: "queued",
+      attachment_id: failed.id,
+      attachment_path: failed.path,
       transcript_note_id: note.id,
       worker: worker ? "kicked" : "sweep-only",
     },

--- a/src/transcription-worker.test.ts
+++ b/src/transcription-worker.test.ts
@@ -305,8 +305,10 @@ describe("transcription worker", () => {
   });
 
   test("FIFO: oldest pending is processed first", async () => {
-    await store.createNote("s", { id: "f1", metadata: { transcribe_stub: true } });
-    await store.createNote("s", { id: "f2", metadata: { transcribe_stub: true } });
+    // Seed the placeholder body so the transcript patches in place (the real
+    // capture shape); ordering is what this test verifies.
+    await store.createNote("_Transcript pending._", { id: "f1", metadata: { transcribe_stub: true } });
+    await store.createNote("_Transcript pending._", { id: "f2", metadata: { transcribe_stub: true } });
     seedAudio("memos/first.webm");
     seedAudio("memos/second.webm");
     await store.addAttachment("f1", "memos/first.webm", "audio/webm", {
@@ -702,7 +704,8 @@ describe("transcription worker — hook-driven", () => {
   });
 
   test("attachment:created event triggers a cycle before the sweep fires", async () => {
-    await hookedStore.createNote("stub", { id: "h1", metadata: { transcribe_stub: true } });
+    // Placeholder body so the transcript patches in place (real capture shape).
+    await hookedStore.createNote("_Transcript pending._", { id: "h1", metadata: { transcribe_stub: true } });
     seedAudio("memos/h1.webm");
 
     let callCount = 0;
@@ -1115,5 +1118,183 @@ describe("transcription worker — auto-origin (vault#353)", () => {
       expect(t).not.toBeNull();
       expect((t!.metadata as any)?.transcript_status).toBe("complete");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// finding F — never destroy content on the legacy in-body memo path. These
+// fixtures carry the `![[<audio>]]` embed (the REAL production capture shape
+// from recorder.ts memoNoteContent), which the pre-existing failure tests all
+// omitted — which is why the data-loss branch went uncaught.
+// ---------------------------------------------------------------------------
+
+describe("transcription worker — legacy in-body memo content safety (finding F)", () => {
+  // Canonical capture body: header + _Recorded_ + placeholder + ![[embed]].
+  const captureBody = (audio: string) =>
+    `# 🎙️ Voice memo\n\n_Recorded sometime._\n\n_Transcript pending._\n\n![[${audio}]]\n`;
+
+  test("failure with placeholder present → marker replaces placeholder, embed intact", async () => {
+    await store.createNote(captureBody("memos/f1.webm"), {
+      id: "f-marker-1",
+      metadata: { transcribe_stub: true },
+    });
+    seedAudio("memos/f1.webm");
+    await store.addAttachment("f-marker-1", "memos/f1.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_attempts: 2,
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ error: "scribe down", status: 500 }]),
+      maxAttempts: 3,
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("f-marker-1");
+    expect(note!.content).toBe(
+      "# 🎙️ Voice memo\n\n_Recorded sometime._\n\n_Transcription unavailable._\n\n![[memos/f1.webm]]\n",
+    );
+    // Embed survives — the whole point.
+    expect(note!.content).toContain("![[memos/f1.webm]]");
+    expect((note!.metadata as any)?.transcribe_stub).toBeUndefined();
+  });
+
+  test("failure with placeholder ABSENT (user-edited body + embed) → marker APPENDED, content preserved", async () => {
+    // The data-loss regression: user edited the note while pending, removing
+    // the _Transcript pending._ placeholder but keeping their text + the
+    // embed. The old code full-replaced the body with the bare marker here,
+    // destroying both. Now we append.
+    const editedBody = "# 🎙️ My trip notes\n\nWent to the coast today.\n\n![[memos/f2.webm]]\n";
+    await store.createNote(editedBody, {
+      id: "f-marker-2",
+      metadata: { transcribe_stub: true },
+    });
+    seedAudio("memos/f2.webm");
+    await store.addAttachment("f-marker-2", "memos/f2.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_attempts: 2,
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ error: "scribe down", status: 500 }]),
+      maxAttempts: 3,
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("f-marker-2");
+    // User text + embed preserved; marker appended.
+    expect(note!.content).toBe(`${editedBody}\n\n_Transcription unavailable._`);
+    expect(note!.content).toContain("Went to the coast today.");
+    expect(note!.content).toContain("![[memos/f2.webm]]");
+    expect((note!.metadata as any)?.transcribe_stub).toBeUndefined();
+  });
+
+  test("double terminal failure → exactly one marker (idempotent, no stacking)", async () => {
+    // First failure writes the marker + clears the stub. Re-arm the stub and
+    // fail again — the marker must NOT stack. (Re-arming models a retry that
+    // fails again.)
+    await store.createNote(captureBody("memos/f3.webm"), {
+      id: "f-marker-3",
+      metadata: { transcribe_stub: true },
+    });
+    seedAudio("memos/f3.webm");
+    await store.addAttachment("f-marker-3", "memos/f3.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_attempts: 2,
+    });
+
+    const worker1 = makeWorker({
+      fetchImpl: mkFetchMock([{ error: "down", status: 500 }]),
+      maxAttempts: 3,
+    });
+    try { await worker1.tick(); } finally { await worker1.stop(); }
+
+    // Re-arm stub + reset attachment to pending (what a retry does), then fail again.
+    const note1 = await store.getNote("f-marker-3");
+    await store.updateNote("f-marker-3", {
+      metadata: { ...((note1!.metadata as any) ?? {}), transcribe_stub: true },
+      skipUpdatedAt: true,
+    });
+    const [att] = await store.getAttachments("f-marker-3");
+    await store.setAttachmentMetadata(att.id, {
+      ...(att.metadata ?? {}),
+      transcribe_status: "pending",
+      transcribe_attempts: 2,
+    });
+
+    const worker2 = makeWorker({
+      fetchImpl: mkFetchMock([{ error: "down again", status: 500 }]),
+      maxAttempts: 3,
+    });
+    try { await worker2.tick(); } finally { await worker2.stop(); }
+
+    const note = await store.getNote("f-marker-3");
+    const occurrences = note!.content.split("_Transcription unavailable._").length - 1;
+    expect(occurrences).toBe(1);
+    expect(note!.content).toContain("![[memos/f3.webm]]");
+  });
+
+  test("success with placeholder absent (stub set) → transcript appended, content preserved", async () => {
+    // Mirror of the failure-append case, on the success path. User edited the
+    // note (cleared the placeholder) but kept the stub. The old code
+    // full-replaced the body with the bare transcript; now we append.
+    const editedBody = "# 🎙️ My trip notes\n\nWent to the coast today.\n\n![[memos/f4.webm]]\n";
+    await store.createNote(editedBody, {
+      id: "f-success-1",
+      metadata: { transcribe_stub: true },
+    });
+    seedAudio("memos/f4.webm");
+    await store.addAttachment("f-success-1", "memos/f4.webm", "audio/webm", {
+      transcribe_status: "pending",
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ text: "the spoken transcript" }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("f-success-1");
+    expect(note!.content).toBe(`${editedBody}\n\nthe spoken transcript`);
+    expect(note!.content).toContain("Went to the coast today.");
+    expect(note!.content).toContain("![[memos/f4.webm]]");
+    expect((note!.metadata as any)?.transcribe_stub).toBeUndefined();
+  });
+
+  test("first-try success with placeholder present + embed → transcript replaces placeholder in place", async () => {
+    // Pins the canonical first-try-success shape the retry round-trip must match.
+    await store.createNote(captureBody("memos/f5.webm"), {
+      id: "f-success-2",
+      metadata: { transcribe_stub: true },
+    });
+    seedAudio("memos/f5.webm");
+    await store.addAttachment("f-success-2", "memos/f5.webm", "audio/webm", {
+      transcribe_status: "pending",
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ text: "the spoken words" }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("f-success-2");
+    expect(note!.content).toBe(
+      "# 🎙️ Voice memo\n\n_Recorded sometime._\n\nthe spoken words\n\n![[memos/f5.webm]]\n",
+    );
   });
 });

--- a/src/transcription-worker.test.ts
+++ b/src/transcription-worker.test.ts
@@ -1297,4 +1297,82 @@ describe("transcription worker — legacy in-body memo content safety (finding F
       "# 🎙️ Voice memo\n\n_Recorded sometime._\n\nthe spoken words\n\n![[memos/f5.webm]]\n",
     );
   });
+
+  test("transcript containing `$&` round-trips byte-identical (no String.replace injection) — first-try success", async () => {
+    // Regression: String.replace with a STRING replacement treats `$&` etc. as
+    // special. A transcript with `$&` must land verbatim in the body, not as
+    // the matched marker text.
+    const dollarTranscript = "it matched $& exactly, and $1 too, plus $` and $'";
+    await store.createNote(captureBody("memos/f6.webm"), {
+      id: "f-dollar-1",
+      metadata: { transcribe_stub: true },
+    });
+    seedAudio("memos/f6.webm");
+    await store.addAttachment("f-dollar-1", "memos/f6.webm", "audio/webm", {
+      transcribe_status: "pending",
+    });
+
+    const worker = makeWorker({
+      fetchImpl: mkFetchMock([{ text: dollarTranscript }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("f-dollar-1");
+    expect(note!.content).toBe(
+      `# 🎙️ Voice memo\n\n_Recorded sometime._\n\n${dollarTranscript}\n\n![[memos/f6.webm]]\n`,
+    );
+    // Belt-and-suspenders: the literal `$&` must be present verbatim.
+    expect(note!.content).toContain("it matched $& exactly");
+  });
+
+  test("transcript containing `$&` round-trips byte-identical on the RETRY path (marker → transcript)", async () => {
+    // Same injection guard, but exercised on the retry surgical-replace: the
+    // transcript replaces `_Transcription unavailable._` in place.
+    const dollarTranscript = "retry text with $& and $0 and $$ literal";
+    await store.createNote(captureBody("memos/f7.webm"), {
+      id: "f-dollar-2",
+      metadata: { transcribe_stub: true },
+    });
+    seedAudio("memos/f7.webm");
+    await store.addAttachment("f-dollar-2", "memos/f7.webm", "audio/webm", {
+      transcribe_status: "pending",
+      transcribe_attempts: 2, // one more failure → terminal at maxAttempts=3
+    });
+
+    // Phase 1: terminal failure → marker replaces placeholder.
+    const worker1 = makeWorker({
+      fetchImpl: mkFetchMock([{ error: "down", status: 500 }]),
+      maxAttempts: 3,
+    });
+    try { await worker1.tick(); } finally { await worker1.stop(); }
+    const failed = await store.getNote("f-dollar-2");
+    expect(failed!.content).toContain("_Transcription unavailable._");
+
+    // Re-arm stub + reset attachment (what the retry route does).
+    await store.updateNote("f-dollar-2", {
+      metadata: { ...((failed!.metadata as any) ?? {}), transcribe_stub: true },
+      skipUpdatedAt: true,
+    });
+    const [att] = await store.getAttachments("f-dollar-2");
+    await store.setAttachmentMetadata(att.id, {
+      ...(att.metadata ?? {}),
+      transcribe_status: "pending",
+    });
+
+    // Phase 2: success with a `$&`-bearing transcript → replaces the marker.
+    const worker2 = makeWorker({
+      fetchImpl: mkFetchMock([{ text: dollarTranscript }]),
+    });
+    try { await worker2.tick(); } finally { await worker2.stop(); }
+
+    const note = await store.getNote("f-dollar-2");
+    expect(note!.content).toBe(
+      `# 🎙️ Voice memo\n\n_Recorded sometime._\n\n${dollarTranscript}\n\n![[memos/f7.webm]]\n`,
+    );
+    expect(note!.content).toContain("retry text with $& and $0 and $$ literal");
+  });
 });

--- a/src/transcription-worker.ts
+++ b/src/transcription-worker.ts
@@ -84,6 +84,14 @@ const TRANSCRIPT_UNAVAILABLE = "_Transcription unavailable._";
  * both means a retried success lands in the same spot a first-try success
  * would, preserving the surrounding capture body (the `![[memo]]` embed,
  * the `_Recorded …_` line, the header).
+ *
+ * Deliberately NO `/g` flag — `.replace` swaps only the FIRST match. A
+ * canonical capture body holds exactly one marker, so first-match is the
+ * correct target. `applyFailureMarker`'s includes-guard (no-op when the
+ * marker is already present) prevents markers accumulating across repeated
+ * terminal failures, so the body never carries two of the same marker. A
+ * hand-edited body that somehow contains both markers patches only the
+ * first — accepted (degenerate, operator-induced).
  */
 const TRANSCRIPT_SUCCESS_TARGET = /_Transcript pending\._|_Transcription unavailable\._/;
 
@@ -467,7 +475,13 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
           //     code full-replaced here, which destroyed both.
           let body: string;
           if (TRANSCRIPT_SUCCESS_TARGET.test(note.content)) {
-            body = note.content.replace(TRANSCRIPT_SUCCESS_TARGET, transcript);
+            // Function replacer, NOT a string — speech-to-text is arbitrary
+            // user content, and String.replace treats `$&`, `$\``, `$'`,
+            // `$1`-`$9` as special patterns in a string replacement. A
+            // transcript containing `$&` would otherwise inject the matched
+            // marker text into the body. `() => transcript` returns the text
+            // verbatim.
+            body = note.content.replace(TRANSCRIPT_SUCCESS_TARGET, () => transcript);
           } else {
             body = note.content.length > 0
               ? `${note.content}\n\n${transcript}`

--- a/src/transcription-worker.ts
+++ b/src/transcription-worker.ts
@@ -25,8 +25,11 @@
  *    (Whisper API shape). Response is `{ text: string }`.
  * 3. On success:
  *    - If `note.metadata.transcribe_stub === true`, replace the
- *      `_Transcript pending._` placeholder with the transcript, or the
- *      whole note body if the placeholder is absent. Clear the stub marker.
+ *      `_Transcript pending._` placeholder (or a prior `_Transcription
+ *      unavailable._` failure marker, on a retry) with the transcript. If
+ *      neither marker is present (user edited the note while pending),
+ *      APPEND the transcript rather than overwriting the body. Clear the
+ *      stub marker.
  *    - Mark `attachment.metadata.transcribe_status = "done"` and record
  *      `transcript` + `transcribe_done_at`.
  *    - If the vault's `audio_retention` is `"until_transcribed"`, unlink
@@ -56,7 +59,7 @@ import { appendContextPart, fetchContextEntries, type ContextPayload } from "./c
 import type { TriggerIncludeContext } from "./config.ts";
 import { upsertTranscriptNote } from "./transcript-note.ts";
 
-/** Placeholder pattern written by Lens's voice-memo stub. */
+/** Placeholder pattern written by the voice-memo capture stub. */
 const TRANSCRIPT_PLACEHOLDER = /_Transcript pending\._/;
 
 /**
@@ -65,8 +68,24 @@ const TRANSCRIPT_PLACEHOLDER = /_Transcript pending\._/;
  * Lens's now-removed scribe client; owning it here means a failed upload
  * stops reading "Transcript pending" forever regardless of which client
  * uploaded the audio.
+ *
+ * NOTE: the notes-ui status chip (parachute-surface TranscriptionStatus.tsx)
+ * keys off this exact string, so don't change the copy without a coordinated
+ * change there. A friendlier "retry available" copy + chip affordance is a
+ * tracked parachute-surface follow-up.
  */
 const TRANSCRIPT_UNAVAILABLE = "_Transcription unavailable._";
+
+/**
+ * On a successful (re)transcription of a legacy in-body memo, the transcript
+ * replaces whichever marker is currently in the body — the original
+ * `_Transcript pending._` on a first-try success, OR `_Transcription
+ * unavailable._` if a prior attempt failed and we're now retrying. Matching
+ * both means a retried success lands in the same spot a first-try success
+ * would, preserving the surrounding capture body (the `![[memo]]` embed,
+ * the `_Recorded …_` line, the header).
+ */
+const TRANSCRIPT_SUCCESS_TARGET = /_Transcript pending\._|_Transcription unavailable\._/;
 
 /**
  * Default sweep cadence (ms). The sweep is the safety net for backoff-
@@ -217,13 +236,23 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
 
   /**
    * On a terminal failure (maxAttempts exhausted, or audio file missing),
-   * swap the stub placeholder for the "unavailable" marker — otherwise
-   * Lens's voice memo sits reading "Transcript pending" forever. Mirrors
-   * the success-path note write in shape: only touches the note when
+   * record the "unavailable" marker on the note — otherwise the voice memo
+   * sits reading "Transcript pending" forever. Only touches the note when
    * `transcribe_stub === true`, clears the stub marker, uses `skipUpdatedAt`
    * so the note's modification time still reflects user intent. Errors
    * are logged and swallowed so a note-write failure doesn't mask the
    * attachment failure we're trying to record.
+   *
+   * Body policy (finding F — never destroy content):
+   *   - Placeholder PRESENT → surgical replace of `_Transcript pending._`
+   *     with the marker. The `![[memo]]` embed + any surrounding text survive.
+   *   - Marker ALREADY PRESENT → no-op (idempotent; a double-terminal-failure
+   *     must not stack markers).
+   *   - Otherwise (placeholder absent — the user edited the note while it was
+   *     pending) → APPEND `\n\n` + marker to the existing content. The old
+   *     code full-replaced the body here, destroying the embed AND the user's
+   *     edits. We append instead so nothing is lost. If the content is empty,
+   *     the marker alone becomes the body (avoids a leading blank line).
    */
   async function applyFailureMarker(store: Store, noteId: string): Promise<void> {
     const note = await store.getNote(noteId);
@@ -231,9 +260,18 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
     const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
     if (noteMeta.transcribe_stub !== true) return;
 
-    const body = TRANSCRIPT_PLACEHOLDER.test(note.content)
-      ? note.content.replace(TRANSCRIPT_PLACEHOLDER, TRANSCRIPT_UNAVAILABLE)
-      : TRANSCRIPT_UNAVAILABLE;
+    let body: string;
+    if (TRANSCRIPT_PLACEHOLDER.test(note.content)) {
+      body = note.content.replace(TRANSCRIPT_PLACEHOLDER, TRANSCRIPT_UNAVAILABLE);
+    } else if (note.content.includes(TRANSCRIPT_UNAVAILABLE)) {
+      // Marker already present — nothing to do. Clear the stub (below) and
+      // return without rewriting the body so we don't stack markers.
+      body = note.content;
+    } else {
+      body = note.content.length > 0
+        ? `${note.content}\n\n${TRANSCRIPT_UNAVAILABLE}`
+        : TRANSCRIPT_UNAVAILABLE;
+    }
     const { transcribe_stub: _drop, ...restMeta } = noteMeta;
     try {
       await store.updateNote(note.id, {
@@ -411,14 +449,30 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
         logger.error(`[transcribe] failed to write transcript note for attachment ${attachment.id}:`, err);
       }
     } else {
-      // Legacy stub-patching path (Lens voice memo flow).
+      // Legacy stub-patching path (voice memo flow). Only acts when the note
+      // still carries the `transcribe_stub` opt-in — a user edit clearing it
+      // before the transcript arrives opts out of the overwrite.
       const note = await store.getNote(attachment.noteId);
       if (note) {
         const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
         if (noteMeta.transcribe_stub === true) {
-          const body = TRANSCRIPT_PLACEHOLDER.test(note.content)
-            ? note.content.replace(TRANSCRIPT_PLACEHOLDER, transcript)
-            : transcript;
+          // Body policy (finding F — never destroy content):
+          //   - placeholder OR failure-marker present → surgical replace in
+          //     place (a retried success replaces the `_Transcription
+          //     unavailable._` marker, landing exactly where a first-try
+          //     success would). The embed + surrounding capture body survive.
+          //   - neither present (user edited the note while pending) → APPEND
+          //     the transcript instead of full-replacing the body, so the
+          //     user's edits + the `![[memo]]` embed are preserved. The old
+          //     code full-replaced here, which destroyed both.
+          let body: string;
+          if (TRANSCRIPT_SUCCESS_TARGET.test(note.content)) {
+            body = note.content.replace(TRANSCRIPT_SUCCESS_TARGET, transcript);
+          } else {
+            body = note.content.length > 0
+              ? `${note.content}\n\n${transcript}`
+              : transcript;
+          }
           const { transcribe_stub: _drop, ...restMeta } = noteMeta;
           try {
             await store.updateNote(note.id, {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -13,6 +13,9 @@ import { getLinksHydrated } from "../core/src/links.ts";
 import { buildVaultProjection } from "../core/src/vault-projection.ts";
 import { handleNotes, handleTags, handleFindPath, handleVault } from "./routes.ts";
 import { extractApiKey } from "./auth.ts";
+import { startTranscriptionWorker } from "./transcription-worker.ts";
+import { setTranscriptionWorker } from "./transcription-registry.ts";
+import type { Store } from "../core/src/types.ts";
 
 let db: Database;
 let store: BunStore;
@@ -2968,7 +2971,10 @@ describe("HTTP /notes", async () => {
       expect(res.status).toBe(404);
     });
 
-    test("400 invalid_target when target is not a transcript note", async () => {
+    test("400 no_failed_attachment when target is a regular note with no failed audio", async () => {
+      // A note without `transcript_status` frontmatter is treated as a
+      // possible legacy in-body memo (finding F). With no attachment carrying
+      // a failed transcription there's nothing to retry → no_failed_attachment.
       await store.createNote("regular note", { id: "regular" });
       const res = await handleNotes(
         mkReq("POST", "/notes/regular/retry-transcription"),
@@ -2978,7 +2984,7 @@ describe("HTTP /notes", async () => {
       );
       expect(res.status).toBe(400);
       const body = await res.json() as any;
-      expect(body.error).toBe("invalid_target");
+      expect(body.error).toBe("no_failed_attachment");
     });
 
     test("400 not_failed when transcript already succeeded", async () => {
@@ -3061,6 +3067,197 @@ describe("HTTP /notes", async () => {
       );
       expect(res.status).toBe(405);
       delete process.env.ASSETS_DIR;
+    });
+
+    // -----------------------------------------------------------------------
+    // Legacy in-body memo retry (finding F). The target is the memo note
+    // itself (no `transcript_status` frontmatter); it directly owns a failed
+    // audio attachment. The request must reset the attachment preserving
+    // `transcribe_origin: "legacy"` and re-arm `transcribe_stub: true` so the
+    // worker's legacy success path will write the transcript back into the
+    // body. End-to-end re-transcription is covered in
+    // transcription-worker.test.ts.
+    // -----------------------------------------------------------------------
+    async function seedLegacyFailedMemo(opts: {
+      noteId?: string;
+      audioPath?: string;
+      withFile?: boolean;
+    } = {}): Promise<{ noteId: string; attachmentId: string; audioPath: string }> {
+      const noteId = opts.noteId ?? "legacy-memo";
+      const audioPath = opts.audioPath ?? `${noteId}/voice.webm`;
+      // The capture body after a terminal failure: marker replaced the
+      // placeholder, embed intact, stub cleared by the worker.
+      const note = await store.createNote(
+        `# 🎙️ Voice memo\n\n_Recorded sometime._\n\n_Transcription unavailable._\n\n![[${audioPath}]]\n`,
+        { id: noteId },
+      );
+      const att = await store.addAttachment(note.id, audioPath, "audio/webm", {
+        transcribe_status: "failed",
+        // legacy origin is the default (undefined); leave it off to model the
+        // genuine legacy capture shape.
+        transcribe_error: "scribe down",
+        transcribe_attempts: 3,
+      });
+      const assetsRoot = join(tmpDir, "assets");
+      if (opts.withFile !== false) {
+        mkdirSync(join(assetsRoot, audioPath.split("/").slice(0, -1).join("/")), { recursive: true });
+        writeFileSync(join(assetsRoot, audioPath), Buffer.from([1, 2, 3]));
+      }
+      process.env.ASSETS_DIR = assetsRoot;
+      return { noteId, attachmentId: att.id, audioPath };
+    }
+
+    test("legacy in-body memo: 202, resets attachment (legacy origin) + re-arms stub", async () => {
+      const { noteId, attachmentId, audioPath } = await seedLegacyFailedMemo();
+      const res = await handleNotes(
+        mkReq("POST", `/notes/${noteId}/retry-transcription`),
+        store,
+        `/${noteId}/retry-transcription`,
+        "default",
+      );
+      expect(res.status).toBe(202);
+      const body = await res.json() as any;
+      expect(body.status).toBe("queued");
+      expect(body.attachment_id).toBe(attachmentId);
+      expect(body.attachment_path).toBe(audioPath);
+      expect(body.transcript_note_id).toBe(noteId);
+
+      // Attachment reset to pending, legacy origin preserved (NOT flipped to
+      // auto — that would orphan the in-body embed), failure state cleared.
+      const att = await store.getAttachment(attachmentId);
+      expect(att?.metadata?.transcribe_status).toBe("pending");
+      expect(att?.metadata?.transcribe_origin).toBe("legacy");
+      expect(att?.metadata?.transcribe_error).toBeUndefined();
+      expect(att?.metadata?.transcribe_attempts).toBeUndefined();
+
+      // Stub re-armed on the note — without this the worker's legacy success
+      // path early-returns and never writes the transcript back.
+      const updated = await store.getNote(noteId);
+      expect((updated!.metadata as any)?.transcribe_stub).toBe(true);
+      // Body untouched by the retry request itself (embed + marker intact).
+      expect(updated!.content).toContain(`![[${audioPath}]]`);
+      expect(updated!.content).toContain("_Transcription unavailable._");
+
+      delete process.env.ASSETS_DIR;
+    });
+
+    test("legacy in-body memo: 404 audio_missing when the file is gone", async () => {
+      const { noteId } = await seedLegacyFailedMemo({
+        noteId: "legacy-gone",
+        withFile: false,
+      });
+      const res = await handleNotes(
+        mkReq("POST", `/notes/${noteId}/retry-transcription`),
+        store,
+        `/${noteId}/retry-transcription`,
+        "default",
+      );
+      expect(res.status).toBe(404);
+      const body = await res.json() as any;
+      expect(body.error).toBe("audio_missing");
+      delete process.env.ASSETS_DIR;
+    });
+
+    test("legacy in-body memo: end-to-end retry round-trip (capture → fail → retry → success)", async () => {
+      // Start from the CANONICAL capture body (recorder.ts memoNoteContent
+      // shape): header + _Recorded_ + _Transcript pending._ + ![[embed]],
+      // with transcribe_stub: true.
+      const audioPath = "e2e/voice.webm";
+      const captureBody =
+        "# 🎙️ Voice memo\n\n_Recorded sometime._\n\n_Transcript pending._\n\n![[e2e/voice.webm]]\n";
+      await store.createNote(captureBody, {
+        id: "e2e-memo",
+        metadata: { transcribe_stub: true },
+      });
+      const att = await store.addAttachment("e2e-memo", audioPath, "audio/webm", {
+        transcribe_status: "pending",
+        transcribe_attempts: 2, // one more failure flips to terminal at maxAttempts=3
+      });
+      const assetsRoot = join(tmpDir, "assets");
+      mkdirSync(join(assetsRoot, "e2e"), { recursive: true });
+      writeFileSync(join(assetsRoot, audioPath), Buffer.from([1, 2, 3]));
+      process.env.ASSETS_DIR = assetsRoot;
+
+      // What a first-try success would have produced (for the final assert).
+      const firstTrySuccessBody =
+        "# 🎙️ Voice memo\n\n_Recorded sometime._\n\nthe spoken words\n\n![[e2e/voice.webm]]\n";
+
+      // --- Phase 1: terminal failure. Worker writes the marker in place,
+      // preserving the embed, and clears the stub.
+      let fetchMode: "fail" | "succeed" = "fail";
+      const fetchImpl = (async () => {
+        if (fetchMode === "fail") {
+          return new Response("scribe down", { status: 500 });
+        }
+        return new Response(JSON.stringify({ text: "the spoken words" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const worker = startTranscriptionWorker({
+        vaultList: () => ["default"],
+        getStore: () => store as unknown as Store,
+        scribeUrl: "http://scribe.test",
+        resolveAssetsDir: () => process.env.ASSETS_DIR!,
+        pollIntervalMs: 10_000_000,
+        maxAttempts: 3,
+        fetchImpl,
+        logger: { error: () => {}, info: () => {} },
+      });
+      setTranscriptionWorker(worker);
+      try {
+        await worker.tick();
+
+        const failedNote = await store.getNote("e2e-memo");
+        // Marker replaced the placeholder in place; embed + surrounding body intact.
+        expect(failedNote!.content).toBe(
+          "# 🎙️ Voice memo\n\n_Recorded sometime._\n\n_Transcription unavailable._\n\n![[e2e/voice.webm]]\n",
+        );
+        expect((failedNote!.metadata as any)?.transcribe_stub).toBeUndefined();
+        const failedAtt = await store.getAttachment(att.id);
+        expect(failedAtt?.metadata?.transcribe_status).toBe("failed");
+
+        // --- Phase 2: retry via the legacy route form (POST on the memo note).
+        // Deregister the worker so the retry is "sweep-only" — that lets us
+        // observe the reset + stub re-arm deterministically before the worker
+        // picks the row back up (otherwise the route's fire-and-forget kick
+        // would race our assertions and complete the success in-line).
+        setTranscriptionWorker(null);
+        fetchMode = "succeed";
+        const retryRes = await handleNotes(
+          mkReq("POST", "/notes/e2e-memo/retry-transcription"),
+          store,
+          "/e2e-memo/retry-transcription",
+          "default",
+        );
+        expect(retryRes.status).toBe(202);
+        expect((await retryRes.json() as any).worker).toBe("sweep-only");
+
+        // Attachment back to pending + legacy origin; stub re-armed on the note.
+        const pendingAtt = await store.getAttachment(att.id);
+        expect(pendingAtt?.metadata?.transcribe_status).toBe("pending");
+        expect(pendingAtt?.metadata?.transcribe_origin).toBe("legacy");
+        const rearmed = await store.getNote("e2e-memo");
+        expect((rearmed!.metadata as any)?.transcribe_stub).toBe(true);
+
+        // --- Phase 3: worker succeeds on the retry (sweep tick). Transcript
+        // replaces the _Transcription unavailable._ marker IN PLACE; embed
+        // preserved; final body is byte-identical to a first-try success.
+        setTranscriptionWorker(worker);
+        await worker.tick();
+        const success = await store.getNote("e2e-memo");
+        expect(success!.content).toBe(firstTrySuccessBody);
+        expect(success!.content).toContain("![[e2e/voice.webm]]");
+        expect((success!.metadata as any)?.transcribe_stub).toBeUndefined();
+        const doneAtt = await store.getAttachment(att.id);
+        expect(doneAtt?.metadata?.transcribe_status).toBe("done");
+        expect(doneAtt?.metadata?.transcript).toBe("the spoken words");
+      } finally {
+        await worker.stop();
+        setTranscriptionWorker(null);
+        delete process.env.ASSETS_DIR;
+      }
     });
   });
 });


### PR DESCRIPTION
## What

Resolves feedback **finding F** — the failed-transcription data-loss + retry gap on the legacy voice-memo flow.

The canonical voice memo is captured as `header + _Recorded …_ + _Transcript pending._ + ![[<audio>]]` with `transcribe_stub: true` (parachute-surface notes-ui `recorder.ts` `memoNoteContent`). Two latent defects:

### The data-loss branch
When transcription failed (or, symmetrically, succeeded) **after the user edited the note** — clearing the `_Transcript pending._` placeholder while keeping their text + the embed — the worker did a **full-body replace**:
- `applyFailureMarker()`: placeholder absent → `body = TRANSCRIPT_UNAVAILABLE` (whole body replaced, embed + edits destroyed).
- Legacy success path: placeholder absent → `body = transcript` (same destruction).

The existing failure tests all seeded bodies **without an embed**, which is why it was never caught.

### No retry for legacy memos
`handleRetryTranscription` required `transcript_status === "failed"` + `transcript_attachment_id` — i.e. only the vault#353 **auto** transcript-note flow. Legacy in-body memos could never be retried.

## Part A — never destroy content (append, don't replace)

- **`applyFailureMarker()`**: placeholder present → surgical replace (unchanged); marker **already present** → no-op (idempotent, no stacking); otherwise → **APPEND** `\n\n` + marker to existing content (marker-only if content is empty). Never full-replaces.
- **Legacy success path**: surgical target broadened to match `_Transcript pending._` **OR** `_Transcription unavailable._`, so a retried success replaces the failure marker **in place** (same final shape as a first-try success). When neither is present → **APPEND** the transcript instead of overwriting. *(Behavior change flagged: success-after-edit used to clobber; now it appends — data-safe.)*

## Part B — retry for legacy in-body memos

`handleRetryTranscription` now dispatches by target shape:
- **Auto-flow (vault#353)**: target has `transcript_status` frontmatter → existing behavior, **byte-identical**.
- **Legacy in-body**: target lacks `transcript_status` → new `handleRetryLegacyInBody`. Finds the note's own attachment with `transcribe_status === "failed"`, resets it to pending **preserving `transcribe_origin: "legacy"`** (forcing `"auto"` would switch to the sibling-transcript-note shape and **orphan the in-body embed**), and **re-stamps `transcribe_stub: true`** on the note.

⚠️ **The stub re-arm is load-bearing.** The legacy worker success path early-returns unless the note carries `transcribe_stub`, and that flag was *cleared* when the failure marker was written. Without re-arming it, the retried success would silently never write the transcript back into the body. Verified by the end-to-end test (`legacy in-body memo: end-to-end retry round-trip` in `src/vault.test.ts`) — fail → marker+embed intact → retry → attachment pending + stub re-armed → success → transcript replaces the marker, embed intact, body byte-identical to a first-try success.

## Marker copy

Stays `_Transcription unavailable._` — the notes-ui status chip (parachute-surface `TranscriptionStatus.tsx`) keys off the exact strings, and that repo is a concurrent session. **A friendlier "retry available" copy + chip affordance is a coordinated parachute-surface follow-up.** Migrating capture to the auto-transcribe path remains the long-term direction; this hardens the legacy path real memos still use today.

## Tests (embed-bearing fixtures — the real production shape)

`src/transcription-worker.test.ts`:
- failure w/ placeholder present → marker replaces placeholder, `![[…]]` intact
- **failure w/ placeholder ABSENT** (user-edited + embed) → marker APPENDED, embed + text intact (the data-loss regression)
- double terminal failure → exactly one marker (idempotent)
- success w/ placeholder absent → transcript appended, content preserved
- first-try success w/ placeholder + embed → replaced in place (pins the canonical shape)

`src/vault.test.ts`:
- legacy retry request: 202, resets attachment (legacy origin preserved) + re-arms stub
- legacy retry: 404 `audio_missing`
- **legacy retry end-to-end** (route + real worker): capture → fail → retry → success round-trip
- updated the former `400 invalid_target` test → `400 no_failed_attachment` (a regular note now routes to the legacy handler)
- auto-flow retry regression unchanged

## Gates (literal counts)

- `bun test ./src/` — **1322 pass, 0 fail**
- `bun test ./core/src/` — **667 pass, 0 fail**
- `bun run typecheck` — clean (`tsc --noEmit`, no output)

## Docs

`docs/HTTP_API.md` retry-transcription section documents both forms (auto + legacy in-body), the `no_failed_attachment` branch, and the append-don't-replace policy on Path A.

**Do not merge** — pending reviewer dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)