### PR TITLE
fix(transcription): optimistic concurrency on memo note re-stamp/marker writes (#435)

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2284,12 +2284,63 @@ async function handleRetryLegacyInBody(
   // never writes the transcript back into the body. Use skipUpdatedAt so the
   // note's modification time still reflects user intent, matching the
   // worker's own note writes.
-  const noteMeta = { ...((note.metadata as Record<string, unknown> | undefined) ?? {}) };
-  noteMeta.transcribe_stub = true;
-  await store.updateNote(note.id, {
-    metadata: noteMeta,
-    skipUpdatedAt: true,
+  //
+  // OC-guarded (vault#435): this read-transform-write would otherwise clobber
+  // a user edit landing between `resolveNote` (above) and this write. Thread
+  // `if_updated_at` and retry once on conflict — re-read, re-apply the
+  // metadata-only re-stamp against the fresh note, write with the fresh
+  // precondition. A second conflict surfaces as 409 so the user can retry.
+  // Only the `transcribe_stub` flag is stamped (never content), so re-applying
+  // against the fresh note is always the correct surgical transform.
+  const restampStub = (current: Note): Record<string, unknown> => ({
+    ...((current.metadata as Record<string, unknown> | undefined) ?? {}),
+    transcribe_stub: true,
   });
+  try {
+    try {
+      await store.updateNote(note.id, {
+        metadata: restampStub(note),
+        skipUpdatedAt: true,
+        if_updated_at: note.updatedAt,
+      });
+    } catch (err: any) {
+      if (!err || err.code !== "CONFLICT") throw err;
+      // Conflict — re-read, re-apply the stub re-stamp, retry once.
+      const fresh = await store.getNote(note.id);
+      if (!fresh) {
+        return json(
+          { error: "note_missing", message: "Target note disappeared during retry." },
+          404,
+        );
+      }
+      await store.updateNote(fresh.id, {
+        metadata: restampStub(fresh),
+        skipUpdatedAt: true,
+        if_updated_at: fresh.updatedAt,
+      });
+    }
+  } catch (err: any) {
+    if (err && err.code === "CONFLICT") {
+      // Double conflict — the note kept changing under us. It's a user-facing
+      // request; return 409 so the caller can retry against fresh state. The
+      // attachment was already reset to pending above; a successful re-stamp
+      // on the user's next retry (or the next sweep, if they re-arm the stub)
+      // will let the worker patch the transcript in.
+      return json(
+        {
+          error_type: "conflict",
+          error: "conflict",
+          note_id: note.id,
+          current_updated_at: err.current_updated_at ?? null,
+          your_updated_at: err.expected_updated_at,
+          message:
+            "Note was modified concurrently while arming the retry; re-fetch and try again.",
+        },
+        409,
+      );
+    }
+    throw err;
+  }
 
   const { getTranscriptionWorker } = await import("./transcription-registry.ts");
   const worker = getTranscriptionWorker();

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2333,6 +2333,10 @@ async function handleRetryLegacyInBody(
           note_id: note.id,
           current_updated_at: err.current_updated_at ?? null,
           your_updated_at: err.expected_updated_at,
+          // Mirror the standard PATCH 409 shape (see the notes-update handler
+          // above) — both `your_updated_at` and `expected_updated_at` carry the
+          // same value, kept for shape-congruence with existing callers.
+          expected_updated_at: err.expected_updated_at,
           message:
             "Note was modified concurrently while arming the retry; re-fetch and try again.",
         },

--- a/src/transcription-worker.test.ts
+++ b/src/transcription-worker.test.ts
@@ -56,18 +56,56 @@ function makeWorker(opts: {
   fetchImpl: typeof fetch;
   retention?: "keep" | "until_transcribed" | "never";
   maxAttempts?: number;
+  // Override the store the worker sees (race-injection tests wrap `store`).
+  store?: Store;
+  logger?: { error: (...args: unknown[]) => void; info?: (...args: unknown[]) => void };
 }) {
+  const workerStore = opts.store ?? (store as unknown as Store);
   return startTranscriptionWorker({
     vaultList: () => ["default"],
-    getStore: () => store as unknown as Store,
+    getStore: () => workerStore,
     scribeUrl: "http://scribe.test",
     resolveAssetsDir: () => assetsRoot,
     getAudioRetention: () => opts.retention ?? "keep",
     pollIntervalMs: 10_000_000, // never auto-fire; tests drive ticks manually
     maxAttempts: opts.maxAttempts ?? 3,
     fetchImpl: opts.fetchImpl,
-    logger: silentLogger,
+    logger: opts.logger ?? silentLogger,
   });
+}
+
+/**
+ * Wrap a store so the first `interfereTimes` `updateNote` calls carrying an
+ * `if_updated_at` precondition fire `userEdit()` (a concurrent user write that
+ * bumps `updated_at`) just before delegating — forcing the precondition stale
+ * exactly that many times. Non-OC writes (and the last-resort no-precondition
+ * write) pass straight through. Drives the vault#435 worker race tests.
+ */
+function withRace(
+  base: Store,
+  interfereTimes: number,
+  userEdit: () => Promise<void>,
+): Store {
+  let fired = 0;
+  return new Proxy(base, {
+    get(target, prop, receiver) {
+      if (prop === "updateNote") {
+        return async (id: string, updates: any) => {
+          if (updates?.if_updated_at !== undefined && fired < interfereTimes) {
+            fired++;
+            // bun:sqlite stamps `updated_at` at ms granularity. Sleep so the
+            // concurrent user write lands at a strictly-greater timestamp than
+            // the precondition the worker captured — making the conflict
+            // deterministic rather than racing inside the same millisecond.
+            await new Promise((r) => setTimeout(r, 5));
+            await userEdit();
+          }
+          return (target as any).updateNote(id, updates);
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as Store;
 }
 
 describe("transcription worker", () => {
@@ -512,6 +550,173 @@ describe("transcription worker", () => {
     const [att] = await store.getAttachments("m1");
     expect(att.metadata?.transcribe_status).toBe("failed");
     expect(att.metadata?.transcribe_error).toContain("audio file not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Optimistic concurrency on the worker's note writes (vault#435).
+//
+// The worker patches the memo note in two read-modify-write cycles — the
+// success path (replace the placeholder/marker with the transcript) and the
+// failure path (`applyFailureMarker`). Without an `if_updated_at` precondition
+// a user edit landing between read and write is silently clobbered (the
+// static-write/stale-read class of vault#208). These tests inject a concurrent
+// user PATCH right before the worker's OC write to assert:
+//   (a) the user's edit is NOT clobbered,
+//   (b) the worker RE-APPLIES the transcript/marker correctly on fresh content,
+//   (c) the double-conflict policy (worker = resilient): last-resort apply when
+//       still safe, safe-skip otherwise — never crash the sweep.
+// ---------------------------------------------------------------------------
+describe("transcription worker — optimistic concurrency (vault#435)", () => {
+  test("success patch: single race → re-applies transcript onto the user's fresh content", async () => {
+    // Placeholder body so the transcript would normally surgical-replace in
+    // place. The user appends a line mid-flight; the worker's first OC write
+    // conflicts, it re-reads, and the surgical replace lands on the FRESH
+    // content — preserving the user's append.
+    await store.createNote(
+      "# memo\n\n_Transcript pending._\n",
+      { id: "oc-succ-1", metadata: { transcribe_stub: true } },
+    );
+    seedAudio("memos/ocs1.webm");
+    await store.addAttachment("oc-succ-1", "memos/ocs1.webm", "audio/webm", {
+      transcribe_status: "pending",
+    });
+
+    const raceStore = withRace(store as unknown as Store, 1, async () => {
+      await store.updateNote("oc-succ-1", { append: "\n\nUSER EDIT" });
+    });
+    const worker = makeWorker({
+      store: raceStore,
+      fetchImpl: mkFetchMock([{ text: "the transcript" }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("oc-succ-1");
+    // (b) transcript replaced the placeholder in place; (a) user edit survives.
+    expect(note!.content).toBe("# memo\n\nthe transcript\n\n\nUSER EDIT");
+    expect((note!.metadata as any)?.transcribe_stub).toBeUndefined();
+    const [att] = await store.getAttachments("oc-succ-1");
+    expect(att.metadata?.transcribe_status).toBe("done");
+    expect(att.metadata?.transcript).toBe("the transcript");
+  });
+
+  test("failure marker: single race → re-applies marker onto the user's fresh content", async () => {
+    // maxAttempts=1 so a single scribe failure is terminal → applyFailureMarker.
+    await store.createNote(
+      "# memo\n\n_Transcript pending._\n",
+      { id: "oc-fail-1", metadata: { transcribe_stub: true } },
+    );
+    seedAudio("memos/ocf1.webm");
+    await store.addAttachment("oc-fail-1", "memos/ocf1.webm", "audio/webm", {
+      transcribe_status: "pending",
+    });
+
+    const raceStore = withRace(store as unknown as Store, 1, async () => {
+      await store.updateNote("oc-fail-1", { append: "\n\nUSER EDIT" });
+    });
+    const worker = makeWorker({
+      store: raceStore,
+      maxAttempts: 1,
+      fetchImpl: mkFetchMock([{ error: "scribe down", status: 500 }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("oc-fail-1");
+    // (b) marker replaced the placeholder in place; (a) user edit survives.
+    expect(note!.content).toBe("# memo\n\n_Transcription unavailable._\n\n\nUSER EDIT");
+    expect((note!.metadata as any)?.transcribe_stub).toBeUndefined();
+    const [att] = await store.getAttachments("oc-fail-1");
+    expect(att.metadata?.transcribe_status).toBe("failed");
+  });
+
+  test("double conflict + still safe → last-resort apply (append path stays applicable)", async () => {
+    // No placeholder in the body → the transform takes the APPEND branch, which
+    // is always safe against fresh content. Interfere on BOTH the first write
+    // and the retry write → the worker falls back to the precondition-less
+    // last-resort apply (safe because the stub survives + append is safe).
+    await store.createNote(
+      "user prose with no marker",
+      { id: "oc-dbl-safe", metadata: { transcribe_stub: true } },
+    );
+    seedAudio("memos/ocd1.webm");
+    await store.addAttachment("oc-dbl-safe", "memos/ocd1.webm", "audio/webm", {
+      transcribe_status: "pending",
+    });
+
+    let edits = 0;
+    const raceStore = withRace(store as unknown as Store, 2, async () => {
+      edits++;
+      await store.updateNote("oc-dbl-safe", { append: ` e${edits}` });
+    });
+    const worker = makeWorker({
+      store: raceStore,
+      fetchImpl: mkFetchMock([{ text: "TRANSCRIPT" }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("oc-dbl-safe");
+    // (a) both user appends survive; (c) transcript still appended (last-resort).
+    expect(note!.content).toBe("user prose with no marker e1 e2\n\nTRANSCRIPT");
+    expect((note!.metadata as any)?.transcribe_stub).toBeUndefined();
+  });
+
+  test("double conflict + unsafe (user cleared the stub) → safe-skip, note untouched", async () => {
+    // The racing user edit clears `transcribe_stub` → the last-resort safety
+    // gate refuses to blind-write. The worker skips the note write entirely
+    // and the user's content is left exactly as they left it. The attachment
+    // transcript is still recorded (we never throw work away).
+    await store.createNote(
+      "# memo\n\n_Transcript pending._\n",
+      { id: "oc-dbl-skip", metadata: { transcribe_stub: true } },
+    );
+    seedAudio("memos/ocd2.webm");
+    await store.addAttachment("oc-dbl-skip", "memos/ocd2.webm", "audio/webm", {
+      transcribe_status: "pending",
+    });
+
+    let edit = 0;
+    const raceStore = withRace(store as unknown as Store, 2, async () => {
+      edit++;
+      // Second interference clears the stub (user opts out mid-flight).
+      if (edit >= 2) {
+        await store.updateNote("oc-dbl-skip", {
+          content: "I took this note over",
+          metadata: {},
+        });
+      } else {
+        await store.updateNote("oc-dbl-skip", { append: " edit1" });
+      }
+    });
+    const worker = makeWorker({
+      store: raceStore,
+      fetchImpl: mkFetchMock([{ text: "WOULD CLOBBER" }]),
+    });
+    try {
+      await worker.tick();
+    } finally {
+      await worker.stop();
+    }
+
+    const note = await store.getNote("oc-dbl-skip");
+    // (c) safe-skip: the worker did NOT overwrite the user's takeover content.
+    expect(note!.content).toBe("I took this note over");
+    expect(note!.content).not.toContain("WOULD CLOBBER");
+    // Transcript still durable on the attachment row.
+    const [att] = await store.getAttachments("oc-dbl-skip");
+    expect(att.metadata?.transcribe_status).toBe("done");
+    expect(att.metadata?.transcript).toBe("WOULD CLOBBER");
   });
 });
 

--- a/src/transcription-worker.test.ts
+++ b/src/transcription-worker.test.ts
@@ -80,6 +80,8 @@ function makeWorker(opts: {
  * bumps `updated_at`) just before delegating — forcing the precondition stale
  * exactly that many times. Non-OC writes (and the last-resort no-precondition
  * write) pass straight through. Drives the vault#435 worker race tests.
+ *
+ * NOTE: duplicated in src/vault.test.ts (routes-layer race tests) — keep in sync.
  */
 function withRace(
   base: Store,

--- a/src/transcription-worker.ts
+++ b/src/transcription-worker.ts
@@ -53,7 +53,7 @@
 
 import { join, normalize } from "path";
 import { existsSync, readFileSync, unlinkSync } from "fs";
-import type { Store, Attachment } from "../core/src/types.ts";
+import type { Store, Attachment, Note } from "../core/src/types.ts";
 import type { HookRegistry } from "../core/src/hooks.ts";
 import { appendContextPart, fetchContextEntries, type ContextPayload } from "./context.ts";
 import type { TriggerIncludeContext } from "./config.ts";
@@ -229,6 +229,100 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
    */
   const inFlightAttachments = new Set<string>();
 
+  /**
+   * Apply a surgical note transform under optimistic concurrency (vault#435).
+   *
+   * The worker's marker/transcript writes are read-modify-write cycles
+   * (`getNote` → transform → `updateNote`). Without a precondition, a user
+   * edit landing between the read and the write is silently clobbered —
+   * the same static-write/stale-read class as vault#208.
+   *
+   * `transform(note)` returns the surgical update to apply (`content` and/or
+   * `metadata`), or `null` when the fresh state means there's nothing to do
+   * (e.g. the stub was cleared, or the marker is already present — the
+   * idempotency guards from #434 live inside the transform, so they re-run
+   * against whatever we re-read). The transform MUST be pure w.r.t. the note
+   * it's handed — it's invoked once per read, and re-invoked on the fresh
+   * read after a conflict.
+   *
+   * Policy on conflict (worker = resilient, never crash the sweep):
+   *   1. First write conflicts → re-read, re-run the transform against fresh
+   *      content, write with the fresh precondition.
+   *   2. Second write also conflicts → fall back to a precondition-less write
+   *      ONLY when `safeWithoutPrecondition(freshNote)` says the transform is
+   *      still safe against the latest content (e.g. the surgical-replace
+   *      target is still present, or an append is always-safe). Otherwise
+   *      skip + log — better to leave the note as the user last left it than
+   *      to blind-overwrite a third concurrent edit.
+   *
+   * All errors are logged + swallowed: a note-write failure must not mask the
+   * attachment-level result we already recorded, nor crash the sweep.
+   */
+  async function applyNoteTransformWithOC(
+    store: Store,
+    noteId: string,
+    op: string,
+    transform: (note: Note) => { content?: string; metadata?: Record<string, unknown> } | null,
+    safeWithoutPrecondition: (note: Note) => boolean,
+  ): Promise<void> {
+    try {
+      const note = await store.getNote(noteId);
+      if (!note) return;
+      const update = transform(note);
+      if (update === null) return;
+
+      try {
+        await store.updateNote(note.id, {
+          ...update,
+          skipUpdatedAt: true,
+          if_updated_at: note.updatedAt,
+        });
+        return;
+      } catch (err: any) {
+        if (!err || err.code !== "CONFLICT") throw err;
+      }
+
+      // Conflict — a user edit landed between read and write. Re-read,
+      // re-apply the same surgical transform against the fresh content, and
+      // write with the fresh precondition.
+      const fresh = await store.getNote(noteId);
+      if (!fresh) return;
+      const reUpdate = transform(fresh);
+      if (reUpdate === null) return;
+
+      try {
+        await store.updateNote(fresh.id, {
+          ...reUpdate,
+          skipUpdatedAt: true,
+          if_updated_at: fresh.updatedAt,
+        });
+        return;
+      } catch (err: any) {
+        if (!err || err.code !== "CONFLICT") throw err;
+      }
+
+      // Double conflict (a third edit raced the retry). Last resort: apply
+      // without a precondition ONLY if the transform is still safe against
+      // the latest content. Otherwise skip — don't clobber the user.
+      const latest = await store.getNote(noteId);
+      if (!latest) return;
+      if (!safeWithoutPrecondition(latest)) {
+        logger.error(
+          `[transcribe] ${op}: note ${noteId} kept changing under us (double conflict); skipping to avoid clobbering a concurrent edit`,
+        );
+        return;
+      }
+      const finalUpdate = transform(latest);
+      if (finalUpdate === null) return;
+      await store.updateNote(latest.id, {
+        ...finalUpdate,
+        skipUpdatedAt: true,
+      });
+    } catch (err) {
+      logger.error(`[transcribe] ${op}: failed to apply to note ${noteId}:`, err);
+    }
+  }
+
   async function processOne(vault: string, attachment: Attachment): Promise<void> {
     // Dedupe: another path (sweep vs hook kick, or a duplicate dispatch)
     // is already working this attachment. Drop — its result is durable
@@ -263,33 +357,39 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
    *     the marker alone becomes the body (avoids a leading blank line).
    */
   async function applyFailureMarker(store: Store, noteId: string): Promise<void> {
-    const note = await store.getNote(noteId);
-    if (!note) return;
-    const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
-    if (noteMeta.transcribe_stub !== true) return;
+    // OC-guarded (vault#435): the read-transform-write below is re-run against
+    // fresh content on a conflict so a concurrent user edit isn't clobbered.
+    // The transform is pure w.r.t. the note it's handed; the stub-set and
+    // marker-already-present idempotency guards re-evaluate on the re-read.
+    await applyNoteTransformWithOC(
+      store,
+      noteId,
+      "apply-failure-marker",
+      (note) => {
+        const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
+        if (noteMeta.transcribe_stub !== true) return null;
 
-    let body: string;
-    if (TRANSCRIPT_PLACEHOLDER.test(note.content)) {
-      body = note.content.replace(TRANSCRIPT_PLACEHOLDER, TRANSCRIPT_UNAVAILABLE);
-    } else if (note.content.includes(TRANSCRIPT_UNAVAILABLE)) {
-      // Marker already present — nothing to do. Clear the stub (below) and
-      // return without rewriting the body so we don't stack markers.
-      body = note.content;
-    } else {
-      body = note.content.length > 0
-        ? `${note.content}\n\n${TRANSCRIPT_UNAVAILABLE}`
-        : TRANSCRIPT_UNAVAILABLE;
-    }
-    const { transcribe_stub: _drop, ...restMeta } = noteMeta;
-    try {
-      await store.updateNote(note.id, {
-        content: body,
-        metadata: restMeta,
-        skipUpdatedAt: true,
-      });
-    } catch (err) {
-      logger.error(`[transcribe] failed to apply failure marker to note ${note.id}:`, err);
-    }
+        let body: string;
+        if (TRANSCRIPT_PLACEHOLDER.test(note.content)) {
+          body = note.content.replace(TRANSCRIPT_PLACEHOLDER, TRANSCRIPT_UNAVAILABLE);
+        } else if (note.content.includes(TRANSCRIPT_UNAVAILABLE)) {
+          // Marker already present — nothing to do. Clear the stub and
+          // return without rewriting the body so we don't stack markers.
+          body = note.content;
+        } else {
+          body = note.content.length > 0
+            ? `${note.content}\n\n${TRANSCRIPT_UNAVAILABLE}`
+            : TRANSCRIPT_UNAVAILABLE;
+        }
+        const { transcribe_stub: _drop, ...restMeta } = noteMeta;
+        return { content: body, metadata: restMeta };
+      },
+      // Last-resort (double-conflict) safety: only blind-write while the note
+      // still carries the stub opt-in. If a racing edit cleared it, the user
+      // opted out — skip rather than re-stamp the marker. The body transform
+      // itself is non-destructive (surgical replace / no-op / append).
+      (note) => ((note.metadata as Record<string, unknown> | undefined)?.transcribe_stub === true),
+    );
   }
 
   /**
@@ -459,11 +559,16 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
     } else {
       // Legacy stub-patching path (voice memo flow). Only acts when the note
       // still carries the `transcribe_stub` opt-in — a user edit clearing it
-      // before the transcript arrives opts out of the overwrite.
-      const note = await store.getNote(attachment.noteId);
-      if (note) {
-        const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
-        if (noteMeta.transcribe_stub === true) {
+      // before the transcript arrives opts out of the overwrite. OC-guarded
+      // (vault#435): re-applied against fresh content on a conflict so a
+      // concurrent user edit isn't clobbered.
+      await applyNoteTransformWithOC(
+        store,
+        attachment.noteId,
+        "apply-transcript",
+        (note) => {
+          const noteMeta = (note.metadata as Record<string, unknown> | undefined) ?? {};
+          if (noteMeta.transcribe_stub !== true) return null;
           // Body policy (finding F — never destroy content):
           //   - placeholder OR failure-marker present → surgical replace in
           //     place (a retried success replaces the `_Transcription
@@ -488,17 +593,12 @@ export function startTranscriptionWorker(opts: TranscriptionWorkerOpts): Transcr
               : transcript;
           }
           const { transcribe_stub: _drop, ...restMeta } = noteMeta;
-          try {
-            await store.updateNote(note.id, {
-              content: body,
-              metadata: restMeta,
-              skipUpdatedAt: true,
-            });
-          } catch (err) {
-            logger.error(`[transcribe] failed to apply transcript to note ${note.id}:`, err);
-          }
-        }
-      }
+          return { content: body, metadata: restMeta };
+        },
+        // Last-resort (double-conflict) safety: only blind-write while the
+        // stub opt-in survives. A racing edit that cleared it opts out.
+        (note) => ((note.metadata as Record<string, unknown> | undefined)?.transcribe_stub === true),
+      );
     }
 
     // Always record the transcript on the attachment, even if the note

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -3276,6 +3276,9 @@ describe("HTTP /notes", async () => {
      * `if_updated_at` precondition fire `userEdit()` (a concurrent user write
      * that bumps `updated_at`) just before delegating — forcing the precondition
      * stale exactly `interfereTimes` times. Non-OC writes pass through.
+     *
+     * NOTE: duplicated in src/transcription-worker.test.ts (worker-layer race
+     * tests) — keep in sync.
      */
     function withRace(
       base: Store,

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -3259,6 +3259,130 @@ describe("HTTP /notes", async () => {
         delete process.env.ASSETS_DIR;
       }
     });
+
+    // ---- Optimistic concurrency on the stub re-stamp (vault#435) ----------
+    // The retry endpoint does a read-transform-write on the memo note to
+    // re-arm `transcribe_stub: true`. Without an `if_updated_at` precondition,
+    // a user edit landing between the read (`resolveNote`) and this write is
+    // silently clobbered — the static-write/stale-read class of vault#208.
+    //
+    // We inject a store wrapper that fires a concurrent USER edit immediately
+    // before the route's first OC `updateNote` runs, making its precondition
+    // stale. The route must NOT clobber the user's edit; it must re-read and
+    // re-apply the metadata-only re-stamp against fresh content.
+
+    /**
+     * Wrap a store so the first `N` `updateNote` calls carrying an
+     * `if_updated_at` precondition fire `userEdit()` (a concurrent user write
+     * that bumps `updated_at`) just before delegating — forcing the precondition
+     * stale exactly `interfereTimes` times. Non-OC writes pass through.
+     */
+    function withRace(
+      base: Store,
+      interfereTimes: number,
+      userEdit: () => Promise<void>,
+    ): Store {
+      let fired = 0;
+      return new Proxy(base, {
+        get(target, prop, receiver) {
+          if (prop === "updateNote") {
+            return async (id: string, updates: any) => {
+              if (updates?.if_updated_at !== undefined && fired < interfereTimes) {
+                fired++;
+                // bun:sqlite stamps `updated_at` at ms granularity. Sleep so
+                // the concurrent user write lands at a strictly-greater
+                // timestamp than the precondition the route captured — making
+                // the conflict deterministic rather than racing inside the
+                // same millisecond.
+                await new Promise((r) => setTimeout(r, 5));
+                await userEdit();
+              }
+              return (target as any).updateNote(id, updates);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      }) as Store;
+    }
+
+    test("OC: single race → user edit survives, stub still re-armed (no clobber)", async () => {
+      const { noteId, attachmentId } = await seedLegacyFailedMemo({ noteId: "race-1" });
+
+      // One interference: the very first OC write conflicts; the route re-reads
+      // and re-applies against the user's new content.
+      const raceStore = withRace(store, 1, async () => {
+        // User appends a line to the body while the retry is in flight.
+        await store.updateNote(noteId, { append: "\n\nMY EDIT WHILE PENDING" });
+      });
+
+      const res = await handleNotes(
+        mkReq("POST", `/notes/${noteId}/retry-transcription`),
+        raceStore,
+        `/${noteId}/retry-transcription`,
+        "default",
+      );
+      // (a) User edit NOT clobbered + (c) re-stamp succeeded on retry → 202.
+      expect(res.status).toBe(202);
+
+      const after = await store.getNote(noteId);
+      // (a) The user's concurrent edit survives.
+      expect(after!.content).toContain("MY EDIT WHILE PENDING");
+      // Original capture body also intact (re-stamp is metadata-only).
+      expect(after!.content).toContain("_Transcription unavailable._");
+      // (c) Stub re-armed despite the race.
+      expect((after!.metadata as any)?.transcribe_stub).toBe(true);
+
+      const att = await store.getAttachment(attachmentId);
+      expect(att?.metadata?.transcribe_status).toBe("pending");
+      expect(att?.metadata?.transcribe_origin).toBe("legacy");
+
+      delete process.env.ASSETS_DIR;
+    });
+
+    test("OC: double race → 409 (user-facing request can retry)", async () => {
+      const { noteId } = await seedLegacyFailedMemo({ noteId: "race-2" });
+
+      // Interfere on BOTH the first write and the retry write → the route
+      // exhausts its single retry and surfaces 409.
+      const raceStore = withRace(store, 2, async () => {
+        await store.updateNote(noteId, { append: " x" });
+      });
+
+      const res = await handleNotes(
+        mkReq("POST", `/notes/${noteId}/retry-transcription`),
+        raceStore,
+        `/${noteId}/retry-transcription`,
+        "default",
+      );
+      // (c) Double-conflict policy for a user-facing endpoint: 409.
+      expect(res.status).toBe(409);
+      const body = await res.json() as any;
+      expect(body.error_type).toBe("conflict");
+      expect(body.note_id).toBe(noteId);
+
+      // The note was never clobbered — the user's two appends are both present.
+      const after = await store.getNote(noteId);
+      expect(after!.content).toContain(" x x");
+
+      delete process.env.ASSETS_DIR;
+    });
+
+    test("OC: happy path unchanged when no race occurs", async () => {
+      // With zero interference the OC write lands first-try, byte-identical to
+      // the pre-#435 behavior — guards against the precondition breaking the
+      // common path.
+      const { noteId } = await seedLegacyFailedMemo({ noteId: "race-0" });
+      const res = await handleNotes(
+        mkReq("POST", `/notes/${noteId}/retry-transcription`),
+        store,
+        `/${noteId}/retry-transcription`,
+        "default",
+      );
+      expect(res.status).toBe(202);
+      const after = await store.getNote(noteId);
+      expect((after!.metadata as any)?.transcribe_stub).toBe(true);
+      delete process.env.ASSETS_DIR;
+    });
   });
 });
 


### PR DESCRIPTION
Resolves #435.

## The class

The transcription flow's note read-modify-write cycles lacked an `if_updated_at` precondition. Each does `store.getNote` → spread/transform metadata+content → `store.updateNote`, with no optimistic-concurrency token. A user edit landing between the read and the write was **silently clobbered** — the same static-write / stale-read class as vault#208. Surfaced during review of #434 (pre-existing, not introduced there).

Three sites:

- **`handleRetryLegacyInBody`** (`src/routes.ts`) — the retry endpoint's `transcribe_stub: true` re-stamp.
- **`applyFailureMarker`** (`src/transcription-worker.ts`) — the terminal-failure `_Transcription unavailable._` marker write.
- **legacy success patch** (`src/transcription-worker.ts`) — the transcript-into-body write.

## The fix

Each site now threads `if_updated_at: note.updatedAt` and **retries once on conflict**: re-read the note, re-apply the same surgical transform against the fresh state, write with the fresh precondition. The store already exposes `if_updated_at` on `updateNote` (throws `ConflictError`, `code: "CONFLICT"`); it composes with `skipUpdatedAt` so the worker's machine-writes still don't bump `updated_at` (preserves #44 semantics).

All of #434's transformation semantics are kept **byte-identical** — surgical replace via function replacer (`() => transcript`, not a string, so `$&`/`$1` in speech-to-text can't inject), append-don't-replace when the placeholder/marker is absent, and the marker-already-present + stub-set idempotency guards. They're hoisted into a pure `transform(note)` closure so they re-evaluate against whatever we re-read.

The two worker sites share one helper, `applyNoteTransformWithOC(store, noteId, op, transform, safeWithoutPrecondition)`.

## Per-site double-conflict policy

After the single retry also conflicts (a third edit raced):

| Site | Policy |
|---|---|
| retry endpoint (`handleRetryLegacyInBody`) | **409** — it's a user-facing request; the caller re-fetches and retries. The attachment was already reset to pending, so a re-stamp on their next retry lets the worker patch the transcript in. |
| worker marker + transcript writes | **last-resort apply WITHOUT precondition only when still safe** (the `transcribe_stub` opt-in survives + the body transform is non-destructive — surgical replace / no-op / append). Otherwise **skip + log** — a racing edit that cleared the stub opts the note out, so we leave it as the user last left it. Never crash the sweep. The attachment-level transcript is recorded regardless. |

The auto-origin transcript-sidecar note (`upsertTranscriptNote`) is intentionally left as a full-overwrite upsert — it's a system-generated `<path>.transcript.md` sidecar, not a surface for user edits, so it's outside this race class.

## How the race test works

A `withRace(base, interfereTimes, userEdit)` store wrapper (`Proxy`) intercepts `updateNote` calls carrying an `if_updated_at` precondition and fires a concurrent **user PATCH** (a real `store.updateNote` that bumps `updated_at`) immediately before delegating — making the precondition stale exactly `interfereTimes` times. A 5ms sleep before the user write keeps it deterministic against `bun:sqlite`'s ms-granularity timestamps.

Coverage (worker + routes):
- **(a)** the user's edit is NOT clobbered;
- **(b)** the worker re-applies the marker/transcript correctly onto the user's fresh content (surgical replace still lands in place);
- **(c)** double-conflict behaves per the site's policy — 409 at the endpoint; last-resort safe-apply (append path) and safe-skip (stub cleared mid-flight, note left untouched, transcript still durable on the attachment) at the worker;
- **(d)** the happy path is unchanged — existing #434 tests stay green.

## Gates

- `bun test ./src/` — **1331 pass**, 0 fail
- `bun test ./core/src/` — **667 pass**, 0 fail
- `bun run typecheck` — clean

No version bump (per governance — this PR doesn't tag a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)