### PR TITLE
per-vault usage endpoint (data footprint monitoring)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -972,6 +972,33 @@ describe("vault stats", async () => {
     expect(stats.topTags).toEqual([]);
     expect(stats.tagCount).toBe(0);
     expect(stats.linkCount).toBe(0);
+    expect(stats.contentBytes).toBe(0);
+  });
+
+  it("contentBytes sums ASCII content as raw byte length", async () => {
+    // "hello" = 5 bytes, "world!" = 6 bytes — for pure ASCII, bytes == chars.
+    await store.createNote("hello");
+    await store.createNote("world!");
+    const stats = await store.getVaultStats();
+    expect(stats.contentBytes).toBe(11);
+  });
+
+  it("contentBytes counts UTF-8 BYTES, not characters (multibyte)", async () => {
+    // The whole point of CAST(content AS BLOB): SQLite's bare LENGTH() would
+    // return the CHARACTER count, undercounting multibyte content.
+    //   - "é"  is U+00E9 → 2 bytes in UTF-8 (1 char)
+    //   - "你好" is 2 CJK chars → 6 bytes (3 bytes each)
+    //   - "😀" is 1 grapheme / 2 UTF-16 code units → 4 bytes in UTF-8
+    const content = "é你好😀";
+    const expectedBytes = Buffer.byteLength(content, "utf8"); // 2 + 6 + 4 = 12
+    expect(expectedBytes).toBe(12);
+    // And it's strictly MORE than the JS character count — proves we're not
+    // accidentally counting chars.
+    expect(expectedBytes).toBeGreaterThan([...content].length);
+
+    await store.createNote(content);
+    const stats = await store.getVaultStats();
+    expect(stats.contentBytes).toBe(expectedBytes);
   });
 
   it("counts total notes and tagCount", async () => {
@@ -1041,6 +1068,7 @@ describe("vault stats", async () => {
     expect(stats).toHaveProperty("topTags");
     expect(stats).toHaveProperty("tagCount");
     expect(stats).toHaveProperty("linkCount");
+    expect(stats).toHaveProperty("contentBytes");
   });
 
   it("counts resolved wikilinks in linkCount", async () => {

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -1579,6 +1579,15 @@ export function getVaultStats(
   const linkCountRow = db.prepare("SELECT COUNT(*) as c FROM links").get() as { c: number };
   const linkCount = linkCountRow.c;
 
+  // Total content bytes. CAST(content AS BLOB) forces SQLite's LENGTH() to
+  // count UTF-8 BYTES rather than characters (bare LENGTH on TEXT returns a
+  // char count, which undercounts multibyte content). COALESCE because SUM
+  // over zero rows is NULL. See VaultStats.contentBytes for the rationale.
+  const contentBytesRow = db
+    .prepare("SELECT COALESCE(SUM(LENGTH(CAST(content AS BLOB))), 0) as b FROM notes")
+    .get() as { b: number };
+  const contentBytes = contentBytesRow.b;
+
   return {
     totalNotes,
     earliestNote: earliestRow
@@ -1592,6 +1601,7 @@ export function getVaultStats(
     tagCount,
     attachmentCount,
     linkCount,
+    contentBytes,
   };
 }
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -67,6 +67,16 @@ export interface VaultStats {
   tagCount: number;
   attachmentCount: number;
   linkCount: number;
+  /**
+   * Total bytes of all note content, computed as the sum of the UTF-8 byte
+   * length of every note's `content`. The SQL uses `LENGTH(CAST(content AS
+   * BLOB))` deliberately: SQLite's bare `LENGTH(text)` returns the number of
+   * *characters*, not bytes, so a note full of multibyte UTF-8 (emoji, CJK,
+   * accents) would undercount its true on-disk/on-wire footprint. Casting to
+   * BLOB forces `LENGTH` to count raw bytes. This is the logical content size,
+   * not the physical DB-file size (see `usage.ts:dbBytes` for the latter).
+   */
+  contentBytes: number;
 }
 
 // ---- Query Options ----

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,6 +115,17 @@ export function vaultConfigPath(name: string): string {
   return join(vaultDir(name), "vault.yaml");
 }
 
+/**
+ * Per-vault attachments directory: `<vaultDir>/assets`, or the `ASSETS_DIR`
+ * env override when set (single-assets-root deployments). Lives here next to
+ * the other path helpers — neutral ground that both `routes.ts` (upload/serve)
+ * and `usage.ts` (footprint dir-walk) import without a cycle. `routes.ts`
+ * re-exports it for the existing callers (mirror-deps, server, triggers, …).
+ */
+export function assetsDir(name: string): string {
+  return process.env.ASSETS_DIR ?? join(vaultDir(name), "assets");
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -44,12 +44,16 @@ import {
 } from "../core/src/expand.ts";
 import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
-import { vaultDir } from "./config.ts";
+import { assetsDir } from "./config.ts";
 import { shouldAutoTranscribe } from "./auto-transcribe.ts";
-// usage.ts imports `assetsDir` from this module — the cycle is function-level
-// only (invalidateUsageCache is *called* at upload time, never at module
-// eval), so ESM resolves it fine.
+// usage.ts imports `assetsDir` from config.ts (neutral ground), so this import
+// of invalidateUsageCache does NOT form a cycle — routes.ts → usage.ts only.
 import { invalidateUsageCache } from "./usage.ts";
+
+// Re-export `assetsDir` (now defined in config.ts) so the existing callers
+// that import it from this module — mirror-deps, mirror-routes, server,
+// triggers, cli — keep working unchanged.
+export { assetsDir };
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2371,11 +2375,12 @@ async function handleRetryLegacyInBody(
 
 // ---------------------------------------------------------------------------
 // Storage (file upload/serve) — kept as-is, Daily needs it
+//
+// `assetsDir` moved to config.ts (next to the other path helpers) to break the
+// usage.ts↔routes.ts import cycle; it's re-exported from this module's top so
+// existing importers are unaffected.
 // ---------------------------------------------------------------------------
 
-export function assetsDir(vault: string): string {
-  return process.env.ASSETS_DIR ?? join(vaultDir(vault), "assets");
-}
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024; // 100MB
 
 // Storage allowlist policy:

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -46,6 +46,10 @@ import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { vaultDir } from "./config.ts";
 import { shouldAutoTranscribe } from "./auto-transcribe.ts";
+// usage.ts imports `assetsDir` from this module — the cycle is function-level
+// only (invalidateUsageCache is *called* at upload time, never at module
+// eval), so ESM resolves it fine.
+import { invalidateUsageCache } from "./usage.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2436,6 +2440,13 @@ export async function handleStorage(
 
     const relativePath = `${date}/${filename}`;
     const mimeType = MIME_TYPES[ext] ?? "application/octet-stream";
+
+    // Invalidate the usage dir-walk cache for this vault — the new attachment
+    // changed the assets-directory footprint, so the next /.parachute/usage
+    // read must re-walk rather than report a stale (smaller) number. Without
+    // this hook the cache's 60s TTL would briefly under-report after an
+    // upload. (usage.ts:invalidateUsageCache is a no-op-cheap map delete.)
+    invalidateUsageCache(vault);
 
     return json({ path: relativePath, size: buffer.length, mimeType }, 201);
   }

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -44,6 +44,7 @@ const {
 const { clearVaultStoreCache, getVaultStore } = await import("./vault-store.ts");
 const { vaultDbPath } = await import("./config.ts");
 const { resetJwksCache, resetRevocationCache } = await import("./hub-jwt.ts");
+const { invalidateUsageCache } = await import("./usage.ts");
 
 // ---------------------------------------------------------------------------
 // Hub-JWT mint fixture (vault#282 Stage 2 — vault is a pure hub
@@ -135,6 +136,12 @@ function seedTagScopedRow(vaultName: string, scopedTags: string[], label = "test
 
 function reset(): void {
   clearVaultStoreCache();
+  // The usage dir-walk cache is module-level (process-wide) and survives the
+  // testDir wipe; its 60s TTL would otherwise leak a prior test's `journal`
+  // entry into the next test and flip a "first read" to cached:true. Clear
+  // the vault names these tests reuse so each test starts cache-cold.
+  invalidateUsageCache("journal");
+  invalidateUsageCache("other");
   if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
   mkdirSync(testDir, { recursive: true });
   mkdirSync(join(testDir, "vault", "data"), { recursive: true });
@@ -1978,5 +1985,183 @@ describe("/vault/<name>/.parachute/mirror/run-now — auth + dispatch", () => {
     );
     // 503 short-circuits the method check when no manager is wired.
     expect([405, 503]).toContain(res.status);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /vault/<name>/.parachute/usage — per-vault data-footprint endpoint.
+//
+// READ-scoped (a vault's own user must see their own vault's size; the
+// operator inherits read via broad/admin). Reports counts + byte sizes; the
+// two dir-walks (assets, mirror) are TTL-cached, `?fresh=1` bypasses, and an
+// attachment upload invalidates the cache. These tests exercise the auth
+// gate, the response shape, the cache hit/bypass, and upload-invalidation
+// end-to-end through `route()` against the real (tmp) filesystem.
+// ---------------------------------------------------------------------------
+
+describe("/vault/<name>/.parachute/usage — data-footprint endpoint", () => {
+  const USAGE_PATH = "/vault/journal/.parachute/usage";
+
+  function authedGet(token: string, path = USAGE_PATH): Request {
+    return new Request(`http://localhost:1940${path}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+  }
+
+  /** Upload an attachment through the real storage route (write-scoped). */
+  async function uploadAttachment(token: string, bytes: number): Promise<Response> {
+    const form = new FormData();
+    const file = new File([new Uint8Array(bytes).fill(7)], "photo.png", { type: "image/png" });
+    form.set("file", file);
+    const p = "/vault/journal/api/storage/upload";
+    return route(
+      new Request(`http://localhost:1940${p}`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+        body: form,
+      }),
+      p,
+    );
+  }
+
+  test("unauthenticated → 401", async () => {
+    createVault("journal");
+    const res = await route(new Request(`http://localhost:1940${USAGE_PATH}`), USAGE_PATH);
+    expect(res.status).toBe(401);
+  });
+
+  test("read-scoped token → 200 with the full shape (owner sees own vault)", async () => {
+    createVault("journal");
+    // Seed two notes so counts + contentBytes are non-trivial.
+    const store = getVaultStore("journal");
+    await store.createNote("hello");
+    await store.createNote("world!");
+
+    const token = await mintJwt({ vaultName: "journal", scopes: ["vault:journal:read"] });
+    const res = await route(authedGet(token), USAGE_PATH);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      counts: { notes: number; attachments: number; links: number; tags: number };
+      bytes: { content: number; db: number; assets: number; total: number; mirror?: number };
+      computedAt: string;
+      cached: boolean;
+    };
+
+    // counts match getVaultStats
+    const stats = await store.getVaultStats();
+    expect(body.counts.notes).toBe(stats.totalNotes);
+    expect(body.counts.notes).toBe(2);
+    expect(body.counts.attachments).toBe(stats.attachmentCount);
+    expect(body.counts.links).toBe(stats.linkCount);
+    expect(body.counts.tags).toBe(stats.tagCount);
+
+    // bytes shape
+    expect(body.bytes.content).toBe(stats.contentBytes);
+    expect(body.bytes.content).toBe(11); // "hello"(5) + "world!"(6)
+    expect(body.bytes.db).toBeGreaterThan(0); // a real SQLite file exists
+    expect(body.bytes.assets).toBe(0); // no uploads yet
+    // total = db + assets (NOT content, NOT mirror)
+    expect(body.bytes.total).toBe(body.bytes.db + body.bytes.assets);
+    // no mirror configured → omitted
+    expect(body.bytes).not.toHaveProperty("mirror");
+
+    expect(typeof body.computedAt).toBe("string");
+    expect(typeof body.cached).toBe("boolean");
+  });
+
+  test("insufficient scope is impossible at read — but no vault: scope at all → 403", async () => {
+    createVault("journal");
+    // A token carrying only a non-vault scope satisfies neither read nor any
+    // vault verb → 403 insufficient_scope.
+    const token = await mintJwt({ vaultName: "journal", scopes: ["openid"] });
+    const res = await route(authedGet(token), USAGE_PATH);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error_type?: string; required_scope?: string };
+    expect(body.error_type).toBe("insufficient_scope");
+    expect(body.required_scope).toBe("vault:read");
+  });
+
+  test("wrong-vault scope is denied (narrowed scope names a different vault)", async () => {
+    createVault("journal");
+    createVault("other");
+    // Token scoped to `other`, used against `journal` → denied.
+    const token = await mintJwt({ vaultName: "journal", scopes: ["vault:other:read"] });
+    const res = await route(authedGet(token), USAGE_PATH);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error_type?: string };
+    expect(body.error_type).toBe("insufficient_scope");
+  });
+
+  test("write/admin scope inherits read → 200", async () => {
+    createVault("journal");
+    const token = await createAdminToken("journal");
+    const res = await route(authedGet(token), USAGE_PATH);
+    expect(res.status).toBe(200);
+  });
+
+  test("non-GET method → 405", async () => {
+    createVault("journal");
+    const token = await mintJwt({ vaultName: "journal", scopes: ["vault:journal:read"] });
+    const res = await route(
+      new Request(`http://localhost:1940${USAGE_PATH}`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      USAGE_PATH,
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("second read within TTL is served from cache (cached:true)", async () => {
+    createVault("journal");
+    const token = await mintJwt({ vaultName: "journal", scopes: ["vault:journal:read"] });
+
+    const first = (await (await route(authedGet(token), USAGE_PATH)).json()) as { cached: boolean };
+    expect(first.cached).toBe(false);
+
+    const second = (await (await route(authedGet(token), USAGE_PATH)).json()) as { cached: boolean };
+    expect(second.cached).toBe(true);
+  });
+
+  test("?fresh=1 bypasses the cache (cached:false even on a warm cache)", async () => {
+    createVault("journal");
+    const token = await mintJwt({ vaultName: "journal", scopes: ["vault:journal:read"] });
+
+    // Prime the cache.
+    await route(authedGet(token), USAGE_PATH);
+
+    // ?fresh=1 must recompute regardless. The server passes `url.pathname`
+    // (query stripped) as the `path` arg while the Request URL retains the
+    // query — the route reads `fresh` from `req.url`, not `path`. Mirror that.
+    const reqWithQuery = new Request(`http://localhost:1940${USAGE_PATH}?fresh=1`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const res = await route(reqWithQuery, USAGE_PATH);
+    const body = (await res.json()) as { cached: boolean };
+    expect(body.cached).toBe(false);
+  });
+
+  test("attachment upload invalidates the cache → assets bytes update", async () => {
+    createVault("journal");
+    const writeToken = await mintJwt({ vaultName: "journal", scopes: ["vault:journal:write"] });
+
+    // Prime: assets empty.
+    const before = (await (await route(authedGet(writeToken), USAGE_PATH)).json()) as {
+      bytes: { assets: number };
+    };
+    expect(before.bytes.assets).toBe(0);
+
+    // Upload a 4096-byte attachment (write-scoped) — this invalidates usage.
+    const up = await uploadAttachment(writeToken, 4096);
+    expect(up.status).toBe(201);
+
+    // Next read must re-walk (cache was invalidated) and reflect the new file.
+    const after = (await (await route(authedGet(writeToken), USAGE_PATH)).json()) as {
+      bytes: { assets: number };
+      cached: boolean;
+    };
+    expect(after.cached).toBe(false); // invalidated → recomputed
+    expect(after.bytes.assets).toBeGreaterThanOrEqual(4096);
   });
 });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -49,7 +49,7 @@ import {
   authenticateGlobalRequest,
   extractApiKey,
 } from "./auth.ts";
-import { hasScopeForVault, SCOPE_ADMIN, scopeForMethod, verbForMethod } from "./scopes.ts";
+import { hasScopeForVault, SCOPE_ADMIN, SCOPE_READ, scopeForMethod, verbForMethod } from "./scopes.ts";
 import { getVaultStore } from "./vault-store.ts";
 import { handleScopedMcp } from "./mcp-http.ts";
 import { defaultAdminSpaDistDir, isAdminSpaPath, serveAdminSpa } from "./admin-spa.ts";
@@ -87,6 +87,7 @@ import {
   handleMirrorRunNow,
 } from "./mirror-routes.ts";
 import { getMirrorManager } from "./mirror-registry.ts";
+import { buildUsageReport } from "./usage.ts";
 
 /**
  * Decorate a 401 response from the MCP endpoint with the RFC 9728 challenge
@@ -460,6 +461,35 @@ export async function route(
       createdAt: vaultConfig.created_at,
       stats,
     });
+  }
+
+  // /.parachute/usage — per-vault data-footprint report ("how big is this
+  // vault"). READ-scoped, deliberately: a vault's own user must be able to
+  // see their own vault's size, and the operator (who holds broad/admin)
+  // inherits read. This mirrors the bare-root stats precedent above (also
+  // read-gated by the method) — same data-disclosure class (counts + sizes,
+  // no note content). The expensive part (two dir-walks) is TTL-cached inside
+  // usage.ts; `?fresh=1` bypasses the cache. Hub-side aggregation/UI is a
+  // separate follow-up; this endpoint is the load-bearing primitive.
+  if (subpath === "/.parachute/usage") {
+    if (req.method !== "GET") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (!hasScopeForVault(auth.scopes, vaultName, "read")) {
+      return Response.json(
+        {
+          error: "Forbidden",
+          error_type: "insufficient_scope",
+          message: `This endpoint requires the '${SCOPE_READ}' scope (or '${SCOPE_READ.replace("vault:", `vault:${vaultName}:`)}').`,
+          required_scope: SCOPE_READ,
+          granted_scopes: auth.scopes,
+        },
+        { status: 403 },
+      );
+    }
+    const fresh = new URL(req.url).searchParams.get("fresh") === "1";
+    const stats = await store.getVaultStats();
+    return Response.json(buildUsageReport(vaultName, stats, { fresh }));
   }
 
   // The per-vault `/tokens` REST surface (pvt_* mint/list/revoke) was removed

--- a/src/usage.test.ts
+++ b/src/usage.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for the usage helpers (src/usage.ts).
+ *
+ * Everything here runs against the injectable `UsageFs` seam — no real disk
+ * I/O — so we can (a) synthesize trees with symlinks/missing dirs and (b)
+ * count how many times the dir-walk actually runs, which is how we prove the
+ * TTL cache skips the walk on a hit.
+ *
+ * The path helpers (`vaultDir`, `assetsDir`, mirror resolution) DO read
+ * `process.env.PARACHUTE_HOME`; we point it at a tmp dir so the resolved paths
+ * are deterministic, but no files are written there — the fake fs intercepts
+ * every stat/readdir.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const testDir = join(
+  tmpdir(),
+  `vault-usage-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+);
+process.env.PARACHUTE_HOME = testDir;
+
+const {
+  dbBytes,
+  dirSize,
+  UsageCache,
+  buildUsageReport,
+} = await import("./usage.ts");
+const { vaultDir } = await import("./config.ts");
+const { assetsDir } = await import("./routes.ts");
+
+import type { UsageFs } from "./usage.ts";
+import type { VaultStats } from "../core/src/types.ts";
+import type { Dirent } from "fs";
+
+// ---------------------------------------------------------------------------
+// Fake filesystem builder
+//
+// A node is either a file (number = size in bytes), a dir (object mapping
+// names → nodes), or a symlink (special marker, never followed).
+// ---------------------------------------------------------------------------
+
+type FileNode = { kind: "file"; size: number };
+type DirNode = { kind: "dir"; children: Record<string, FsNode> };
+type LinkNode = { kind: "link" };
+type FsNode = FileNode | DirNode | LinkNode;
+
+const file = (size: number): FileNode => ({ kind: "file", size });
+const dir = (children: Record<string, FsNode>): DirNode => ({ kind: "dir", children });
+const link = (): LinkNode => ({ kind: "link" });
+
+function makeDirent(name: string, node: FsNode): Dirent {
+  return {
+    name,
+    isFile: () => node.kind === "file",
+    isDirectory: () => node.kind === "dir",
+    isSymbolicLink: () => node.kind === "link",
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+  } as unknown as Dirent;
+}
+
+/**
+ * Build a fake `UsageFs` rooted at a set of absolute paths. `roots` maps an
+ * absolute path → the node that lives there. Lookups resolve a requested
+ * absolute path by walking from the matching root prefix. `readCount` exposes
+ * how many `readDir` calls happened (for cache assertions).
+ */
+function makeFakeFs(roots: Record<string, FsNode>): UsageFs & { readCount: number } {
+  function resolve(path: string): FsNode | undefined {
+    // Exact root match first.
+    if (roots[path]) return roots[path];
+    // Otherwise find the root that's a prefix and descend by segment.
+    for (const [rootPath, rootNode] of Object.entries(roots)) {
+      if (path === rootPath) return rootNode;
+      if (path.startsWith(rootPath + "/")) {
+        const rest = path.slice(rootPath.length + 1).split("/");
+        let cur: FsNode | undefined = rootNode;
+        for (const seg of rest) {
+          if (!cur || cur.kind !== "dir") return undefined;
+          cur = cur.children[seg];
+        }
+        return cur;
+      }
+    }
+    return undefined;
+  }
+
+  const fs = {
+    readCount: 0,
+    statFile(path: string) {
+      const node = resolve(path);
+      if (!node) throw new Error(`ENOENT: ${path}`);
+      return {
+        size: node.kind === "file" ? node.size : 0,
+        isDirectory: () => node.kind === "dir",
+        isSymbolicLink: () => node.kind === "link",
+      };
+    },
+    readDir(path: string): Dirent[] {
+      fs.readCount++;
+      const node = resolve(path);
+      if (!node || node.kind !== "dir") throw new Error(`ENOTDIR: ${path}`);
+      return Object.entries(node.children).map(([name, child]) => makeDirent(name, child));
+    },
+  };
+  return fs;
+}
+
+// ---------------------------------------------------------------------------
+// dbBytes — sums the WAL trio (vault.db + -wal + -shm)
+// ---------------------------------------------------------------------------
+
+describe("dbBytes (WAL-aware DB file sizing)", () => {
+  const VAULT = "journal";
+  const dbBase = join(vaultDir(VAULT), "vault.db");
+
+  test("sums vault.db + vault.db-wal + vault.db-shm", () => {
+    const fs = makeFakeFs({
+      [dbBase]: file(4096),
+      [`${dbBase}-wal`]: file(800),
+      [`${dbBase}-shm`]: file(32),
+    });
+    expect(dbBytes(VAULT, fs)).toBe(4096 + 800 + 32);
+  });
+
+  test("tolerates missing -wal/-shm (checkpointed at rest)", () => {
+    const fs = makeFakeFs({ [dbBase]: file(4096) });
+    // -wal and -shm absent → contribute 0, not an error.
+    expect(dbBytes(VAULT, fs)).toBe(4096);
+  });
+
+  test("missing DB entirely → 0", () => {
+    const fs = makeFakeFs({});
+    expect(dbBytes(VAULT, fs)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dirSize — recursive, missing-dir tolerant, symlink-safe
+// ---------------------------------------------------------------------------
+
+describe("dirSize (recursive directory byte sum)", () => {
+  const ROOT = "/fake/assets";
+
+  test("sums files across nested directories", () => {
+    const fs = makeFakeFs({
+      [ROOT]: dir({
+        "a.png": file(100),
+        "2026-06-03": dir({
+          "x.jpg": file(250),
+          nested: dir({ "y.pdf": file(50) }),
+        }),
+      }),
+    });
+    expect(dirSize(ROOT, fs)).toBe(100 + 250 + 50);
+  });
+
+  test("empty directory → 0", () => {
+    const fs = makeFakeFs({ [ROOT]: dir({}) });
+    expect(dirSize(ROOT, fs)).toBe(0);
+  });
+
+  test("missing directory → 0 (no throw)", () => {
+    const fs = makeFakeFs({});
+    expect(dirSize(ROOT, fs)).toBe(0);
+  });
+
+  test("does NOT follow symlinks (file or dir)", () => {
+    const fs = makeFakeFs({
+      [ROOT]: dir({
+        "real.png": file(100),
+        "linked-file": link(), // would be a file if followed
+        "linked-dir": link(), // would be a dir if followed
+      }),
+      // A target tree the symlink "points at" — if dirSize followed the link
+      // it would walk this and add 9999. It must NOT.
+      [join(ROOT, "linked-dir")]: dir({ "huge.bin": file(9999) }),
+    });
+    expect(dirSize(ROOT, fs)).toBe(100);
+  });
+
+  test("symlink loop does not hang (link is skipped, never descended)", () => {
+    // The classic infinite-walk trap: a dir containing a symlink to itself.
+    // Because we skip symlinks outright, this terminates immediately.
+    const fs = makeFakeFs({
+      [ROOT]: dir({
+        "f.png": file(10),
+        loop: link(),
+      }),
+    });
+    expect(dirSize(ROOT, fs)).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UsageCache — 60s TTL, fresh bypass, invalidation, call-count proof
+// ---------------------------------------------------------------------------
+
+describe("UsageCache (dir-walk TTL cache)", () => {
+  const VAULT = "journal";
+  const assets = assetsDir(VAULT);
+
+  function fsWith(assetsBytes: number) {
+    return makeFakeFs({ [assets]: dir({ "a.png": file(assetsBytes) }) });
+  }
+
+  test("first read walks (cached:false); second read within TTL is cached (no walk)", () => {
+    const fs = fsWith(500);
+    let clock = 1_000;
+    const cache = new UsageCache(fs, () => clock, 60_000);
+
+    const first = cache.get(VAULT);
+    expect(first.cached).toBe(false);
+    expect(first.result.assets).toBe(500);
+    const afterFirst = fs.readCount;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    clock += 30_000; // within the 60s TTL
+    const second = cache.get(VAULT);
+    expect(second.cached).toBe(true);
+    expect(second.result.assets).toBe(500);
+    // The cache MUST NOT have re-walked — call count is unchanged.
+    expect(fs.readCount).toBe(afterFirst);
+  });
+
+  test("entry expires after TTL → re-walks (cached:false)", () => {
+    const fs = fsWith(500);
+    let clock = 1_000;
+    const cache = new UsageCache(fs, () => clock, 60_000);
+
+    cache.get(VAULT); // prime
+    const afterPrime = fs.readCount;
+
+    clock += 60_001; // just past TTL
+    const stale = cache.get(VAULT);
+    expect(stale.cached).toBe(false);
+    expect(fs.readCount).toBeGreaterThan(afterPrime);
+  });
+
+  test("fresh:true bypasses a valid cache entry and re-walks", () => {
+    const fs = fsWith(500);
+    let clock = 1_000;
+    const cache = new UsageCache(fs, () => clock, 60_000);
+
+    cache.get(VAULT); // prime
+    const afterPrime = fs.readCount;
+
+    clock += 1_000; // well within TTL — a normal read would be cached
+    const forced = cache.get(VAULT, { fresh: true });
+    expect(forced.cached).toBe(false);
+    expect(fs.readCount).toBeGreaterThan(afterPrime);
+  });
+
+  test("invalidate() forces the next read to re-walk", () => {
+    const fs = fsWith(500);
+    let clock = 1_000;
+    const cache = new UsageCache(fs, () => clock, 60_000);
+
+    cache.get(VAULT); // prime
+    const afterPrime = fs.readCount;
+
+    cache.invalidate(VAULT);
+    clock += 1_000; // within TTL, but the entry is gone
+    const after = cache.get(VAULT);
+    expect(after.cached).toBe(false);
+    expect(fs.readCount).toBeGreaterThan(afterPrime);
+  });
+
+  test("no mirror configured → mirror:null (omitted from report)", () => {
+    // No mirror-config.yaml written for this vault → resolveVaultMirrorDir
+    // returns null → mirror is null.
+    const fs = fsWith(500);
+    const cache = new UsageCache(fs, () => 1_000, 60_000);
+    const { result } = cache.get(VAULT);
+    expect(result.mirror).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildUsageReport — shape + total math + mirror handling
+// ---------------------------------------------------------------------------
+
+describe("buildUsageReport", () => {
+  const VAULT = "journal";
+  const dbBase = join(vaultDir(VAULT), "vault.db");
+  const assets = assetsDir(VAULT);
+
+  function makeStats(overrides: Partial<VaultStats> = {}): VaultStats {
+    return {
+      totalNotes: 12,
+      earliestNote: null,
+      latestNote: null,
+      notesByMonth: [],
+      topTags: [],
+      tagCount: 4,
+      attachmentCount: 3,
+      linkCount: 7,
+      contentBytes: 1234,
+      ...overrides,
+    };
+  }
+
+  test("full shape: counts, bytes, total = db + assets, mirror omitted when none", () => {
+    const fs = makeFakeFs({
+      [dbBase]: file(4096),
+      [`${dbBase}-wal`]: file(900),
+      [assets]: dir({ "a.png": file(2000) }),
+    });
+    const cache = new UsageCache(fs, () => 1_000, 60_000);
+    const report = buildUsageReport(VAULT, makeStats(), { cache, fs, now: () => 1_700_000_000_000 });
+
+    expect(report.counts).toEqual({ notes: 12, attachments: 3, links: 7, tags: 4 });
+    expect(report.bytes.content).toBe(1234);
+    expect(report.bytes.db).toBe(4096 + 900);
+    expect(report.bytes.assets).toBe(2000);
+    // total = db + assets only. NOT content (logical, already inside db) and
+    // NOT mirror (projection).
+    expect(report.bytes.total).toBe(4096 + 900 + 2000);
+    expect(report.bytes).not.toHaveProperty("mirror");
+    expect(report.cached).toBe(false);
+    expect(report.computedAt).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
+  test("mirror is a separate line item, NOT added to total", () => {
+    // Configure an internal mirror so resolveVaultMirrorDir returns a dir.
+    const { writeMirrorConfigForVault, defaultMirrorConfig } = require("./mirror-config.ts");
+    writeMirrorConfigForVault(VAULT, { ...defaultMirrorConfig(), location: "internal", enabled: true });
+    const mirrorDir = join(vaultDir(VAULT), "mirror");
+
+    const fs = makeFakeFs({
+      [dbBase]: file(1000),
+      [assets]: dir({ "a.png": file(500) }),
+      [mirrorDir]: dir({ "note.md": file(8000) }),
+    });
+    const cache = new UsageCache(fs, () => 1_000, 60_000);
+    const report = buildUsageReport(VAULT, makeStats(), { cache, fs });
+
+    expect(report.bytes.mirror).toBe(8000);
+    // total stays db + assets — the 8000-byte mirror does not inflate it.
+    expect(report.bytes.total).toBe(1000 + 500);
+  });
+
+  test("cached flag reflects a cache hit", () => {
+    const fs = makeFakeFs({
+      [dbBase]: file(100),
+      [assets]: dir({}),
+    });
+    let clock = 1_000;
+    const cache = new UsageCache(fs, () => clock, 60_000);
+
+    const first = buildUsageReport(VAULT, makeStats(), { cache, fs });
+    expect(first.cached).toBe(false);
+
+    clock += 5_000;
+    const second = buildUsageReport(VAULT, makeStats(), { cache, fs });
+    expect(second.cached).toBe(true);
+  });
+});

--- a/src/usage.test.ts
+++ b/src/usage.test.ts
@@ -28,8 +28,7 @@ const {
   UsageCache,
   buildUsageReport,
 } = await import("./usage.ts");
-const { vaultDir } = await import("./config.ts");
-const { assetsDir } = await import("./routes.ts");
+const { vaultDir, assetsDir } = await import("./config.ts");
 
 import type { UsageFs } from "./usage.ts";
 import type { VaultStats } from "../core/src/types.ts";

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,310 @@
+/**
+ * Per-vault usage monitoring — a cheap, read-scoped "how big is this vault"
+ * report (data footprint). Built for running many vaults for many users: the
+ * operator needs to see each vault's size, and a vault's own user should be
+ * able to see their own vault's footprint.
+ *
+ * The endpoint that consumes these helpers lives in `routing.ts` at
+ * `GET /vault/<name>/.parachute/usage` (read-scoped). This module owns the
+ * filesystem arithmetic and the dir-walk cache.
+ *
+ * Cost model:
+ *   - counts + contentBytes come from `getVaultStats` (a handful of indexed
+ *     COUNT/SUM queries) — cheap, computed on every request.
+ *   - `dbBytes` is three `statSync` calls (the WAL trio) — cheap, every request.
+ *   - the two recursive directory walks (`assets`, `mirror`) can traverse
+ *     thousands of files, so they go through a 60s TTL cache keyed by vault
+ *     name. `?fresh=1` bypasses the cache; an attachment upload invalidates it.
+ *
+ * Everything I/O-touching goes through an injectable `UsageFs` seam + an
+ * injectable clock so tests can assert call counts and TTL behavior without
+ * touching the real disk.
+ */
+
+import {
+  statSync as realStatSync,
+  readdirSync as realReaddirSync,
+  type Dirent,
+} from "fs";
+import { join } from "path";
+import { vaultDir } from "./config.ts";
+import { assetsDir } from "./routes.ts";
+import { readMirrorConfigForVault, resolveMirrorPath } from "./mirror-config.ts";
+import type { VaultStats } from "../core/src/types.ts";
+
+// ---------------------------------------------------------------------------
+// Injectable seams
+// ---------------------------------------------------------------------------
+
+/**
+ * The minimal filesystem surface the usage helpers depend on. Injecting it
+ * lets tests count how many times the dir-walk runs (to prove the cache
+ * actually skips it) and synthesize a tree without writing real files.
+ *
+ * `lstatSync` semantics for `statFile` are deliberate: we DON'T follow
+ * symlinks when summing directory contents, so a symlink-loop or a symlink
+ * pointing at a huge tree elsewhere can't inflate the count or hang the walk.
+ */
+export interface UsageFs {
+  /** `lstatSync`-style: returns the size of a file (or 0 / throws if absent). */
+  statFile(path: string): { size: number; isDirectory(): boolean; isSymbolicLink(): boolean };
+  /** `readdirSync(path, { withFileTypes: true })`. */
+  readDir(path: string): Dirent[];
+}
+
+/** Monotonic-enough clock seam: returns epoch millis. */
+export type Clock = () => number;
+
+/** Real filesystem implementation (production default). */
+export const realUsageFs: UsageFs = {
+  statFile: (path) => realStatSync(path),
+  readDir: (path) => realReaddirSync(path, { withFileTypes: true }),
+};
+
+// ---------------------------------------------------------------------------
+// Primitive byte counters
+// ---------------------------------------------------------------------------
+
+/**
+ * Physical bytes of a vault's SQLite database, WAL-aware: `vault.db` +
+ * `vault.db-wal` + `vault.db-shm`. The WAL (write-ahead log) and shared-memory
+ * index files hold committed-but-not-yet-checkpointed pages; ignoring them
+ * undercounts a busy vault. A missing `-wal`/`-shm` (the common case at rest,
+ * after a checkpoint) contributes 0 rather than erroring.
+ *
+ * This is the PHYSICAL DB-file size — it includes SQLite page overhead, free
+ * pages from deletes, etc. It is intentionally distinct from the LOGICAL
+ * `contentBytes` in `VaultStats` (sum of note-content UTF-8 bytes).
+ */
+export function dbBytes(vaultName: string, fs: UsageFs = realUsageFs): number {
+  const base = join(vaultDir(vaultName), "vault.db");
+  const candidates = [base, `${base}-wal`, `${base}-shm`];
+  let total = 0;
+  for (const path of candidates) {
+    total += safeFileSize(path, fs);
+  }
+  return total;
+}
+
+/** Size of a single file, or 0 if it's missing / unreadable. */
+function safeFileSize(path: string, fs: UsageFs): number {
+  try {
+    return fs.statFile(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Recursively sum the size of every regular file under `dirPath`.
+ *
+ *   - Missing directory → 0 (never throws; a vault may have no assets / no
+ *     mirror yet).
+ *   - Symlinks are NOT followed — a symlink (file or dir) is skipped entirely.
+ *     This guards against symlink loops (which would hang an infinite walk)
+ *     and against a symlink that points at a large tree outside the vault
+ *     inflating the reported footprint.
+ *
+ * Uses an explicit stack (not recursion) so a deep tree can't blow the call
+ * stack, and reads dirents with types so we avoid an extra `stat` per entry
+ * just to learn directory-ness.
+ */
+export function dirSize(dirPath: string, fs: UsageFs = realUsageFs): number {
+  let total = 0;
+  const stack: string[] = [dirPath];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    let entries: Dirent[];
+    try {
+      entries = fs.readDir(current);
+    } catch {
+      // Missing/unreadable dir (including the root) → contributes 0.
+      continue;
+    }
+    for (const entry of entries) {
+      // Never follow symlinks — neither symlinked files nor symlinked dirs.
+      if (entry.isSymbolicLink()) continue;
+      const childPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(childPath);
+      } else if (entry.isFile()) {
+        total += safeFileSize(childPath, fs);
+      }
+      // Sockets/FIFOs/devices: ignored.
+    }
+  }
+  return total;
+}
+
+/**
+ * Resolve a vault's mirror directory on disk, or `null` when no mirror is
+ * configured / resolvable (never configured, or external-without-path). The
+ * usage endpoint reports `mirror: 0` (and omits it from the total) in that
+ * case.
+ */
+export function resolveVaultMirrorDir(vaultName: string): string | null {
+  const config = readMirrorConfigForVault(vaultName);
+  if (!config) return null;
+  return resolveMirrorPath(vaultDir(vaultName), config);
+}
+
+// ---------------------------------------------------------------------------
+// Dir-walk cache (the only expensive part)
+// ---------------------------------------------------------------------------
+
+export interface DirWalkResult {
+  /** Bytes under the vault's assets directory. */
+  assets: number;
+  /**
+   * Bytes under the vault's mirror directory, or `null` when no mirror is
+   * configured. `null` → omit `mirror` from the response (or report 0).
+   */
+  mirror: number | null;
+}
+
+interface CacheEntry {
+  value: DirWalkResult;
+  /** Epoch millis when this entry was computed. */
+  computedAt: number;
+}
+
+/** Default cache lifetime for the dir-walk numbers. */
+export const DIR_WALK_TTL_MS = 60_000;
+
+/**
+ * In-process, per-vault cache of the two dir-walk numbers. Module-level so it
+ * survives across requests within a server process. Tests construct their own
+ * `UsageCache` to get isolation + a controllable clock.
+ */
+export class UsageCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  constructor(
+    private readonly fs: UsageFs = realUsageFs,
+    private readonly now: Clock = Date.now,
+    private readonly ttlMs: number = DIR_WALK_TTL_MS,
+  ) {}
+
+  /**
+   * Get the dir-walk numbers for a vault. Returns whether the numbers came
+   * from cache (`cached: true`) or were freshly walked (`cached: false`).
+   *
+   *   - `fresh: true` always recomputes (and refreshes the cache entry).
+   *   - Otherwise a non-expired entry is returned as-is (no walk); an absent
+   *     or expired entry triggers a walk + store.
+   */
+  get(vaultName: string, opts: { fresh?: boolean } = {}): { result: DirWalkResult; cached: boolean } {
+    const existing = this.entries.get(vaultName);
+    const ts = this.now();
+    if (!opts.fresh && existing && ts - existing.computedAt < this.ttlMs) {
+      return { result: existing.value, cached: true };
+    }
+    const value = this.compute(vaultName);
+    this.entries.set(vaultName, { value, computedAt: ts });
+    return { result: value, cached: false };
+  }
+
+  /** Drop a vault's cached dir-walk so the next read recomputes. */
+  invalidate(vaultName: string): void {
+    this.entries.delete(vaultName);
+  }
+
+  /** Run the (expensive) walks. */
+  private compute(vaultName: string): DirWalkResult {
+    const assets = dirSize(assetsDir(vaultName), this.fs);
+    const mirrorDir = resolveVaultMirrorDir(vaultName);
+    const mirror = mirrorDir === null ? null : dirSize(mirrorDir, this.fs);
+    return { assets, mirror };
+  }
+}
+
+/**
+ * The process-wide cache the live HTTP route uses. A single instance shared
+ * across requests gives the 60s TTL its meaning. `invalidateUsageCache` is the
+ * write-path hook (attachment upload, post-export).
+ */
+export const usageCache = new UsageCache();
+
+/** Invalidate the process-wide usage cache for a vault (write-path hook). */
+export function invalidateUsageCache(vaultName: string): void {
+  usageCache.invalidate(vaultName);
+}
+
+// ---------------------------------------------------------------------------
+// Report assembly (consumed by the HTTP route)
+// ---------------------------------------------------------------------------
+
+export interface UsageReport {
+  counts: {
+    notes: number;
+    attachments: number;
+    links: number;
+    tags: number;
+  };
+  bytes: {
+    /** Logical: sum of note-content UTF-8 bytes (from VaultStats). */
+    content: number;
+    /** Physical: vault.db + WAL + shm. */
+    db: number;
+    /** Bytes under the vault's assets directory (dir-walk, cached). */
+    assets: number;
+    /**
+     * Bytes under the vault's mirror directory (dir-walk, cached), present
+     * only when a mirror is configured. The mirror is a git PROJECTION of the
+     * same notes/attachments — it is NOT added to `total` (that would
+     * double-count the data); it's reported as a separate line item.
+     */
+    mirror?: number;
+    /**
+     * The vault's footprint: `db + assets`. Mirror is excluded on purpose
+     * (projection of the same data); content is excluded because it's the
+     * logical size already physically counted inside `db`.
+     */
+    total: number;
+  };
+  /** ISO-8601 timestamp of when this report was assembled. */
+  computedAt: string;
+  /** Whether the dir-walk numbers (assets/mirror) came from cache. */
+  cached: boolean;
+}
+
+/**
+ * Assemble the usage report for a vault. `stats` is the already-computed
+ * `getVaultStats()` result (counts + contentBytes); the cache supplies the two
+ * dir-walk numbers and reports whether they were cached.
+ *
+ * `total = db + assets` — the physical footprint. Mirror is a separate line
+ * item (projection of the same data; adding it double-counts). Content is the
+ * logical note size, already inside `db` physically.
+ */
+export function buildUsageReport(
+  vaultName: string,
+  stats: VaultStats,
+  opts: { fresh?: boolean; cache?: UsageCache; fs?: UsageFs; now?: Clock } = {},
+): UsageReport {
+  const cache = opts.cache ?? usageCache;
+  const { result, cached } = cache.get(vaultName, { fresh: opts.fresh });
+  const db = dbBytes(vaultName, opts.fs ?? realUsageFs);
+  const total = db + result.assets;
+
+  const bytes: UsageReport["bytes"] = {
+    content: stats.contentBytes,
+    db,
+    assets: result.assets,
+    total,
+  };
+  if (result.mirror !== null) bytes.mirror = result.mirror;
+
+  return {
+    counts: {
+      notes: stats.totalNotes,
+      attachments: stats.attachmentCount,
+      links: stats.linkCount,
+      tags: stats.tagCount,
+    },
+    bytes,
+    computedAt: new Date((opts.now ?? Date.now)()).toISOString(),
+    cached,
+  };
+}

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -27,8 +27,7 @@ import {
   type Dirent,
 } from "fs";
 import { join } from "path";
-import { vaultDir } from "./config.ts";
-import { assetsDir } from "./routes.ts";
+import { vaultDir, assetsDir } from "./config.ts";
 import { readMirrorConfigForVault, resolveMirrorPath } from "./mirror-config.ts";
 import type { VaultStats } from "../core/src/types.ts";
 
@@ -41,12 +40,21 @@ import type { VaultStats } from "../core/src/types.ts";
  * lets tests count how many times the dir-walk runs (to prove the cache
  * actually skips it) and synthesize a tree without writing real files.
  *
- * `lstatSync` semantics for `statFile` are deliberate: we DON'T follow
- * symlinks when summing directory contents, so a symlink-loop or a symlink
- * pointing at a huge tree elsewhere can't inflate the count or hang the walk.
+ * Symlink safety lives in the WALK, not in `statFile`: `dirSize` never
+ * descends into or sizes a symlink entry (it filters on
+ * `Dirent.isSymbolicLink()` before ever calling `statFile`), so a symlink
+ * loop can't hang the walk and a symlink pointing at a huge tree elsewhere
+ * can't inflate the count. `statFile` is therefore only ever called on real
+ * files / the WAL trio (which are never symlinks).
  */
 export interface UsageFs {
-  /** `lstatSync`-style: returns the size of a file (or 0 / throws if absent). */
+  /**
+   * `stat` (symlink-FOLLOWING, like `statSync`): returns the size of a file
+   * (or throws if absent — callers wrap in try/catch → 0). Following symlinks
+   * is safe here because dir descent already filters symlinks via
+   * `Dirent.isSymbolicLink()`, and the WAL files (`vault.db{,-wal,-shm}`) are
+   * never symlinks.
+   */
   statFile(path: string): { size: number; isDirectory(): boolean; isSymbolicLink(): boolean };
   /** `readdirSync(path, { withFileTypes: true })`. */
   readDir(path: string): Dirent[];
@@ -257,9 +265,9 @@ export interface UsageReport {
      */
     mirror?: number;
     /**
-     * The vault's footprint: `db + assets`. Mirror is excluded on purpose
-     * (projection of the same data); content is excluded because it's the
-     * logical size already physically counted inside `db`.
+     * Physical on-disk footprint (db + assets); excludes content (inside db)
+     * and mirror (separate projection). This is the number an operator sizes a
+     * vault by.
      */
     total: number;
   };


### PR DESCRIPTION
## What

Adds `GET /vault/<name>/.parachute/usage` — a cheap, **read-scoped** report of a vault's data footprint, so the operator (running many vaults for many users) and a vault's own user can both answer "how big is this vault."

## Response shape

```jsonc
{
  "counts": { "notes": 12, "attachments": 3, "links": 7, "tags": 4 },
  "bytes": {
    "content": 1234,   // logical: SUM of note-content UTF-8 bytes
    "db": 4996,         // physical: vault.db + -wal + -shm
    "assets": 2000,     // dir-walk of the vault's assets dir (cached)
    "mirror": 8000,     // OPTIONAL — present only when a mirror is configured
    "total": 6996       // db + assets
  },
  "computedAt": "2026-06-03T…Z",
  "cached": false        // whether the dir-walk numbers came from cache
}
```

### `total` = `db + assets` only — mirror is a separate line item

The mirror is a **git projection of the same notes/attachments**, so adding it to `total` would double-count the vault's data. It's reported as its own line item and **omitted** entirely when no mirror is configured. `content` is the *logical* note size — it's already physically counted inside `db`, so it's also excluded from `total`.

## Read-scope rationale

The endpoint is gated by **read** scope (`hasScopeForVault(auth.scopes, vaultName, "read")`), mirroring the bare-root `/vault/<name>` stats precedent — same disclosure class (counts + byte sizes, **no note content**). A vault's own user must be able to see their own vault's size; the operator inherits read via broad/admin. Wrong-vault narrowed scopes and no-vault-scope tokens get `403 insufficient_scope`; unauthenticated gets `401`.

## `contentBytes` — true UTF-8 bytes, not char count

`getVaultStats` gains `contentBytes`, computed as `SUM(LENGTH(CAST(content AS BLOB)))`. The **`CAST(... AS BLOB)` is load-bearing**: SQLite's bare `LENGTH(text)` returns a *character* count, which undercounts multibyte UTF-8 (emoji, CJK, accents). Casting to BLOB forces `LENGTH` to count raw bytes. `COALESCE(..., 0)` so an empty vault reports `0`. Cheap, always-on.

## Caching design + cost

- **Always computed (cheap):** counts + `contentBytes` (indexed COUNT/SUM) and `dbBytes` (3 `statSync` calls — the WAL trio).
- **Cached (expensive):** the two recursive directory walks (`assets`, `mirror`) can traverse thousands of files, so they go through an **in-process 60s-TTL cache keyed by vault name**.
- `?fresh=1` forces a recompute (bypasses the cache). `cached` in the response reflects whether the walk numbers were served from cache.
- **Invalidation:** an attachment upload invalidates the vault's cache (the storage upload path), so the next read re-walks instead of under-reporting. Otherwise the 60s TTL governs.

### fs seam

All filesystem access goes through an injectable `UsageFs` seam (`statFile` / `readDir`) + an injectable clock, so tests assert TTL behavior and dir-walk **call counts** (proving a cache hit does NOT re-walk) without touching real disk. `dirSize` is stack-based (deep trees don't blow the call stack), tolerates a missing dir (→ 0), and **never follows symlinks** (no loop hang, no out-of-vault inflation). `dbBytes` tolerates missing `-wal`/`-shm` (the at-rest, post-checkpoint case → 0).

## Tests

- core: `contentBytes` correct for ASCII + multibyte (asserts BYTES > chars), empty vault → 0, shape complete.
- `usage.test.ts` (fake fs): `dbBytes` WAL-trio sum + missing-WAL tolerance; `dirSize` nested/empty/missing/symlink-not-followed/loop-safe; `UsageCache` TTL hit (no re-walk, via call count), expiry, `fresh` bypass, `invalidate`; `buildUsageReport` shape + `total = db + assets` + mirror-as-separate-line-item.
- routing: read token → 200 full shape; counts match `getVaultStats`; no-vault-scope → 403; wrong-vault scope → 403; write/admin inherits read → 200; non-GET → 405; cache hit within TTL → `cached:true`; `?fresh=1` → `cached:false`; upload invalidates cache → assets bytes update.

## Gates

- `bun test ./src/` — **1356 pass / 0 fail**
- `bun test ./core/src/` — **669 pass / 0 fail**
- `bun run typecheck` — clean

No version bump (per RC discipline; bump+tag happen on Aaron's ship signal).

## Follow-up

Hub-side aggregation + UI (a "vault sizes across all users" operator view, and surfacing `contentBytes` in the per-vault SPA) is a separate follow-up. This endpoint is the load-bearing primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)