### PR TITLE
fix(security): tag-scope confidentiality — close expand_links/wikilink content + metadata leaks

### DIFF
--- a/core/src/expand-visibility.test.ts
+++ b/core/src/expand-visibility.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { initSchema } from "./schema.js";
+import { createNote } from "./notes.js";
+import { expandContent, type ExpandContext } from "./expand.js";
+import type { Note } from "./types.js";
+
+/**
+ * Security regression (vault security review — tag-scope confidentiality).
+ *
+ * `expandContent`'s optional `isVisible` predicate is the seam that keeps
+ * core scope-unaware while letting the server enforce tag scope during
+ * wikilink inlining. These tests pin the load-bearing invariant: when the
+ * predicate rejects a target, the wikilink is left UNRESOLVED — byte-for-byte
+ * identical to a genuinely-missing target, so the response can't reveal that
+ * the out-of-scope note exists. They MUST fail if the predicate is removed.
+ */
+
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  initSchema(db);
+});
+
+function ctx(over: Partial<ExpandContext> = {}): ExpandContext {
+  return { db, mode: "full", expanded: new Set<string>(), ...over };
+}
+
+describe("expandContent isVisible predicate (tag-scope confidentiality)", () => {
+  it("inlines an in-scope target's content when no predicate is set (baseline)", () => {
+    createNote(db, "SECRET BODY", { path: "Secret", tags: ["personal"] });
+    const out = expandContent("see [[Secret]]", ctx(), 1);
+    expect(out).toContain("SECRET BODY");
+  });
+
+  it("leaves an out-of-scope wikilink unresolved — no content inlined", () => {
+    createNote(db, "SECRET BODY", { path: "Secret", tags: ["personal"] });
+    // Predicate: only #work notes are visible. The target is #personal.
+    const isVisible = (n: Note) => (n.tags ?? []).includes("work");
+    const out = expandContent("see [[Secret]]", ctx({ isVisible }), 1);
+    expect(out).not.toContain("SECRET BODY");
+    // The wikilink stays literal.
+    expect(out).toBe("see [[Secret]]");
+  });
+
+  it("out-of-scope target is INDISTINGUISHABLE from a missing target", () => {
+    // Case A: target exists but is out of scope.
+    createNote(db, "SECRET BODY", { path: "Secret", tags: ["personal"] });
+    const isVisible = (n: Note) => (n.tags ?? []).includes("work");
+    const outOfScope = expandContent("see [[Secret]]", ctx({ isVisible }), 1);
+
+    // Case B: target genuinely does not exist (fresh db, same predicate).
+    const db2 = new Database(":memory:");
+    initSchema(db2);
+    const missing = expandContent("see [[Secret]]", { db: db2, mode: "full", expanded: new Set(), isVisible }, 1);
+
+    // Byte-identical output → existence is not leaked.
+    expect(outOfScope).toBe(missing);
+    expect(outOfScope).toBe("see [[Secret]]");
+  });
+
+  it("a second reference to an out-of-scope note does NOT render `(expanded above)`", () => {
+    // Pins that an out-of-scope note never enters the `expanded` set — else a
+    // repeat reference would render `(expanded above)` and leak existence via
+    // a different output than a missing target.
+    createNote(db, "SECRET BODY", { path: "Secret", tags: ["personal"] });
+    const isVisible = (n: Note) => (n.tags ?? []).includes("work");
+    const out = expandContent("[[Secret]] and again [[Secret]]", ctx({ isVisible }), 1);
+    expect(out).toBe("[[Secret]] and again [[Secret]]");
+    expect(out).not.toContain("expanded above");
+    expect(out).not.toContain("SECRET BODY");
+  });
+
+  it("multi-hop (depth>1) does not leak out-of-scope content at any depth", () => {
+    // in-scope #work note → wikilinks an out-of-scope #personal note.
+    createNote(db, "DEEP SECRET", { path: "Deep", tags: ["personal"] });
+    createNote(db, "intro [[Deep]]", { path: "Mid", tags: ["work"] });
+    createNote(db, "top [[Mid]]", { path: "Top", tags: ["work"] });
+
+    const isVisible = (n: Note) => (n.tags ?? []).includes("work");
+    // Depth 3 — would walk Top → Mid → Deep without the predicate.
+    const out = expandContent("[[Top]]", ctx({ isVisible }), 3);
+    // The in-scope Mid IS inlined; the out-of-scope Deep is NOT.
+    expect(out).toContain("intro");
+    expect(out).not.toContain("DEEP SECRET");
+    // The Deep wikilink stays literal inside Mid's inlined content.
+    expect(out).toContain("[[Deep]]");
+  });
+
+  it("predicate is also honored in summary mode", () => {
+    createNote(db, "x", {
+      path: "Secret",
+      tags: ["personal"],
+      metadata: { summary: "SECRET SUMMARY" },
+    });
+    const isVisible = (n: Note) => (n.tags ?? []).includes("work");
+    const out = expandContent("see [[Secret]]", ctx({ mode: "summary", isVisible }), 1);
+    expect(out).not.toContain("SECRET SUMMARY");
+    expect(out).toBe("see [[Secret]]");
+  });
+});

--- a/core/src/expand.ts
+++ b/core/src/expand.ts
@@ -22,6 +22,22 @@ export interface ExpandContext {
   mode: ExpandMode;
   /** Note IDs already expanded in this query. Shared across all expansions. */
   expanded: Set<string>;
+  /**
+   * Optional visibility predicate (tag-scope confidentiality, vault security
+   * review). When set and it returns `false` for a resolved target note, the
+   * wikilink is left UNRESOLVED — byte-identical to the not-found/unresolved
+   * branch, so an out-of-scope target is indistinguishable from a missing one
+   * (we never reveal existence differently across the scope boundary).
+   *
+   * Core stays scope-unaware: the server constructs this predicate from its
+   * tag-scope machinery and injects it; core only ever *calls* it. When
+   * unset (every unscoped caller), expansion behaves exactly as before.
+   *
+   * Applied at every hop — multi-hop (`expand_depth > 1`) expansion runs the
+   * predicate on each resolved target before inlining, so a deep chain can't
+   * tunnel out-of-scope content through an in-scope intermediary.
+   */
+  isVisible?: (note: Note) => boolean;
 }
 
 /**
@@ -62,13 +78,25 @@ export function expandContent(
     const noteId = resolveWikilink(ctx.db, target);
     if (!noteId) return match; // unresolved or ambiguous — leave as-is
 
+    // Resolve the target BEFORE the dedup check so the visibility gate can run
+    // first — an out-of-scope target must never enter `expanded` (otherwise a
+    // second reference to it would render `(expanded above)` and leak its
+    // existence via a different output than a genuinely-missing target).
+    const note = noteOps.getNote(ctx.db, noteId);
+    if (!note) return match; // shouldn't happen, but be safe
+
+    // Tag-scope confidentiality (vault security review): if a visibility
+    // predicate is installed and the resolved target is out of scope, leave
+    // the wikilink UNRESOLVED — byte-identical to the not-found / unresolved
+    // branches above. The out-of-scope case must be indistinguishable from a
+    // missing target so the response can't leak the target's existence. Runs
+    // at every hop, so multi-hop expansion can't tunnel out-of-scope content.
+    if (ctx.isVisible && !ctx.isVisible(note)) return match;
+
     if (ctx.expanded.has(noteId)) {
       return `${match} (expanded above)`;
     }
     ctx.expanded.add(noteId);
-
-    const note = noteOps.getNote(ctx.db, noteId);
-    if (!note) return match; // shouldn't happen, but be safe
 
     if (ctx.mode === "summary") {
       // Summary mode doesn't recurse: depth > 1 has no additional effect.

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -304,6 +304,16 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
         }
 
         // --- Build near-scope (graph-filtered set of allowed IDs) ---
+        //
+        // Tag-scope policy for `near[]` (output-filter, not hop-guard): core
+        // is scope-unaware, so this BFS walks the FULL graph from the anchor —
+        // including out-of-scope intermediate hops. For a tag-scoped session
+        // the server's `applyTagScopeWrappers` (mcp-tools.ts) tag-filters the
+        // RESULT list AFTER execute, so out-of-scope notes never survive into
+        // the response — no content/ids leak. This is ASYMMETRIC with
+        // `find-path`, which guards every hop (it returns the path itself, so
+        // an out-of-scope intermediary would be a leak there). The asymmetry is
+        // deliberate; tracked at vault#439.
         let nearScope: Set<string> | null = null;
         if (params.near) {
           const near = params.near as { note_id: string; depth?: number; relationship?: string };

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -100,12 +100,30 @@ function removeWikilinkBrackets(content: string, targetPath: string): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Options for {@link generateMcpTools}.
+ *
+ * `expandVisibility` (vault security review) is an OPTIONAL per-note
+ * visibility predicate threaded into the wikilink-expansion context for
+ * `query-notes`. When provided, `expand_links` inlining leaves any wikilink
+ * whose target fails the predicate UNRESOLVED — so a tag-scoped MCP session
+ * can't inline out-of-scope note content during expansion (the filtering
+ * happens DURING expansion, not after). Core stays scope-unaware: it
+ * receives a plain `(note) => boolean` closure and never imports the
+ * server's tag-scope module. Omitted (every internal / unscoped caller) →
+ * expansion behaves exactly as before.
+ */
+export interface GenerateMcpToolsOpts {
+  expandVisibility?: (note: Note) => boolean;
+}
+
+/**
  * Generate the consolidated MCP tools for a vault. Surface (10):
  * query-notes, create-note, update-note, delete-note, list-tags, update-tag,
  * delete-tag, find-path, vault-info, prune-schema (admin).
  */
-export function generateMcpTools(store: Store): McpToolDef[] {
+export function generateMcpTools(store: Store, opts?: GenerateMcpToolsOpts): McpToolDef[] {
   const db: Database = (store as any).db;
+  const expandVisibility = opts?.expandVisibility;
 
   return [
 
@@ -246,7 +264,16 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           ),
         );
         const expandCtx: ExpandContext | null = expandLinks
-          ? { db, mode: expandMode, expanded: new Set() }
+          ? {
+              db,
+              mode: expandMode,
+              expanded: new Set(),
+              // Tag-scope confidentiality (security review): when a visibility
+              // predicate was injected, wikilinks to out-of-scope notes are
+              // left unresolved DURING inlining — never embedded. Unscoped
+              // callers pass no predicate and inlining is unchanged.
+              ...(expandVisibility ? { isVisible: expandVisibility } : {}),
+            }
           : null;
 
         // --- Single note by ID/path ---

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -26,7 +26,8 @@ import {
   hashKey,
 } from "./config.ts";
 import { getVaultStore, clearVaultStoreCache } from "./vault-store.ts";
-import { authenticateVaultRequest, authenticateGlobalRequest } from "./auth.ts";
+import { authenticateVaultRequest, authenticateGlobalRequest, warnLegacyGlobalApiKeys } from "./auth.ts";
+import type { StoredKey } from "./config.ts";
 
 let tmpHome: string;
 let prevHome: string | undefined;
@@ -440,5 +441,40 @@ describe("auth — VAULT_AUTH_TOKEN server-wide operator bearer", () => {
 
     const result = await authenticateVaultRequest(bearer(nearMiss), journalConfig);
     expect("error" in result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy GLOBAL api_keys boot warning (security review — multi-user
+// hardening). Cross-vault credentials in config.yaml must be surfaced loudly
+// at boot, but never altered. Pure-function unit tests (no server boot).
+// ---------------------------------------------------------------------------
+describe("warnLegacyGlobalApiKeys (legacy cross-vault key boot warning)", () => {
+  function key(id: string): StoredKey {
+    return {
+      id,
+      label: id,
+      key_hash: `sha256:${id}`,
+      scope: "full",
+      created_at: new Date().toISOString(),
+    };
+  }
+
+  test("warns when global api_keys are present", () => {
+    const msgs: string[] = [];
+    const count = warnLegacyGlobalApiKeys([key("a"), key("b")], (m) => msgs.push(m));
+    expect(count).toBe(2);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toContain("legacy GLOBAL api_key");
+    expect(msgs[0]).toContain("CROSS-VAULT");
+    // Heads-up only — must signal it does NOT alter the keys.
+    expect(msgs[0]).toContain("remain active");
+  });
+
+  test("silent when there are no global api_keys", () => {
+    const msgs: string[] = [];
+    expect(warnLegacyGlobalApiKeys([], (m) => msgs.push(m))).toBe(0);
+    expect(warnLegacyGlobalApiKeys(undefined, (m) => msgs.push(m))).toBe(0);
+    expect(msgs).toHaveLength(0);
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -171,6 +171,35 @@ export function warnLegacyOnce(cacheKey: string, context: string): void {
   );
 }
 
+/**
+ * Boot-time warning for legacy GLOBAL `api_keys` in `config.yaml` (security
+ * review — multi-user hardening). Those keys are CROSS-VAULT credentials: a
+ * single key authenticates against EVERY vault on this server (see the global
+ * `api_keys` branch in `authenticate` ~L283). That predates per-vault keys +
+ * tag-scoped hub JWTs and is a confidentiality hazard once a server hosts
+ * multiple users' vaults — one user's global key reads another's vault.
+ *
+ * WARNING ONLY — never touches the keys (the operator owns them). The
+ * verification flagged 6 such keys on the live box; this surfaces them at
+ * boot so they're rotated/removed before multi-user sharing. Returns the
+ * count it warned about (0 = silent) so callers / tests can assert.
+ */
+export function warnLegacyGlobalApiKeys(
+  globalApiKeys: StoredKey[] | undefined,
+  warn: (msg: string) => void = console.warn,
+): number {
+  const count = globalApiKeys?.length ?? 0;
+  if (count === 0) return 0;
+  warn(
+    `[auth] WARNING: ${count} legacy GLOBAL api_key(s) found in config.yaml. ` +
+      "These are CROSS-VAULT credentials (each grants access to every vault on this server) " +
+      "and predate per-vault keys + tag-scoped hub JWTs. Before multi-user sharing, ROTATE or " +
+      "REMOVE them — a global key leaks one user's vault to another. They remain active (the " +
+      "operator owns them); this is a heads-up, not an automatic change.",
+  );
+  return count;
+}
+
 /** Read-only tools (the only tools allowed for "read" permission). */
 const READ_TOOLS = new Set([
   "query-notes",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -826,8 +826,14 @@ async function cmdCreate(args: string[]) {
     process.exit(1);
   }
 
-  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-    console.error("Vault name must contain only letters, numbers, hyphens, and underscores.");
+  // Lowercase-only (security review — multi-user hardening). An uppercase
+  // vault name flips the audience case (`vault.<Name>` vs `vault.<name>`)
+  // and drifts from hub-side / init-path lowercasing, breaking JWT
+  // audience matching. `init` already enforces lowercase via
+  // `validateVaultName`; mirror that rule here so uppercase can't enter
+  // through `create` either.
+  if (!/^[a-z0-9_-]+$/.test(name)) {
+    console.error("Vault name must be lowercase alphanumeric with hyphens or underscores (no uppercase).");
     process.exit(1);
   }
   if (name === "list") {

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -229,6 +229,14 @@ function applyTagScopeWrappers(
   // set `include_links`) so out-of-scope NEIGHBOR summaries (id/path/tags)
   // don't leak — symmetric with the REST `include_links` fix. Mutates in
   // place and returns the note for chaining. No-op when `links` is absent.
+  //
+  // Ordering invariant: reading `allowedHolder.value` here is safe ONLY
+  // because every wrapper that calls scrubNoteLinks first does
+  // `await getAllowed()` (which populates the holder) before `orig(params)`
+  // and before this scrub runs. So by the time we read `holder.value` it is
+  // the resolved allowlist, never the initial `null`. The `?? null` fallback
+  // is the unscoped/holder-absent path; `filterHydratedLinksByTagScope` then
+  // keys off `rawTags` (non-null here) for the actual scope check.
   const scrubNoteLinks = (n: any): any => {
     if (n && Array.isArray(n.links)) {
       n.links = filterHydratedLinksByTagScope(n.links, allowedHolder?.value ?? null, rawTags);

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -7,6 +7,7 @@
 
 import { generateMcpTools } from "../core/src/mcp.ts";
 import type { McpToolDef } from "../core/src/mcp.ts";
+import type { Note } from "../core/src/types.ts";
 import {
   buildVaultProjection,
   projectionToMarkdown,
@@ -18,6 +19,7 @@ import { hasScopeForVault, parseScopes, validateMintedScopes } from "./scopes.ts
 import type { AuthResult } from "./auth.ts";
 import {
   expandTokenTagScope,
+  filterHydratedLinksByTagScope,
   noteWithinTagScope,
   tagsWithinScope,
 } from "./tag-scope.ts";
@@ -117,11 +119,30 @@ export function generateScopedMcpTools(
   callerBearer?: string | null,
 ): McpToolDef[] {
   const store = getVaultStore(vaultName);
-  const tools = generateMcpTools(store);
+
+  // Tag-scope confidentiality (security review): when the session is
+  // tag-scoped, build an expand-visibility predicate so `query-notes`'s
+  // `expand_links` inlining can't embed out-of-scope note content. The
+  // predicate reads from a SHARED holder that `applyTagScopeWrappers`
+  // populates with the resolved allowlist before core's execute runs the
+  // (synchronous) expansion — so by the time core calls `isVisible(note)`
+  // the allowlist is ready. Core stays scope-unaware: it only receives the
+  // plain closure. Unscoped sessions pass no predicate (unchanged path).
+  const scoped = Boolean(auth?.scoped_tags && auth.scoped_tags.length > 0);
+  const allowedHolder: { value: Set<string> | null } = { value: null };
+  const rawTags = scoped ? auth!.scoped_tags : null;
+  const expandVisibility = scoped
+    ? (note: Note) => noteWithinTagScope(note, allowedHolder.value, rawTags)
+    : undefined;
+
+  const tools = generateMcpTools(
+    store,
+    expandVisibility ? { expandVisibility } : undefined,
+  );
 
   overrideVaultInfo(tools, vaultName, auth);
   applyTagDependencyGuards(tools, vaultName);
-  applyTagScopeWrappers(tools, vaultName, auth);
+  applyTagScopeWrappers(tools, vaultName, auth, allowedHolder);
 
   // manage-token is server-only (needs token-store + auth context), so it
   // lives here rather than in core. Always appended to the surface; the
@@ -181,6 +202,7 @@ function applyTagScopeWrappers(
   tools: McpToolDef[],
   vaultName: string,
   auth: AuthResult | undefined,
+  allowedHolder?: { value: Set<string> | null },
 ): void {
   if (!auth || !auth.scoped_tags || auth.scoped_tags.length === 0) return;
   const store = getVaultStore(vaultName);
@@ -188,11 +210,31 @@ function applyTagScopeWrappers(
   let allowedPromise: Promise<Set<string> | null> | null = null;
   const getAllowed = (): Promise<Set<string> | null> => {
     if (!allowedPromise) {
-      allowedPromise = expandTokenTagScope(store, auth.scoped_tags);
+      allowedPromise = expandTokenTagScope(store, auth.scoped_tags).then((a) => {
+        // Publish the resolved allowlist into the shared holder so the
+        // expand-visibility predicate (wired in generateScopedMcpTools and
+        // baked into the query-notes expand context) sees the same set.
+        // The query-notes wrapper awaits getAllowed() before calling the
+        // core execute that runs expansion, so the holder is populated in
+        // time. Security review: closes the expand_links content leak.
+        if (allowedHolder) allowedHolder.value = a;
+        return a;
+      });
     }
     return allowedPromise;
   };
   const rawTags = auth.scoped_tags;
+
+  // Scrub a returned note's hydrated `links` array (present when the caller
+  // set `include_links`) so out-of-scope NEIGHBOR summaries (id/path/tags)
+  // don't leak — symmetric with the REST `include_links` fix. Mutates in
+  // place and returns the note for chaining. No-op when `links` is absent.
+  const scrubNoteLinks = (n: any): any => {
+    if (n && Array.isArray(n.links)) {
+      n.links = filterHydratedLinksByTagScope(n.links, allowedHolder?.value ?? null, rawTags);
+    }
+    return n;
+  };
 
   wrapReadTool(tools, "query-notes", async (orig, params) => {
     const allowed = await getAllowed();
@@ -203,7 +245,9 @@ function applyTagScopeWrappers(
     //   - `{notes, next_cursor}` (cursor mode, vault#313)
     //   - `{...note}` with `id`+`tags` (single-note by id)
     if (Array.isArray(result)) {
-      return result.filter((n: any) => noteWithinTagScope(n, allowed, rawTags));
+      return result
+        .filter((n: any) => noteWithinTagScope(n, allowed, rawTags))
+        .map(scrubNoteLinks);
     }
     if (
       result &&
@@ -214,13 +258,15 @@ function applyTagScopeWrappers(
     ) {
       const r = result as { notes: any[]; next_cursor: string | null };
       return {
-        notes: r.notes.filter((n: any) => noteWithinTagScope(n, allowed, rawTags)),
+        notes: r.notes
+          .filter((n: any) => noteWithinTagScope(n, allowed, rawTags))
+          .map(scrubNoteLinks),
         next_cursor: r.next_cursor,
       };
     }
     if (result && typeof result === "object" && "id" in result && "tags" in result) {
       return noteWithinTagScope(result as any, allowed, rawTags)
-        ? result
+        ? scrubNoteLinks(result)
         : { error: "Note not found", id: (result as any).id };
     }
     return result;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -817,6 +817,15 @@ async function handleNotesInner(
         }
         const depth = Math.min(parseInt10(parseQuery(url, "near[depth]")) ?? 2, 5);
         const relationship = parseQuery(url, "near[relationship]") ?? undefined;
+        // Tag-scope policy for `near[]` (output-filter, not hop-guard): the
+        // BFS walks the FULL graph from the anchor, including out-of-scope
+        // intermediate hops, then the RESULT set is tag-scope-filtered below
+        // (`filterNotesByTagScope`). No out-of-scope content or ids leak —
+        // out-of-scope notes never survive into the response. This is
+        // ASYMMETRIC with `find-path`, which guards every hop (it returns the
+        // path itself, so an out-of-scope intermediary would be a leak there).
+        // The asymmetry is deliberate; tracked at vault#439 should we ever want
+        // `near[]` to also constrain traversal hops.
         const traversed = linkOps.traverseLinks(db, anchor.id, { max_depth: depth, relationship });
         const nearScope = new Set([anchor.id, ...traversed.map((t) => t.noteId)]);
         results = results.filter((n) => nearScope.has(n.id));

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,6 +18,8 @@ import { attachValidationStatus } from "../core/src/mcp.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
 import {
+  buildExpandVisibility,
+  filterHydratedLinksByTagScope,
   filterNotesByTagScope,
   noteWithinTagScope,
   tagScopeForbidden,
@@ -453,10 +455,20 @@ function parseIncludeMetadata(url: URL): boolean | string[] | undefined {
 /**
  * Parse expand_links/expand_depth/expand_mode from query params, returning
  * an (ExpandContext, depth) pair if expansion is requested, else null.
+ *
+ * `tagScope` (security review): when the caller is tag-scoped, an `isVisible`
+ * predicate is built from the SAME tag-scope allowlist the rest of the
+ * handler uses and injected into the expand context. The expander then
+ * leaves any `[[wikilink]]` whose target is out of scope UNRESOLVED — so
+ * `expand_links=true` can never inline out-of-scope note content (and the
+ * out-of-scope case is byte-indistinguishable from a missing target). For
+ * an unscoped token the predicate is `undefined` and expansion behaves
+ * exactly as before.
  */
 function parseExpandParams(
   url: URL,
   db: any,
+  tagScope: TagScopeCtx = NO_TAG_SCOPE,
 ): { ctx: ExpandContext; depth: number } | null {
   if (!parseBool(parseQuery(url, "expand_links"), false)) return null;
   const modeRaw = parseQuery(url, "expand_mode");
@@ -468,7 +480,8 @@ function parseExpandParams(
       MAX_EXPAND_DEPTH,
     ),
   );
-  return { ctx: { db, mode, expanded: new Set() }, depth };
+  const isVisible = buildExpandVisibility(tagScope.allowed, tagScope.raw);
+  return { ctx: { db, mode, expanded: new Set(), ...(isVisible ? { isVisible } : {}) }, depth };
 }
 
 
@@ -575,14 +588,21 @@ async function handleNotesInner(
         }
         const includeContent = parseBool(parseQuery(url, "include_content"), true);
         let result: any = includeContent ? { ...note } : toNoteIndex(note);
-        const expand = parseExpandParams(url, db);
+        const expand = parseExpandParams(url, db, tagScope);
         if (expand && includeContent && typeof result.content === "string") {
           expand.ctx.expanded.add(note.id);
           result.content = expandContent(result.content, expand.ctx, expand.depth);
         }
         result = filterMetadata(result, parseIncludeMetadata(url));
         if (parseBool(parseQuery(url, "include_links"), false)) {
-          result.links = linkOps.getLinksHydrated(db, note.id);
+          // Tag-scope: drop links whose neighbor is out of scope so the
+          // hydrated sourceNote/targetNote summaries can't leak out-of-scope
+          // ids/paths/tags. No-op for unscoped tokens.
+          result.links = filterHydratedLinksByTagScope(
+            linkOps.getLinksHydrated(db, note.id),
+            tagScope.allowed,
+            tagScope.raw,
+          );
         }
         if (parseBool(parseQuery(url, "include_attachments"), false)) {
           result.attachments = await store.getAttachments(note.id);
@@ -622,7 +642,7 @@ async function handleNotesInner(
         const includeContent = parseBool(parseQuery(url, "include_content"), false);
         const inclMeta = parseIncludeMetadata(url);
         let output: any[] = includeContent ? results.map((n) => ({ ...n })) : results.map(toNoteIndex);
-        const expand = parseExpandParams(url, db);
+        const expand = parseExpandParams(url, db, tagScope);
         if (expand && includeContent) {
           for (const n of output) expand.ctx.expanded.add(n.id);
           for (const n of output) {
@@ -813,7 +833,7 @@ async function handleNotesInner(
       const includeLinkCount = parseBool(parseQuery(url, "include_link_count"), false);
       const inclMeta = parseIncludeMetadata(url);
       let output: any[] = includeContent ? results.map((n) => ({ ...n })) : results.map(toNoteIndex);
-      const expand = parseExpandParams(url, db);
+      const expand = parseExpandParams(url, db, tagScope);
       if (expand && includeContent) {
         for (const n of output) expand.ctx.expanded.add(n.id);
         for (const n of output) {
@@ -866,7 +886,14 @@ async function handleNotesInner(
         const enrichedOut: any[] = [];
         for (const n of output) {
           const enriched: any = { ...n };
-          if (includeLinks) enriched.links = linkOps.getLinksHydrated(db, n.id);
+          if (includeLinks) {
+            // Tag-scope: strip out-of-scope-neighbor links (no-op unscoped).
+            enriched.links = filterHydratedLinksByTagScope(
+              linkOps.getLinksHydrated(db, n.id),
+              tagScope.allowed,
+              tagScope.raw,
+            );
+          }
           if (includeAttachments) enriched.attachments = await store.getAttachments(n.id);
           enrichedOut.push(enriched);
         }
@@ -1123,14 +1150,19 @@ async function handleNotesInner(
     }
     const includeContent = parseBool(parseQuery(url, "include_content"), true);
     let result: any = includeContent ? { ...note } : toNoteIndex(note);
-    const expand = parseExpandParams(url, db);
+    const expand = parseExpandParams(url, db, tagScope);
     if (expand && includeContent && typeof result.content === "string") {
       expand.ctx.expanded.add(note.id);
       result.content = expandContent(result.content, expand.ctx, expand.depth);
     }
     result = filterMetadata(result, parseIncludeMetadata(url));
     if (parseBool(parseQuery(url, "include_links"), false)) {
-      result.links = linkOps.getLinksHydrated(db, note.id);
+      // Tag-scope: drop out-of-scope-neighbor links (no-op unscoped).
+      result.links = filterHydratedLinksByTagScope(
+        linkOps.getLinksHydrated(db, note.id),
+        tagScope.allowed,
+        tagScope.raw,
+      );
     }
     if (parseBool(parseQuery(url, "include_attachments"), false)) {
       result.attachments = await store.getAttachments(note.id);
@@ -1414,7 +1446,14 @@ async function handleNotesInner(
       const linkMutated = body.links?.add !== undefined || body.links?.remove !== undefined;
       const includeLinksResp = linkMutated || parseBool(parseQuery(url, "include_links"), false);
       if (includeLinksResp) {
-        validated.links = linkOps.getLinksHydrated(db, updatedNote.id);
+        // Tag-scope: strip out-of-scope-neighbor links from the echoed set
+        // (no-op unscoped). A write token tag-scoped to #work mustn't learn
+        // about a #personal note it happened to link to.
+        validated.links = filterHydratedLinksByTagScope(
+          linkOps.getLinksHydrated(db, updatedNote.id),
+          tagScope.allowed,
+          tagScope.raw,
+        );
       }
       const includeContentResp = body.include_content !== false;
       // `created: false` is appended to every update-path response so

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,7 +13,7 @@
 
 import type { Store, Note } from "../core/src/types.ts";
 import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
-import { toNoteIndex, filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "../core/src/notes.ts";
+import { getNote, toNoteIndex, filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "../core/src/notes.ts";
 import { attachValidationStatus } from "../core/src/mcp.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
@@ -1932,12 +1932,32 @@ export async function handleVault(
 // Unresolved wikilinks — REST-only (admin/maintenance)
 // ---------------------------------------------------------------------------
 
-export function handleUnresolvedWikilinks(req: Request, store: Store): Response {
+export function handleUnresolvedWikilinks(
+  req: Request,
+  store: Store,
+  tagScope: TagScopeCtx = NO_TAG_SCOPE,
+): Response {
   const url = new URL(req.url);
   const limitStr = url.searchParams.get("limit");
   const limit = limitStr ? parseInt(limitStr, 10) : 50;
   const db = (store as any).db;
-  return Response.json(listUnresolvedWikilinks(db, limit));
+  const result = listUnresolvedWikilinks(db, limit);
+
+  // Unscoped token → return as-is (unchanged behavior).
+  if (tagScope.raw === null) return Response.json(result);
+
+  // Tag-scope confidentiality (security review): each unresolved row carries
+  // a `source_id` (+ `source_path`) plus the raw `target_path` wikilink
+  // string. For a tag-scoped token, surface ONLY rows whose SOURCE note is
+  // within the token's tag scope — otherwise we'd leak out-of-scope note IDs
+  // and the wikilink target strings those notes contain. Filter the page and
+  // recompute `count` from the filtered set so the aggregate total of
+  // out-of-scope rows doesn't leak either.
+  const filtered = result.unresolved.filter((row) => {
+    const note = getNote(db, row.source_id);
+    return note !== null && noteWithinTagScope(note, tagScope.allowed, tagScope.raw);
+  });
+  return Response.json({ unresolved: filtered, count: filtered.length });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -738,7 +738,7 @@ export async function route(
       writeVaultConfig(vaultConfig);
     });
   }
-  if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store);
+  if (apiPath === "/unresolved-wikilinks") return handleUnresolvedWikilinks(req, store, tagScope);
   if (apiPath.startsWith("/storage")) return handleStorage(req, apiPath.slice(8), vaultName, store, tagScope);
   if (apiPath === "/health") return Response.json({ status: "ok", vault: vaultName });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,7 @@ import {
 } from "./mirror-config.ts";
 import { GLOBAL_CONFIG_PATH } from "./config.ts";
 import { selfRegister } from "./self-register.ts";
+import { warnLegacyGlobalApiKeys } from "./auth.ts";
 import pkg from "../package.json" with { type: "json" };
 
 // Register webhook triggers from global config. Replaces the old hardcoded
@@ -143,6 +144,12 @@ if (scribeUrl) {
 if (process.env.VAULT_AUTH_TOKEN?.trim()) {
   console.log("[auth] VAULT_AUTH_TOKEN set — server-wide operator bearer active");
 }
+
+// Legacy GLOBAL api_keys warning (security review — multi-user hardening).
+// Surfaced at boot so the operator rotates/removes cross-vault credentials
+// before multi-user sharing. Warning only — never touches the keys. The
+// logic lives in auth.ts (import-safe + unit-tested); see warnLegacyGlobalApiKeys.
+warnLegacyGlobalApiKeys(readGlobalConfig().api_keys);
 
 // Auto-init: create a default vault if none exist (first run in Docker).
 // The vault name comes from PARACHUTE_VAULT_NAME when set + valid; otherwise

--- a/src/tag-scope.ts
+++ b/src/tag-scope.ts
@@ -19,7 +19,7 @@
  * `rootOf` walk is needed at the boundary.
  */
 
-import type { Store, Note } from "../core/src/types.ts";
+import type { Store, Note, HydratedLink, NoteSummary } from "../core/src/types.ts";
 
 /**
  * Build the effective tag-allowlist for a token: union of `{root} ∪
@@ -98,6 +98,73 @@ export function tagsWithinScope(
     if (root && rawRoots.includes(root)) return true;
   }
   return false;
+}
+
+/**
+ * Build a per-note visibility predicate for wikilink expansion
+ * (`ExpandContext.isVisible` in core/src/expand.ts). When the token is
+ * unscoped (`rawRoots === null`) this returns `undefined` so the expander
+ * keeps its original scope-unaware behavior (no predicate installed). When
+ * scoped, it returns a closure over the SAME `noteWithinTagScope` allowlist
+ * logic every other read path uses — so a wikilink whose target is outside
+ * the token's tag scope is left unresolved during inlining, never embedded.
+ *
+ * This is the seam that keeps core scope-unaware: the predicate is built
+ * server-side from the tag-scope machinery and injected into the context;
+ * core only calls it.
+ */
+export function buildExpandVisibility(
+  allowed: Set<string> | null,
+  rawRoots: string[] | null,
+): ((note: Note) => boolean) | undefined {
+  if (rawRoots === null) return undefined;
+  return (note: Note) => noteWithinTagScope(note, allowed, rawRoots);
+}
+
+/**
+ * Treat a hydrated link's endpoint summary as a scope-checkable note. The
+ * summary carries `id` + `tags`, which is all `noteWithinTagScope` needs.
+ * A summary with no tags is out of scope under a tag-scoped token (same as
+ * a real note with no tags).
+ */
+function summaryWithinTagScope(
+  summary: NoteSummary | undefined,
+  allowed: Set<string> | null,
+  rawRoots: string[] | null,
+): boolean {
+  if (!summary) return true; // no summary → no out-of-scope info to leak (dangling/deleted)
+  return noteWithinTagScope({ id: summary.id, tags: summary.tags ?? [] } as Note, allowed, rawRoots);
+}
+
+/**
+ * Filter hydrated links for a tag-scoped token so no out-of-scope NEIGHBOR
+ * metadata leaks (security review — MINOR). A `query-notes`/REST response
+ * with `include_links=true` returns `sourceNote`/`targetNote` summaries
+ * ({id, path, tags, metadata, …}) for every link touching the returned
+ * note — INCLUDING links to notes the token can't otherwise see. Those
+ * summaries leak the out-of-scope neighbor's id, path, and tags.
+ *
+ * Policy: drop any link whose source OR target endpoint summary is outside
+ * the token's tag scope. The queried note itself is always in-scope (it had
+ * to be visible to be returned), so dropping out-of-scope-neighbor links
+ * removes exactly the leak while keeping every link between in-scope notes
+ * fully hydrated. Dropping the whole row (vs. just nulling the summary) is
+ * required because the raw row still carries the neighbor's note id.
+ *
+ * No-op when the token is unscoped (`rawRoots === null`) — identical to the
+ * pre-fix behavior.
+ */
+export function filterHydratedLinksByTagScope(
+  links: HydratedLink[],
+  allowed: Set<string> | null,
+  rawRoots: string[] | null,
+): HydratedLink[] {
+  if (rawRoots === null) return links;
+  return links.filter(
+    (link) =>
+      summaryWithinTagScope(link.sourceNote, allowed, rawRoots) &&
+      summaryWithinTagScope(link.targetNote, allowed, rawRoots),
+  );
 }
 
 /**

--- a/src/vault-create.test.ts
+++ b/src/vault-create.test.ts
@@ -107,7 +107,20 @@ describe("vault create --json", () => {
     );
     expect(exitCode).not.toBe(0);
     expect(stdout).toBe("");
-    expect(stderr).toContain("letters, numbers");
+    expect(stderr).toContain("lowercase alphanumeric");
+  });
+
+  test("UPPERCASE vault name is rejected (security review — audience case-drift)", () => {
+    // An uppercase name would flip the JWT audience case (vault.<Name> vs
+    // vault.<name>) and drift from hub/init lowercasing. cmdCreate must
+    // reject it the same way `init` does.
+    const { exitCode, stdout, stderr } = runCli(
+      ["create", "MyVault", "--json"],
+      { PARACHUTE_HOME: home },
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("lowercase");
   });
 
   test("duplicate name in --json mode errors on stderr and exits non-zero", () => {

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -11,7 +11,7 @@ import { BunStore } from "./vault-store.ts";
 import { generateMcpTools } from "../core/src/mcp.ts";
 import { getLinksHydrated } from "../core/src/links.ts";
 import { buildVaultProjection } from "../core/src/vault-projection.ts";
-import { handleNotes, handleTags, handleFindPath, handleVault } from "./routes.ts";
+import { handleNotes, handleTags, handleFindPath, handleVault, handleUnresolvedWikilinks } from "./routes.ts";
 import { expandTokenTagScope } from "./tag-scope.ts";
 import type { TagScopeCtx } from "./routes.ts";
 import { extractApiKey } from "./auth.ts";
@@ -3624,6 +3624,39 @@ describe("HTTP tag-scope confidentiality (security review)", async () => {
     const body = await res.json() as any;
     expect((body.links ?? []).length).toBe(1);
     expect(JSON.stringify(body.links)).toContain(secret.id);
+  });
+
+  test("unresolved-wikilinks surfaces only in-scope source rows", async () => {
+    // #personal source with a dangling wikilink → out-of-scope row.
+    await store.createNote("p [[NoSuchPersonal]]", { path: "P", tags: ["personal"] });
+    // #work source with a dangling wikilink → in-scope row.
+    await store.createNote("w [[NoSuchWork]]", { path: "W", tags: ["work"] });
+
+    const res = handleUnresolvedWikilinks(
+      mkReq("GET", "/unresolved-wikilinks"),
+      store,
+      await scopeCtx(["work"]),
+    );
+    const body = await res.json() as any;
+    const targets = (body.unresolved as any[]).map((r) => r.target_path);
+    expect(targets).toContain("NoSuchWork");
+    expect(targets).not.toContain("NoSuchPersonal");
+    expect(body.count).toBe(1);
+  });
+
+  test("UNSCOPED unresolved-wikilinks surfaces every row (regression)", async () => {
+    await store.createNote("p [[NoSuchPersonal]]", { path: "P", tags: ["personal"] });
+    await store.createNote("w [[NoSuchWork]]", { path: "W", tags: ["work"] });
+
+    const res = handleUnresolvedWikilinks(
+      mkReq("GET", "/unresolved-wikilinks"),
+      store,
+      NO_SCOPE,
+    );
+    const body = await res.json() as any;
+    const targets = (body.unresolved as any[]).map((r) => r.target_path);
+    expect(targets).toContain("NoSuchWork");
+    expect(targets).toContain("NoSuchPersonal");
   });
 
 });

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -12,6 +12,8 @@ import { generateMcpTools } from "../core/src/mcp.ts";
 import { getLinksHydrated } from "../core/src/links.ts";
 import { buildVaultProjection } from "../core/src/vault-projection.ts";
 import { handleNotes, handleTags, handleFindPath, handleVault } from "./routes.ts";
+import { expandTokenTagScope } from "./tag-scope.ts";
+import type { TagScopeCtx } from "./routes.ts";
 import { extractApiKey } from "./auth.ts";
 import { startTranscriptionWorker } from "./transcription-worker.ts";
 import { setTranscriptionWorker } from "./transcription-registry.ts";
@@ -1464,6 +1466,143 @@ describe("scoped MCP wrapper", async () => {
     expect(after.metadata.name).toBe("");
 
     close();
+  });
+
+  // -- tag-scope confidentiality: expand_links + include_links (security
+  //    review) -----------------------------------------------------------
+  //
+  // These pin the MCP side of the expand_links / include_links leaks. A
+  // tag-scoped session must NOT inline out-of-scope note content via
+  // expand_links, and must NOT hydrate out-of-scope neighbor summaries via
+  // include_links. The unscoped path must remain fully functional. They
+  // MUST fail if the predicate / link-scrub is removed.
+
+  test("MCP expand_links does NOT inline out-of-scope wikilinked content", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `tagscope-expand-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+    const store = getVaultStore(vaultName);
+    // Out-of-scope #personal note holds the secret; in-scope #work note links it.
+    await store.createNote("SECRET PERSONAL BODY", { path: "Secret", tags: ["personal"] });
+    const work = await store.createNote("intro [[Secret]]", { path: "Work", tags: ["work"] });
+
+    const tools = generateScopedMcpTools(vaultName, authForTags(["work"]) as any);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = await query.execute({
+      id: work.id,
+      include_content: true,
+      expand_links: true,
+    }) as any;
+
+    expect(result.content).not.toContain("SECRET PERSONAL BODY");
+    // Wikilink stays literal — indistinguishable from not-found.
+    expect(result.content).toContain("[[Secret]]");
+
+    closeAllStores();
+  });
+
+  test("MCP expand_links multi-hop (depth>1) does not leak out-of-scope content", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `tagscope-expand-deep-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+    const store = getVaultStore(vaultName);
+    await store.createNote("DEEP PERSONAL SECRET", { path: "Deep", tags: ["personal"] });
+    await store.createNote("mid [[Deep]]", { path: "Mid", tags: ["work"] });
+    const top = await store.createNote("top [[Mid]]", { path: "Top", tags: ["work"] });
+
+    const tools = generateScopedMcpTools(vaultName, authForTags(["work"]) as any);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = await query.execute({
+      id: top.id,
+      include_content: true,
+      expand_links: true,
+      expand_depth: 3,
+    }) as any;
+
+    // In-scope Mid inlines; out-of-scope Deep never does, at any depth.
+    expect(result.content).toContain("mid");
+    expect(result.content).not.toContain("DEEP PERSONAL SECRET");
+
+    closeAllStores();
+  });
+
+  test("UNSCOPED MCP expand_links still inlines wikilinked content (regression)", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `tagscope-expand-unscoped-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+    const store = getVaultStore(vaultName);
+    await store.createNote("PERSONAL BODY", { path: "Secret", tags: ["personal"] });
+    const work = await store.createNote("intro [[Secret]]", { path: "Work", tags: ["work"] });
+
+    // No auth → unscoped session. Expansion must behave exactly as before.
+    const tools = generateScopedMcpTools(vaultName);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = await query.execute({
+      id: work.id,
+      include_content: true,
+      expand_links: true,
+    }) as any;
+
+    expect(result.content).toContain("PERSONAL BODY");
+
+    closeAllStores();
+  });
+
+  test("MCP include_links strips out-of-scope NEIGHBOR summaries", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `tagscope-incl-links-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+    const store = getVaultStore(vaultName);
+    const secret = await store.createNote("secret", { path: "Secret", tags: ["personal"] });
+    const work = await store.createNote("work", { path: "Work", tags: ["work"] });
+    await store.createLink(work.id, secret.id, "references");
+
+    const tools = generateScopedMcpTools(vaultName, authForTags(["work"]) as any);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = await query.execute({ id: work.id, include_links: true }) as any;
+
+    const links = (result.links ?? []) as any[];
+    // No surviving link may reference the out-of-scope note's id/path.
+    const serialized = JSON.stringify(links);
+    expect(serialized).not.toContain(secret.id);
+    expect(serialized).not.toContain("Secret");
+
+    closeAllStores();
+  });
+
+  test("UNSCOPED MCP include_links still hydrates the full neighbor (regression)", async () => {
+    const { generateScopedMcpTools } = await import("./mcp-tools.ts");
+    const { writeVaultConfig } = await import("./config.ts");
+    const { getVaultStore, closeAllStores } = await import("./vault-store.ts");
+
+    const vaultName = `tagscope-incl-links-unscoped-${Date.now()}`;
+    writeVaultConfig({ name: vaultName, api_keys: [], created_at: new Date().toISOString() });
+    const store = getVaultStore(vaultName);
+    const secret = await store.createNote("secret", { path: "Secret", tags: ["personal"] });
+    const work = await store.createNote("work", { path: "Work", tags: ["work"] });
+    await store.createLink(work.id, secret.id, "references");
+
+    const tools = generateScopedMcpTools(vaultName);
+    const query = tools.find((t) => t.name === "query-notes")!;
+    const result = await query.execute({ id: work.id, include_links: true }) as any;
+
+    const links = (result.links ?? []) as any[];
+    expect(links.length).toBe(1);
+    expect(JSON.stringify(links)).toContain(secret.id);
+
+    closeAllStores();
   });
 });
 
@@ -3387,6 +3526,106 @@ describe("HTTP /notes", async () => {
       delete process.env.ASSETS_DIR;
     });
   });
+});
+
+// ---------------------------------------------------------------------------
+// REST tag-scope confidentiality (security review). expand_links must not
+// inline out-of-scope wikilinked content; include_links must not hydrate
+// out-of-scope neighbor summaries; unresolved-wikilinks must not surface
+// out-of-scope source rows. Unscoped path stays fully functional. Each
+// security assertion MUST fail without the fix.
+// ---------------------------------------------------------------------------
+describe("HTTP tag-scope confidentiality (security review)", async () => {
+  // Build a TagScopeCtx the same way routing.ts does, so handlers see the
+  // exact shape a real tag-scoped request produces.
+  async function scopeCtx(roots: string[]): Promise<TagScopeCtx> {
+    return { allowed: await expandTokenTagScope(store, roots), raw: roots };
+  }
+  const NO_SCOPE: TagScopeCtx = { allowed: null, raw: null };
+
+  test("expand_links does NOT inline out-of-scope wikilinked content", async () => {
+    await store.createNote("SECRET PERSONAL BODY", { path: "Secret", tags: ["personal"] });
+    const work = await store.createNote("intro [[Secret]]", { path: "Work", tags: ["work"] });
+
+    const res = await handleNotes(
+      mkReq("GET", `/notes?id=${work.id}&include_content=true&expand_links=true`),
+      store,
+      "",
+      "v",
+      await scopeCtx(["work"]),
+    );
+    const body = await res.json() as any;
+    expect(body.content).not.toContain("SECRET PERSONAL BODY");
+    expect(body.content).toContain("[[Secret]]"); // literal — like not-found
+  });
+
+  test("UNSCOPED expand_links still inlines content (regression)", async () => {
+    await store.createNote("PERSONAL BODY", { path: "Secret", tags: ["personal"] });
+    const work = await store.createNote("intro [[Secret]]", { path: "Work", tags: ["work"] });
+
+    const res = await handleNotes(
+      mkReq("GET", `/notes?id=${work.id}&include_content=true&expand_links=true`),
+      store,
+      "",
+      "v",
+      NO_SCOPE,
+    );
+    const body = await res.json() as any;
+    expect(body.content).toContain("PERSONAL BODY");
+  });
+
+  test("expand_links multi-hop (depth>1) does not leak out-of-scope content", async () => {
+    await store.createNote("DEEP PERSONAL SECRET", { path: "Deep", tags: ["personal"] });
+    await store.createNote("mid [[Deep]]", { path: "Mid", tags: ["work"] });
+    const top = await store.createNote("top [[Mid]]", { path: "Top", tags: ["work"] });
+
+    const res = await handleNotes(
+      mkReq("GET", `/notes?id=${top.id}&include_content=true&expand_links=true&expand_depth=3`),
+      store,
+      "",
+      "v",
+      await scopeCtx(["work"]),
+    );
+    const body = await res.json() as any;
+    expect(body.content).toContain("mid");
+    expect(body.content).not.toContain("DEEP PERSONAL SECRET");
+  });
+
+  test("include_links strips out-of-scope NEIGHBOR summaries", async () => {
+    const secret = await store.createNote("secret", { path: "Secret", tags: ["personal"] });
+    const work = await store.createNote("work", { path: "Work", tags: ["work"] });
+    await store.createLink(work.id, secret.id, "references");
+
+    const res = await handleNotes(
+      mkReq("GET", `/notes?id=${work.id}&include_links=true`),
+      store,
+      "",
+      "v",
+      await scopeCtx(["work"]),
+    );
+    const body = await res.json() as any;
+    const serialized = JSON.stringify(body.links ?? []);
+    expect(serialized).not.toContain(secret.id);
+    expect(serialized).not.toContain("Secret");
+  });
+
+  test("UNSCOPED include_links hydrates the full neighbor (regression)", async () => {
+    const secret = await store.createNote("secret", { path: "Secret", tags: ["personal"] });
+    const work = await store.createNote("work", { path: "Work", tags: ["work"] });
+    await store.createLink(work.id, secret.id, "references");
+
+    const res = await handleNotes(
+      mkReq("GET", `/notes?id=${work.id}&include_links=true`),
+      store,
+      "",
+      "v",
+      NO_SCOPE,
+    );
+    const body = await res.json() as any;
+    expect((body.links ?? []).length).toBe(1);
+    expect(JSON.stringify(body.links)).toContain(secret.id);
+  });
+
 });
 
 describe("HTTP /notes include_link_count + order_by=link_count (vault feedback #4)", async () => {


### PR DESCRIPTION
## The vulnerability

A token carrying `vault:<name>:read` **plus a TAG SCOPE** (`permissions.scoped_tags`, e.g. `["work"]`) is meant to see only notes within its tag scope. Three paths leaked across that boundary:

- **CRITICAL — `expand_links` inlined out-of-scope note CONTENT.** A scoped token reading an in-scope note N1 (#work) containing `[[SecretNote]]` → N2 (#personal) got N2's **full text** inlined into N1.content via `GET …/api/notes?id=N1&expand_links=true&include_content=true` (and MCP `query-notes {id:N1, expand_links:true}`). Root cause: core's `expandContent` called `getNote` with no scope awareness; the tag-scope filter only ran over the result LIST, after expansion had already embedded the content into the string.
- **MEDIUM — `…/api/unresolved-wikilinks`** leaked out-of-scope note IDs (`source_id`/`source_path`) + raw wikilink target strings (no tag-scope filtering).
- **MINOR — `include_links=true`** hydration leaked out-of-scope NEIGHBOR summaries (`sourceNote`/`targetNote` `{id, path, tags}`) via `getLinksHydrated`.

## The predicate approach (how scope threads into core's expander)

Core stays **scope-unaware** — it never imports the server's tag-scope module. `ExpandContext` gains an optional `isVisible?: (note: Note) => boolean` **predicate**. In `expandContent`, after resolving a target but **before** inlining (and before the dedup `expanded` set), if `isVisible` returns false the wikilink is left **UNRESOLVED** — the identical return to the not-found branch. So **an out-of-scope target is byte-indistinguishable from a missing one** (we never reveal existence differently). The check runs at **every hop**, so multi-hop (`expand_depth>1`) can't tunnel content through an in-scope intermediary. The server builds the predicate from its tag-scope machinery (the same `noteWithinTagScope` allowlist every read path uses) and injects it; unscoped callers pass nothing (unchanged behavior).

## Each path closed

- **expand_links (REST):** `parseExpandParams` builds `isVisible` from the request's `TagScopeCtx` and injects it at all four expand sites.
- **expand_links (MCP):** `generateMcpTools` takes an optional `expandVisibility`; `generateScopedMcpTools` builds it over a shared allowlist holder that `applyTagScopeWrappers` populates (via `getAllowed`) **before** core's execute runs the synchronous expansion — so the predicate sees the resolved set. Filtering happens DURING expansion, not after.
- **unresolved-wikilinks:** TagScopeCtx threaded into `handleUnresolvedWikilinks`; scoped tokens get only rows whose SOURCE note is in scope, and `count` is recomputed from the filtered set (no aggregate-total leak).
- **include_links neighbor leak:** `filterHydratedLinksByTagScope` drops any link whose endpoint summary is out of scope (dropping the row, not just nulling the summary — the raw row still carries the neighbor's id). Applied at every REST `include_links` site and in the MCP `query-notes` wrapper. This preserves full hydration of in-scope↔in-scope links while leaking nothing out-of-scope.

**Out-of-scope is indistinguishable from not-found** — the expander returns the literal `[[wikilink]]` for an out-of-scope target, identical to a genuinely-missing/unresolved target; a repeat reference does NOT render `(expanded above)` (the out-of-scope note never enters the dedup set). Pinned by a dedicated core test.

## Included multi-user hardening

- **Lowercase vault-name at `cmdCreate`** — mirrors `init`'s `[a-z0-9_-]` rule so an uppercase name can't enter and cause hub/vault audience case-drift.
- **Loud boot warning for legacy GLOBAL `config.yaml` api_keys** — cross-vault credentials that should be rotated/removed before multi-user sharing (the verification flagged 6 on the live box). Warning only; no key is altered.

## Tests (the security regressions FAIL without the fix)

- expand_links: scoped token does not inline out-of-scope content; wikilink stays literal (indistinguishable from not-found); multi-hop safe at every depth; summary mode honored; unscoped still inlines. Both REST + MCP.
- unresolved-wikilinks: scoped → only in-scope sources + count; unscoped → all rows.
- include_links: scoped → no out-of-scope neighbor id/path; unscoped → full hydration. Both REST + MCP.
- vault-name: uppercase create rejected. api_keys-warning: present→warn, absent→silent.

Verified load-bearing by neutralizing each fix and confirming the matching tests fail.

## Gates (no version bump per process)

- `bun test ./core/src/` — 675 pass, 0 fail
- `bun test ./src/` — 1371 pass, 0 fail
- `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)