### PR TITLE
vault creation defaults to internal live mirror (opt-out via default_mirror)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,6 +102,13 @@ import { listTokens, revokeToken, migrateVaultKeys } from "./token-store.ts";
 import { VAULT_SCOPES } from "./scopes.ts";
 import { validateVaultName, decideInitVaultName } from "./vault-name.ts";
 import { getVaultStore } from "./vault-store.ts";
+import {
+  defaultMirrorConfig,
+  resolveMirrorPath,
+  writeMirrorConfigForVault,
+  type MirrorConfig,
+} from "./mirror-config.ts";
+import { bootstrapInternalMirror } from "./mirror-manager.ts";
 import { selfRegister } from "./self-register.ts";
 import {
   hasOwnerPassword,
@@ -814,11 +821,15 @@ async function cmdCreate(args: string[]) {
   // POST /vaults shells out to this CLI and parses stdout). Errors still go
   // to stderr as plain text and exit nonzero — callers branch on exit code.
   const jsonMode = args.includes("--json");
+  // `--no-mirror` opts THIS create out of the default internal live mirror
+  // even when the server-wide `default_mirror` knob is `internal`. Parity for
+  // operators who want one bare vault without flipping the global default.
+  const noMirror = args.includes("--no-mirror");
   // Greedy strip of any `--*` token to recover the positional vault name.
-  // Today only `--json` is recognized; any other `--foo` is silently dropped.
-  // If a future flag (e.g. `--force`, `--dry-run`) is added, the parsing
-  // here needs to whitelist it — otherwise an invalid flag becomes a silent
-  // no-op rather than a usage error.
+  // `--json` and `--no-mirror` are recognized; any other `--foo` is silently
+  // dropped. If a future flag (e.g. `--force`, `--dry-run`) is added, the
+  // parsing here needs to whitelist it — otherwise an invalid flag becomes a
+  // silent no-op rather than a usage error.
   const positional = args.filter((a) => !a.startsWith("--"));
   const name = positional[0];
   if (!name) {
@@ -852,7 +863,7 @@ async function cmdCreate(args: string[]) {
 
   ensureConfigDirSync();
   const wasFirst = listVaults().length === 0;
-  const credential = await createVault(name);
+  const credential = await createVault(name, noMirror ? { enableMirror: false } : {});
 
   // If this is the only vault now, make it the default so unscoped routes
   // (/mcp, /api/*, /oauth/*) target it. Avoids the "single vault named
@@ -3339,7 +3350,59 @@ async function mintBootstrapCredential(name: string): Promise<VaultCredential> {
  * is reachable — vault#282 Stage 2). The DB is created lazily via
  * `getVaultStore` so migrations + schema run; we no longer write any pvt_* row.
  */
-async function createVault(name: string): Promise<VaultCredential> {
+interface CreateVaultOptions {
+  /**
+   * Override the server-wide `default_mirror` knob for this one create.
+   * `--no-mirror` on `parachute-vault create` sets this to `false` so the
+   * vault is created with no mirror config even when the knob is `internal`.
+   * Unset → fall back to the `default_mirror` global config knob (default
+   * `internal`).
+   */
+  enableMirror?: boolean;
+  /**
+   * Test seam threaded straight into `bootstrapInternalMirror` (default
+   * `Bun.which`). Inject a fn returning `null` to exercise the
+   * git-not-installed best-effort path without uninstalling git from the
+   * test host.
+   */
+  which?: (cmd: string) => string | null;
+}
+
+/**
+ * The History / "Live Mirror" preset, written at create time when the
+ * `default_mirror` knob resolves to `internal`. Matches the History preset
+ * the admin SPA's VaultMirror page applies:
+ *   `{enabled:true, location:internal, sync_mode:events, auto_commit:true,
+ *    auto_push:false}`.
+ * Built on top of `defaultMirrorConfig()` so the non-preset fields
+ * (commit_template, safety_net_seconds) stay canonical.
+ */
+function historyPresetMirrorConfig(): MirrorConfig {
+  return {
+    ...defaultMirrorConfig(),
+    enabled: true,
+    location: "internal",
+    sync_mode: "events",
+    auto_commit: true,
+    auto_push: false,
+  };
+}
+
+/**
+ * Resolve whether a freshly created vault should get the internal mirror.
+ * Precedence: explicit per-create override (`--no-mirror`) → server-wide
+ * `default_mirror` knob (default `internal`).
+ */
+function shouldEnableCreateTimeMirror(opts: CreateVaultOptions): boolean {
+  if (opts.enableMirror !== undefined) return opts.enableMirror;
+  // Default to "internal" when the knob is unset — backup-on-by-default.
+  return (readGlobalConfig().default_mirror ?? "internal") === "internal";
+}
+
+async function createVault(
+  name: string,
+  opts: CreateVaultOptions = {},
+): Promise<VaultCredential> {
   const config: VaultConfig = {
     name,
     api_keys: [],
@@ -3350,6 +3413,47 @@ async function createVault(name: string): Promise<VaultCredential> {
   // Touch the store so the vault's SQLite DB + schema are created. No token
   // row is written — vault is a pure hub resource-server post-0.5.0.
   getVaultStore(name);
+
+  // Default new vaults to an internal live mirror (local git backup of the
+  // markdown projection). Backup-on-by-default; GitHub off-site backup is an
+  // opt-in upgrade layered on top later. Opt out via the `default_mirror: off`
+  // global knob (operators on git-less / disk-constrained / cloud boxes) or
+  // the `--no-mirror` flag (this one create only).
+  //
+  // BEST-EFFORT, NON-FATAL: write the mirror config first (so the operator's
+  // intent persists even if git is absent), then attempt the bootstrap. A
+  // git-less box leaves the config written but inactive + logs an actionable
+  // hint — it must NEVER fail the vault create. Create-time ONLY: existing
+  // vaults are never retroactively migrated.
+  if (shouldEnableCreateTimeMirror(opts)) {
+    const mirrorConfig = historyPresetMirrorConfig();
+    writeMirrorConfigForVault(name, mirrorConfig);
+    const mirrorPath = resolveMirrorPath(vaultDir(name), mirrorConfig);
+    if (mirrorPath) {
+      try {
+        const result = await bootstrapInternalMirror(mirrorPath, opts.which);
+        if (!result.ok) {
+          // git-not-installed (or refuse-to-clobber) — config stays written,
+          // mirror just isn't active yet. Surface an actionable line; the
+          // vault create succeeds regardless.
+          console.error(
+            `Note: local git backup configured but not yet active — ${result.error} ` +
+              `Install git to activate; the backup turns on automatically on the next vault restart.`,
+          );
+        }
+      } catch (err) {
+        // Defense-in-depth: bootstrapInternalMirror already converts the
+        // git-missing case into a non-throwing { ok:false } result, but a
+        // truly unexpected throw must still not fail the create.
+        console.error(
+          `Note: local git backup configured but bootstrap hit an unexpected error ` +
+            `(${(err as Error).message ?? err}). The vault was still created; ` +
+            `the backup will retry on the next vault restart.`,
+        );
+      }
+    }
+  }
+
   return mintBootstrapCredential(name);
 }
 
@@ -3454,7 +3558,13 @@ Setup:
   parachute --version                      Print the installed version (alias: -v, version)
 
 Vaults:
-  parachute-vault create <name> [--json]   Create a new vault (--json: emit { name, token, paths, set_as_default })
+  parachute-vault create <name> [--json] [--no-mirror]
+                                           Create a new vault (--json: emit { name, token, paths, set_as_default }).
+                                           New vaults default to an internal live mirror — a local git backup of
+                                           the markdown projection (backup on by default; GitHub off-site is an
+                                           opt-in upgrade). --no-mirror creates a bare vault with no mirror config.
+                                           Operators can flip the server-wide default with 'default_mirror: off' in
+                                           config.yaml (recommended for cloud / disk-constrained boxes).
   parachute-vault list                     List all vaults
   parachute-vault remove <name> [--yes]    Remove a vault
   parachute-vault mcp-install [--mint|--token <t>]

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -250,6 +250,22 @@ describe("config", () => {
     writeGlobalConfig({ port: 1940, autostart: false });
     expect(readGlobalConfig().autostart).toBe(false);
   });
+
+  test("round-trips default_mirror: internal|off", () => {
+    // Absent: createVault falls back to the in-code default ("internal" —
+    // backup-on-by-default). The knob is only persisted when explicitly set.
+    writeGlobalConfig({ port: 1940 });
+    expect(readGlobalConfig().default_mirror).toBeUndefined();
+
+    // Explicit internal — new vaults get the History-preset local git mirror.
+    writeGlobalConfig({ port: 1940, default_mirror: "internal" });
+    expect(readGlobalConfig().default_mirror).toBe("internal");
+
+    // Explicit off — the opt-out operators set on git-less / disk-constrained
+    // / cloud boxes so new vaults are created with no mirror config.
+    writeGlobalConfig({ port: 1940, default_mirror: "off" });
+    expect(readGlobalConfig().default_mirror).toBe("off");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/config.ts
+++ b/src/config.ts
@@ -292,6 +292,29 @@ export interface GlobalConfig {
    */
   mirror?: MirrorConfigType;
   /**
+   * Server-wide DEFAULT for newly created vaults' backup posture. Decides
+   * whether `createVault` writes the History-preset internal mirror
+   * (local git backup of the markdown projection) at create time.
+   *
+   *   - `"internal"` (default) — new vaults get a local git mirror enabled
+   *     out of the box (backup-on-by-default). The History preset:
+   *     `{enabled:true, location:internal, sync_mode:events, auto_commit:true,
+   *     auto_push:false}`. GitHub off-site backup remains an opt-in upgrade.
+   *   - `"off"` — new vaults are created with no mirror config (the historical
+   *     pre-default behavior). The escape hatch for git-less / disk-constrained
+   *     boxes and cloud deploys, where doubling disk per vault is unwanted.
+   *     Cloud / container deploys SHOULD set this to `off`.
+   *
+   * Create-time ONLY — this knob does NOT retroactively enable mirrors on
+   * already-created vaults (that would ~double disk across every existing
+   * vault). Existing-vault opt-in is a separate, deliberate follow-up.
+   *
+   * The container/cloud first-boot auto-create path in `server.ts` does NOT
+   * funnel through `createVault`, so it is unaffected by this knob and stays
+   * mirror-off regardless — matching the recommended cloud posture.
+   */
+  default_mirror?: "internal" | "off";
+  /**
    * Auto-transcribe configuration for the vault↔scribe handoff (vault#353,
    * design 2026-05-21 Part 2). When `enabled: true` AND scribe is discoverable
    * (`services.json` or `SCRIBE_URL` env), audio attachments uploaded to any
@@ -1173,6 +1196,7 @@ export function readGlobalConfig(): GlobalConfig {
       const totpSecretMatch = yaml.match(/^totp_secret:\s*"([^"]+)"/m);
       const discoveryMatch = yaml.match(/^discovery:\s*(enabled|disabled)/m);
       const autostartMatch = yaml.match(/^autostart:\s*(true|false)/m);
+      const defaultMirrorMatch = yaml.match(/^default_mirror:\s*(internal|off)/m);
       // auto_transcribe block — currently single boolean `enabled` (vault#353).
       // Parsed as a nested 2-space-indent block so future fields can grow under
       // it without breaking the regex; only `enabled` is read for v0.6.
@@ -1200,6 +1224,9 @@ export function readGlobalConfig(): GlobalConfig {
       }
       if (autostartMatch) {
         config.autostart = autostartMatch[1]! === "true";
+      }
+      if (defaultMirrorMatch) {
+        config.default_mirror = defaultMirrorMatch[1]! as "internal" | "off";
       }
       if (autoTranscribeEnabled !== undefined) {
         config.auto_transcribe = { enabled: autoTranscribeEnabled };
@@ -1270,6 +1297,7 @@ export function writeGlobalConfig(config: GlobalConfig): void {
   if (config.default_vault) lines.push(`default_vault: ${config.default_vault}`);
   if (config.discovery) lines.push(`discovery: ${config.discovery}`);
   if (config.autostart !== undefined) lines.push(`autostart: ${config.autostart}`);
+  if (config.default_mirror) lines.push(`default_mirror: ${config.default_mirror}`);
   if (config.owner_password_hash) {
     lines.push(`owner_password_hash: "${config.owner_password_hash}"`);
   }

--- a/src/vault-create.test.ts
+++ b/src/vault-create.test.ts
@@ -10,7 +10,15 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { resolve } from "path";
-import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  mkdirSync,
+  writeFileSync,
+  symlinkSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -31,6 +39,23 @@ function runCli(
     stdout: new TextDecoder().decode(proc.stdout),
     stderr: new TextDecoder().decode(proc.stderr),
   };
+}
+
+/** Path to a vault's per-vault mirror-config file inside a temp PARACHUTE_HOME. */
+function mirrorConfigPath(home: string, name: string): string {
+  return join(home, "vault", "data", name, "mirror-config.yaml");
+}
+
+/** Path to a vault's internal mirror git working tree. */
+function mirrorRepoPath(home: string, name: string): string {
+  return join(home, "vault", "data", name, "mirror");
+}
+
+/** Write a minimal config.yaml carrying a `default_mirror` knob value. */
+function writeDefaultMirrorKnob(home: string, value: "internal" | "off"): void {
+  const dir = join(home, "vault");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.yaml"), `port: 1940\ndefault_mirror: ${value}\n`);
 }
 
 let home: string;
@@ -210,5 +235,159 @@ describe("vault create (human mode)", () => {
     expect(stdout).toContain("Install the hub");
     // Human output should NOT be valid JSON.
     expect(() => JSON.parse(stdout.trim())).toThrow();
+  });
+});
+
+/**
+ * Create-time default backup posture: new vaults default to an internal live
+ * mirror (local git backup of the markdown projection). The History preset
+ * `{enabled:true, location:internal, sync_mode:events, auto_commit:true,
+ * auto_push:false}` is written to `data/<vault>/mirror-config.yaml` and (when
+ * git is present) the internal mirror dir is git-bootstrapped. The behavior is
+ * controlled by the server-wide `default_mirror` knob (default `internal`) and
+ * overridable per-create by `--no-mirror`.
+ *
+ * Critically: create-time ONLY — already-created vaults are NOT retroactively
+ * migrated, and the git-less box stays a successful create (best-effort
+ * bootstrap, config still written, actionable log).
+ */
+describe("vault create — default internal live mirror", () => {
+  test("default (no knob) → History-preset mirror config written + git-bootstrapped", () => {
+    const { exitCode } = runCli(["create", "backed", "--json"], {
+      PARACHUTE_HOME: home,
+    });
+    expect(exitCode).toBe(0);
+
+    // Mirror config exists with the exact History preset.
+    const cfgPath = mirrorConfigPath(home, "backed");
+    expect(existsSync(cfgPath)).toBe(true);
+    const cfg = readFileSync(cfgPath, "utf-8");
+    expect(cfg).toContain("enabled: true");
+    expect(cfg).toContain("location: internal");
+    expect(cfg).toContain("sync_mode: events");
+    expect(cfg).toContain("auto_commit: true");
+    expect(cfg).toContain("auto_push: false");
+
+    // Git present on the test host → the internal mirror dir is a real repo
+    // with the seed commit (bootstrap ran). counts/usage reflect it: the
+    // mirror working tree exists under the vault data dir.
+    const repo = mirrorRepoPath(home, "backed");
+    expect(existsSync(join(repo, ".git"))).toBe(true);
+    const log = Bun.spawnSync({
+      cmd: ["git", "-C", repo, "log", "--oneline"],
+      stdout: "pipe",
+    });
+    expect(new TextDecoder().decode(log.stdout)).toContain("initial mirror bootstrap");
+  });
+
+  test("default_mirror: off knob → no mirror config written", () => {
+    writeDefaultMirrorKnob(home, "off");
+    const { exitCode } = runCli(["create", "bare", "--json"], {
+      PARACHUTE_HOME: home,
+    });
+    expect(exitCode).toBe(0);
+
+    // Vault is created…
+    expect(existsSync(join(home, "vault", "data", "bare", "vault.db"))).toBe(true);
+    // …but NO mirror config + NO mirror dir.
+    expect(existsSync(mirrorConfigPath(home, "bare"))).toBe(false);
+    expect(existsSync(mirrorRepoPath(home, "bare"))).toBe(false);
+  });
+
+  test("default_mirror: internal knob (explicit) → mirror config written", () => {
+    writeDefaultMirrorKnob(home, "internal");
+    const { exitCode } = runCli(["create", "explicit", "--json"], {
+      PARACHUTE_HOME: home,
+    });
+    expect(exitCode).toBe(0);
+    expect(existsSync(mirrorConfigPath(home, "explicit"))).toBe(true);
+  });
+
+  test("--no-mirror → no mirror config even when knob is internal", () => {
+    writeDefaultMirrorKnob(home, "internal");
+    const { exitCode } = runCli(["create", "optout", "--no-mirror", "--json"], {
+      PARACHUTE_HOME: home,
+    });
+    expect(exitCode).toBe(0);
+
+    expect(existsSync(join(home, "vault", "data", "optout", "vault.db"))).toBe(true);
+    expect(existsSync(mirrorConfigPath(home, "optout"))).toBe(false);
+    expect(existsSync(mirrorRepoPath(home, "optout"))).toBe(false);
+  });
+
+  test("--no-mirror in human mode keeps the rest of the create working", () => {
+    const { exitCode, stdout } = runCli(["create", "humanbare", "--no-mirror"], {
+      PARACHUTE_HOME: home,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Vault "humanbare" created.');
+    expect(existsSync(mirrorConfigPath(home, "humanbare"))).toBe(false);
+  });
+
+  test("git missing → vault still creates, config written, mirror NOT bootstrapped, actionable log, no crash", () => {
+    // Simulate a git-less server: spawn the CLI with a PATH that resolves
+    // `bun` (so the test can run) but NOT `git`. `bootstrapInternalMirror`'s
+    // `Bun.which("git")` preflight then returns null → friendly,
+    // best-effort failure. The vault create MUST still succeed.
+    const bunBin = Bun.which("bun");
+    expect(bunBin).toBeTruthy();
+    const fakeBin = mkdtempSync(join(tmpdir(), "vault-create-nogit-bin-"));
+    symlinkSync(bunBin!, join(fakeBin, "bun"));
+    try {
+      const proc = Bun.spawnSync({
+        cmd: [bunBin!, CLI, "create", "nogit", "--json"],
+        stdout: "pipe",
+        stderr: "pipe",
+        // Replace PATH entirely so `git` is unresolvable — only our fake bin
+        // (bun only) is on the path.
+        env: { ...process.env, PARACHUTE_HOME: home, PATH: fakeBin },
+      });
+      const exitCode = proc.exitCode ?? -1;
+      const stdout = new TextDecoder().decode(proc.stdout);
+      const stderr = new TextDecoder().decode(proc.stderr);
+
+      // No crash — the vault create succeeds on a git-less box.
+      expect(exitCode).toBe(0);
+      // The vault itself was created.
+      expect(existsSync(join(home, "vault", "data", "nogit", "vault.db"))).toBe(true);
+      // The mirror CONFIG was still written (intent persists for when git
+      // lands later).
+      expect(existsSync(mirrorConfigPath(home, "nogit"))).toBe(true);
+      // But the mirror was NOT git-bootstrapped (no .git — git was absent).
+      expect(existsSync(join(mirrorRepoPath(home, "nogit"), ".git"))).toBe(false);
+      // And the operator got an actionable, clear log on stderr.
+      expect(stderr).toContain("local git backup configured but not yet active");
+      expect(stderr).toContain("Install git");
+      // JSON stdout stays clean + parseable (the note went to stderr).
+      const payload = JSON.parse(stdout.trim());
+      expect(payload.name).toBe("nogit");
+    } finally {
+      rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  test("EXISTING vault (created before this change) is NOT auto-migrated on a later create", () => {
+    // Simulate a vault that predates the default-mirror behavior: create it
+    // with the knob OFF so it gets no mirror config (stand-in for "created by
+    // an older vault build").
+    writeDefaultMirrorKnob(home, "off");
+    const first = runCli(["create", "legacy", "--json"], { PARACHUTE_HOME: home });
+    expect(first.exitCode).toBe(0);
+    expect(existsSync(mirrorConfigPath(home, "legacy"))).toBe(false);
+
+    // Now flip the knob ON and create a SECOND, different vault. The act of
+    // creating "fresh" (which DOES get a mirror) must not retroactively write
+    // a mirror config onto the pre-existing "legacy" vault — create-time only,
+    // never a sweep over existing vaults.
+    writeDefaultMirrorKnob(home, "internal");
+    const second = runCli(["create", "fresh", "--json"], { PARACHUTE_HOME: home });
+    expect(second.exitCode).toBe(0);
+
+    // The new vault is backed…
+    expect(existsSync(mirrorConfigPath(home, "fresh"))).toBe(true);
+    // …but the pre-existing vault is left exactly as it was — no surprise
+    // mirror config, no surprise disk-doubling mirror repo.
+    expect(existsSync(mirrorConfigPath(home, "legacy"))).toBe(false);
+    expect(existsSync(mirrorRepoPath(home, "legacy"))).toBe(false);
   });
 });


### PR DESCRIPTION
## What

New vaults now **default to an internal live mirror** — a local git backup of the vault's markdown projection — so backup is **on by default**. GitHub off-site backup remains an opt-in upgrade layered on top (the device-flow already exists; not wired here).

Implements the create-time default from the [Individual Users and Vault Operations design doc](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-06-04-individual-users-and-vault-operations.md). Aaron's words: "default vaults to be internal live mirror backed up to git."

## How

- **`default_mirror: internal | off` global-config knob** (`src/config.ts` — `GlobalConfig`, `readGlobalConfig`, `writeGlobalConfig`), defaulting to `internal`. Lets operators on git-less / disk-constrained / cloud boxes opt out without a code change. Round-trips through read/write.
- **`createVault` writes the History preset** when `default_mirror` resolves to `internal`:
  `{enabled:true, location:internal, sync_mode:events, auto_commit:true, auto_push:false}`
  to `data/<vault>/mirror-config.yaml`, then best-effort bootstraps the internal mirror git repo. This is the single funnel for **all** create paths — CLI `create`, `init`, and hub-SPA `POST /vaults` (which shells out to `create --json`) — so one hook covers them all.
- **`--no-mirror` flag** on `parachute-vault create` overrides the default to off for that one create (parity escape hatch without flipping the global knob).

## Git-graceful (no-crash on git-absence)

Mirror-enable is **best-effort and non-fatal**. On a git-less box: the mirror config is still written (intent persists for when git lands later), the bootstrap is skipped, an actionable `local git backup configured but not yet active — … Install git to activate` note is logged to stderr, and **the vault create still succeeds (exit 0)**. A vault must always create successfully on a git-less box. Proven by the `git missing → vault still creates …` test (spawns the CLI with a PATH that resolves `bun` but not `git`).

## Explicitly out of scope

- **Existing vaults are NOT auto-migrated.** This is **create-time only** — no boot-pass retroactively enables mirrors on already-created vaults (that would ~double disk across every existing vault, the open question deferred to Aaron). Existing-vault opt-in is a follow-up. Proven by the `EXISTING vault … is NOT auto-migrated` test.
- **Cloud / container deploys should set `default_mirror: off`.** The container/cloud first-boot auto-create path in `server.ts` does **not** funnel through `createVault` (it writes the vault config inline via `writeVaultConfig` + `getVaultStore`), so it stays mirror-off regardless of the knob — matching the recommended cloud=off posture. No code special-casing; the knob documents the intent.
- GitHub auto-linking is unchanged (separate UX wiring).
- Frontend `VaultMirror.tsx` "Backup" copy reframe skipped (kept this PR backend-only).

## Tests

- default (no knob) → History-preset config written + git-bootstrapped
- `default_mirror: off` → no mirror config written
- `--no-mirror` → no mirror config even when knob is `internal`
- git-missing → vault still creates, config written, mirror not bootstrapped, clear log, no crash
- existing vault → NOT auto-migrated on a later create
- `default_mirror` round-trip through read/write global config

## Gates (no version bump)

- `bun run typecheck`: clean
- `bun test ./core/src/`: 675 pass, 0 fail
- `bun test ./src/`: 1379 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)