### PR TITLE
release: vault 0.5.2-rc.1 (rc cut)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.1",
+  "version": "0.5.2-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Cuts vault **0.5.2-rc.1** so post-0.5.1 work on main deploys to the our./friends.parachute.computer boxes for validation before promoting to `@latest`.

Pure version bump (0.5.1 → 0.5.2-rc.1). Substantive code reviewed PR-by-PR (#426–#440). Tag `v0.5.2-rc.1` publishes to npm dist-tag `rc`, leaving `@latest` at 0.5.1.

Carries: #437 usage endpoint · #438 tag-scope content/metadata leak fix (CRITICAL) · #440 internal-mirror default · #426–#436 REST/query/transcription fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)