### PR TITLE
release: vault 0.5.2-rc.2 (OAuth-first create)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.2-rc.1",
+  "version": "0.5.2-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Cuts **0.5.2-rc.2** to ship #443 (OAuth-first vault create — no auto-mint admin token) to friends. Pure version bump; #443 reviewed + merged. Tag publishes to npm `rc`, `@latest` stays 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)