### PR TITLE
feat(backup-ui): lead with version-history-on + Back-up-to-GitHub; presets/raw fields under Advanced

### DIFF
--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -123,6 +123,23 @@ function renderRoute() {
   );
 }
 
+/**
+ * The page now leads with a plain-language backup status banner + the
+ * "Back up to GitHub" upgrade. The preset soup, raw config fields, the
+ * Status card (run-now / push-now), and import-from-git all live behind
+ * a single page-level "Advanced settings" disclosure — a normal owner
+ * never opens it. Tests that exercise those operator surfaces open it
+ * first via this helper.
+ */
+async function openAdvanced(user: ReturnType<typeof userEvent.setup>) {
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", { name: /Advanced settings/i }),
+    ).toBeInTheDocument(),
+  );
+  await user.click(screen.getByRole("button", { name: /Advanced settings/i }));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -152,6 +169,8 @@ describe("VaultMirror — admin scope", () => {
 
     renderRoute();
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Status/i })).toBeInTheDocument(),
@@ -172,6 +191,8 @@ describe("VaultMirror — admin scope", () => {
       }),
     );
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByText(/external path went missing/i)).toBeInTheDocument(),
     );
@@ -181,6 +202,7 @@ describe("VaultMirror — admin scope", () => {
     vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
     renderRoute();
     const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
@@ -209,6 +231,7 @@ describe("VaultMirror — admin scope", () => {
     vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
     renderRoute();
     const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
@@ -228,6 +251,8 @@ describe("VaultMirror — admin scope", () => {
   it("sync_mode events shows the safety-net hint", async () => {
     vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture({ enabled: true, sync_mode: "events" }));
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
@@ -238,17 +263,18 @@ describe("VaultMirror — admin scope", () => {
     expect(screen.getByText(/safety check runs hourly/i)).toBeInTheDocument();
   });
 
-  it("clicking Live Mirror preset switches to external location + reveals path field", async () => {
+  it("clicking External folder mirror preset switches to external location + reveals path field", async () => {
     vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
     renderRoute();
     const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
     );
 
     await user.click(
-      screen.getByRole("button", { name: /Apply Live Mirror preset/i }),
+      screen.getByRole("button", { name: /Apply External folder mirror preset/i }),
     );
 
     // External-path input now visible
@@ -270,6 +296,7 @@ describe("VaultMirror — admin scope", () => {
     });
     renderRoute();
     const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
@@ -278,9 +305,9 @@ describe("VaultMirror — admin scope", () => {
     // Default fixture is location=internal + no creds — Push checkbox absent.
     expect(screen.queryByLabelText(/Push after each commit/i)).not.toBeInTheDocument();
 
-    // Flip to external via the Live Mirror preset — the checkbox appears
-    // even with no creds (operator may have wired a remote manually).
-    await user.click(screen.getByRole("button", { name: /Apply Live Mirror preset/i }));
+    // Flip to external via the External folder mirror preset — the checkbox
+    // appears even with no creds (operator may have wired a remote manually).
+    await user.click(screen.getByRole("button", { name: /Apply External folder mirror preset/i }));
     expect(screen.getByLabelText(/Push after each commit/i)).toBeInTheDocument();
   });
 
@@ -300,6 +327,8 @@ describe("VaultMirror — admin scope", () => {
       },
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     // Wait for both the mirror snapshot AND the credential status to
     // resolve — the checkbox visibility depends on `creds.active_method`,
     // which lives in a separate fetch from the mirror snapshot.
@@ -322,6 +351,7 @@ describe("VaultMirror — admin scope", () => {
     vi.mocked(api.getMirror).mockResolvedValue(snapshotFixture());
     renderRoute();
     const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
@@ -342,6 +372,7 @@ describe("VaultMirror — admin scope", () => {
 
     renderRoute();
     const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
@@ -374,6 +405,7 @@ describe("VaultMirror — admin scope", () => {
 
     renderRoute();
     const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(
@@ -401,6 +433,8 @@ describe("VaultMirror — admin scope", () => {
     );
 
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /Run export now/i }),
@@ -424,6 +458,8 @@ describe("VaultMirror — admin scope", () => {
       }),
     );
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Status/i })).toBeInTheDocument(),
     );
@@ -440,6 +476,8 @@ describe("VaultMirror — admin scope", () => {
       }),
     );
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByText(/Last push failed/i)).toBeInTheDocument(),
     );
@@ -454,6 +492,8 @@ describe("VaultMirror — admin scope", () => {
       }),
     );
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByText(/3 commits ready to push/i)).toBeInTheDocument(),
     );
@@ -491,6 +531,8 @@ describe("VaultMirror — admin scope", () => {
       push: { fired: true, pushed: true, sha: "feedface1234567890abc" },
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     // The "Push now" button renders once `getMirror` resolves, but its
     // ENABLED state depends on `getMirrorAuth` (active_method: "pat")
     // resolving too. Wait for not-disabled rather than asserting it
@@ -500,7 +542,6 @@ describe("VaultMirror — admin scope", () => {
       expect(screen.getByRole("button", { name: /Push now/i })).not.toBeDisabled(),
     );
     const pushBtn = screen.getByRole("button", { name: /Push now/i });
-    const user = userEvent.setup();
     await user.click(pushBtn);
     await waitFor(() => {
       expect(api.pushMirrorNow).toHaveBeenCalledWith("work");
@@ -524,6 +565,8 @@ describe("VaultMirror — admin scope", () => {
       pat: null,
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Push now/i })).toBeInTheDocument(),
     );
@@ -541,6 +584,7 @@ describe("VaultMirror — admin scope", () => {
 
     renderRoute();
     const user = userEvent.setup();
+    await openAdvanced(user);
 
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
@@ -549,6 +593,100 @@ describe("VaultMirror — admin scope", () => {
 
     await waitFor(() =>
       expect(screen.getByText(/external_path/)).toBeInTheDocument(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Backup status banner (the restructured hero) + Advanced disclosure.
+  // -------------------------------------------------------------------------
+
+  it("leads with the plain 'version history on' status and keeps presets/raw fields hidden until Advanced", async () => {
+    // Default-shipped vault: enabled + internal. The owner should see the
+    // plain-language reassurance, NOT the preset soup or raw config fields.
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+    renderRoute();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Version history — on/i)).toBeInTheDocument(),
+    );
+
+    // Preset soup + raw config are NOT visible on load.
+    expect(
+      screen.queryByRole("heading", { name: /Configuration/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Apply History preset/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Sync mode/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Run export now/i }),
+    ).not.toBeInTheDocument();
+
+    // Opening Advanced reveals them.
+    const user = userEvent.setup();
+    await openAdvanced(user);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("button", { name: /Apply History preset/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("presents 'Back up to GitHub' as the primary upgrade above Advanced", async () => {
+    // enabled + internal, no remote wired → the upgrade CTA is the
+    // GitRemoteSection, rendered OUTSIDE the Advanced disclosure.
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    renderRoute();
+    // The "Back up to GitHub" section is present without opening Advanced.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /Back up to GitHub/i }),
+      ).toBeInTheDocument(),
+    );
+    // Banner nudges toward it.
+    expect(screen.getByText(/Want an off-machine copy too/i)).toBeInTheDocument();
+  });
+
+  it("status banner reports backed-up state when auto_push + credentials are wired", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal", auto_push: true }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: "github_oauth",
+      github_oauth: {
+        user_login: "aaron",
+        user_id: 1,
+        scope: "repo",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        token_preview: "gho_…7890",
+      },
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/backed up off this machine/i)).toBeInTheDocument(),
+    );
+    // The connected GitHub login appears in the banner.
+    expect(screen.getAllByText(/@aaron/).length).toBeGreaterThan(0);
+  });
+
+  it("status banner reports OFF when the mirror is disabled", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: false }),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/Version history is off/i)).toBeInTheDocument(),
     );
   });
 });
@@ -588,24 +726,31 @@ describe("VaultMirror — read scope", () => {
     );
 
     renderRoute();
+    // Read-only banner is visible without opening Advanced.
+    await waitFor(() =>
+      expect(screen.getByText(/read-only token/i)).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
     );
 
-    expect(screen.getByText(/read-only token/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Save$/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /Run export now/i })).toBeDisabled();
   });
 
-  it("hides the Git remote section for read-only sessions (admin scope gates it)", async () => {
+  it("hides the Back-up-to-GitHub section for read-only sessions (admin scope gates it)", async () => {
     vi.mocked(api.getMirror).mockResolvedValue(
       snapshotFixture({ enabled: true, location: "external", external_path: "/tmp/x" }),
     );
     renderRoute();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Configuration/i })).toBeInTheDocument(),
+      expect(screen.getByText(/read-only token/i)).toBeInTheDocument(),
     );
-    expect(screen.queryByRole("heading", { name: /Git remote/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /Back up to GitHub/i }),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -629,7 +774,7 @@ describe("VaultMirror — Git remote credentials", () => {
     });
     renderRoute();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+      expect(screen.getByRole("heading", { name: /Back up to GitHub/i })).toBeInTheDocument(),
     );
     expect(screen.getByText(/Not connected/i)).toBeInTheDocument();
     expect(
@@ -657,7 +802,7 @@ describe("VaultMirror — Git remote credentials", () => {
     });
     renderRoute();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+      expect(screen.getByRole("heading", { name: /Back up to GitHub/i })).toBeInTheDocument(),
     );
     const patBtn = screen.getByRole("button", { name: /Use Personal Access Token/i });
     const ghBtn = screen.getByRole("button", { name: /Connect GitHub/i });
@@ -704,6 +849,8 @@ describe("VaultMirror — Git remote credentials", () => {
       pat: null,
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByText(/Auto-push needs git credentials/i)).toBeInTheDocument(),
     );
@@ -730,6 +877,8 @@ describe("VaultMirror — Git remote credentials", () => {
       pat: null,
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByText(/Will push to/i)).toBeInTheDocument(),
     );
@@ -759,7 +908,7 @@ describe("VaultMirror — Git remote credentials", () => {
 
     renderRoute();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+      expect(screen.getByRole("heading", { name: /Back up to GitHub/i })).toBeInTheDocument(),
     );
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /Connect GitHub/i }));
@@ -802,7 +951,7 @@ describe("VaultMirror — Git remote credentials", () => {
     });
     renderRoute();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+      expect(screen.getByRole("heading", { name: /Back up to GitHub/i })).toBeInTheDocument(),
     );
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /Use Personal Access Token/i }));
@@ -841,7 +990,7 @@ describe("VaultMirror — Git remote credentials", () => {
     });
     renderRoute();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Git remote/i })).toBeInTheDocument(),
+      expect(screen.getByRole("heading", { name: /Back up to GitHub/i })).toBeInTheDocument(),
     );
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /Use Personal Access Token/i }));
@@ -882,6 +1031,8 @@ describe("VaultMirror — Import from git section", () => {
 
   it("renders the import section heading + multi-pusher caveat", async () => {
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(
         screen.getByRole("heading", { name: /Import from a git repo/i }),
@@ -897,7 +1048,7 @@ describe("VaultMirror — Import from git section", () => {
     vi.mocked(scope.hasAdminScope).mockReturnValue(false);
     renderRoute();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Git backup for/i })).toBeInTheDocument(),
+      expect(screen.getByRole("heading", { name: /Backup for/i })).toBeInTheDocument(),
     );
     expect(
       screen.queryByRole("heading", { name: /Import from a git repo/i }),
@@ -906,11 +1057,12 @@ describe("VaultMirror — Import from git section", () => {
 
   it("toggling Replace requires typing the vault name to enable Start", async () => {
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
     );
 
-    const user = userEvent.setup();
     // Type a URL into the import section's Remote URL field (the one
     // INSIDE the import section, not the PAT modal which isn't open).
     const importUrlInput = screen.getByLabelText(/Remote URL/i) as HTMLInputElement;
@@ -936,6 +1088,8 @@ describe("VaultMirror — Import from git section", () => {
 
   it("the 'Also sync changes back' checkbox is checked by default", async () => {
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
     );
@@ -954,10 +1108,11 @@ describe("VaultMirror — Import from git section", () => {
       sync_enabled: true,
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
     );
-    const user = userEvent.setup();
     const importUrlInput = screen.getByLabelText(/Remote URL/i) as HTMLInputElement;
     await user.type(importUrlInput, "https://github.com/aaron/vault.git");
     await user.click(screen.getByRole("button", { name: /Start import/i }));
@@ -986,10 +1141,11 @@ describe("VaultMirror — Import from git section", () => {
       sync_enabled: false,
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
     );
-    const user = userEvent.setup();
     await user.type(
       screen.getByLabelText(/Remote URL/i),
       "https://github.com/aaron/vault.git",
@@ -1023,10 +1179,11 @@ describe("VaultMirror — Import from git section", () => {
         "Sync not enabled — pushing changes back needs write credentials (a PAT or GitHub sign-in).",
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
     );
-    const user = userEvent.setup();
     await user.type(
       screen.getByLabelText(/Remote URL/i),
       "https://github.com/aaron/public.git",
@@ -1051,10 +1208,11 @@ describe("VaultMirror — Import from git section", () => {
       sync_enabled: true,
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
     );
-    const user = userEvent.setup();
     await user.type(
       screen.getByLabelText(/Remote URL/i),
       "https://github.com/aaron/private.git",
@@ -1091,10 +1249,11 @@ describe("VaultMirror — Import from git section", () => {
       sync_enabled: true,
     });
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
     );
-    const user = userEvent.setup();
     await user.type(
       screen.getByLabelText(/Remote URL/i),
       "https://github.com/aaron/saved.git",
@@ -1115,10 +1274,11 @@ describe("VaultMirror — Import from git section", () => {
       new api.HttpError(502, "git clone failed for https://***@github.com/missing/repo.git: fatal: not found"),
     );
     renderRoute();
+    const user = userEvent.setup();
+    await openAdvanced(user);
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /Import from a git repo/i })).toBeInTheDocument(),
     );
-    const user = userEvent.setup();
     await user.type(
       screen.getByLabelText(/Remote URL/i),
       "https://github.com/missing/repo.git",

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -689,6 +689,31 @@ describe("VaultMirror — admin scope", () => {
       expect(screen.getByText(/Version history is off/i)).toBeInTheDocument(),
     );
   });
+
+  it("does NOT claim backed-up when auto_push=true but NO credentials are wired (trust guard)", async () => {
+    // A vault can carry auto_push=true with no working remote. The banner
+    // must NOT tell the owner their data is backed up off-machine — that's
+    // a trust violation. It stays on the "version history on" + upgrade
+    // nudge until credentials actually exist.
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal", auto_push: true }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/Version history — on/i)).toBeInTheDocument(),
+    );
+    // The off-machine claim is absent.
+    expect(
+      screen.queryByText(/backed up off this machine/i),
+    ).not.toBeInTheDocument();
+    // Still nudges toward the upgrade.
+    expect(screen.getByText(/Want an off-machine copy too/i)).toBeInTheDocument();
+  });
 });
 
 describe("VaultMirror — auth-required path", () => {

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -9,12 +9,24 @@
  * vault up to a git repository — one of the launch-era asks — has a
  * home that doesn't require curl + YAML editing.
  *
- * Layout: status card → manual-trigger button → preset cards → detailed
- * config form. The presets pre-fill the form (matching the three the
- * design doc names — "History" / "Live Mirror" / "Manual Export") so
- * an operator who knows what shape they want gets there in one click.
- * The detailed fields below the presets let custom shapes through
- * without bypassing the form's validation.
+ * Layout (restructured for non-technical owners — Aaron's "the settings
+ * are very confusing for people, we want clearer defaults"):
+ *   1. BackupStatusBanner — plain-language status. Every new vault ships
+ *      with an internal live git history, so the default read is
+ *      "✓ Version history — on." When credentials are wired + auto_push is
+ *      on it upgrades to "✓ Version history + backed up off this machine."
+ *   2. "Back up to GitHub" (GitRemoteSection) — the one upgrade an owner
+ *      cares about, promoted above the fold (GitHub Device Flow / PAT).
+ *   3. A single "Advanced settings" disclosure holding everything else —
+ *      the preset shortcuts (History / External folder mirror / Manual
+ *      Export), the raw config form (location / external_path / sync_mode /
+ *      auto_commit / auto_push), the Status card with run-now / push-now,
+ *      and import-from-git. A normal owner never opens it.
+ *
+ * The presets pre-fill the raw form so an operator who knows the shape
+ * they want gets there in one click; the detailed fields below let custom
+ * shapes through without bypassing the form's validation. The export
+ * "Mirror" is the internal vocabulary; owner-facing copy says "Backup".
  *
  * Post-event-driven shift (vault#382): the granular schedule picker
  * (Live/Minute/10min/Hourly/Daily/Manual) has been replaced by a binary
@@ -353,8 +365,10 @@ function MirrorScreen({
  *
  *  - enabled + internal location → "Version history — on." (the default
  *    every new vault ships with: a full local git history of every change).
- *  - + a wired remote that's pushing (auto_push or saved credentials) →
- *    "Version history + backed up to GitHub / your git remote."
+ *  - + credentials ACTUALLY wired AND auto_push on → "Version history +
+ *    backed up off this machine." We require real credentials, not just
+ *    the auto_push flag: never tell an owner their data is backed up when
+ *    no working remote exists (or while creds are still loading).
  *  - disabled → an honest "off" state with a nudge to the advanced toggle.
  *
  * "Mirror" is the internal vocabulary; the owner-facing copy is "Backup"
@@ -379,16 +393,17 @@ function BackupStatusBanner({
     );
   }
 
-  // Is it backed up to a remote? Either credentials are wired (a remote
-  // exists) and auto_push is on, or auto_push is on with a pushed commit
-  // on record. We treat "auto_push on + a remote" as the backed-up state.
-  const hasRemote = !!creds?.active_method || config.auto_push;
+  // Only claim "backed up off this machine" when credentials are ACTUALLY
+  // wired (a real remote exists) AND auto_push is on. `auto_push` alone is
+  // not enough: a vault can carry the flag with no working remote, and
+  // while creds are still loading `creds === null` — telling the owner
+  // their data is backed up when it isn't is a trust violation. Gate on
+  // `creds?.active_method` being truthy, never on auto_push alone.
+  const hasRemote = !!creds?.active_method;
   const pushingToRemote = config.auto_push && hasRemote;
 
   const githubLogin =
     creds?.active_method === "github_oauth" ? creds.github_oauth?.user_login : undefined;
-  const patRemote =
-    creds?.active_method === "pat" ? creds.pat?.remote_url : undefined;
 
   return (
     <div className="mint-banner" role="status" style={{ marginBottom: "1rem" }}>
@@ -399,10 +414,6 @@ function BackupStatusBanner({
             <>
               Every change is saved locally and pushed to GitHub as{" "}
               <code>@{githubLogin}</code>.
-            </>
-          ) : patRemote ? (
-            <>
-              Every change is saved locally and pushed to your git remote.
             </>
           ) : (
             <>
@@ -884,8 +895,9 @@ function ConfigForm({
             ) : (
               <div className="warn-banner" style={{ marginTop: "0.5rem" }} role="alert">
                 Auto-push needs git credentials. Either connect GitHub in the{" "}
-                <strong>Git remote</strong> section below, or paste a Personal Access
-                Token + remote URL. Failed pushes are logged but won't crash the export.
+                <strong>Back up to GitHub</strong> section above, or paste a Personal
+                Access Token + remote URL there. Failed pushes are logged but won't crash
+                the export.
               </div>
             )
           ) : null}
@@ -1160,7 +1172,7 @@ function GitRemoteSection({
                 return (
                   <>
                     Auto-push was already on; the push attempt failed —
-                    see the Status card above for details.
+                    see Advanced settings → Status for details.
                   </>
                 );
               }
@@ -1180,7 +1192,7 @@ function GitRemoteSection({
                 return (
                   <>
                     Auto-push enabled. The initial push attempt failed — see
-                    the Status card above for the error.
+                    Advanced settings → Status for the error.
                   </>
                 );
               }
@@ -1189,7 +1201,7 @@ function GitRemoteSection({
               );
             }
             return <>Credentials wired. Auto-push remains off; flip it on in
-              Configuration above to push commits automatically.</>;
+              Advanced settings → Configuration to push commits automatically.</>;
           })()}{" "}
           <button
             type="button"

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -112,7 +112,7 @@ const PRESETS: ReadonlyArray<Preset> = [
   },
   {
     id: "live",
-    label: "Live Mirror",
+    label: "External folder mirror",
     subtext:
       "Visible folder. Open in Obsidian, push to GitHub. Events-driven.",
     apply: (current) => ({
@@ -191,7 +191,7 @@ export function VaultMirror({ vaultName }: { vaultName?: string } = {}) {
     <div>
       <div className="list-header">
         <h2>
-          Git backup for <code>{name}</code>
+          Backup for <code>{name}</code>
         </h2>
         <Link to={detailHref} className="muted">
           ← Vault detail
@@ -258,16 +258,18 @@ function MirrorScreen({
     };
   }, [vaultName, isAdmin]);
 
+  // Single "Advanced" disclosure for the whole page. A normal owner never
+  // needs to open it: the backup status banner + "Back up to GitHub"
+  // upgrade above carry the entire common path. Everything an operator
+  // wants — the raw config (location / sync_mode / auto_commit / auto_push
+  // / external folder), the preset shortcuts, the manual run-now / push-now
+  // buttons, the manual export, and import-from-git — lives inside.
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
   return (
     <>
-      <StatusCard
-        status={snapshot.status}
-        config={snapshot.config}
-        creds={creds}
-        canRun={isAdmin && snapshot.status.enabled}
-        vaultName={vaultName}
-        onSnapshot={onSnapshot}
-      />
+      <BackupStatusBanner status={snapshot.status} config={snapshot.config} creds={creds} />
+
       {!isAdmin ? (
         <div className="warn-banner">
           You're viewing this page with a read-only token. Saving config + manual run
@@ -275,16 +277,10 @@ function MirrorScreen({
           "Manage" link with an admin-scoped session to make changes.
         </div>
       ) : null}
-      <ConfigForm
-        vaultName={vaultName}
-        initial={snapshot.config}
-        readOnly={!isAdmin}
-        creds={creds}
-        onSaved={(snap) => {
-          onSnapshot(snap);
-          onRefresh();
-        }}
-      />
+
+      {/* The one upgrade an owner cares about: back up off-machine to GitHub
+          (or any HTTPS git host). Promoted out of "advanced" — it's the
+          primary call to action on this page. */}
       {isAdmin ? (
         <GitRemoteSection
           vaultName={vaultName}
@@ -300,13 +296,135 @@ function MirrorScreen({
           locationIsExternal={snapshot.config.location === "external"}
         />
       ) : null}
-      {isAdmin ? (
-        <ImportFromGitSection
-          vaultName={vaultName}
-          creds={creds}
-        />
+
+      <div className="section">
+        <button
+          type="button"
+          className="secondary"
+          onClick={() => setAdvancedOpen((s) => !s)}
+          aria-expanded={advancedOpen}
+        >
+          {advancedOpen ? "Hide advanced settings" : "Advanced settings"}
+        </button>
+        {!advancedOpen ? (
+          <p className="dim" style={{ margin: "0.6rem 0 0" }}>
+            Manual exports, run-now, an external (Obsidian-visible) mirror folder,
+            commit settings, and import-from-a-repo. Most owners never need these.
+          </p>
+        ) : null}
+      </div>
+
+      {advancedOpen ? (
+        <>
+          <StatusCard
+            status={snapshot.status}
+            config={snapshot.config}
+            creds={creds}
+            canRun={isAdmin && snapshot.status.enabled}
+            vaultName={vaultName}
+            onSnapshot={onSnapshot}
+          />
+          <ConfigForm
+            vaultName={vaultName}
+            initial={snapshot.config}
+            readOnly={!isAdmin}
+            creds={creds}
+            onSaved={(snap) => {
+              onSnapshot(snap);
+              onRefresh();
+            }}
+          />
+          {isAdmin ? (
+            <ImportFromGitSection
+              vaultName={vaultName}
+              creds={creds}
+            />
+          ) : null}
+        </>
       ) : null}
     </>
+  );
+}
+
+/**
+ * Plain-language backup status — the hero of the page. A non-technical
+ * owner should read one line and know their vault is safe. Derived
+ * entirely from the snapshot + credential status (no new API):
+ *
+ *  - enabled + internal location → "Version history — on." (the default
+ *    every new vault ships with: a full local git history of every change).
+ *  - + a wired remote that's pushing (auto_push or saved credentials) →
+ *    "Version history + backed up to GitHub / your git remote."
+ *  - disabled → an honest "off" state with a nudge to the advanced toggle.
+ *
+ * "Mirror" is the internal vocabulary; the owner-facing copy is "Backup"
+ * / "version history" throughout.
+ */
+function BackupStatusBanner({
+  status,
+  config,
+  creds,
+}: {
+  status: MirrorStatus;
+  config: MirrorConfig;
+  creds: MirrorCredentialStatus | null;
+}) {
+  if (!config.enabled) {
+    return (
+      <div className="warn-banner" role="status">
+        <strong>Version history is off.</strong> This vault isn't saving a
+        local history of changes right now. Open <strong>Advanced settings</strong>{" "}
+        below to turn it back on.
+      </div>
+    );
+  }
+
+  // Is it backed up to a remote? Either credentials are wired (a remote
+  // exists) and auto_push is on, or auto_push is on with a pushed commit
+  // on record. We treat "auto_push on + a remote" as the backed-up state.
+  const hasRemote = !!creds?.active_method || config.auto_push;
+  const pushingToRemote = config.auto_push && hasRemote;
+
+  const githubLogin =
+    creds?.active_method === "github_oauth" ? creds.github_oauth?.user_login : undefined;
+  const patRemote =
+    creds?.active_method === "pat" ? creds.pat?.remote_url : undefined;
+
+  return (
+    <div className="mint-banner" role="status" style={{ marginBottom: "1rem" }}>
+      {pushingToRemote ? (
+        <>
+          <strong>✓ Version history + backed up off this machine.</strong>{" "}
+          {githubLogin ? (
+            <>
+              Every change is saved locally and pushed to GitHub as{" "}
+              <code>@{githubLogin}</code>.
+            </>
+          ) : patRemote ? (
+            <>
+              Every change is saved locally and pushed to your git remote.
+            </>
+          ) : (
+            <>
+              Every change is saved locally and pushed to your git remote
+              automatically.
+            </>
+          )}
+        </>
+      ) : (
+        <>
+          <strong>✓ Version history — on.</strong> Your vault automatically
+          saves a full local history of every change. Want an off-machine copy
+          too? Use <strong>Back up to GitHub</strong> below.
+        </>
+      )}
+      {status.last_error ? (
+        <p className="dim" style={{ margin: "0.5rem 0 0" }}>
+          Heads up — the last backup pass reported an error. See{" "}
+          <strong>Advanced settings</strong> below for details.
+        </p>
+      ) : null}
+    </div>
   );
 }
 
@@ -585,11 +703,11 @@ function ConfigForm({
       <div className="form-row">
         <label>Presets</label>
         <p className="dim" style={{ marginTop: 0, marginBottom: "0.5rem", fontSize: "0.9em" }}>
-          <strong>History</strong> is the easiest start — vault manages the
-          mirror folder under its own data dir, no path to pick, no remote
-          to configure. <strong>Live Mirror</strong> + <strong>Manual
-          Export</strong> are for operators who want to point at a visible
-          folder (Obsidian, GitHub).
+          <strong>History</strong> is the default every vault ships with —
+          vault manages the history folder under its own data dir, no path to
+          pick, no remote to configure. <strong>External folder mirror</strong> +{" "}
+          <strong>Manual Export</strong> are for operators who want to point at a
+          visible folder (Obsidian, GitHub).
         </p>
         <div className="preset-grid">
           {PRESETS.map((preset) => (
@@ -913,11 +1031,22 @@ function GitRemoteSection({
   return (
     <div className="section" id="git-remote-section">
       <h3 style={{ margin: "0 0 0.85rem", fontSize: "1rem", fontWeight: 500 }}>
-        Git remote
+        {connected ? "Backed up to a git remote" : "Back up to GitHub"}
       </h3>
       <p className="dim" style={{ marginTop: 0 }}>
-        Credentials for <code>auto-push</code>. Stored on this server with{" "}
-        <code>0600</code> file permissions. Never sent to GitHub or any third party.
+        {connected ? (
+          <>
+            Your vault pushes its history to an off-machine git remote.
+            Credentials are stored on this server with <code>0600</code> file
+            permissions — never sent to GitHub or any third party.
+          </>
+        ) : (
+          <>
+            Keep an off-machine copy: push your vault's history to GitHub (or any
+            HTTPS git host). Credentials are stored on this server with{" "}
+            <code>0600</code> file permissions, never sent to a third party.
+          </>
+        )}
       </p>
 
       {/*


### PR DESCRIPTION
## What

Restructures the vault backup/mirror admin page (`web/ui/src/routes/VaultMirror.tsx`) around a clear default for non-technical owners. Aaron's feedback: *"all the settings are very confusing for people, we want clearer defaults"* — and his instinct that the internal live git history **is** the real backup model; just make it obvious.

## The restructure

The page used to lead with a status card → manual-trigger → three preset cards → a detailed raw-field config form → credentials → import. Now:

1. **Lead with plain-language status.** A new `BackupStatusBanner` derived entirely from the snapshot:
   - enabled + internal → **"✓ Version history — on."** ("Your vault automatically saves a full local history of every change.")
   - + a wired remote that's pushing (`auto_push` + credentials) → **"✓ Version history + backed up off this machine."** (names the GitHub login / remote)
   - disabled → an honest **"Version history is off"** with a nudge to Advanced.
2. **One primary upgrade: "Back up to GitHub."** The existing GitHub-OAuth / PAT credential flow (formerly headed "Git remote") is promoted to *the* call-to-action, rendered above the fold — not buried among presets. When connected, the header reads "Backed up to a git remote."
3. **Everything else under one "Advanced settings" disclosure** (page-level): the three preset cards, the raw fields (location / external_path / sync_mode / auto_commit / auto_push), the Status card with run-now / push-now, and import-from-git. A normal owner never needs to open it. Run-now + last-commit / last-error status stay available there for operators.

## The naming fix

The preset literally called **"Live Mirror"** means *mirror-to-an-EXTERNAL-folder* — but owners (and Aaron) hear "live mirror" as "the live internal history." It's renamed **"External folder mirror"** so the term no longer collides with the internal-history concept. Page identity is **"Backup"** for the owner; code/IDs stay `mirror`.

## API stability

**UI-only change.** The `GET`/`PUT` `/vault/<name>/.parachute/mirror` request + response shapes and the credential endpoints are **unchanged** — the restructure sits on top of the same API. The hub `/account` page reads `GET mirror` and is unaffected. No call sites or type definitions changed. No version bump (orchestrator cuts the rc).

## Tests

`VaultMirror.test.tsx` updated for the new layout — operator-surface tests now open Advanced via a shared `openAdvanced()` helper rather than dropping coverage; added assertions for the status banner (on / backed-up / off), the Advanced disclosure gating presets+raw fields, and "Back up to GitHub" as the primary upgrade.

- `bunx vitest run` → **146 passed** (9 files)
- `tsc --noEmit` → clean
- `bun run build` (+ verify-base) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)