### PR TITLE
release: vault 0.5.2-rc.3 (backup UI simplification)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.2-rc.2",
+  "version": "0.5.2-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Cuts **0.5.2-rc.3** to ship #447 (backup config simplification — version-history-on banner + Back-up-to-GitHub primary + Advanced disclosure) to friends. Pure version bump; #447 reviewed + merged. Tag publishes to npm `rc`, `@latest` stays 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)