### PR TITLE
release: vault 0.5.2-rc.4 (hub-aware init copy #449)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.2-rc.3",
+  "version": "0.5.2-rc.4",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Version-only bump to 0.5.2-rc.4, shipping #449 (fixes #445 + vault half of parachute-hub#568).

Tag v0.5.2-rc.4 on the merge commit → CI publishes to npm dist-tag `rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)