### PR TITLE
release: vault 0.5.2-rc.5 (hub-aware autostart default + banner 403 copy #452)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.2-rc.4",
+  "version": "0.5.2-rc.5",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Version-only bump to 0.5.2-rc.5, shipping #452 (fixes #451 + vault side of parachute-hub#580).

Tag v0.5.2-rc.5 on the merge commit → CI publishes to npm dist-tag `rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)