### PR TITLE
release: vault 0.5.2 stable (hub-aware init + supervised lifecycle)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.2-rc.5",
+  "version": "0.5.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Version-only bump 0.5.2-rc.5 → 0.5.2 stable, per Aaron's ship decision.

Tag v0.5.2 on the merge commit → CI publishes to npm dist-tag `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)