### PR TITLE
release: vault 0.5.3-rc.1 (security hardening #456)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.2",
+  "version": "0.5.3-rc.1",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
First rc of the 0.5.3 line. Ships #456 (fixes #439 #234 #259 #404 — security/correctness hardening atop 0.5.2 stable).

Tag v0.5.3-rc.1 → npm dist-tag `rc`. Stable @latest stays at 0.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)