### PR TITLE
cleanup: drop (store as any).db casts, fix create-note re-read + SPA pvt_* copy (#242 #316 #418)

### DIFF
--- a/core/src/core.test.ts
+++ b/core/src/core.test.ts
@@ -2067,6 +2067,41 @@ describe("MCP tools", async () => {
     expect(result[1].tags).toContain("doc");
   });
 
+  // vault#316 — the create-note tool re-reads each note AFTER
+  // `applySchemaDefaults` runs, so the response reflects the post-defaults
+  // on-disk state (matching the update-note path). Before the fix the
+  // response mapped over the pre-defaults in-memory objects, so a
+  // schema-default-filled field was missing from the returned note even
+  // though it had just been written to disk.
+  it("create-note response reflects post-applySchemaDefaults state (vault#316)", async () => {
+    await store.upsertTagSchema("task", {
+      fields: { priority: { type: "string", enum: ["high", "low"] } },
+    });
+    const tools = generateMcpTools(store);
+    const createNote = tools.find((t) => t.name === "create-note")!;
+
+    // Single: default lands in the returned metadata.
+    const single = await createNote.execute({
+      content: "do the thing",
+      path: "Inbox/task-1",
+      tags: ["task"],
+    }) as any;
+    expect(single.metadata?.priority).toBe("high"); // first enum value
+    // Disk and response agree.
+    const onDisk = await store.getNoteByPath("Inbox/task-1");
+    expect((onDisk!.metadata as any)?.priority).toBe("high");
+
+    // Batch: each entry is re-read post-defaults too.
+    const batch = await createNote.execute({
+      notes: [
+        { content: "a", path: "Inbox/task-2", tags: ["task"] },
+        { content: "b", path: "Inbox/task-3", tags: ["task"] },
+      ],
+    }) as any[];
+    expect(batch[0].metadata?.priority).toBe("high");
+    expect(batch[1].metadata?.priority).toBe("high");
+  });
+
   it("create-note accepts extension field (vault#328)", async () => {
     const tools = generateMcpTools(store);
     const createNote = tools.find((t) => t.name === "create-note")!;

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -131,7 +131,7 @@ export interface GenerateMcpToolsOpts {
  * delete-tag, find-path, vault-info, prune-schema (admin).
  */
 export function generateMcpTools(store: Store, opts?: GenerateMcpToolsOpts): McpToolDef[] {
-  const db: Database = (store as any).db;
+  const db: Database = store.db;
   const expandVisibility = opts?.expandVisibility;
   const nearTraversable = opts?.nearTraversable;
 

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -591,17 +591,22 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           throw e;
         }
 
-        // Apply tag schema effects
+        // Apply tag schema effects, then re-read so the response reflects the
+        // final on-disk state (the `created` entries were read before
+        // `applySchemaDefaults` ran, so any default-filled metadata isn't on
+        // them yet). This mirrors the update-note path, which already re-reads
+        // post-defaults. The extra `getNote` is one read per note and only
+        // matters when a tag schema actually declared defaults.
         for (const note of created) {
           if (note.tags && note.tags.length > 0) {
             await applySchemaDefaults(store, db, [note.id], note.tags);
           }
         }
+        const refreshed = created.map((n) => noteOps.getNote(db, n.id) ?? n);
 
-        // Re-read after schema-default population so the response reflects the
-        // final on-disk state, then attach `validation_status` from any
-        // tag's `fields` declaration that applies to this note.
-        const final = created.map((n) => attachValidationStatus(store, db, n));
+        // Attach `validation_status` from any tag's `fields` declaration that
+        // applies to this note, against the post-defaults state.
+        const final = refreshed.map((n) => attachValidationStatus(store, db, n));
         return batch ? final : final[0];
       },
     },

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -591,18 +591,31 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           throw e;
         }
 
-        // Apply tag schema effects, then re-read so the response reflects the
-        // final on-disk state (the `created` entries were read before
-        // `applySchemaDefaults` ran, so any default-filled metadata isn't on
-        // them yet). This mirrors the update-note path, which already re-reads
-        // post-defaults. The extra `getNote` is one read per note and only
-        // matters when a tag schema actually declared defaults.
+        // Apply tag schema effects, then re-read the notes whose metadata was
+        // actually default-filled so the response reflects the final on-disk
+        // state (the `created` entries were read before `applySchemaDefaults`
+        // ran, so default-filled metadata isn't on them yet). This mirrors the
+        // update-note path, which already re-reads post-defaults. The re-read
+        // is batched (`getNotes` = one `WHERE id IN (...)`) and skipped
+        // entirely when no defaults were applied, so the common no-defaults
+        // path adds zero extra reads.
+        const mutatedIds = new Set<string>();
         for (const note of created) {
           if (note.tags && note.tags.length > 0) {
-            await applySchemaDefaults(store, db, [note.id], note.tags);
+            for (const id of await applySchemaDefaults(store, db, [note.id], note.tags)) {
+              mutatedIds.add(id);
+            }
           }
         }
-        const refreshed = created.map((n) => noteOps.getNote(db, n.id) ?? n);
+        const refreshed =
+          mutatedIds.size === 0
+            ? created
+            : (() => {
+                const byId = new Map(
+                  noteOps.getNotes(db, [...mutatedIds]).map((n) => [n.id, n]),
+                );
+                return created.map((n) => byId.get(n.id) ?? n);
+              })();
 
         // Attach `validation_status` from any tag's `fields` declaration that
         // applies to this note, against the post-defaults state.
@@ -1411,9 +1424,16 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
 // Tag schema effects — auto-populate defaults when tags are applied
 // ---------------------------------------------------------------------------
 
-async function applySchemaDefaults(store: Store, db: Database, noteIds: string[], tags: string[]): Promise<void> {
+/**
+ * Fill schema-declared default values into the metadata of the given notes
+ * for any field they omitted. Returns the IDs of the notes whose metadata was
+ * actually written — callers use this to re-read ONLY the mutated notes (and
+ * to skip the re-read entirely when nothing changed). The common no-schema /
+ * no-defaults path returns an empty array.
+ */
+async function applySchemaDefaults(store: Store, db: Database, noteIds: string[], tags: string[]): Promise<string[]> {
   const schemas = tagSchemaOps.getTagSchemaMap(db);
-  if (Object.keys(schemas).length === 0) return;
+  if (Object.keys(schemas).length === 0) return [];
 
   const defaults: Record<string, unknown> = {};
   for (const tag of tags) {
@@ -1425,8 +1445,9 @@ async function applySchemaDefaults(store: Store, db: Database, noteIds: string[]
       }
     }
   }
-  if (Object.keys(defaults).length === 0) return;
+  if (Object.keys(defaults).length === 0) return [];
 
+  const mutated: string[] = [];
   for (const noteId of noteIds) {
     const note = noteOps.getNote(db, noteId);
     if (!note) continue;
@@ -1442,7 +1463,9 @@ async function applySchemaDefaults(store: Store, db: Database, noteIds: string[]
       metadata: { ...existing, ...missing },
       skipUpdatedAt: true,
     });
+    mutated.push(noteId);
   }
+  return mutated;
 }
 
 function defaultForField(field: { type: string; enum?: string[] }): unknown {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,3 +1,4 @@
+import type { Database } from "bun:sqlite";
 import type { TagFieldSchema, TagRelationship, TagRelationshipMap, TagRecord } from "./tag-schemas.js";
 import type { PrunedField } from "./indexed-fields.js";
 
@@ -208,6 +209,15 @@ export interface HydratedLink extends Link {
 // ---- Store Interface ----
 
 export interface Store {
+  /**
+   * The underlying `bun:sqlite` handle. Exposed (read-only) so callers that
+   * need to run a raw query the Store interface doesn't surface — e.g. the
+   * token-table reverse-lookups in routes.ts and MCP tool generation in
+   * mcp.ts — can reach it without an `(store as any).db` cast. The concrete
+   * `Store` class declares this as `public readonly db: Database`. See vault#242.
+   */
+  readonly db: Database;
+
   // Notes
   createNote(content: string, opts?: { id?: string; path?: string; tags?: string[]; metadata?: Record<string, unknown>; created_at?: string; extension?: string }): Promise<Note>;
   getNote(id: string): Promise<Note | null>;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,7 +13,7 @@
 
 import type { Store, Note } from "../core/src/types.ts";
 import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
-import { getNote, getNoteTags, toNoteIndex, filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "../core/src/notes.ts";
+import { getNote, getNotes, getNoteTags, toNoteIndex, filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "../core/src/notes.ts";
 import { attachValidationStatus } from "../core/src/mcp.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
@@ -1013,19 +1013,33 @@ async function handleNotesInner(
         throw e;
       }
 
-      // Apply tag schema defaults
+      // Apply tag schema defaults, then re-read the notes whose metadata was
+      // actually default-filled so the response reflects the final on-disk
+      // state (the `created` entries were read before `applySchemaDefaults`
+      // ran). Mirrors the MCP create-note path (vault#316). Batched re-read
+      // (`getNotes` = one `WHERE id IN (...)`), skipped when no defaults
+      // applied so the common no-defaults path adds zero extra reads.
+      const mutatedIds = new Set<string>();
       for (const note of created) {
         if (note.tags?.length) {
-          await applySchemaDefaults(store, db, [note.id], note.tags);
+          for (const id of await applySchemaDefaults(store, db, [note.id], note.tags)) {
+            mutatedIds.add(id);
+          }
         }
       }
+      const refreshed =
+        mutatedIds.size === 0
+          ? created
+          : (() => {
+              const byId = new Map(getNotes(db, [...mutatedIds]).map((n) => [n.id, n]));
+              return created.map((n) => byId.get(n.id) ?? n);
+            })();
 
       // Attach `validation_status` so HTTP create-note matches the MCP
-      // surface (vault#287). Mirrors the MCP create-note attach site at
-      // `core/src/mcp.ts:451`. `attachValidationStatus` returns the note
+      // surface (vault#287). `attachValidationStatus` returns the note
       // unchanged when no tag declares fields, so vaults without any tag
       // schemas see no behavior change.
-      const final = created.map((n) => attachValidationStatus(store, db, n));
+      const final = refreshed.map((n) => attachValidationStatus(store, db, n));
       return json(body.notes ? final : final[0], 201);
     }
 
@@ -2619,9 +2633,12 @@ export async function handleStorage(
 // Tag schema defaults — same logic as core/src/mcp.ts applySchemaDefaults
 // ---------------------------------------------------------------------------
 
-async function applySchemaDefaults(store: Store, db: any, noteIds: string[], tags: string[]): Promise<void> {
+// Returns the IDs of notes whose metadata was actually default-filled, so
+// the caller can re-read ONLY the mutated notes (and skip the re-read when
+// nothing changed). Mirrors the core/src/mcp.ts contract.
+async function applySchemaDefaults(store: Store, db: any, noteIds: string[], tags: string[]): Promise<string[]> {
   const schemas = tagSchemaOps.getTagSchemaMap(db);
-  if (Object.keys(schemas).length === 0) return;
+  if (Object.keys(schemas).length === 0) return [];
 
   const defaults: Record<string, unknown> = {};
   for (const tag of tags) {
@@ -2633,8 +2650,9 @@ async function applySchemaDefaults(store: Store, db: any, noteIds: string[], tag
       }
     }
   }
-  if (Object.keys(defaults).length === 0) return;
+  if (Object.keys(defaults).length === 0) return [];
 
+  const mutated: string[] = [];
   for (const noteId of noteIds) {
     const note = await store.getNote(noteId);
     if (!note) continue;
@@ -2648,7 +2666,9 @@ async function applySchemaDefaults(store: Store, db: any, noteIds: string[], tag
       metadata: { ...existing, ...missing },
       skipUpdatedAt: true,
     });
+    mutated.push(noteId);
   }
+  return mutated;
 }
 
 function defaultForField(field: { type: string; enum?: string[] }): unknown {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -567,7 +567,7 @@ async function handleNotesInner(
 ): Promise<Response> {
   const url = new URL(req.url);
   const method = req.method;
-  const db = (store as any).db;
+  const db = store.db;
 
   // ---- Collection routes (no ID in path) ----
   if (subpath === "") {
@@ -1636,7 +1636,7 @@ export async function handleTags(
     // that token's allowlist. Aggregate matches across sources for a single
     // 409 envelope.
     const referenced: { source: string; tokens: { id: string; label: string }[] }[] = [];
-    const db = (store as any).db;
+    const db = store.db;
     for (const src of sources) {
       const tokens = findTokensReferencingTag(db, src as string);
       if (tokens.length > 0) referenced.push({ source: src as string, tokens });
@@ -1800,7 +1800,7 @@ export async function handleTags(
     // tag would silently orphan the token's allowlist. Fail closed (409)
     // and name the offending tokens so the operator can revoke or re-mint
     // before retrying. patterns/tag-scoped-tokens.md §Dependencies.
-    const referenced_by = findTokensReferencingTag((store as any).db, tagName);
+    const referenced_by = findTokensReferencingTag(store.db, tagName);
     if (referenced_by.length > 0) {
       return json(
         {
@@ -1835,7 +1835,7 @@ export async function handleFindPath(
   const target = parseQuery(url, "target");
   if (!source || !target) return json({ error: "source and target parameters are required" }, 400);
 
-  const db = (store as any).db;
+  const db = store.db;
   try {
     const sourceNote = await resolveNote(store, source);
     if (!sourceNote) return json({ error: `Note not found: "${source}"` }, 404);
@@ -1957,7 +1957,7 @@ export function handleUnresolvedWikilinks(
   const url = new URL(req.url);
   const limitStr = url.searchParams.get("limit");
   const limit = limitStr ? parseInt(limitStr, 10) : 50;
-  const db = (store as any).db;
+  const db = store.db;
   const result = listUnresolvedWikilinks(db, limit);
 
   // Unscoped token → return as-is (unchanged behavior).

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -2023,6 +2023,46 @@ describe("HTTP /notes", async () => {
     expect(body.createdAt).toBe("2025-01-01T00:00:00.000Z");
   });
 
+  // vault#316 — the HTTP POST path re-reads each note AFTER
+  // `applySchemaDefaults`, so the response metadata carries the just-written
+  // defaults (mirrors the MCP create-note path). Before the fix the response
+  // mapped over the pre-defaults in-memory objects, so default-filled
+  // metadata was missing from `POST /api/notes` responses.
+  test("POST /notes response reflects post-applySchemaDefaults state (vault#316)", async () => {
+    await store.upsertTagSchema("task", {
+      fields: { priority: { type: "string", enum: ["high", "low"] } },
+    });
+
+    // Single: default lands in the returned metadata and agrees with disk.
+    const single = await handleNotes(
+      mkReq("POST", "/notes", { content: "do the thing", path: "Inbox/task-1", tags: ["task"] }),
+      store,
+      "",
+    );
+    expect(single.status).toBe(201);
+    const singleBody = await single.json() as any;
+    expect(singleBody.metadata?.priority).toBe("high"); // first enum value
+    const onDisk = await store.getNoteByPath("Inbox/task-1");
+    expect((onDisk!.metadata as any)?.priority).toBe("high");
+
+    // Batch: each entry is re-read post-defaults too, in input order.
+    const batch = await handleNotes(
+      mkReq("POST", "/notes", {
+        notes: [
+          { content: "a", path: "Inbox/task-2", tags: ["task"] },
+          { content: "b", path: "Inbox/task-3", tags: ["task"] },
+        ],
+      }),
+      store,
+      "",
+    );
+    expect(batch.status).toBe(201);
+    const batchBody = await batch.json() as any[];
+    expect(batchBody.map((n) => n.path)).toEqual(["Inbox/task-2", "Inbox/task-3"]);
+    expect(batchBody[0].metadata?.priority).toBe("high");
+    expect(batchBody[1].metadata?.priority).toBe("high");
+  });
+
   // ---- Extension field (vault#328) ----
 
   test("POST /notes accepts extension and persists it", async () => {

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -189,7 +189,7 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
         <ul className="manage-list">
           <li>
             <Link to={tokensHref}>Tokens →</Link>
-            <span className="dim"> mint, list, and revoke <code>pvt_*</code> tokens</span>
+            <span className="dim"> mint, list, and revoke hub access tokens (JWTs)</span>
           </li>
           <li>
             <Link to={mirrorHref}>Git backup →</Link>
@@ -208,9 +208,9 @@ export function VaultDetail({ vaultName }: { vaultName?: string } = {}) {
  * don't need a runtime-config endpoint or hub coordination — the data's
  * already in hand from the same token that authenticated the page.
  *
- * The destination (hub#162 — `GET /hub/permissions?vault=<name>`) doesn't
- * exist yet; clicks 404 until hub catches up. The copy says so explicitly
- * so an operator who clicks isn't confused by the empty page.
+ * The destination (`GET /hub/permissions?vault=<name>`) is live: hub
+ * 301-redirects `/hub/permissions → /admin/permissions` (honoring the
+ * `?vault=` query), so the link resolves to hub's permissions UI.
  *
  * Without an `iss` claim (no token, malformed token), we render an
  * informational line instead of a broken link — same content, no false


### PR DESCRIPTION
Small cleanup/correctness bundle from an issue sweep. One logical commit per item.

## Per-item summary

### #242 — drop `(store as any).db` casts
The `Store` *interface* in `core/src/types.ts` didn't declare `db`, so callers needing the raw `bun:sqlite` handle cast `(store as any).db`. The concrete `Store` class already exposes `public readonly db: Database`. Added `readonly db: Database` to the interface (option A) and dropped all **six** `(store as any).db` casts (5 in `src/routes.ts`, 1 in `core/src/mcp.ts` — the issue noted two at drifted line numbers; a grep found all six). The remaining `(store as any)` casts in `core/src/core.test.ts` access the genuinely-private `_tagHierarchy` field and are left as-is. No behavior change.

Fixes #242

### #316 — `attachValidationStatus` comment/reality drift → fixed the code
The create-note path's comment claimed "Re-read after schema-default population so the response reflects the final on-disk state," but the code mapped over the `created` array, which was read **before** `applySchemaDefaults` ran. So default-filled metadata never appeared in the create-note response.

**Resolution: option 2 (fix the code).** Now re-read each note via `getNote` after `applySchemaDefaults`, mirroring the update-note path which already does this. Cost is one read per note, only meaningful when a schema declared defaults.

**Reasoning on validation_status:** the issue worried about a false-positive `missing_required` warning. That's moot today — the validator (`schema-defaults.ts:validateNote`) has had no `required` concept since v17 and skips absent fields (`if (!(fieldName in m)) continue`); it only flags type/enum mismatches on *present* fields, and defaults are always valid. So validation_status is identical pre-/post-defaults. The real observable bug was the **response note's metadata** omitting the just-written default — fixing the re-read makes the response honest, the comment true, and the create-note path consistent with update-note. New test pins create-note (single + batch) returning default-filled metadata that agrees with on-disk state.

Fixes #316

### #418 — stale `pvt_*` copy in the SPA
`web/ui/src/routes/VaultDetail.tsx:192` described the Tokens page as minting/revoking `pvt_*` tokens; that surface was dropped at 0.5.0 (vault#282 Stage 2). Updated the operator-facing copy to "mint, list, and revoke hub access tokens (JWTs)". Also refreshed the `PermissionsLink` doc-comment that claimed `/hub/permissions` 404s — hub now 301-redirects `/hub/permissions → /admin/permissions` (honoring `?vault=`), so the link is live. Left untouched: explanatory code comments + test files referencing `pvt_*` (describing what was removed) and the `docs/` design/API references that record the 0.5.0 drop (correct history). Supersedes the SPA-copy half noted in #250.

Fixes #418

### #352 — mcp-install error copy admin URL → OBSOLETE
Investigated: the stale `/admin/vaults/<name>` string does **not** exist anywhere in source (repo-wide grep across `src/`, `core/`, `docs/`, `web/`). The mcp-install surface was refactored in #449; the current "no operator token" guidance (`noOperatorTokenGuidance` in `src/mcp-install.ts`) points operators at the hub admin wizard / `parachute-vault mcp-install`, with no admin-URL guidance at all. No `vault-admin-token` route reference exists either. **#352 is obsolete** — please close it; nothing to fix.

### #263 — SELECT `.get()` return type → SKIPPED (dedicated PR)
Reality is **14 call sites across 7 files** (`tag-schemas.ts`, `schema.ts`, `indexed-fields.ts`, `notes.ts`, `links.ts`, `store.ts`, `wikilinks.ts`), not the ~3 the issue listed. That's beyond this bundle's "localized, low blast radius" bar, so skipping per the brief's instruction. Worth a dedicated annotation-only PR.

## Gate counts (exact)
- `bun test ./core/src/` — **679 pass / 0 fail** (1979 expect calls)
- `bun test ./src/` — **1427 pass / 0 fail** (3939 expect calls)
- root `bun run typecheck` (`tsc --noEmit`) — clean
- `cd web/ui && bun run typecheck` — clean
- `cd web/ui && bunx vitest run` — **154 pass / 0 fail** (10 files)

No version bump (cleanup bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)