### PR TITLE
release: vault 0.5.3-rc.2 (create-note default metadata fix + cleanups #458)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.3-rc.1",
+  "version": "0.5.3-rc.2",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Bumps to 0.5.3-rc.2, bundling #458 (fixes #242 #316 #418) atop rc.1's security hardening.

Tag v0.5.3-rc.2 → npm dist-tag `rc`. Stable @latest stays at 0.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)