### PR TITLE
fix: SELECT .get() return-type casts should be `| null` not `| undefined`

### DIFF
--- a/core/src/indexed-fields.ts
+++ b/core/src/indexed-fields.ts
@@ -101,7 +101,7 @@ export function listIndexedFields(db: Database): IndexedField[] {
 export function getIndexedField(db: Database, field: string): IndexedField | null {
   const row = db
     .prepare("SELECT field, sqlite_type, declarer_tags FROM indexed_fields WHERE field = ?")
-    .get(field) as IndexedFieldRow | undefined;
+    .get(field) as IndexedFieldRow | null;
   return row ? rowToField(row) : null;
 }
 

--- a/core/src/links.ts
+++ b/core/src/links.ts
@@ -106,7 +106,7 @@ function parseMetadata(raw: string | null): Record<string, unknown> | undefined 
 function getNoteSummary(db: Database, noteId: string): NoteSummary | undefined {
   const row = db.prepare(
     "SELECT id, path, metadata, created_at, updated_at FROM notes WHERE id = ?",
-  ).get(noteId) as SummaryRow | undefined;
+  ).get(noteId) as SummaryRow | null;
   if (!row) return undefined;
   return {
     id: row.id,

--- a/core/src/notes.ts
+++ b/core/src/notes.ts
@@ -83,7 +83,7 @@ export function createNote(
 }
 
 export function getNote(db: Database, id: string): Note | null {
-  const row = db.prepare("SELECT * FROM notes WHERE id = ?").get(id) as NoteRow | undefined;
+  const row = db.prepare("SELECT * FROM notes WHERE id = ?").get(id) as NoteRow | null;
   if (!row) return null;
 
   const note = rowToNote(row);
@@ -111,7 +111,7 @@ export function getNoteByPath(db: Database, path: string, extension?: string): N
   if (extension !== undefined) {
     const row = db.prepare(
       "SELECT * FROM notes WHERE path = ? COLLATE NOCASE AND LOWER(extension) = ?",
-    ).get(path, extension.toLowerCase()) as NoteRow | undefined;
+    ).get(path, extension.toLowerCase()) as NoteRow | null;
     if (!row) return null;
     const note = rowToNote(row);
     note.tags = getNoteTags(db, note.id);
@@ -459,7 +459,7 @@ export function updateNote(
     if (isPathUniqueError(err)) {
       const conflictPath = updates.path !== undefined
         ? (normalizePath(updates.path) ?? updates.path)
-        : ((db.prepare("SELECT path FROM notes WHERE id = ?").get(id) as { path: string | null } | undefined)?.path ?? "<unknown>");
+        : ((db.prepare("SELECT path FROM notes WHERE id = ?").get(id) as { path: string | null } | null)?.path ?? "<unknown>");
       throw new PathConflictError(conflictPath);
     }
     throw err;
@@ -475,7 +475,7 @@ export function updateNote(
 function throwConflictOrMissing(db: Database, id: string, expected: string): never {
   const row = db.prepare("SELECT updated_at, path FROM notes WHERE id = ?").get(id) as
     | { updated_at: string | null; path: string | null }
-    | undefined;
+    | null;
   if (!row) {
     throw new Error(`Note not found: "${id}"`);
   }
@@ -972,7 +972,7 @@ export function listTags(db: Database): { name: string; count: number }[] {
 export function deleteTag(db: Database, name: string): { deleted: boolean; notes_untagged: number } {
   const row = db.prepare("SELECT fields FROM tags WHERE name = ?").get(name) as
     | { fields: string | null }
-    | undefined;
+    | null;
   if (!row) return { deleted: false, notes_untagged: 0 };
 
   const countRow = db.prepare("SELECT COUNT(*) as c FROM note_tags WHERE tag_name = ?").get(name) as { c: number };
@@ -1133,7 +1133,7 @@ export function renameTag(db: Database, oldName: string, newName: string): Renam
     for (const { from, to } of renames) {
       const old = readStmt.get(from) as
         | { description: string | null; fields: string | null; relationships: string | null; parent_names: string | null; created_at: string | null }
-        | undefined;
+        | null;
       insertStmt.run(
         to,
         old?.description ?? null,
@@ -1548,11 +1548,11 @@ export function getVaultStats(
 
   const earliestRow = db.prepare(
     "SELECT id, created_at FROM notes ORDER BY created_at ASC, id ASC LIMIT 1",
-  ).get() as { id: string; created_at: string } | undefined;
+  ).get() as { id: string; created_at: string } | null;
 
   const latestRow = db.prepare(
     "SELECT id, created_at FROM notes ORDER BY created_at DESC, id DESC LIMIT 1",
-  ).get() as { id: string; created_at: string } | undefined;
+  ).get() as { id: string; created_at: string } | null;
 
   const monthRows = db.prepare(`
     SELECT strftime('%Y-%m', created_at) AS month, COUNT(*) AS count

--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -797,7 +797,7 @@ function migrateToV15(db: Database): void {
     // 2. Copy `_schema_defaults` note → schema_mappings.
     const mappingNote = db.prepare(
       "SELECT metadata FROM notes WHERE path = '_schema_defaults'",
-    ).get() as { metadata: string | null } | undefined;
+    ).get() as { metadata: string | null } | null;
     if (mappingNote?.metadata) {
       const insertMapping = db.prepare(
         "INSERT OR IGNORE INTO schema_mappings (schema_name, match_kind, match_value) VALUES (?, ?, ?)",

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -730,7 +730,7 @@ export class BunSqliteStore implements Store {
     // Scope by noteId so a token authorized for note A can't delete note B's attachments.
     const row = this.db.prepare(
       "SELECT path FROM attachments WHERE id = ? AND note_id = ?",
-    ).get(attachmentId, noteId) as { path: string } | undefined;
+    ).get(attachmentId, noteId) as { path: string } | null;
     if (!row) return { deleted: false, path: null, orphaned: false };
 
     this.db.prepare("DELETE FROM attachments WHERE id = ? AND note_id = ?").run(attachmentId, noteId);
@@ -756,7 +756,7 @@ export class BunSqliteStore implements Store {
   async getAttachment(attachmentId: string): Promise<Attachment | null> {
     const row = this.db.prepare(
       "SELECT * FROM attachments WHERE id = ?",
-    ).get(attachmentId) as { id: string; note_id: string; path: string; mime_type: string; metadata: string | null; created_at: string } | undefined;
+    ).get(attachmentId) as { id: string; note_id: string; path: string; mime_type: string; metadata: string | null; created_at: string } | null;
     if (!row) return null;
     let metadata: Record<string, unknown> | undefined;
     if (row.metadata && row.metadata !== "{}") {

--- a/core/src/tag-schemas.ts
+++ b/core/src/tag-schemas.ts
@@ -115,7 +115,7 @@ export function listTagRecords(db: Database): TagRecord[] {
 export function getTagRecord(db: Database, tag: string): TagRecord | null {
   const row = db.prepare(
     "SELECT name, description, fields, relationships, parent_names, created_at, updated_at FROM tags WHERE name = ?",
-  ).get(tag) as TagRow | undefined;
+  ).get(tag) as TagRow | null;
   return row ? rowToRecord(row) : null;
 }
 
@@ -189,7 +189,7 @@ export function listTagSchemas(db: Database): TagSchema[] {
 export function getTagSchema(db: Database, tag: string): TagSchema | null {
   const row = db.prepare(
     "SELECT name, description, fields FROM tags WHERE name = ?",
-  ).get(tag) as { name: string; description: string | null; fields: string | null } | undefined;
+  ).get(tag) as { name: string; description: string | null; fields: string | null } | null;
   if (!row) return null;
   if (row.description === null && row.fields === null) return null;
   return {

--- a/core/src/wikilinks.ts
+++ b/core/src/wikilinks.ts
@@ -137,7 +137,7 @@ export function resolveWikilink(db: Database, target: string): string | null {
     const extPart = extMatch[2]!.toLowerCase();
     const explicit = db.prepare(
       "SELECT id FROM notes WHERE path = ? COLLATE NOCASE AND LOWER(extension) = ?",
-    ).get(pathPart, extPart) as { id: string } | undefined;
+    ).get(pathPart, extPart) as { id: string } | null;
     if (explicit) return explicit.id;
     // No match for explicit (path, ext) — fall through to the looser
     // rules so a literal note named `Recipe.v2` (where `v2` isn't an
@@ -199,7 +199,7 @@ export function resolveWikilinkDetailed(db: Database, target: string): WikilinkR
     const extPart = extMatch[2]!.toLowerCase();
     const explicit = db.prepare(
       "SELECT id, path FROM notes WHERE path = ? COLLATE NOCASE AND LOWER(extension) = ?",
-    ).get(pathPart, extPart) as { id: string; path: string } | undefined;
+    ).get(pathPart, extPart) as { id: string; path: string } | null;
     if (explicit) {
       return { resolved: true, note_id: explicit.id, path: explicit.path, candidates: [] };
     }


### PR DESCRIPTION
Fixes #263.

bun:sqlite's `Statement.get()` returns `null` (not `undefined`) on no-match, for both `SELECT` and `RETURNING` paths. #262 typed the new `RETURNING` sites correctly as `| null`; this PR brings the pre-existing typed `SELECT .get()` casts into line so the type matches the real runtime contract. `Statement.all()` (array, never null) is left alone.

## Call sites changed (17)

| File | Line(s) | Cast |
|---|---|---|
| `core/src/schema.ts` | 800 | `{ metadata: string \| null }` |
| `core/src/indexed-fields.ts` | 104 | `IndexedFieldRow` |
| `core/src/tag-schemas.ts` | 118, 192 | `TagRow` / `{ name; description; fields }` |
| `core/src/wikilinks.ts` | 140, 202 | `{ id }` / `{ id; path }` |
| `core/src/notes.ts` | 86, 114, 462, 478, 975, 1136, 1551, 1555 | `NoteRow` (×2), `{ path }`, `{ updated_at; path }`, `{ fields }`, tag-rename read row, earliest/latest stats rows |
| `core/src/store.ts` | 733, 759 | `{ path }` / attachment row |
| `core/src/links.ts` | 109 | `SummaryRow` |

(17 cast edits; 17 insertions / 17 deletions across 7 files.)

## Latent null-handling bugs surfaced + fixed

**None — all sites already guard the no-row case** via `if (!row)`, optional-chaining (`?.`), or a `row ? … : null` ternary. The wrong annotation was cosmetic and never bit at runtime. As a result this PR is annotation-only with no behavioral commits and no new regression tests (per the mission's "annotation-only changes don't need tests").

## Out of scope

- `src/token-store.ts` and the `RETURNING` sites are already `| null` (post-#262) — nothing to change. The issue's `src/token-store.ts:206` referenced pre-#262 line numbers.
- `core/src/links.ts` `getNoteSummary` still *returns* `NoteSummary | undefined` by its own declared signature (it deliberately maps the no-row case to `undefined`); only the `.get()` cast inside it changed to `| null`.

## Gates

- `bun run typecheck` (tsc --noEmit): clean, exit 0 — the load-bearing gate; proves the annotations are consistent and surfaces no newly-visible null mishandling.
- `bun test ./core/src/`: **679 pass / 0 fail** (1979 expect calls, 12 files)
- `bun test ./src/`: **1428 pass / 0 fail** (3946 expect calls, 52 files)
- web/ui untouched — its suite not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)