### PR TITLE
ci: add PR-time CI workflow (catch Linux-only/fresh-clone bugs before tag-burn)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+# PR-time CI — runs the FULL gate surface on a clean Linux checkout so
+# Linux-only + fresh-clone bugs surface BEFORE a release tag is pushed.
+#
+# Why this exists (vault#365):
+#   release.yml is tag-triggered and only runs `bun test ./src/`. A stale
+#   Linux-only test failure burned tag v0.4.8-rc.7 (2026-05-25): the PR
+#   merged cleanly, the tag pushed, release CI then failed at the test job,
+#   and the tag was wasted. Vault was the only committed-core repo without
+#   a PR-time CI workflow.
+#
+# Why broader than the release gate:
+#   release.yml runs only the canonical `bun test ./src/` surface. PR CI is
+#   deliberately MORE protective — it also runs typecheck, the core bun:test
+#   suite (core/src/), and the web/ui SPA's own typecheck + vitest — so a
+#   typecheck regression, a core-suite break, or a #418-class SPA change
+#   can't slip through to tag-time.
+#
+# Fresh-clone fidelity:
+#   Runs on a clean checkout with `bun install --frozen-lockfile` and no
+#   manual pre-build steps. That's the point — a #505-class "dist not built"
+#   gap should surface here as a real failure, not be papered over.
+#
+# Runner + bun version are pinned to match release.yml (ubuntu-latest, bun 1.3)
+# so PR CI and the release gate exercise the same platform + toolchain.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  # Supersede in-flight runs on the same ref so PR pushes don't pile up
+  # runners. Keyed on workflow + ref so a push-to-main and a PR don't
+  # cancel each other.
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  server-and-core:
+    name: server + core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: typecheck
+        run: bun run typecheck
+      - name: vault tests (src/)
+        # Mirrors the release gate's canonical surface (package.json "test").
+        run: bun test ./src/
+      - name: core tests (core/src/)
+        # The core bun:test suite — exercised in normal dev but NOT by the
+        # release gate. Running it here keeps a core-suite break from
+        # slipping to tag-time.
+        run: bun test ./core/src/
+
+  web-ui:
+    name: web/ui SPA
+    runs-on: ubuntu-latest
+    # Separate job so a SPA failure is distinguishable from a server/core
+    # failure (and runs in parallel with server-and-core).
+    defaults:
+      run:
+        working-directory: web/ui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: install deps
+        # web/ui has its own bun.lock — install against it on a clean checkout.
+        run: bun install --frozen-lockfile
+      - name: typecheck
+        run: bun run typecheck
+      - name: vitest
+        run: bunx vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
     name: server + core
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to the exact last-stable v4 tag (Node-20-compatible) rather
+      # than the mutable @v4 alias: GitHub force-migrates @v4 to Node 24 on
+      # 2026-06-16, so the explicit pin buys runway on a deliberate bump.
+      - uses: actions/checkout@v4.2.2
+      # setup-bun left at @v2 to match release.yml (it doesn't pin a
+      # narrower tag); keep the two workflows on the same action ref.
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
@@ -70,7 +75,9 @@ jobs:
       run:
         working-directory: web/ui
     steps:
-      - uses: actions/checkout@v4
+      # See note on the server+core job re: the @v4.2.2 pin (Node 24 force-
+      # migration on 2026-06-16).
+      - uses: actions/checkout@v4.2.2
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3


### PR DESCRIPTION
Fixes #365

## What

Adds `.github/workflows/ci.yml` — vault was the only committed-core repo without a PR-time CI workflow. release.yml is tag-triggered and only runs `bun test ./src/`, so Linux-only + fresh-clone bugs only surfaced when a release tag was pushed. A stale test failure burned tag `v0.4.8-rc.7` (2026-05-25); this workflow is the gate that prevents that class.

## Triggers

- `pull_request` → `main`
- `push` → `main`
- `workflow_dispatch` (manual)
- Concurrency group keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` so superseded PR pushes don't pile up runners.

## Runner + toolchain

`ubuntu-latest` (Linux — the whole point), bun `1.3` pinned to **match release.yml** so PR CI and the release gate exercise the same platform + toolchain.

## Jobs — broader than the release gate on purpose

release.yml only runs `bun test ./src/`. PR CI is deliberately more protective so nothing slips to tag-time. Split into two jobs for clear failure attribution + parallelism:

**`server + core`**
1. `actions/checkout@v4`
2. `oven-sh/setup-bun@v2` (bun 1.3)
3. `bun install --frozen-lockfile`
4. `bun run typecheck`
5. `bun test ./src/` (the canonical release surface)
6. `bun test ./core/src/` (core bun:test suite — exercised in dev, NOT by the release gate)

**`web/ui SPA`** (separate job)
1. checkout + setup-bun
2. `bun install --frozen-lockfile` (web/ui has its own `bun.lock`)
3. `bun run typecheck`
4. `bunx vitest run` (the SPA's own vitest suite — #418-class changes get PR coverage)

### Note on the core surface

`core/package.json` has no scripts and no vitest config; the root `test:core` vitest path is legacy. The agents in this repo run `bun test ./core/src/`, which is a real bun:test surface — verified it runs clean on a fresh checkout (679 pass). That's what the workflow uses.

## Fresh-clone fidelity

No manual pre-build steps — runs on a clean checkout via `--frozen-lockfile`, exactly so a #505-class "dist not built" gap would surface here as a real failure rather than being papered over. Matches how release.yml handles setup.

## Safety verification (workflow YAML fails silently if invalid)

- `python3 -c "import yaml; yaml.safe_load(...)"` → **parses clean**
- `actionlint .github/workflows/ci.yml` → **no errors**
- Local dry-run of every step on this checkout: root typecheck ✅, `bun test ./src/` ✅, `bun test ./core/src/` ✅ (679 pass), web/ui typecheck ✅ + vitest ✅ (154 pass).

The actual CI run conclusion on this very PR is reported in a comment below (the load-bearing proof — a workflow only proves itself by going green on a real PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)