### PR TITLE
ci: bump actions/checkout + setup-node → v6 (Node-20 migration #462)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       # Pinned to the exact last-stable v4 tag (Node-20-compatible) rather
       # than the mutable @v4 alias: GitHub force-migrates @v4 to Node 24 on
       # 2026-06-16, so the explicit pin buys runway on a deliberate bump.
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6
       # setup-bun left at @v2 to match release.yml (it doesn't pin a
       # narrower tag); keep the two workflows on the same action ref.
       - uses: oven-sh/setup-bun@v2
@@ -77,7 +77,7 @@ jobs:
     steps:
       # See note on the server+core job re: the @v4.2.2 pin (Node 24 force-
       # migration on 2026-06-16).
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
@@ -67,11 +67,11 @@ jobs:
       # Required for npm provenance attestation + Trusted Publishing OIDC.
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # Node 24 ships npm 11.5+ which has Trusted Publishing OIDC
           # support built in. Node 20 LTS only has npm 10 and would


### PR DESCRIPTION
Bumps `actions/checkout` + `actions/setup-node` to `@v6` in `release.yml` (was bare `@v4`) and reconciles `ci.yml` (was the interim `@v4.2.2` pin from #365) — ahead of GitHub's 2026-06-16 Node-20→24 force-migration. `@v6` natively targets Node 24 and matches parachute-surface.

The PR-time CI workflow (ci.yml, from #365) re-runs on this PR with the bumped actions — its green conclusion is the proof the bump works. Part of #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)