### PR TITLE
fix(auth): fetch JWKS from local hub, validate iss against public (#464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ code-touching PR bumps the `rc.N` suffix and gets published to npm
 under the `@rc` dist-tag; stable promotes drop the suffix and publish
 to `@latest`.
 
+## [Unreleased]
+
+### Fixed
+
+- **JWKS hairpin through the public Cloudflare tunnel (vault#464).** Vault now
+  fetches the hub's JWKS from the **local** hub (loopback
+  `http://127.0.0.1:1939`) by default instead of from the public `iss` origin,
+  so a co-located vault no longer hairpins the keys fetch out through the
+  Cloudflare tunnel and back to the same box after `parachute expose` (which
+  timed out the first MCP-over-public auth). `iss` is still validated against
+  `PARACHUTE_HUB_ORIGIN`; a vault on a separate box from its hub overrides the
+  fetch origin with the new `PARACHUTE_HUB_JWKS_ORIGIN` env var. Bumps
+  `@openparachute/scope-guard` → `0.4.1-rc.1` for the `jwksOrigin` seam. (No
+  rc bump in this entry — the version bump lands at tag time.)
+
 ## [0.5.2] - 2026-06-06
 
 The `0.5.2-rc.1` through `rc.5` chain promoted to stable. This entry was

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,26 @@ Operator-facing migration guidance. For the full chronological CHANGELOG,
 see [CHANGELOG.md](./CHANGELOG.md) — note the meta-note at the top about
 what's actually been published to npm.
 
+## JWKS now fetched from the local hub (vault#464)
+
+Vault now fetches the hub's JWKS (the signing keys it uses to verify
+hub-issued JWTs) from the **local** hub on loopback (`http://127.0.0.1:1939`)
+by default, while still validating the token's `iss` against
+`PARACHUTE_HUB_ORIGIN`. This fixes the JWKS fetch hairpinning out through the
+public Cloudflare tunnel and back to the same box after `parachute expose` —
+which timed out the first MCP-over-public auth on co-located deploys.
+
+**The overwhelming common case needs no action** — co-located (hub supervises
+vault on the same box), standalone, and Render / single-container deploys all
+read keys from loopback automatically.
+
+**If you run vault on a SEPARATE box from its hub** (the rare non-co-located
+topology), set `PARACHUTE_HUB_JWKS_ORIGIN` to the hub's reachable internal
+address (e.g. `http://10.0.0.5:1939`). Without it, vault defaults the JWKS
+fetch to `http://127.0.0.1:1939` — where no hub is listening — and every
+hub-JWT validation 401s. `PARACHUTE_HUB_ORIGIN` stays the public origin for
+`iss` validation; only the JWKS-fetch origin moves.
+
 ## pvt_* token removal — REJECTED as of 0.5.0 (BREAKING)
 
 **TL;DR:** `pvt_*` tokens (the opaque `pvt_…` bearers vault used to mint into

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "parachute-vault",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@openparachute/scope-guard": "^0.4.0",
+        "@openparachute/scope-guard": "^0.4.1-rc.1",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode-terminal": "^0.12.0",
@@ -26,7 +26,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
-    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.4.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Atzc2TcEAdZvOK+BBN7iNEYzllO3svn63Rmn5+ZnJZkRo2jBWfent9J6nazS/uVrvoP6eGj2F1kuHKe93JkwsQ=="],
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.4.1-rc.1", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-nFLTct8+URdG4T/eSr3dXOP+HXbsU2HRhmLAakvO8zID9CLicv4BaMehSBHTdMoZKiPRs+qUQeIzOMhx0D7O+w=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/docs/auth-model.md
+++ b/docs/auth-model.md
@@ -30,6 +30,15 @@ Vault validates them via `validateHubJwt` (`src/hub-jwt.ts`):
 
 - `iss` must equal the hub origin (`PARACHUTE_HUB_ORIGIN`, defaulting to
   `http://127.0.0.1:1939`).
+- The JWKS used to verify the signature is fetched from the **local** hub
+  (loopback `http://127.0.0.1:1939` by default), **not** from the `iss`
+  origin. The two are separate concerns: `iss` validates against the public
+  origin the hub mints with, while the keys are read from the co-located hub
+  to avoid hairpinning the fetch out through the public Cloudflare tunnel and
+  back to the same box (vault#464). A vault running on a **separate box** from
+  its hub overrides the fetch origin with `PARACHUTE_HUB_JWKS_ORIGIN` (the
+  hub's reachable internal address); co-located / standalone / single-container
+  deploys need no action.
 - `aud` is strict-checked against `vault.<name>` so a token stamped for one
   vault can't reach another.
 - `scope` claim carries OAuth-standard scopes (see "API tokens" below for the

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@openparachute/scope-guard": "^0.4.0",
+    "@openparachute/scope-guard": "^0.4.1-rc.1",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode-terminal": "^0.12.0"

--- a/src/auth-hub-jwt.test.ts
+++ b/src/auth-hub-jwt.test.ts
@@ -143,6 +143,7 @@ function bearer(token: string): Request {
 let tmpHome: string;
 let prevHome: string | undefined;
 let prevHubOrigin: string | undefined;
+let prevJwksOrigin: string | undefined;
 let fixture: HubFixture;
 let kp: Keypair;
 
@@ -159,7 +160,11 @@ beforeEach(async () => {
   kp = await makeKeypair("k1");
   fixture = startHubFixture([kp]);
   prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+  prevJwksOrigin = process.env.PARACHUTE_HUB_JWKS_ORIGIN;
   process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
+  // Post-vault#464 the JWKS fetch origin resolves separately (loopback by
+  // default); point it at the fixture so keys are reachable in-test.
+  process.env.PARACHUTE_HUB_JWKS_ORIGIN = fixture.origin;
   resetJwksCache();
   resetRevocationCache();
 });
@@ -171,6 +176,8 @@ afterEach(() => {
   else process.env.PARACHUTE_HOME = prevHome;
   if (prevHubOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
   else process.env.PARACHUTE_HUB_ORIGIN = prevHubOrigin;
+  if (prevJwksOrigin === undefined) delete process.env.PARACHUTE_HUB_JWKS_ORIGIN;
+  else process.env.PARACHUTE_HUB_JWKS_ORIGIN = prevJwksOrigin;
   if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
 });
 

--- a/src/hub-jwt.test.ts
+++ b/src/hub-jwt.test.ts
@@ -14,7 +14,14 @@
  */
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
 import { generateKeyPair, exportJWK, SignJWT } from "jose";
-import { resetJwksCache, resetRevocationCache, validateHubJwt, looksLikeJwt } from "./hub-jwt.ts";
+import {
+  resetJwksCache,
+  resetRevocationCache,
+  validateHubJwt,
+  looksLikeJwt,
+  getHubOrigin,
+  getJwksOrigin,
+} from "./hub-jwt.ts";
 
 interface Keypair {
   privateKey: CryptoKey;
@@ -113,6 +120,7 @@ async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
 let fixture: JwksFixture;
 let kp: Keypair;
 let prevHubOrigin: string | undefined;
+let prevJwksOrigin: string | undefined;
 
 beforeAll(async () => {
   fixture = startJwksFixture();
@@ -124,12 +132,19 @@ afterAll(() => {
   fixture.stop();
   if (prevHubOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
   else process.env.PARACHUTE_HUB_ORIGIN = prevHubOrigin;
+  if (prevJwksOrigin === undefined) delete process.env.PARACHUTE_HUB_JWKS_ORIGIN;
+  else process.env.PARACHUTE_HUB_JWKS_ORIGIN = prevJwksOrigin;
 });
 
 beforeEach(() => {
-  // Each test sets its own origin for clarity.
+  // Each test sets its own origin for clarity. Post-vault#464 the JWKS *fetch*
+  // origin is resolved separately from the iss-validation origin, so point the
+  // JWKS fetch at the fixture too — otherwise the guard would read keys from
+  // the loopback default (no JWKS server there) and every case would fail.
   prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+  prevJwksOrigin = process.env.PARACHUTE_HUB_JWKS_ORIGIN;
   process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
+  process.env.PARACHUTE_HUB_JWKS_ORIGIN = fixture.origin;
   fixture.setUnreachable(false);
   fixture.setKeys([kp]);
   resetJwksCache();
@@ -150,6 +165,64 @@ describe("looksLikeJwt", () => {
   test("empty / random → false", () => {
     expect(looksLikeJwt("")).toBe(false);
     expect(looksLikeJwt("hello-world")).toBe(false);
+  });
+});
+
+describe("origin resolvers — iss/jwks split (vault#464)", () => {
+  test("getHubOrigin honors PARACHUTE_HUB_ORIGIN (iss-validation origin)", () => {
+    process.env.PARACHUTE_HUB_ORIGIN = "https://vault.example.com/";
+    expect(getHubOrigin()).toBe("https://vault.example.com");
+  });
+
+  test("getHubOrigin falls back to loopback when unset", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
+  });
+
+  test("getJwksOrigin defaults to loopback (no env override)", () => {
+    delete process.env.PARACHUTE_HUB_JWKS_ORIGIN;
+    expect(getJwksOrigin()).toBe("http://127.0.0.1:1939");
+  });
+
+  test("getJwksOrigin honors PARACHUTE_HUB_JWKS_ORIGIN and strips trailing slash", () => {
+    process.env.PARACHUTE_HUB_JWKS_ORIGIN = "http://10.0.0.5:1939/";
+    expect(getJwksOrigin()).toBe("http://10.0.0.5:1939");
+  });
+
+  test("jwks fetch is decoupled from the iss origin: keys served ONLY at the jwks origin still validate a token whose iss is the (separate) public origin", async () => {
+    // Mirrors the vault#464 deploy shape: iss + revocation live at the public
+    // origin (the default `fixture` here), while the JWKS is reachable only at
+    // a SEPARATE jwks origin (a second fixture standing in for loopback). The
+    // guard must fetch keys from the jwks origin, not the iss origin.
+    const jwksOnly = startJwksFixture();
+    jwksOnly.setKeys([kp]);
+    // The public iss origin (default fixture) serves revocation but NOT keys —
+    // if the guard fetched JWKS from here, verification would fail "no key".
+    fixture.setKeys([]);
+    try {
+      process.env.PARACHUTE_HUB_ORIGIN = fixture.origin; // iss + revocation
+      process.env.PARACHUTE_HUB_JWKS_ORIGIN = jwksOnly.origin; // keys only
+      resetJwksCache();
+      const token = await signJwt(kp, { iss: fixture.origin });
+      const claims = await validateHubJwt(token);
+      expect(claims.sub).toBe("user-1");
+    } finally {
+      jwksOnly.stop();
+    }
+  });
+
+  test("token whose iss does NOT match the iss origin is rejected even when keys resolve at the jwks origin", async () => {
+    const jwksOnly = startJwksFixture();
+    jwksOnly.setKeys([kp]);
+    try {
+      process.env.PARACHUTE_HUB_ORIGIN = fixture.origin;
+      process.env.PARACHUTE_HUB_JWKS_ORIGIN = jwksOnly.origin;
+      resetJwksCache();
+      const token = await signJwt(kp, { iss: "https://attacker.example" });
+      await expect(validateHubJwt(token)).rejects.toThrow(/verification failed/);
+    } finally {
+      jwksOnly.stop();
+    }
   });
 });
 

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -23,13 +23,18 @@ import {
 const DEFAULT_HUB_LOOPBACK = "http://127.0.0.1:1939";
 
 /**
- * Resolve the hub origin used to fetch JWKS and validate `iss`. Strips a
+ * Resolve the hub origin used to validate the token's `iss` claim. Strips a
  * trailing slash so we get a single canonical form.
  *
  * Order: env var → loopback fallback. We deliberately don't read
  * `~/.parachute/services.json` — the hub is the dispatcher, not a registered
  * service in that file. If a deployment exposes the hub on a non-default
  * origin, the env var is the contract.
+ *
+ * `parachute expose` pins `PARACHUTE_HUB_ORIGIN` to the PUBLIC FQDN so the
+ * `iss` we validate against matches what the hub stamps on the tokens it
+ * mints — keep using this origin for iss-validation. The JWKS *fetch* origin
+ * is resolved separately by `getJwksOrigin()`; see vault#464.
  */
 export function getHubOrigin(): string {
   const env = process.env.PARACHUTE_HUB_ORIGIN?.replace(/\/$/, "");
@@ -37,12 +42,44 @@ export function getHubOrigin(): string {
   return DEFAULT_HUB_LOOPBACK;
 }
 
+/**
+ * Resolve the origin used to FETCH the hub's JWKS — kept distinct from
+ * `getHubOrigin()` (the iss-validation origin) per vault#464.
+ *
+ * Vault is co-located with its hub (the hub supervises vault on the same box,
+ * the common deploy). After `parachute expose --cloudflare`, `getHubOrigin()`
+ * is the public Cloudflare FQDN. If we fetched JWKS from that public origin we
+ * would hairpin out through the tunnel and back to the same box — a round-trip
+ * that times out (hard fail under Docker NAT-loopback, slow/flaky on a real
+ * VPS) and 401s the first MCP connect after expose. So we always read keys
+ * from the LOCAL hub on loopback instead.
+ *
+ * Order: `PARACHUTE_HUB_JWKS_ORIGIN` override → loopback default. The override
+ * exists for the rare non-co-located case — a vault running on a DIFFERENT box
+ * than its hub sets `PARACHUTE_HUB_JWKS_ORIGIN` to the hub's reachable
+ * internal address. Trailing-slash-stripped, matching `getHubOrigin()`.
+ */
+export function getJwksOrigin(): string {
+  const env = process.env.PARACHUTE_HUB_JWKS_ORIGIN?.replace(/\/$/, "");
+  if (env && env.length > 0) return env;
+  return DEFAULT_HUB_LOOPBACK;
+}
+
 // Process-wide guard. The resolver form lets tests flip
-// `PARACHUTE_HUB_ORIGIN` between cases — the lib re-resolves on every
-// `validateHubJwt` and `resetJwksCache` call so the env-var change picks up
-// without a server restart. JWKS cache (5min/30s defaults) lives inside the
-// guard, shared across requests.
-const guard = createScopeGuard({ hubOrigin: () => getHubOrigin() });
+// `PARACHUTE_HUB_ORIGIN` / `PARACHUTE_HUB_JWKS_ORIGIN` between cases — the lib
+// re-resolves on every `validateHubJwt` and `resetJwksCache` call so the
+// env-var change picks up without a server restart. JWKS cache (5min/30s
+// defaults) lives inside the guard, shared across requests.
+//
+// The iss/jwks split (vault#464): `hubOrigin` validates the token's `iss`
+// (public FQDN post-expose, via PARACHUTE_HUB_ORIGIN); `jwksOrigin` fetches
+// the keys from the local hub (loopback by default, via
+// PARACHUTE_HUB_JWKS_ORIGIN). Co-located vault never egresses to read its own
+// hub's keys, so no tunnel hairpin.
+const guard = createScopeGuard({
+  hubOrigin: () => getHubOrigin(),
+  jwksOrigin: () => getJwksOrigin(),
+});
 
 /**
  * Verify a presented JWT against the hub's JWKS. Throws `HubJwtError` on any

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -149,7 +149,12 @@ function reset(): void {
   // Default every test to the fixture hub origin so the hub-JWT mint path
   // resolves JWKS + validates `iss`. Describes that assert the loopback
   // default (OAuth discovery metadata) override this in their own beforeEach.
-  if (hubFixtureOrigin) process.env.PARACHUTE_HUB_ORIGIN = hubFixtureOrigin;
+  if (hubFixtureOrigin) {
+    process.env.PARACHUTE_HUB_ORIGIN = hubFixtureOrigin;
+    // Post-vault#464 the JWKS fetch origin resolves separately (loopback by
+    // default); point it at the fixture so the mint path's JWKS fetch resolves.
+    process.env.PARACHUTE_HUB_JWKS_ORIGIN = hubFixtureOrigin;
+  }
   resetJwksCache();
   resetRevocationCache();
 }
@@ -183,6 +188,7 @@ afterAll(() => {
   clearVaultStoreCache();
   hubServer?.stop(true);
   delete process.env.PARACHUTE_HUB_ORIGIN;
+  delete process.env.PARACHUTE_HUB_JWKS_ORIGIN;
   if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

Fixes #464 — vault hairpins its JWKS fetch through the public Cloudflare tunnel after `parachute expose`, timing out the first MCP-over-public auth on co-located deploys.

Vault is co-located with its hub. `parachute expose --cloudflare` pins `PARACHUTE_HUB_ORIGIN` to the public Cloudflare FQDN so the token's `iss` validates against what the hub mints. But scope-guard previously ALSO fetched the JWKS from that same origin — so a co-located vault read its own hub's keys via `https://<public-fqdn>/.well-known/jwks.json`, which **hairpins out through the tunnel and back to the same box**. That round-trip times out (hard fail under Docker NAT-loopback, slow/flaky on a real VPS) → 401 on the first MCP connect after expose. Same origin-pinned-credential class as #481/#503/#531, now on the JWKS-fetch surface.

## The iss / jwks split

Adopt scope-guard `0.4.1-rc.1`'s optional `jwksOrigin` seam to decouple the two concerns in `src/hub-jwt.ts`:

- **iss-validation** → keeps using `getHubOrigin()` (`PARACHUTE_HUB_ORIGIN`, the public FQDN post-expose) — **unchanged**, so the token's `iss` still matches what the hub stamps.
- **JWKS fetch** → new `getJwksOrigin()`: `PARACHUTE_HUB_JWKS_ORIGIN` override → **loopback default `http://127.0.0.1:1939`** (reuses `DEFAULT_HUB_LOOPBACK`, trailing-slash-stripped to match `getHubOrigin()`). Co-located vault never egresses to read its own hub's keys → no tunnel hairpin.

```ts
const guard = createScopeGuard({
  hubOrigin: () => getHubOrigin(),     // public iss (PARACHUTE_HUB_ORIGIN)
  jwksOrigin: () => getJwksOrigin(),   // loopback (PARACHUTE_HUB_JWKS_ORIGIN | default)
});
```

Both are resolver functions → re-evaluated per call. `getJwksOrigin` is exported (matching `getHubOrigin`) for testability.

### The `PARACHUTE_HUB_JWKS_ORIGIN` override

Exists for the rare **non-co-located** case: a vault running on a DIFFERENT box than its hub sets `PARACHUTE_HUB_JWKS_ORIGIN` to the hub's reachable internal address. Default loopback covers the common (co-located) deploy.

## Scope-guard bump

`@openparachute/scope-guard` `^0.4.0` → `^0.4.1-rc.1` (matches the existing caret pinning). Resolves to the published `0.4.1-rc.1` on npm (no workspace/link leak); lockfile updated.

## Harness contract

Flips the hub e2e harness's `stage3-mcp-public` from XFAIL(#464) back to a hard PASS (asserted hub-side, parachute-hub PR #611 — not touched here).

## Tests

- `getJwksOrigin` resolver: loopback default + `PARACHUTE_HUB_JWKS_ORIGIN` override + trailing-slash strip; `getHubOrigin` honored/default coverage.
- Integration: keys served ONLY at a separate jwks origin (loopback stand-in) while iss+revocation live at the public origin → token still validates. Negative: wrong `iss` still rejected even when keys resolve at the jwks origin.
- Existing `hub-jwt` / `auth-hub-jwt` / `routing` fixtures updated to set `PARACHUTE_HUB_JWKS_ORIGIN` at their fixture origin (the JWKS fetch no longer follows `PARACHUTE_HUB_ORIGIN`). No existing validation assertion weakened.

## Gates (exact)

- `bun test ./src/` — **1434 pass, 0 fail** (3952 expect calls, 52 files)
- `bun test ./core/src/` — **679 pass, 0 fail** (1979 expect calls, 12 files)
- `bun run typecheck` (`tsc --noEmit`) — **exit 0**
- `bun install` clean; scope-guard resolves to published `0.4.1-rc.1` (no `workspace:`/`link:` in manifest or lockfile)

Fixes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)