### PR TITLE
release: vault 0.5.3-rc.3 (loopback JWKS #464 + type sweep #263)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.3-rc.2",
+  "version": "0.5.3-rc.3",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Bumps to 0.5.3-rc.3, bundling #464 (loopback JWKS fetch — fixes the post-expose hairpin found by the E2E harness) + #263 (type annotations) atop rc.2.

Tag v0.5.3-rc.3 → npm dist-tag `rc`. Stable @latest stays at 0.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)