### PR TITLE
feat(query): tag expand axis — subtypes (default) | namespace | both | exact

### DIFF
--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -3,6 +3,7 @@ import type { Store, Note } from "./types.js";
 import * as noteOps from "./notes.js";
 import { filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "./notes.js";
 import { QueryError } from "./query-operators.js";
+import { TAG_EXPAND_MODES, type TagExpandMode } from "./tag-hierarchy.js";
 import * as linkOps from "./links.js";
 import * as tagSchemaOps from "./tag-schemas.js";
 import type { TagFieldSchema } from "./tag-schemas.js";
@@ -165,6 +166,11 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             description: "Filter by tag(s)",
           },
           tag_match: { type: "string", enum: ["any", "all"], description: "How to match multiple tags: 'any' (OR, default) or 'all' (AND)" },
+          expand: {
+            type: "string",
+            enum: ["subtypes", "namespace", "both", "exact"],
+            description: "How each `tag` expands. 'subtypes' (DEFAULT): the tag plus its declared parent_names descendants — the semantic is-a axis (e.g. tag:entity also matches person/work). 'namespace': the tag plus everything filed under it by NAME (tag:entity also matches entity/archived) — the lexical filing axis. 'both': union of the two. 'exact': only the literal tag, no expansion. Omit for 'subtypes' (current behavior).",
+          },
           exclude_tags: {
             oneOf: [
               { type: "string" },
@@ -361,6 +367,18 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             "INVALID_QUERY",
           );
         }
+        // Tag-expansion axis (vault tag `expand` axis). Validate loudly so a
+        // typo'd value doesn't silently fall back to the default.
+        let expand: TagExpandMode | undefined;
+        if (params.expand !== undefined && params.expand !== null) {
+          if (typeof params.expand !== "string" || !(TAG_EXPAND_MODES as readonly string[]).includes(params.expand)) {
+            throw new QueryError(
+              `invalid \`expand\` value ${JSON.stringify(params.expand)} — must be one of ${TAG_EXPAND_MODES.map((m) => `"${m}"`).join(", ")}. Omit for the default ("subtypes").`,
+              "INVALID_QUERY",
+            );
+          }
+          expand = params.expand as TagExpandMode;
+        }
 
         // --- Full-text search ---
         let results: Note[];
@@ -376,6 +394,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           results = await store.searchNotes(params.search as string, {
             tags,
             limit: (params.limit as number) ?? 50,
+            expand,
           });
         } else {
           // --- Structured query ---
@@ -395,6 +414,7 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
           const queryOpts = {
             tags,
             tagMatch: (params.tag_match as "all" | "any") ?? (tags && tags.length > 1 ? "any" : undefined),
+            expand,
             excludeTags,
             hasTags: params.has_tags as boolean | undefined,
             hasLinks: params.has_links as boolean | undefined,

--- a/core/src/store.ts
+++ b/core/src/store.ts
@@ -15,10 +15,12 @@ import { pathTitle } from "./paths.js";
 import { HookRegistry } from "./hooks.js";
 import {
   loadTagHierarchy,
-  getTagDescendants,
+  getTagExpansion,
   TAG_CONFIG_PREFIX,
   DEFAULT_TAG_NAME,
+  DEFAULT_TAG_EXPAND_MODE,
   type TagHierarchy,
+  type TagExpandMode,
 } from "./tag-hierarchy.js";
 import {
   loadSchemaConfig,
@@ -278,13 +280,25 @@ export class BunSqliteStore implements Store {
    *   the other tags' notes — wrong).
    *
    * Other filters (path, metadata, dates) still apply in both cases.
+   *
+   * `expand` axis (vault tag `expand` axis): `opts.expand` selects WHICH axis
+   * each tag expands along — `"subtypes"` (default, the parent_names path
+   * documented above, with the `_default` magic), `"namespace"` (lexical
+   * `tag/*`), `"both"` (union), or `"exact"` (no expansion). The `_default`
+   * universal-parent magic is a SUBTYPES-axis concept, so it fires only when
+   * the resolved mode includes subtypes (`"subtypes"`/`"both"`); under
+   * `"namespace"`/`"exact"` a literal `_default` tag is treated like any other.
    */
   private expandQueryTags(opts: QueryOpts): QueryOpts {
     if (!opts.tags || opts.tags.length === 0) return opts;
     const hierarchy = this.getTagHierarchy();
+    const mode: TagExpandMode = opts.expand ?? DEFAULT_TAG_EXPAND_MODE;
+    const subtypeAxis = mode === "subtypes" || mode === "both";
 
     let tags = opts.tags;
-    if (hierarchy.allTags.has(DEFAULT_TAG_NAME) && tags.includes(DEFAULT_TAG_NAME)) {
+    // `_default` collapse only applies on the subtypes axis — it's the
+    // universal *parent* (an is-a relationship), not a namespace prefix.
+    if (subtypeAxis && hierarchy.allTags.has(DEFAULT_TAG_NAME) && tags.includes(DEFAULT_TAG_NAME)) {
       const match = opts.tagMatch ?? "all";
       if (match === "any") {
         const { tags: _drop, ..._rest } = opts;
@@ -298,33 +312,60 @@ export class BunSqliteStore implements Store {
       opts = { ...opts, tags };
     }
 
-    if (hierarchy.childrenOf.size === 0) return opts;
-    const expanded = tags.map((t) => Array.from(getTagDescendants(hierarchy, t)));
+    // Subtypes fast-path: with no declared hierarchy there are no descendants,
+    // so the engine's `[tag]` fallback already produces the literal-tag join —
+    // skip attaching `_tagsExpanded` to stay byte-identical to pre-axis
+    // behavior. `exact` likewise needs no expansion. Namespace/both must still
+    // run (lexical expansion is independent of `parent_names`).
+    if (mode === "exact") return opts;
+    if (mode === "subtypes" && hierarchy.childrenOf.size === 0) return opts;
+
+    const expanded = tags.map((t) => Array.from(getTagExpansion(hierarchy, t, mode)));
     return { ...opts, _tagsExpanded: expanded } as QueryOpts;
   }
 
-  async searchNotes(query: string, opts?: { tags?: string[]; limit?: number }): Promise<Note[]> {
-    // Same hierarchy-expansion treatment as queryNotes — searching `#manual`
-    // should match notes tagged with any descendant tag. The underlying
-    // FTS path already uses `IN (...)` for tags, so we flatten the
-    // per-input expansions into a single union (search semantics are
-    // "any tag matches"). When `_default` is among the requested tags
-    // (and a `_default` row exists), the OR collapses to "every note" —
-    // drop the tag filter entirely so the search hits the full corpus
-    // and untagged notes are reachable.
+  async searchNotes(query: string, opts?: { tags?: string[]; limit?: number; expand?: TagExpandMode }): Promise<Note[]> {
+    // Same tag-expansion treatment as queryNotes, along the SAME `expand` axis
+    // (vault tag `expand` axis) — searching `#manual` should match notes
+    // tagged with any descendant under "subtypes", any `manual/*` under
+    // "namespace", etc. The underlying FTS path already uses `IN (...)` for
+    // tags, so we flatten the per-input expansions into a single union (search
+    // semantics are "any tag matches").
+    //
+    // `_default` collapse is a SUBTYPES-axis concept (the universal *parent*):
+    // when `_default` is among the requested tags and a `_default` row exists,
+    // the OR collapses to "every note" — drop the tag filter entirely so the
+    // search hits the full corpus and untagged notes are reachable. It fires
+    // only on the subtypes/both axes (mirrors `expandQueryTags`).
     if (opts?.tags && opts.tags.length > 0) {
+      const mode: TagExpandMode = opts.expand ?? DEFAULT_TAG_EXPAND_MODE;
+      const subtypeAxis = mode === "subtypes" || mode === "both";
       const hierarchy = this.getTagHierarchy();
-      if (hierarchy.allTags.has(DEFAULT_TAG_NAME) && opts.tags.includes(DEFAULT_TAG_NAME)) {
-        const { tags: _drop, ..._rest } = opts;
+      if (subtypeAxis && hierarchy.allTags.has(DEFAULT_TAG_NAME) && opts.tags.includes(DEFAULT_TAG_NAME)) {
+        const { tags: _drop, expand: _e, ..._rest } = opts;
         return noteOps.searchNotes(this.db, query, _rest);
       }
-      if (hierarchy.childrenOf.size > 0) {
+      // Subtypes fast-path: with no declared hierarchy there are no
+      // descendants, so the tags pass through unchanged (byte-identical to
+      // pre-axis behavior). `exact` likewise needs no expansion.
+      // Namespace/both must still run (lexical expansion is independent of
+      // `parent_names`).
+      const skipExpansion =
+        mode === "exact" || (mode === "subtypes" && hierarchy.childrenOf.size === 0);
+      if (!skipExpansion) {
         const expanded = new Set<string>();
         for (const t of opts.tags) {
-          for (const x of getTagDescendants(hierarchy, t)) expanded.add(x);
+          for (const x of getTagExpansion(hierarchy, t, mode)) expanded.add(x);
         }
-        return noteOps.searchNotes(this.db, query, { ...opts, tags: Array.from(expanded) });
+        const { expand: _e, ..._rest } = opts;
+        return noteOps.searchNotes(this.db, query, { ..._rest, tags: Array.from(expanded) });
       }
+    }
+    // Strip the internal `expand` before passing to noteOps (it has no field
+    // for it; harmless but keep the boundary clean).
+    if (opts && "expand" in opts) {
+      const { expand: _e, ..._rest } = opts;
+      return noteOps.searchNotes(this.db, query, _rest);
     }
     return noteOps.searchNotes(this.db, query, opts);
   }
@@ -340,11 +381,17 @@ export class BunSqliteStore implements Store {
   }
 
   async expandTagsWithDescendants(tags: string[]): Promise<Set<string>> {
+    // Thin `mode:"subtypes"` shim over the mode-aware `expandTags`, so existing
+    // callers (tag-scope auth, search) keep the exact descendant semantics.
+    return this.expandTags(tags, "subtypes");
+  }
+
+  async expandTags(tags: string[], mode: TagExpandMode = DEFAULT_TAG_EXPAND_MODE): Promise<Set<string>> {
     const expanded = new Set<string>();
     if (tags.length === 0) return expanded;
     const hierarchy = this.getTagHierarchy();
     for (const t of tags) {
-      for (const x of getTagDescendants(hierarchy, t)) expanded.add(x);
+      for (const x of getTagExpansion(hierarchy, t, mode)) expanded.add(x);
     }
     return expanded;
   }

--- a/core/src/tag-expand-axis.test.ts
+++ b/core/src/tag-expand-axis.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tag-expansion axis (`expand`) tests — vault tag `expand` axis
+ * (design `design/2026-06-09-tag-expand-axis.md`).
+ *
+ * Covers the query engine (`store.queryNotes` → `expandQueryTags` →
+ * `_tagsExpanded`) and the mode-aware core helpers
+ * (`getTagExpansion`/`getTagNamespace`). REST + MCP + SSE parity are exercised
+ * in their own suites (`routes`/`mcp` here, `subscribe`/`live-match` in src/).
+ *
+ * The corpus deliberately separates the two axes so a mode that confuses them
+ * fails loudly:
+ *   - `entity` is the SUBTYPE parent of `person` (declared via parent_names).
+ *     `person` is NOT name-prefixed `entity/`.
+ *   - `entity/archived` is NAME-prefixed under `entity` but is NOT a declared
+ *     subtype (no parent_names link to `entity`).
+ *   - `entity/person` is BOTH a declared subtype-child of `entity` AND
+ *     name-prefixed `entity/` — the dedupe case.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { SqliteStore } from "./store.js";
+import {
+  loadTagHierarchy,
+  getTagExpansion,
+  getTagNamespace,
+  getTagDescendants,
+} from "./tag-hierarchy.js";
+
+let store: SqliteStore;
+let db: Database;
+
+/**
+ * Seed the two-axis corpus and return the set of note ids by their kind so
+ * tests can assert membership without depending on insertion order.
+ */
+async function seedTwoAxisCorpus(s: SqliteStore) {
+  // SUBTYPE axis: person is-a entity (declared), but NOT filed under entity/.
+  await s.upsertTagRecord("entity", { description: "an entity" });
+  await s.upsertTagRecord("person", { parent_names: ["entity"] });
+  // NAMESPACE axis: entity/archived is filed under entity/ but declares no
+  // parent_names (pure filing, no is-a edge).
+  await s.upsertTagRecord("entity/archived", {});
+  // BOTH axes: entity/person is a declared subtype-child AND name-prefixed.
+  await s.upsertTagRecord("entity/person", { parent_names: ["entity"] });
+
+  const nEntity = await s.createNote("literal entity", { tags: ["entity"] });
+  const nPerson = await s.createNote("a person (subtype)", { tags: ["person"] });
+  const nArchived = await s.createNote("filed under entity/", { tags: ["entity/archived"] });
+  const nBoth = await s.createNote("subtype AND filed", { tags: ["entity/person"] });
+  const nUnrelated = await s.createNote("unrelated", { tags: ["work"] });
+
+  return {
+    entity: nEntity.id,
+    person: nPerson.id,
+    archived: nArchived.id,
+    both: nBoth.id,
+    unrelated: nUnrelated.id,
+  };
+}
+
+const idsOf = (notes: { id: string }[]) => new Set(notes.map((n) => n.id));
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  store = new SqliteStore(db);
+});
+
+describe("tag expand axis — core helpers", () => {
+  it("getTagNamespace returns the tag + lexically prefixed names, no parent_names subtypes", async () => {
+    await seedTwoAxisCorpus(store);
+    const h = loadTagHierarchy(db);
+    const ns = getTagNamespace(h, "entity");
+    // tag itself + name-prefixed entity/*
+    expect(ns).toContain("entity");
+    expect(ns).toContain("entity/archived");
+    expect(ns).toContain("entity/person");
+    // `person` is a subtype but NOT name-prefixed → must be absent.
+    expect(ns.has("person")).toBe(false);
+  });
+
+  it("getTagExpansion: subtypes = descendants, namespace = lexical, both = union, exact = literal", async () => {
+    await seedTwoAxisCorpus(store);
+    const h = loadTagHierarchy(db);
+
+    const subtypes = getTagExpansion(h, "entity", "subtypes");
+    // descendants via parent_names: entity, person, entity/person — NOT entity/archived
+    expect(subtypes).toEqual(getTagDescendants(h, "entity"));
+    expect(subtypes).toContain("person");
+    expect(subtypes).toContain("entity/person");
+    expect(subtypes.has("entity/archived")).toBe(false);
+
+    const ns = getTagExpansion(h, "entity", "namespace");
+    expect(ns).toContain("entity/archived");
+    expect(ns).toContain("entity/person");
+    expect(ns.has("person")).toBe(false);
+
+    const both = getTagExpansion(h, "entity", "both");
+    // union: subtype-only person + namespace-only entity/archived + shared
+    expect(both).toContain("person");
+    expect(both).toContain("entity/archived");
+    expect(both).toContain("entity/person");
+
+    const exact = getTagExpansion(h, "entity", "exact");
+    expect(exact).toEqual(new Set(["entity"]));
+  });
+
+  it("dedupe: entity/person (subtype AND name-prefixed) appears once under both", async () => {
+    await seedTwoAxisCorpus(store);
+    const h = loadTagHierarchy(db);
+    const both = getTagExpansion(h, "entity", "both");
+    const count = Array.from(both).filter((t) => t === "entity/person").length;
+    expect(count).toBe(1);
+  });
+
+  it("store.expandTags mirrors the helper modes and unions multi-tag input", async () => {
+    await seedTwoAxisCorpus(store);
+    expect(await store.expandTags(["entity"], "exact")).toEqual(new Set(["entity"]));
+    const ns = await store.expandTags(["entity"], "namespace");
+    expect(ns).toContain("entity/archived");
+    expect(ns.has("person")).toBe(false);
+    // default (no mode) === subtypes === expandTagsWithDescendants
+    const def = await store.expandTags(["entity"]);
+    expect(def).toEqual(await store.expandTagsWithDescendants(["entity"]));
+  });
+});
+
+describe("tag expand axis — query engine", () => {
+  it("subtypes (default / absent) is a pure regression: descendants only, no namespaced sibling", async () => {
+    const ids = await seedTwoAxisCorpus(store);
+
+    const absent = await store.queryNotes({ tags: ["entity"] });
+    const explicit = await store.queryNotes({ tags: ["entity"], expand: "subtypes" });
+
+    // Absent ≡ explicit "subtypes" — byte-identical result set.
+    expect(idsOf(explicit)).toEqual(idsOf(absent));
+
+    // Returns the literal + declared subtypes…
+    expect(idsOf(absent)).toEqual(new Set([ids.entity, ids.person, ids.both]));
+    // …and NOT the namespace-only sibling entity/archived.
+    expect(idsOf(absent).has(ids.archived)).toBe(false);
+  });
+
+  it("namespace returns tag + tag/* lexical, NOT parent_names-only subtypes", async () => {
+    const ids = await seedTwoAxisCorpus(store);
+    const res = await store.queryNotes({ tags: ["entity"], expand: "namespace" });
+    // entity (literal) + entity/archived + entity/person (name-prefixed)
+    expect(idsOf(res)).toEqual(new Set([ids.entity, ids.archived, ids.both]));
+    // `person` is a subtype but not name-prefixed → excluded.
+    expect(idsOf(res).has(ids.person)).toBe(false);
+  });
+
+  it("both = union of subtypes and namespace", async () => {
+    const ids = await seedTwoAxisCorpus(store);
+    const res = await store.queryNotes({ tags: ["entity"], expand: "both" });
+    expect(idsOf(res)).toEqual(
+      new Set([ids.entity, ids.person, ids.archived, ids.both]),
+    );
+  });
+
+  it("exact = literal tag only, no descendants", async () => {
+    const ids = await seedTwoAxisCorpus(store);
+    const res = await store.queryNotes({ tags: ["entity"], expand: "exact" });
+    expect(idsOf(res)).toEqual(new Set([ids.entity]));
+  });
+
+  it("dedupe: a note tagged with a both-axis tag is returned once under both", async () => {
+    await seedTwoAxisCorpus(store);
+    const res = await store.queryNotes({ tags: ["entity"], expand: "both" });
+    const bothCount = res.filter((n) => n.content === "subtype AND filed").length;
+    expect(bothCount).toBe(1);
+  });
+
+  it("_default magic stays subtypes-only: namespace on _default does NOT collapse to all notes", async () => {
+    // _default declared → universal subtype parent. With a namespaced child.
+    await store.upsertTagRecord("_default", { description: "universal" });
+    await store.upsertTagRecord("_default/scoped", {});
+    const nA = await store.createNote("a", { tags: ["alpha"] });
+    const nScoped = await store.createNote("scoped", { tags: ["_default/scoped"] });
+
+    // subtypes: _default expands to ALL tags → every note matches.
+    const sub = await store.queryNotes({ tags: ["_default"], expand: "subtypes" });
+    expect(idsOf(sub).has(nA.id)).toBe(true);
+
+    // namespace: _default is treated literally → only _default + _default/* —
+    // does NOT collapse to "all notes" (nA, tagged only `alpha`, is excluded).
+    const ns = await store.queryNotes({ tags: ["_default"], expand: "namespace" });
+    expect(idsOf(ns).has(nA.id)).toBe(false);
+    expect(idsOf(ns).has(nScoped.id)).toBe(true);
+  });
+
+  it("both + _default collapses to all-notes via the subtypes axis", async () => {
+    // `both` includes the subtypes axis, so the `_default` universal-parent
+    // magic must still fire — the union with the namespace axis can only widen
+    // the set, and subtypes alone already means "every note." Untagged notes
+    // included (the _default collapse drops the tag filter entirely).
+    await store.upsertTagRecord("_default", { description: "universal" });
+    const nTagged = await store.createNote("tagged", { tags: ["alpha"] });
+    const nUntagged = await store.createNote("untagged", {});
+
+    const res = await store.queryNotes({ tags: ["_default"], expand: "both" });
+    const got = idsOf(res);
+    expect(got.has(nTagged.id)).toBe(true);
+    expect(got.has(nUntagged.id)).toBe(true);
+    // Equivalent to the no-filter corpus.
+    const all = await store.queryNotes({});
+    expect(got).toEqual(idsOf(all));
+  });
+});
+
+describe("tag expand axis — MCP query-notes schema + handler", () => {
+  it("query-notes schema advertises the four expand values", async () => {
+    const { generateMcpTools } = await import("./mcp.js");
+    const tools = generateMcpTools(store);
+    const q = tools.find((t) => t.name === "query-notes")!;
+    const props = (q.inputSchema as any).properties;
+    expect(props.expand).toBeDefined();
+    expect(props.expand.enum).toEqual(["subtypes", "namespace", "both", "exact"]);
+  });
+
+  it("query-notes handler honors expand=namespace", async () => {
+    const { generateMcpTools } = await import("./mcp.js");
+    const ids = await seedTwoAxisCorpus(store);
+    const tools = generateMcpTools(store);
+    const q = tools.find((t) => t.name === "query-notes")!;
+    // Non-cursor structured query returns a flat array of note-index entries.
+    const res: any = await q.execute({ tag: "entity", expand: "namespace" });
+    const got = new Set<string>(res.map((n: any) => n.id));
+    expect(got).toEqual(new Set([ids.entity, ids.archived, ids.both]));
+    expect(got.has(ids.person)).toBe(false);
+  });
+
+  it("query-notes handler rejects an unknown expand value with INVALID_QUERY", async () => {
+    const { generateMcpTools } = await import("./mcp.js");
+    const tools = generateMcpTools(store);
+    const q = tools.find((t) => t.name === "query-notes")!;
+    let err: any;
+    try {
+      await q.execute({ tag: "entity", expand: "bogus" });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.code).toBe("INVALID_QUERY");
+  });
+});
+
+describe("tag expand axis — MCP search path honors expand", () => {
+  // Corpus shares the FTS term "fox" so search(tag=entity) differs ONLY by the
+  // expand axis — proving the search branch threads it into store.searchNotes.
+  async function seedSearchCorpus(s: SqliteStore) {
+    await s.upsertTagRecord("entity", { description: "entity root" });
+    await s.upsertTagRecord("person", { parent_names: ["entity"] }); // subtype, not name-prefixed
+    await s.upsertTagRecord("entity/archived", {}); // name-prefixed, not subtype
+    await s.createNote("fox literal", { tags: ["entity"] });
+    await s.createNote("fox subtype", { tags: ["person"] });
+    await s.createNote("fox filed", { tags: ["entity/archived"] });
+    await s.createNote("dog unrelated", { tags: ["entity"] }); // no "fox" → FTS excludes
+  }
+
+  it("search + tag, absent expand ≡ subtypes (descendants, no namespaced sibling)", async () => {
+    const { generateMcpTools } = await import("./mcp.js");
+    await seedSearchCorpus(store);
+    const q = generateMcpTools(store).find((t) => t.name === "query-notes")!;
+    const absent: any = await q.execute({ search: "fox", tag: "entity", include_content: true });
+    const sub: any = await q.execute({ search: "fox", tag: "entity", expand: "subtypes", include_content: true });
+    const absentSet = new Set(absent.map((n: any) => n.content));
+    expect(new Set(sub.map((n: any) => n.content))).toEqual(absentSet);
+    expect(absentSet).toEqual(new Set(["fox literal", "fox subtype"]));
+  });
+
+  it("search + tag + expand=namespace returns lexical tag/*, NOT subtype sibling", async () => {
+    const { generateMcpTools } = await import("./mcp.js");
+    await seedSearchCorpus(store);
+    const q = generateMcpTools(store).find((t) => t.name === "query-notes")!;
+    const res: any = await q.execute({ search: "fox", tag: "entity", expand: "namespace", include_content: true });
+    expect(new Set(res.map((n: any) => n.content))).toEqual(new Set(["fox literal", "fox filed"]));
+  });
+
+  it("search + tag + expand=exact returns only the literal-tagged match", async () => {
+    const { generateMcpTools } = await import("./mcp.js");
+    await seedSearchCorpus(store);
+    const q = generateMcpTools(store).find((t) => t.name === "query-notes")!;
+    const res: any = await q.execute({ search: "fox", tag: "entity", expand: "exact", include_content: true });
+    expect(res.map((n: any) => n.content)).toEqual(["fox literal"]);
+  });
+
+  it("search + expand=bogus is rejected with INVALID_QUERY before the search runs", async () => {
+    const { generateMcpTools } = await import("./mcp.js");
+    await store.createNote("fox here", { tags: ["entity"] });
+    const q = generateMcpTools(store).find((t) => t.name === "query-notes")!;
+    let err: any;
+    try {
+      await q.execute({ search: "fox", tag: "entity", expand: "bogus" });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.code).toBe("INVALID_QUERY");
+  });
+});

--- a/core/src/tag-hierarchy.ts
+++ b/core/src/tag-hierarchy.ts
@@ -144,6 +144,86 @@ export function getTagDescendants(h: TagHierarchy, tag: string): Set<string> {
 }
 
 /**
+ * Tag-expansion axis (vault tag `expand` axis — design
+ * `design/2026-06-09-tag-expand-axis.md`). A tag relates to others along two
+ * orthogonal axes; this selects which one (or both, or neither) a query expands
+ * along:
+ *
+ * - `"subtypes"` (DEFAULT): tag ∪ `parent_names` descendants. The semantic
+ *   is-a axis — today's always-on behavior, unchanged. `_default` universal
+ *   parent magic fires here.
+ * - `"namespace"`: tag ∪ {names lexically prefixed `tag/`}. The organizational
+ *   filing axis — purely lexical over the known tag set, no `parent_names`, no
+ *   `_default` magic.
+ * - `"both"`: union of subtypes and namespace.
+ * - `"exact"`: the literal tag only, no expansion.
+ */
+export type TagExpandMode = "subtypes" | "namespace" | "both" | "exact";
+
+export const TAG_EXPAND_MODES: readonly TagExpandMode[] = [
+  "subtypes",
+  "namespace",
+  "both",
+  "exact",
+] as const;
+
+export const DEFAULT_TAG_EXPAND_MODE: TagExpandMode = "subtypes";
+
+/**
+ * Lexical namespace expansion for a single tag: the tag itself plus every
+ * known tag name filed under it (`name === tag` OR `name` starts with
+ * `tag + "/"`). Purely a string-prefix match over `h.allTags` — namespacing is
+ * free-form (the slash in the tag *name*), declared nowhere, which is the whole
+ * point: subtyping is declared via `parent_names`, filing is not. No `_default`
+ * magic here — that's a subtypes-axis concept.
+ */
+export function getTagNamespace(h: TagHierarchy, tag: string): Set<string> {
+  // Pre-seeded with `tag` itself, so the loop only needs the strict `tag/*`
+  // prefix test (the `name === tag` case is already covered by the seed).
+  const result = new Set<string>([tag]);
+  const prefix = tag + "/";
+  for (const name of h.allTags) {
+    if (name.startsWith(prefix)) result.add(name);
+  }
+  return result;
+}
+
+/**
+ * Mode-aware single-tag expansion (vault tag `expand` axis). Returns the set of
+ * tag names a query for `tag` should match under `mode`. Always includes `tag`
+ * itself. Set semantics: a tag that is BOTH a declared subtype-child AND
+ * name-prefixed appears once.
+ *
+ * - `"subtypes"` → `getTagDescendants` (parent_names + `_default` magic).
+ * - `"namespace"` → `getTagNamespace` (lexical `tag/*`).
+ * - `"both"` → union of the two.
+ * - `"exact"` → `{tag}`.
+ */
+export function getTagExpansion(
+  h: TagHierarchy,
+  tag: string,
+  mode: TagExpandMode,
+): Set<string> {
+  switch (mode) {
+    case "exact":
+      return new Set<string>([tag]);
+    case "namespace":
+      return getTagNamespace(h, tag);
+    case "both": {
+      const union = new Set<string>(getTagDescendants(h, tag));
+      for (const name of getTagNamespace(h, tag)) union.add(name);
+      return union;
+    }
+    case "subtypes":
+    default:
+      // `default` is a defensive fallback — `TagExpandMode` already constrains
+      // the value to the four cases above; it can only be reached if an
+      // untyped caller passes a bad string.
+      return getTagDescendants(h, tag);
+  }
+}
+
+/**
  * Detect cycles in the declared hierarchy. Returns the list of tags
  * reachable from themselves via parent declarations. Used by
  * `update-tag` write paths to surface a warning to the caller without

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,11 +1,13 @@
 import type { Database } from "bun:sqlite";
 import type { TagFieldSchema, TagRelationship, TagRelationshipMap, TagRecord } from "./tag-schemas.js";
 import type { PrunedField } from "./indexed-fields.js";
+import type { TagExpandMode } from "./tag-hierarchy.js";
 
 // ---- Re-exports ----
 
 export type { TagFieldSchema, TagRelationship, TagRelationshipMap, TagRecord } from "./tag-schemas.js";
 export type { PrunedField } from "./indexed-fields.js";
+export type { TagExpandMode } from "./tag-hierarchy.js";
 
 // ---- Note ----
 
@@ -85,6 +87,18 @@ export interface VaultStats {
 export interface QueryOpts {
   tags?: string[];
   tagMatch?: "all" | "any"; // "all" = must have ALL tags (default), "any" = must have ANY tag
+  /**
+   * Tag-expansion axis (vault tag `expand` axis — design
+   * `design/2026-06-09-tag-expand-axis.md`). Selects how each `tags` entry
+   * expands:
+   * - `"subtypes"` (DEFAULT): tag ∪ `parent_names` descendants. Today's
+   *   semantic is-a behavior, unchanged. `_default` universal magic fires here.
+   * - `"namespace"`: tag ∪ lexically name-prefixed `tag/*` (the filing axis).
+   * - `"both"`: union of subtypes + namespace.
+   * - `"exact"`: the literal tag only, no expansion.
+   * Absent → `"subtypes"` → byte-identical to pre-axis behavior.
+   */
+  expand?: TagExpandMode;
   excludeTags?: string[];
   // Presence filters. `true` → has at least one; `false` → has none.
   // When `tags` is also set, `hasTags` is ignored (the tag filter already constrains the set).
@@ -256,7 +270,7 @@ export interface Store {
    * agent loop can persist a single watermark and keep polling.
    */
   queryNotesPaged(opts: QueryOpts): Promise<QueryNotesPage>;
-  searchNotes(query: string, opts?: { tags?: string[]; limit?: number }): Promise<Note[]>;
+  searchNotes(query: string, opts?: { tags?: string[]; limit?: number; expand?: TagExpandMode }): Promise<Note[]>;
 
   // Tags
   tagNote(noteId: string, tags: string[]): Promise<void>;
@@ -268,6 +282,18 @@ export interface Store {
    * compute the effective allowlisted tag-set at auth time.
    */
   expandTagsWithDescendants(tags: string[]): Promise<Set<string>>;
+  /**
+   * Mode-aware tag expansion (vault tag `expand` axis). Expands each input tag
+   * along the selected axis and returns the union:
+   * - `"subtypes"` (default): `{tag} ∪ parent_names-descendants` — identical to
+   *   `expandTagsWithDescendants` (which is a thin shim over this).
+   * - `"namespace"`: `{tag} ∪ lexically name-prefixed tag/*`.
+   * - `"both"`: union of the two.
+   * - `"exact"`: `{tag}` only.
+   * Always includes each input tag. Used by the live-query matcher to lower the
+   * IDENTICAL expansion the snapshot query engine uses for the same `expand`.
+   */
+  expandTags(tags: string[], mode?: TagExpandMode): Promise<Set<string>>;
   listTags(): Promise<{ name: string; count: number }[]>;
   deleteTag(name: string): Promise<{ deleted: boolean; notes_untagged: number }>;
   renameTag(

--- a/design/2026-06-09-tag-expand-axis.md
+++ b/design/2026-06-09-tag-expand-axis.md
@@ -1,0 +1,104 @@
+# Tag query expansion axes — `expand` param
+
+**Status:** design → build (2026-06-09)
+**Scope:** parachute-vault. Additive, backward-compatible (default = current behavior).
+
+## The problem
+
+A vault tag relates to another along **two orthogonal axes**, but the query
+engine only knows one of them:
+
+| Axis | Meaning | Declared by | Today |
+|---|---|---|---|
+| **Subtype (is-a)** | semantic inheritance | `tags.parent_names` | expands by default |
+| **Namespace (path)** | organizational filing | the slash in the tag *name* | **not a query axis at all** |
+
+So `query-notes { tag: "entity" }` returns `person`/`work`/… (subtypes, via
+`parent_names`) — but a tag *named* `entity/archived` is invisible to it, because
+the slash is purely cosmetic. There's no way to say "also give me everything
+filed under `entity/`," and no way to say "give me ONLY `#entity`, no expansion."
+
+This bit us in parachute-channel: `#channel-message/inbound` was assumed to be
+queryable under `#channel-message` and wasn't (fixed there by tagging both
+literally). The root fix is to make namespace a real, opt-in query axis.
+
+## The model
+
+Make tag expansion mode-selectable via a new `expand` field on `QueryOpts`:
+
+```
+expand: "subtypes"   (DEFAULT) — tag ∪ parent_names-descendants. Current behavior, unchanged.
+expand: "namespace"            — tag ∪ {names lexically prefixed `tag/`}. New.
+expand: "both"                 — union of the two.
+expand: "exact"                — just the literal tag, no expansion. New escape hatch.
+```
+
+- **Default `"subtypes"`** — semantic. "Give me everything that *is a* message."
+  Namespaced things never show up unbidden (the surprise we just hit). This is
+  the behavior every existing caller already gets, so the change is a pure
+  superset — no migration, no semantic shift for anyone not passing `expand`.
+- **Namespace is purely lexical** — `name = tag OR name LIKE tag || '/%'` over the
+  known tag set. No schema, no `parent_names` — namespacing is free-form, which
+  is the whole point (subtyping is declared; filing is not).
+- `"exact"` turns off the descendant expansion that's currently always-on — useful
+  for "this precise tag only."
+
+Per-input-tag: `expand` applies to each tag in a multi-tag query independently
+(mirrors today's per-input expansion).
+
+## Where it threads (the "few places")
+
+1. **Expansion core** (`core/src/store.ts expandTagsWithDescendants` +
+   `core/src/tag-hierarchy.ts`): generalize to `expandTags(tags, mode)`. Subtypes
+   = today's `getTagDescendants` (parent_names). Namespace = lexical prefix over
+   `TagHierarchy.allTags` (already loaded). Both = union. Exact = identity.
+   Keep `expandTagsWithDescendants` as a `mode:"subtypes"` shim so existing
+   callers are untouched.
+2. **Query engine** (`core/src/notes.ts queryNotes`): honor `opts.expand` when
+   building `_tagsExpanded`. Default `"subtypes"`.
+3. **REST** (`src/routes.ts parseNotesQueryOpts`): parse `?expand=`; validate
+   against the enum (unknown → 400). Flows into both `/notes` and `/subscribe`.
+4. **MCP** (`core/src/mcp.ts query-notes`): add `expand` to the tool schema with
+   the four values + doc text; default `"subtypes"`.
+5. **Live-query SSE** (`src/live-match.ts buildLiveMatcher` + `src/subscribe.ts`):
+   the matcher's tag expansion MUST use the same mode as the snapshot, so a
+   subscription's snapshot and live events agree. Thread `opts.expand` through
+   `buildLiveMatcher`; it currently hardcodes subtype expansion. **This is the
+   consistency-load-bearing point** — snapshot and live must lower the identical
+   expansion.
+6. **Types** (`core/src/types.ts`): add `expand?: "subtypes" | "namespace" | "both" | "exact"` to `QueryOpts` and to the `Store.expandTags` signature.
+
+## `_default` interaction
+
+`_default` (the universal-parent magic, vault#270) stays a **subtypes-axis**
+concept — namespace mode does not trigger it. `expand: "namespace"` on `_default`
+is just the lexical `_default/*` prefix (almost certainly empty); the universal
+expansion only fires under `"subtypes"`/`"both"`. Keep that branch in the
+subtype path only.
+
+## Backward compatibility
+
+`expand` is optional; absent → `"subtypes"` → byte-identical to today's behavior.
+No data migration, no schema change. Every existing query, REST call, MCP call,
+and the live-query snapshot/matcher keep their current results.
+
+## Channel follow-on (not this PR)
+
+Once shipped, `#channel-message/inbound|outbound` *could* be modeled as declared
+subtypes of `#channel-message` (semantically honest — an inbound message is-a
+channel message) so a default search returns them, letting channel drop the
+tag-both. Optional cleanup; tag-both stays correct meanwhile.
+
+## Test plan
+
+- `expand:"subtypes"` (and absent) == current behavior over a corpus with a
+  `parent_names` hierarchy (regression: identical results).
+- `expand:"namespace"` returns `tag` + `tag/*` lexical, and does NOT return
+  `parent_names`-only subtypes that aren't name-prefixed.
+- `expand:"both"` = union; `expand:"exact"` = literal tag only (no descendants).
+- A tag that is BOTH a declared subtype-child AND name-prefixed appears once
+  (set semantics, no dup).
+- REST `?expand=` parses + validates (bad value → 400); MCP schema accepts it.
+- **SSE consistency:** subscribe with each `expand` mode → snapshot set ≡ live
+  matcher acceptance for that mode (extends the existing parity tests).
+- `bun test ./src` + `bun test ./core/src` + `bun run typecheck` green.

--- a/src/live-match.ts
+++ b/src/live-match.ts
@@ -203,15 +203,17 @@ function isOperatorObject(value: unknown): value is Record<string, unknown> {
 export async function buildLiveMatcher(store: Store, opts: QueryOpts): Promise<LiveMatcher> {
   const tags = opts.tags ?? [];
   const tagMatch: "all" | "any" = opts.tagMatch ?? "all";
-  // Per-input expansion: each input tag → {tag} ∪ descendants(tag). Mirrors
-  // store.expandQueryTags / queryNotes `_tagsExpanded`. expandTagsWithDescendants
-  // already includes the tag itself.
+  // Per-input expansion along the SAME axis the snapshot query uses
+  // (vault tag `expand` axis). `opts.expand` (default "subtypes") MUST be
+  // threaded through here so the live matcher and the snapshot query engine
+  // lower the IDENTICAL expansion — otherwise a subscription's snapshot and
+  // its live events would disagree on which notes match. `expandTags` already
+  // includes each input tag.
   const tagSets: string[][] = [];
   for (const t of tags) {
-    const set = await store.expandTagsWithDescendants([t]);
-    // expandTagsWithDescendants returns {} for empty input but always
-    // includes the root for a non-empty input; be defensive and ensure the
-    // root is present.
+    const set = await store.expandTags([t], opts.expand);
+    // Be defensive: ensure the root is present (expandTags always includes it
+    // for non-empty input, but the contract should not rely on it here).
     set.add(t);
     tagSets.push(Array.from(set));
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Store, Note, QueryOpts } from "../core/src/types.ts";
+import { TAG_EXPAND_MODES, type TagExpandMode } from "../core/src/tag-hierarchy.ts";
 import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
 import { getNote, getNotes, getNoteTags, toNoteIndex, filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "../core/src/notes.ts";
 import { attachValidationStatus } from "../core/src/mcp.ts";
@@ -436,6 +437,33 @@ function parseMetadataJsonAlias(url: URL): {
 }
 
 /**
+ * Parse + validate the `?expand=` tag-expansion axis (vault tag `expand` axis).
+ * Shared by `parseNotesQueryOpts` (structured + subscribe) AND the full-text
+ * search branch of `handleNotes` (which bypasses `parseNotesQueryOpts`), so the
+ * enum lives in exactly one place and `GET /notes?search=...&expand=bogus` is
+ * validated identically to the structured path.
+ *
+ * Returns `{ expand }` (undefined when absent/empty → store defaults to
+ * "subtypes") or `{ error }` (a 400 Response) on an unknown value.
+ */
+export function parseExpandParam(url: URL): { expand?: TagExpandMode; error?: Response } {
+  const expandParam = parseQuery(url, "expand");
+  if (expandParam === null || expandParam === "") return {};
+  if (!(TAG_EXPAND_MODES as readonly string[]).includes(expandParam)) {
+    return {
+      error: json(
+        {
+          error: `invalid \`expand\` value "${expandParam}" — must be one of ${TAG_EXPAND_MODES.map((m) => `"${m}"`).join(", ")}. Omit for the default ("subtypes": parent_names descendants).`,
+          code: "INVALID_QUERY",
+        },
+        400,
+      ),
+    };
+  }
+  return { expand: expandParam as TagExpandMode };
+}
+
+/**
  * Parse the shared notes-query parameters (tags / excludeTags / path /
  * pathPrefix / extension / metadata filters / date filters / sort / paging /
  * cursor) into a `QueryOpts`, plus flags for the query shapes that the live
@@ -483,9 +511,18 @@ export function parseNotesQueryOpts(url: URL): {
     };
   }
 
+  // Tag-expansion axis (vault tag `expand` axis). Optional; absent →
+  // "subtypes" (resolved at the store, kept undefined here so it stays
+  // byte-identical to pre-axis behavior). Unknown value → 400 via the shared
+  // helper (same shape the search branch uses).
+  const expandParsed = parseExpandParam(url);
+  if (expandParsed.error) return { hasSearch, hasNear, hasCursor, error: expandParsed.error };
+  const expand = expandParsed.expand;
+
   const queryOpts: QueryOpts = {
     tags,
     tagMatch: (parseQuery(url, "tag_match") as "all" | "any") ?? (tags && tags.length > 1 ? "any" : undefined),
+    expand,
     excludeTags: parseQueryList(url, "exclude_tag"),
     hasTags: parseBoolOrUndef(parseQuery(url, "has_tags")),
     hasLinks: parseBoolOrUndef(parseQuery(url, "has_links")),
@@ -716,7 +753,17 @@ async function handleNotesInner(
       if (search) {
         const searchTags = parseQueryList(url, "tag");
         const limit = parseInt10(parseQuery(url, "limit")) ?? 50;
-        const rawResults = await store.searchNotes(search, { tags: searchTags, limit });
+        // Tag-expansion axis (vault tag `expand` axis). This branch bypasses
+        // `parseNotesQueryOpts`, so validate `?expand=` here too — otherwise
+        // `GET /notes?search=x&expand=bogus` would silently ignore the bad
+        // value. The validated mode is threaded into the search tag-narrowing.
+        const tagExpand = parseExpandParam(url);
+        if (tagExpand.error) return tagExpand.error;
+        const rawResults = await store.searchNotes(search, {
+          tags: searchTags,
+          limit,
+          expand: tagExpand.expand,
+        });
         // Tag-scope: drop any result the token isn't permitted to see. Filter
         // happens after the store query so an empty post-filter list still
         // returns 200 [] (consistent with "no matches"), not 403.

--- a/src/subscribe.test.ts
+++ b/src/subscribe.test.ts
@@ -461,6 +461,99 @@ describe("handleSubscribe — snapshot completeness (M3)", () => {
   });
 });
 
+describe("handleSubscribe — expand axis snapshot↔live consistency", () => {
+  // vault tag `expand` axis (design 2026-06-09): a subscription's snapshot
+  // (query engine) and its live matcher MUST lower the IDENTICAL tag
+  // expansion. We seed the two-axis corpus, then for each `expand` mode assert
+  // the snapshot set EQUALS the set the live matcher would accept over every
+  // note in the vault.
+  async function seedTwoAxis() {
+    await store.upsertTagRecord("entity", { description: "entity root" });
+    await store.upsertTagRecord("person", { parent_names: ["entity"] }); // subtype, not name-prefixed
+    await store.upsertTagRecord("entity/archived", {}); // name-prefixed, not subtype
+    await store.upsertTagRecord("entity/person", { parent_names: ["entity"] }); // both
+    await store.createNote("literal", { tags: ["entity"] });
+    await store.createNote("subtype", { tags: ["person"] });
+    await store.createNote("filed", { tags: ["entity/archived"] });
+    await store.createNote("both", { tags: ["entity/person"] });
+    await store.createNote("unrelated", { tags: ["work"] });
+  }
+
+  for (const mode of ["subtypes", "namespace", "both", "exact"] as const) {
+    it(`expand=${mode}: snapshot set ≡ live-matcher acceptance`, async () => {
+      await seedTwoAxis();
+      const { buildLiveMatcher } = await import("./live-match.ts");
+
+      const res = await handleSubscribe(
+        subscribeReq(`tag=entity&expand=${mode}`),
+        store,
+        VAULT,
+        unscopedScope(),
+        manager,
+      );
+      expect(res.status).toBe(200);
+      const r = sseReader(res);
+      await r.pump();
+      const snap = r.frames().find((f) => f.event === "snapshot")!;
+      const snapIds = new Set<string>(snap.data.notes.map((n: any) => n.id));
+
+      // The matcher accepts/rejects each note in the vault — compute its set.
+      const matcher = await buildLiveMatcher(store, { tags: ["entity"], expand: mode });
+      const allNotes = await store.queryNotes({ limit: Number.MAX_SAFE_INTEGER });
+      const liveIds = new Set<string>(allNotes.filter((n) => matcher.match(n)).map((n) => n.id));
+
+      expect(liveIds).toEqual(snapIds);
+      await r.close();
+    });
+  }
+
+  it("expand=namespace: a live insert filed under entity/ arrives; a subtype-only insert does NOT", async () => {
+    await seedTwoAxis();
+    // The matcher freezes its tag expansion at subscribe time (mirroring the
+    // snapshot query — design "resolved ONCE at subscribe time"). So the tags
+    // these live notes carry must already be KNOWN at subscribe time:
+    //   - entity/inbox: name-prefixed → in the frozen namespace set.
+    //   - agent: declared subtype of entity, NOT name-prefixed → excluded by
+    //     namespace mode.
+    await store.upsertTagRecord("entity/inbox", {});
+    await store.upsertTagRecord("agent", { parent_names: ["entity"] });
+
+    const res = await handleSubscribe(
+      subscribeReq("tag=entity&expand=namespace"),
+      store,
+      VAULT,
+      unscopedScope(),
+      manager,
+    );
+    const r = sseReader(res);
+    await r.pump();
+
+    await store.createNote("new filed", { tags: ["entity/inbox"] }); // name-prefixed → upsert
+    await store.createNote("new subtype", { tags: ["agent"] }); // subtype-only → no upsert
+    await settle();
+    await r.pump();
+
+    const upserts = r.frames().filter((f) => f.event === "upsert");
+    const contents = upserts.map((u) => u.data.note.content);
+    expect(contents).toContain("new filed");
+    expect(contents).not.toContain("new subtype");
+    await r.close();
+  });
+
+  it("invalid expand value → 400 INVALID_QUERY before any stream opens", async () => {
+    const res = await handleSubscribe(
+      subscribeReq("tag=entity&expand=bogus"),
+      store,
+      VAULT,
+      unscopedScope(),
+      manager,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("INVALID_QUERY");
+  });
+});
+
 describe("handleSubscribe — cap", () => {
   it("over-cap subscribe → 503", async () => {
     const capped = new SubscriptionManager(hooks, { maxPerVault: 1, resolveVault: () => VAULT });

--- a/src/tag-expand-routes.test.ts
+++ b/src/tag-expand-routes.test.ts
@@ -1,0 +1,45 @@
+/**
+ * REST `?expand=` parsing for `parseNotesQueryOpts` — vault tag `expand` axis
+ * (design 2026-06-09). Validates the four-value enum, the 400 on a bad value,
+ * and that an ABSENT param leaves `expand` undefined (so the store resolves it
+ * to "subtypes" → byte-identical to pre-axis behavior).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { parseNotesQueryOpts } from "./routes.ts";
+
+function parse(qs: string) {
+  return parseNotesQueryOpts(new URL(`http://localhost/api/notes?${qs}`));
+}
+
+describe("parseNotesQueryOpts — expand axis", () => {
+  it("absent → queryOpts.expand is undefined (default = subtypes at the store)", () => {
+    const r = parse("tag=entity");
+    expect(r.error).toBeUndefined();
+    expect(r.queryOpts!.expand).toBeUndefined();
+  });
+
+  for (const mode of ["subtypes", "namespace", "both", "exact"] as const) {
+    it(`expand=${mode} parses through`, () => {
+      const r = parse(`tag=entity&expand=${mode}`);
+      expect(r.error).toBeUndefined();
+      expect(r.queryOpts!.expand).toBe(mode);
+    });
+  }
+
+  it("empty expand= is treated as absent (undefined)", () => {
+    const r = parse("tag=entity&expand=");
+    expect(r.error).toBeUndefined();
+    expect(r.queryOpts!.expand).toBeUndefined();
+  });
+
+  it("unknown expand value → 400 with INVALID_QUERY", async () => {
+    const r = parse("tag=entity&expand=bogus");
+    expect(r.queryOpts).toBeUndefined();
+    expect(r.error).toBeDefined();
+    expect(r.error!.status).toBe(400);
+    const body = await r.error!.json();
+    expect(body.code).toBe("INVALID_QUERY");
+    expect(body.error).toContain("expand");
+  });
+});

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1692,6 +1692,56 @@ describe("HTTP /notes", async () => {
     expect(body).toHaveLength(1);
   });
 
+  // ---- search path honors the `expand` axis (vault tag `expand` axis) ----
+  //
+  // Corpus: all three notes share the FTS term "fox". Tags separate the two
+  // axes — `person` is a declared subtype of `entity` (parent_names) but NOT
+  // name-prefixed; `entity/archived` is name-prefixed but NOT a subtype. So
+  // search(tag=entity) returns DIFFERENT sets per `expand` mode, proving the
+  // search branch threads it (regression for the "validated then dropped" bug).
+  async function seedSearchAxisCorpus() {
+    await store.upsertTagRecord("entity", { description: "entity root" });
+    await store.upsertTagRecord("person", { parent_names: ["entity"] });
+    await store.upsertTagRecord("entity/archived", {});
+    await store.createNote("fox literal", { tags: ["entity"], path: "s-entity" });
+    await store.createNote("fox subtype", { tags: ["person"], path: "s-person" });
+    await store.createNote("fox filed", { tags: ["entity/archived"], path: "s-archived" });
+  }
+
+  test("GET /notes?search=fox&tag=entity — absent expand ≡ subtypes (descendants, no namespaced sibling)", async () => {
+    await seedSearchAxisCorpus();
+    const absent = await (await handleNotes(mkReq("GET", "/notes?search=fox&tag=entity&include_content=true"), store, "")).json() as any[];
+    const sub = await (await handleNotes(mkReq("GET", "/notes?search=fox&tag=entity&expand=subtypes&include_content=true"), store, "")).json() as any[];
+    const absentSet = new Set(absent.map((n) => n.content));
+    expect(new Set(sub.map((n) => n.content))).toEqual(absentSet);
+    // entity (literal) + person (subtype); NOT entity/archived.
+    expect(absentSet).toEqual(new Set(["fox literal", "fox subtype"]));
+  });
+
+  test("GET /notes?search=fox&tag=entity&expand=namespace — lexical tag/* only, NOT subtype sibling", async () => {
+    await seedSearchAxisCorpus();
+    const res = await handleNotes(mkReq("GET", "/notes?search=fox&tag=entity&expand=namespace&include_content=true"), store, "");
+    const body = await res.json() as any[];
+    // entity (literal) + entity/archived (name-prefixed); NOT person (subtype).
+    expect(new Set(body.map((n) => n.content))).toEqual(new Set(["fox literal", "fox filed"]));
+  });
+
+  test("GET /notes?search=fox&tag=entity&expand=exact — literal tag only", async () => {
+    await seedSearchAxisCorpus();
+    const res = await handleNotes(mkReq("GET", "/notes?search=fox&tag=entity&expand=exact&include_content=true"), store, "");
+    const body = await res.json() as any[];
+    expect(body.map((n) => n.content)).toEqual(["fox literal"]);
+  });
+
+  test("GET /notes?search=...&expand=bogus → 400 INVALID_QUERY (search branch validates too)", async () => {
+    await store.createNote("fox here");
+    const res = await handleNotes(mkReq("GET", "/notes?search=fox&expand=bogus"), store, "");
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.code).toBe("INVALID_QUERY");
+    expect(body.error).toContain("expand");
+  });
+
   test("GET /notes?has_tags=false returns only untagged notes", async () => {
     await store.createNote("tagged", { tags: ["x"], path: "t" });
     await store.createNote("plain", { path: "p" });


### PR DESCRIPTION
## What

Adds an `expand` query axis that selects HOW a `tag:` query expands — making **namespace** (the slash-name) a real, opt-in query axis distinct from **subtype** (semantic `parent_names` inheritance). They were conflated before; the vault only ever expanded via `parent_names`, and a slash in a name meant nothing for queries.

```
expand: "subtypes"   (DEFAULT) — tag ∪ parent_names-descendants.  Current behavior, UNCHANGED.
expand: "namespace"            — tag ∪ {tag names lexically prefixed `tag/`}.
expand: "both"                 — union of the two.
expand: "exact"                — just the literal tag, no expansion.
```

`query-notes { tag: "entity" }` keeps returning subtypes (`person`/`work`/…) by default — namespaced things never show up unbidden. Opt into namespace (or `both`/`exact`) explicitly.

## Why

`#channel-message/inbound` exposed the gap: a slash-named tag is invisible to a parent-tag query because the slash isn't a query axis. This makes it one — opt-in, lexical, no schema. Default `"subtypes"` keeps it semantic-first (an inbound message *is a* message); namespacing is free-form filing you ask for when you want it.

## Threaded through (design doc `design/2026-06-09-tag-expand-axis.md`)
- Core expansion (`tag-hierarchy.ts` `getTagExpansion` + `store.ts`), query engine, REST (`?expand=`, shared `parseExpandParam` validator — 400 on bad value, **including the search branch**), MCP `query-notes`, full-text `searchNotes` (honors the axis), and the **live-query SSE matcher** (snapshot + live lower the identical expansion).
- `_default` universal-parent stays a subtypes-axis concept (not triggered on namespace).

## Backward compatibility
`expand` is optional; absent → `"subtypes"` → **byte-identical to today** for every caller (REST/MCP/query-engine/SSE). No migration, no schema change. Pinned by a regression test asserting absent ≡ `subtypes` over a corpus with both a `parent_names` hierarchy and a namespaced sibling (which must be excluded under subtypes).

## Review
Design-doc-first → reviewer (caught the search-path "validated-but-silently-ignored" gap → fixed: search now honors `expand` on both REST + MCP, and REST search validation no longer bypassed) → gates re-verified by hand.

Gates: `bun run typecheck` clean · `bun test ./core/src` 697/0 · `bun test ./src` 1488/0. Additive; version untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)