### PR TITLE
feat(triggers): runtime per-vault trigger-registration API (persisted, admin-scoped, JWT webhook auth)

### DIFF
--- a/core/src/schema.ts
+++ b/core/src/schema.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { normalizePath } from "./paths.js";
 import { rebuildIndexes } from "./indexed-fields.js";
 
-export const SCHEMA_VERSION = 20;
+export const SCHEMA_VERSION = 21;
 
 export const SCHEMA_SQL = `
 -- Notes: the universal record.
@@ -184,6 +184,23 @@ CREATE TABLE IF NOT EXISTS mcp_mint_ledger (
   created_at TEXT NOT NULL,
   expires_at TEXT,
   revoked_at TEXT
+);
+
+-- Triggers (v21, vault frictionless-channel-setup PR 1): runtime, persisted,
+-- per-vault webhook triggers. Complements the static config.yaml trigger
+-- system — config.yaml triggers stay global; rows here are scoped to THIS
+-- vault's DB and fire only for events on this vault. The structured columns
+-- (events/when/action) are JSON-encoded; the action column carries the webhook
+-- URL, send mode, timeout, and an optional auth { bearer } for the JWT webhook
+-- path. Managed at runtime via the admin-scoped /api/triggers REST surface
+-- and re-registered on the live hook registry at boot. See src/triggers-api.ts.
+CREATE TABLE IF NOT EXISTS triggers (
+  name TEXT PRIMARY KEY,
+  events TEXT NOT NULL DEFAULT '[]',
+  "when" TEXT NOT NULL DEFAULT '{}',
+  action TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
 );
 
 -- OAuth: registered clients (Dynamic Client Registration)
@@ -451,6 +468,11 @@ export function initSchema(db: Database): void {
   // — present for symmetry with the other migration steps and to anchor the
   // version bump. See vault#403 (MGT — manage-token mints hub JWTs).
   migrateToV20(db);
+
+  // Migrate v20 → v21: ensure the `triggers` table exists (runtime per-vault
+  // webhook triggers). Created by SCHEMA_SQL's CREATE TABLE IF NOT EXISTS
+  // above, so this is a defensive confirmation hook for upgrading vaults.
+  migrateToV21(db);
 
   // Rebuild any generated columns + indexes declared in indexed_fields.
   // No-op for a fresh vault; idempotent on existing vaults.
@@ -1075,6 +1097,28 @@ function migrateToV20(db: Database): void {
   db.exec(
     "CREATE INDEX IF NOT EXISTS idx_mcp_mint_ledger_session ON mcp_mint_ledger(parent_jti, vault_name)",
   );
+}
+
+/**
+ * Migrate v20 → v21: ensure the `triggers` table exists (runtime per-vault
+ * webhook triggers — vault frictionless-channel-setup PR 1). SCHEMA_SQL's
+ * `CREATE TABLE IF NOT EXISTS` already covers fresh AND upgrading vaults
+ * (it runs unconditionally before the migration steps), so this is a
+ * defensive no-op confirmation for vaults created before v21. The reserved
+ * keyword `when` is quoted in the column definition. Idempotent.
+ */
+function migrateToV21(db: Database): void {
+  if (hasTable(db, "triggers")) return;
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS triggers (
+      name TEXT PRIMARY KEY,
+      events TEXT NOT NULL DEFAULT '[]',
+      "when" TEXT NOT NULL DEFAULT '{}',
+      action TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
 }
 
 function hasTable(db: Database, name: string): boolean {

--- a/core/src/triggers-store.test.ts
+++ b/core/src/triggers-store.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the persisted-triggers store (core/src/triggers-store.ts) —
+ * JSON encode/decode round-trip + upsert/list/get/delete semantics over an
+ * in-memory SQLite DB (schema v21).
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { initSchema } from "./schema.js";
+import {
+  upsertTrigger,
+  listTriggers,
+  getTrigger,
+  deleteTrigger,
+  loadAllTriggers,
+} from "./triggers-store.js";
+
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  initSchema(db);
+});
+
+function sample(name: string) {
+  return {
+    name,
+    events: ["created", "updated"] as Array<"created" | "updated">,
+    when: { tags: ["channel-message"], has_content: true },
+    action: {
+      webhook: "https://example.test/hook",
+      send: "json" as const,
+      timeout: 30000,
+      auth: { bearer: "jwt-token" },
+    },
+  };
+}
+
+describe("triggers-store", () => {
+  test("the triggers table exists after initSchema (v21)", () => {
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='triggers'")
+      .get();
+    expect(row).toBeTruthy();
+  });
+
+  test("upsert → get round-trips the structured JSON columns", () => {
+    upsertTrigger(db, sample("inbound"));
+    const got = getTrigger(db, "inbound");
+    expect(got).not.toBeNull();
+    expect(got!.when).toEqual({ tags: ["channel-message"], has_content: true });
+    expect(got!.action.webhook).toBe("https://example.test/hook");
+    expect(got!.action.auth).toEqual({ bearer: "jwt-token" });
+    expect(got!.events).toEqual(["created", "updated"]);
+    expect(got!.created_at).toBeTruthy();
+    expect(got!.updated_at).toBeTruthy();
+  });
+
+  test("upsert by name replaces + preserves created_at, bumps updated_at", async () => {
+    const first = upsertTrigger(db, sample("inbound"));
+    // Ensure clock advances so updated_at differs.
+    await new Promise((r) => setTimeout(r, 5));
+    const second = upsertTrigger(db, {
+      ...sample("inbound"),
+      action: { webhook: "https://example.test/v2" },
+    });
+
+    expect(listTriggers(db)).toHaveLength(1);
+    expect(second.created_at).toBe(first.created_at);
+    expect(second.updated_at >= first.updated_at).toBe(true);
+    expect(getTrigger(db, "inbound")!.action.webhook).toBe("https://example.test/v2");
+  });
+
+  test("events defaults to [created, updated] when omitted", () => {
+    upsertTrigger(db, {
+      name: "no-events",
+      when: { tags: ["x"] },
+      action: { webhook: "https://example.test/hook" },
+    });
+    expect(getTrigger(db, "no-events")!.events).toEqual(["created", "updated"]);
+  });
+
+  test("list / loadAllTriggers return all rows ordered by name", () => {
+    upsertTrigger(db, sample("zebra"));
+    upsertTrigger(db, sample("alpha"));
+    expect(listTriggers(db).map((t) => t.name)).toEqual(["alpha", "zebra"]);
+    expect(loadAllTriggers(db).map((t) => t.name)).toEqual(["alpha", "zebra"]);
+  });
+
+  test("delete removes the row; returns false on a missing name", () => {
+    upsertTrigger(db, sample("inbound"));
+    expect(deleteTrigger(db, "inbound")).toBe(true);
+    expect(getTrigger(db, "inbound")).toBeNull();
+    expect(deleteTrigger(db, "inbound")).toBe(false);
+  });
+
+  test("getTrigger returns null for an unknown name", () => {
+    expect(getTrigger(db, "nope")).toBeNull();
+  });
+});

--- a/core/src/triggers-store.ts
+++ b/core/src/triggers-store.ts
@@ -1,0 +1,165 @@
+/**
+ * Persisted runtime triggers — per-vault CRUD over the `triggers` table
+ * (schema v21).
+ *
+ * Complements the static `config.yaml` trigger system: config.yaml triggers
+ * are loaded at boot and fire globally (all vaults); rows in this table live
+ * in a single vault's SQLite DB and are re-registered at boot scoped to that
+ * vault (they fire ONLY for events on the vault they were stored under).
+ *
+ * The structured columns (`events`, `when`, `action`) are JSON-encoded on
+ * write and parsed on read. `name` is the primary key, so `upsertTrigger`
+ * is a true upsert (insert-or-replace by name). The shape here is kept
+ * structurally compatible with `src/config.ts`'s `TriggerConfig` /
+ * `TriggerWhen` / `TriggerAction` without importing from `src/` — core stays
+ * dependency-free of the server layer.
+ *
+ * `action.auth.bearer`, when present, becomes an `Authorization: Bearer`
+ * header on the webhook POST (the JWT webhook-auth path that retires the
+ * old `?secret=` query param). It is stored verbatim in the JSON column.
+ */
+
+import type { Database } from "bun:sqlite";
+
+/** Predicate shape — mirrors src/config.ts:TriggerWhen. */
+export interface StoredTriggerWhen {
+  tags?: string[];
+  has_content?: boolean;
+  missing_metadata?: string[];
+  has_metadata?: string[];
+}
+
+/** Webhook auth — only the bearer-JWT path for now. */
+export interface StoredTriggerAuth {
+  bearer?: string;
+}
+
+/** Action shape — mirrors src/config.ts:TriggerAction plus `auth`. */
+export interface StoredTriggerAction {
+  webhook: string;
+  timeout?: number;
+  send?: "json" | "attachment" | "content";
+  auth?: StoredTriggerAuth;
+  // Forward-compat: include_context and any other action fields round-trip
+  // through the JSON column verbatim even though core doesn't interpret them.
+  [key: string]: unknown;
+}
+
+/** A persisted trigger row, decoded. */
+export interface StoredTrigger {
+  name: string;
+  events: Array<"created" | "updated">;
+  when: StoredTriggerWhen;
+  action: StoredTriggerAction;
+  created_at: string;
+  updated_at: string;
+}
+
+/** The writable subset callers pass to upsert. */
+export interface TriggerInput {
+  name: string;
+  events?: Array<"created" | "updated">;
+  when: StoredTriggerWhen;
+  action: StoredTriggerAction;
+}
+
+interface TriggerRow {
+  name: string;
+  events: string;
+  when: string;
+  action: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function decodeRow(row: TriggerRow): StoredTrigger {
+  return {
+    name: row.name,
+    events: safeParse(row.events, ["created", "updated"]) as Array<"created" | "updated">,
+    when: safeParse(row.when, {}) as StoredTriggerWhen,
+    action: safeParse(row.action, { webhook: "" }) as StoredTriggerAction,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function safeParse(json: string, fallback: unknown): unknown {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Insert or replace a trigger by name. Preserves `created_at` on update
+ * (re-fetches the existing row's timestamp) and stamps a fresh `updated_at`.
+ * Returns the stored shape.
+ */
+export function upsertTrigger(db: Database, input: TriggerInput): StoredTrigger {
+  const now = new Date().toISOString();
+  const existing = db
+    .prepare("SELECT created_at FROM triggers WHERE name = ?")
+    .get(input.name) as { created_at: string } | null;
+  const createdAt = existing?.created_at ?? now;
+  const events = input.events ?? ["created", "updated"];
+
+  db.prepare(
+    `INSERT INTO triggers (name, events, "when", action, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(name) DO UPDATE SET
+       events = excluded.events,
+       "when" = excluded."when",
+       action = excluded.action,
+       updated_at = excluded.updated_at`,
+  ).run(
+    input.name,
+    JSON.stringify(events),
+    JSON.stringify(input.when),
+    JSON.stringify(input.action),
+    createdAt,
+    now,
+  );
+
+  return {
+    name: input.name,
+    events,
+    when: input.when,
+    action: input.action,
+    created_at: createdAt,
+    updated_at: now,
+  };
+}
+
+/** List all persisted triggers for this vault, ordered by name. */
+export function listTriggers(db: Database): StoredTrigger[] {
+  const rows = db
+    .prepare(
+      `SELECT name, events, "when", action, created_at, updated_at
+       FROM triggers ORDER BY name`,
+    )
+    .all() as TriggerRow[];
+  return rows.map(decodeRow);
+}
+
+/** Fetch a single trigger by name, or null. */
+export function getTrigger(db: Database, name: string): StoredTrigger | null {
+  const row = db
+    .prepare(
+      `SELECT name, events, "when", action, created_at, updated_at
+       FROM triggers WHERE name = ?`,
+    )
+    .get(name) as TriggerRow | null;
+  return row ? decodeRow(row) : null;
+}
+
+/** Delete a trigger by name. Returns true if a row was removed. */
+export function deleteTrigger(db: Database, name: string): boolean {
+  const res = db.prepare("DELETE FROM triggers WHERE name = ?").run(name);
+  return res.changes > 0;
+}
+
+/** Load all persisted triggers (boot path). Alias of listTriggers for clarity. */
+export function loadAllTriggers(db: Database): StoredTrigger[] {
+  return listTriggers(db);
+}

--- a/design/2026-06-09-frictionless-channel-setup.md
+++ b/design/2026-06-09-frictionless-channel-setup.md
@@ -1,0 +1,66 @@
+# Frictionless channel setup — hub-orchestrated, UI-first
+
+**Status:** design → build (2026-06-09). Cross-repo arc (vault + channel + hub).
+**Goal:** "add a vault-backed channel" becomes **one hub action** (UI button; CLI is the escape hatch), with **zero hand-wiring** — no minted-and-pasted token, no shared secret, no hand-edited `config.yaml` trigger.
+
+## Why
+
+Today, wiring a vault-backed channel means a human: (1) mints a `vault:<v>:write` JWT and pastes it into `channels.json`, (2) invents a shared webhook secret and pastes it in two places, (3) hand-edits the vault's `config.yaml` to add a trigger. Three manual, fragile, un-Parachute artifacts. The hub is already the OAuth issuer + token minter + admin SPA — we should lean on it so the operator does *one thing* and authorizes once. Most users never touch the CLI; the **hub UI is the front door**.
+
+## Target UX
+
+Hub admin SPA → **Channels** → "Add channel" → pick a vault + name → **one click**. Behind it, the hub provisions everything. The UI then shows the copy-paste `claude mcp add --transport http <hub>/channel/mcp/<name>` + launch line to attach a Claude Code session (OAuth — already works). CLI parity: `parachute channel add <name> --vault <v>`.
+
+## The three sins → their fixes
+
+| Manual artifact today | Replaced by | Built in |
+|---|---|---|
+| hand-minted vault token in `channels.json` | hub mints it off the **operator's session** and wires it in | hub orchestration |
+| shared webhook `?secret=` | a **hub JWT** the trigger presents; channel validates via scope-guard | vault trigger-auth + channel |
+| hand-edited `config.yaml` trigger | a **runtime trigger-registration API** the hub calls | **vault (keystone)** |
+
+## Architecture — the hub orchestrates; the vault gains a capability
+
+A vault-backed channel is a **hub-brokered connection** between two modules. The hub (acting on the operator's authenticated session) is the orchestrator; the vault gains the *capability* (runtime triggers); the channel exposes a thin config surface and stops trusting a shared secret.
+
+This is the first concrete slice of the earlier **"Connections"** vision — channel↔vault as the first instance of "wire module event → module action," which later generalizes to a hub Connections UI.
+
+## PR sequence
+
+### PR 1 — Vault: runtime trigger-registration API (keystone)
+
+Triggers today are static `config.yaml`, loaded at boot, fired on the global hook registry (all vaults). Add runtime, persisted, **per-vault** triggers.
+
+- **Storage:** a `triggers` table in each vault's SQLite DB (migration): `name` (PK), `events` (JSON), `when` (JSON predicate), `action` (JSON: `webhook`, `send`, `timeout`, **`auth`**), `created_at`, `updated_at`.
+- **API** (`/vault/<v>/api/triggers`), **admin-scoped** (a webhook trigger exfiltrates note data to a URL — that's an admin capability, not `write`):
+  - `POST` — upsert `{name, events, when, action}`; validates webhook URL; persists; registers on the live hook registry immediately.
+  - `GET` — list this vault's triggers.
+  - `DELETE /:name` — unregister + delete.
+- **Per-vault firing:** the registered hook only acts when the event's vault matches (reuse `getVaultNameForStore`, as the live-query SSE does). Runtime triggers are scoped to the vault they were registered under; `config.yaml` triggers stay global (back-comat).
+- **Webhook auth:** `action.auth = { bearer: "<JWT>" }` → the trigger sends `Authorization: Bearer <JWT>` instead of a URL secret. Retires `?secret=`.
+- **Boot:** load persisted triggers from each vault DB alongside `config.yaml` ones. Reuse `registerTriggers`/`buildPredicate`; don't fork the two-phase claim logic.
+- Backward-compatible: existing `config.yaml` triggers untouched.
+
+### PR 2 — Channel: config API + webhook JWT auth
+
+- **Config API** (hub-JWT-gated, `channel:admin`): `POST/GET/DELETE` vault-backed channels — writes `channels.json` programmatically (no hand-edit). The hub calls this.
+- **Webhook auth:** `POST /api/vault/inbound` validates a **hub JWT** (scope-guard, e.g. `channel:send`) instead of the `?secret=` query param. Retires the shared secret.
+- **Prescribed trigger as data:** the channel exposes the trigger definition it needs (the `#channel-message/inbound` → `/api/vault/inbound` shape) as module-owned data the hub reads to know what to register — same spirit as `CHANNEL_VAULT_TAG_SCHEMA`. Keep `ensureSchema`.
+
+### PR 3 — Hub: orchestration endpoint + Channels UI (the front door)
+
+- **`POST /admin/channels`** (operator-session gated): mint the channel's `vault:<v>:write` token off the operator session → call the channel config API to add the channel → register the prescribed inbound trigger in the vault (admin) with the hub-JWT webhook auth. Plus list/remove (which also tears down the vault trigger). The one action that does all of PR1+PR2's plumbing.
+- **Channels admin-SPA surface:** add (pick vault + name → one click), list, remove, and show the copy-paste session-connect line. No tokens/secrets/YAML ever shown to or touched by the user.
+
+## Auth decisions
+
+- **Credential brokering:** the hub mints the channel's vault token **off the operator's authenticated session** (simplest; the operator's hub auth is the trust anchor) — not a separate channel OAuth client-credentials flow (more moving parts; revisit if channels must self-provision headlessly).
+- **Trigger registration is admin** — it's a data-exfiltration capability. Only the hub (on the operator's behalf) registers triggers; the channel never needs trigger-admin (it only declares its *schema*, which is `write`).
+- **Webhook is a hub JWT**, validated by the channel via the scope-guard it already uses. No secrets at rest beyond the brokered tokens (same posture as today's `channels.json` token).
+
+## Test plan (per PR + end-to-end)
+
+- PR1: API CRUD + persistence-across-restart + per-vault firing (a trigger on vault A doesn't fire for vault B) + JWT-auth webhook + admin-scope enforcement + config.yaml back-compat.
+- PR2: config API CRUD writes channels.json; inbound webhook accepts a valid hub JWT and rejects a bad/absent one (no more secret).
+- PR3: orchestration provisions all three; UI add/list/remove; remove tears down the vault trigger.
+- **E2E:** UI "add channel" → connect a session via OAuth → inbound note wakes it → reply round-trips. Zero hand-wiring.

--- a/src/config.ts
+++ b/src/config.ts
@@ -240,6 +240,20 @@ export interface TriggerAction {
    * top-level `context` field (send=json). send=content ignores this.
    */
   include_context?: TriggerIncludeContext[];
+  /**
+   * Optional webhook auth. When `auth.bearer` is set, the trigger sends
+   * `Authorization: Bearer <bearer>` on the webhook POST — the JWT path that
+   * retires the shared `?secret=` query param. Back-compat: a webhook URL
+   * carrying its own `?secret=` still works; `auth` is purely additive.
+   * Runtime triggers (registered via the /api/triggers REST surface) are the
+   * primary users; config.yaml triggers may also carry it.
+   */
+  auth?: TriggerAuth;
+}
+
+export interface TriggerAuth {
+  /** Bearer token (typically a hub-issued JWT) for the webhook Authorization header. */
+  bearer?: string;
 }
 
 export interface TriggerConfig {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -64,6 +64,7 @@ import {
   type TagScopeCtx,
 } from "./routes.ts";
 import { handleSubscribe } from "./subscribe.ts";
+import { handleTriggers } from "./triggers-api.ts";
 import { expandTokenTagScope } from "./tag-scope.ts";
 import {
   handleProtectedResource,
@@ -727,6 +728,18 @@ export async function route(
   const apiMatch = subpath.match(/^\/api(\/.*)?$/);
   if (!apiMatch) {
     return Response.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // /api/triggers — runtime trigger-registration API. Dispatched BEFORE the
+  // generic method→verb scope gate below because it's ADMIN-scoped on EVERY
+  // method (a webhook trigger exfiltrates note data; even GET is admin). The
+  // gate lives inside `handleTriggers`. Subpath is everything after
+  // `/api/triggers`. See src/triggers-api.ts.
+  {
+    const triggersPath = apiMatch[1] ?? "";
+    if (triggersPath === "/triggers" || triggersPath.startsWith("/triggers/")) {
+      return handleTriggers(req, store, triggersPath.slice("/triggers".length), vaultName, auth);
+    }
   }
 
   // REST API — scope gate. GET/HEAD/OPTIONS → vault:read,

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { resolveFirstBootVaultName } from "./vault-name.ts";
 import { getVaultStore, getVaultNameForStore } from "./vault-store.ts";
 import { defaultHookRegistry } from "../core/src/hooks.ts";
 import { registerTriggers } from "./triggers.ts";
+import { loadVaultTriggers } from "./triggers-api.ts";
 import { route } from "./routing.ts";
 import { startTranscriptionWorker, registerTranscriptionHook, type TranscriptionWorker } from "./transcription-worker.ts";
 import { setTranscriptionWorker } from "./transcription-registry.ts";
@@ -241,6 +242,31 @@ for (const vaultName of listVaults()) {
     } catch (err) {
       console.error(`[tokens] migration error for vault "${vaultName}":`, err);
     }
+  }
+}
+
+// Load persisted runtime triggers for each vault and register them
+// vault-scoped on the shared hook registry (frictionless-channel-setup PR 1).
+// Runs alongside the config.yaml trigger registration above; config.yaml
+// triggers stay global, these fire only for their own vault. Survives
+// restart — the `triggers` table is the source of truth. Per-vault failure
+// is isolated so one bad vault can't block the others.
+{
+  let totalTriggers = 0;
+  for (const vaultName of listVaults()) {
+    try {
+      const store = getVaultStore(vaultName);
+      const n = loadVaultTriggers(vaultName, store);
+      totalTriggers += n;
+      if (n > 0) {
+        console.log(`[triggers] loaded ${n} runtime trigger(s) for vault "${vaultName}"`);
+      }
+    } catch (err) {
+      console.error(`[triggers] failed to load runtime triggers for vault "${vaultName}":`, err);
+    }
+  }
+  if (totalTriggers === 0) {
+    console.log("[triggers] no persisted runtime triggers");
   }
 }
 

--- a/src/triggers-api.test.ts
+++ b/src/triggers-api.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Runtime trigger-registration API (frictionless-channel-setup PR 1).
+ *
+ * Covers:
+ *  - CRUD over the REST surface (POST creates+persists+lists, DELETE removes,
+ *    POST same name replaces).
+ *  - Persistence across restart (loadAllTriggers → re-register → still fires).
+ *  - Per-vault firing isolation (a trigger for vault A does NOT fire on a
+ *    vault-B note event) — the load-bearing test.
+ *  - JWT webhook auth (action.auth.bearer → Authorization: Bearer header).
+ *  - Admin-scope enforcement (read/write token → 403, admin → 200).
+ *  - Live registration (POST then a matching note fires WITHOUT a restart).
+ *
+ * Uses PARACHUTE_HOME override + a real hub-JWT mint fixture (JWKS server) so
+ * the admin-scope path exercises the surviving credential shape end-to-end,
+ * mirroring routing.test.ts.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach, afterEach, afterAll } from "bun:test";
+import { rmSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { generateKeyPair, exportJWK, SignJWT } from "jose";
+
+const testDir = join(
+  tmpdir(),
+  `vault-triggers-api-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+);
+process.env.PARACHUTE_HOME = testDir;
+
+const { route } = await import("./routing.ts");
+const { writeGlobalConfig, writeVaultConfig } = await import("./config.ts");
+const { clearVaultStoreCache, getVaultStore, defaultHookRegistry } = await import("./vault-store.ts");
+const {
+  loadVaultTriggers,
+  registerLiveTrigger,
+  clearLiveTriggers,
+} = await import("./triggers-api.ts");
+const { registerTriggers } = await import("./triggers.ts");
+const { listTriggers, getTrigger } = await import("../core/src/triggers-store.ts");
+const { resetJwksCache, resetRevocationCache } = await import("./hub-jwt.ts");
+
+// ---------------------------------------------------------------------------
+// Hub-JWT fixture (same shape as routing.test.ts).
+// ---------------------------------------------------------------------------
+
+let hubServer: ReturnType<typeof Bun.serve>;
+let signingKey: CryptoKey;
+let publicJwk: Record<string, unknown>;
+let hubFixtureOrigin = "";
+const KID = "triggers-api-test-k1";
+
+async function mintJwt(vaultName: string, scopes: string[]): Promise<string> {
+  const iat = Math.floor(Date.now() / 1000);
+  return await new SignJWT({ scope: scopes.join(" "), client_id: "triggers-api-test" })
+    .setProtectedHeader({ alg: "RS256", kid: KID })
+    .setIssuer(hubServer ? `http://127.0.0.1:${hubServer.port}` : "")
+    .setSubject("triggers-api-test-user")
+    .setAudience(`vault.${vaultName}`)
+    .setIssuedAt(iat)
+    .setExpirationTime(iat + 60)
+    .setJti(`jti-${Math.random().toString(36).slice(2)}`)
+    .sign(signingKey);
+}
+
+function adminToken(vaultName: string) {
+  return mintJwt(vaultName, [`vault:${vaultName}:admin`]);
+}
+
+function createVault(name: string): void {
+  writeVaultConfig({ name, api_keys: [], created_at: new Date().toISOString() });
+}
+
+// ---------------------------------------------------------------------------
+// A local webhook receiver — records every hit (and its Authorization header).
+// ---------------------------------------------------------------------------
+
+interface WebhookHit {
+  url: string;
+  auth: string | null;
+  body: unknown;
+}
+
+let webhookServer: ReturnType<typeof Bun.serve>;
+let hits: WebhookHit[] = [];
+let webhookBase = "";
+
+/** Await pending hook handlers: flush the queued microtask, then drain. */
+async function settleHooks(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  await defaultHookRegistry.drain();
+}
+
+function reset(): void {
+  clearLiveTriggers();
+  defaultHookRegistry.clear();
+  clearVaultStoreCache();
+  hits = [];
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(testDir, "vault", "data"), { recursive: true });
+  writeGlobalConfig({ port: 1940 });
+  if (hubFixtureOrigin) {
+    process.env.PARACHUTE_HUB_ORIGIN = hubFixtureOrigin;
+    process.env.PARACHUTE_HUB_JWKS_ORIGIN = hubFixtureOrigin;
+  }
+  resetJwksCache();
+  resetRevocationCache();
+}
+
+beforeAll(async () => {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  signingKey = privateKey;
+  const jwk = await exportJWK(publicKey);
+  publicJwk = { kty: "RSA", n: jwk.n, e: jwk.e, kid: KID, alg: "RS256", use: "sig" };
+  hubServer = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/.well-known/jwks.json") return Response.json({ keys: [publicJwk] });
+      if (url.pathname === "/.well-known/parachute-revocation.json") {
+        return Response.json({ generated_at: new Date().toISOString(), jtis: [] });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  hubFixtureOrigin = `http://127.0.0.1:${hubServer.port}`;
+
+  webhookServer = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      let body: unknown = null;
+      try {
+        body = await req.json();
+      } catch {
+        body = null;
+      }
+      hits.push({
+        url: req.url,
+        auth: req.headers.get("authorization"),
+        body,
+      });
+      // Standard json webhook response — no content/metadata mutation needed.
+      return Response.json({});
+    },
+  });
+  webhookBase = `http://127.0.0.1:${webhookServer.port}`;
+});
+
+beforeEach(() => {
+  reset();
+});
+
+afterEach(() => {
+  clearLiveTriggers();
+  defaultHookRegistry.clear();
+});
+
+afterAll(() => {
+  clearVaultStoreCache();
+  hubServer?.stop(true);
+  webhookServer?.stop(true);
+  delete process.env.PARACHUTE_HUB_ORIGIN;
+  delete process.env.PARACHUTE_HUB_JWKS_ORIGIN;
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+});
+
+function triggerBody(name: string, extra: Record<string, unknown> = {}) {
+  return {
+    name,
+    events: ["created", "updated"],
+    when: { tags: ["channel-message"] },
+    action: { webhook: `${webhookBase}/hook`, ...extra },
+  };
+}
+
+async function post(vault: string, token: string, body: unknown): Promise<Response> {
+  const path = `/vault/${vault}/api/triggers`;
+  return route(
+    new Request(`http://localhost:1940${path}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    path,
+  );
+}
+
+async function get(vault: string, token: string): Promise<Response> {
+  const path = `/vault/${vault}/api/triggers`;
+  return route(
+    new Request(`http://localhost:1940${path}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    path,
+  );
+}
+
+async function getOne(vault: string, token: string, name: string): Promise<Response> {
+  const path = `/vault/${vault}/api/triggers/${name}`;
+  return route(
+    new Request(`http://localhost:1940${path}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    path,
+  );
+}
+
+async function del(vault: string, token: string, name: string): Promise<Response> {
+  const path = `/vault/${vault}/api/triggers/${name}`;
+  return route(
+    new Request(`http://localhost:1940${path}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    path,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+describe("triggers REST CRUD", () => {
+  test("POST creates + persists + lists", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+
+    const res = await post("alpha", token, triggerBody("inbound"));
+    expect(res.status).toBe(200);
+    const created = await res.json();
+    expect(created.trigger.name).toBe("inbound");
+    expect(created.trigger.created_at).toBeTruthy();
+
+    // Persisted to the table.
+    const rows = listTriggers(getVaultStore("alpha").db);
+    expect(rows.map((r) => r.name)).toEqual(["inbound"]);
+
+    // Listed via GET.
+    const listRes = await get("alpha", token);
+    expect(listRes.status).toBe(200);
+    const listed = await listRes.json();
+    expect(listed.triggers.map((t: { name: string }) => t.name)).toEqual(["inbound"]);
+  });
+
+  test("DELETE removes the row + 404 on a missing name", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    await post("alpha", token, triggerBody("inbound"));
+
+    const res = await del("alpha", token, "inbound");
+    expect(res.status).toBe(200);
+    expect(listTriggers(getVaultStore("alpha").db)).toHaveLength(0);
+
+    const missing = await del("alpha", token, "inbound");
+    expect(missing.status).toBe(404);
+  });
+
+  test("POST with the same name replaces (upsert by name)", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+
+    await post("alpha", token, triggerBody("inbound", { timeout: 1000 }));
+    await post("alpha", token, triggerBody("inbound", { timeout: 5000 }));
+
+    const rows = listTriggers(getVaultStore("alpha").db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.action.timeout).toBe(5000);
+  });
+
+  test("POST with an invalid webhook URL → 400", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    const res = await post("alpha", token, {
+      name: "bad",
+      when: { tags: ["x"] },
+      action: { webhook: "ftp://nope" },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Admin-scope enforcement
+// ---------------------------------------------------------------------------
+
+describe("triggers admin-scope", () => {
+  test("read token → 403", async () => {
+    createVault("alpha");
+    const readTok = await mintJwt("alpha", ["vault:alpha:read"]);
+    const res = await get("alpha", readTok);
+    expect(res.status).toBe(403);
+  });
+
+  test("write token → 403 on POST", async () => {
+    createVault("alpha");
+    const writeTok = await mintJwt("alpha", ["vault:alpha:write"]);
+    const res = await post("alpha", writeTok, triggerBody("inbound"));
+    expect(res.status).toBe(403);
+  });
+
+  test("admin token → 200", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    const res = await post("alpha", token, triggerBody("inbound"));
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live registration (no restart) + JWT webhook auth
+// ---------------------------------------------------------------------------
+
+describe("triggers live registration", () => {
+  test("POST then a matching note fires the webhook WITHOUT a restart", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    await post("alpha", token, triggerBody("inbound"));
+
+    const store = getVaultStore("alpha");
+    await store.createNote("hello from alpha", { tags: ["channel-message"] });
+    await settleHooks();
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.url).toContain("/hook");
+  });
+
+  test("action.auth.bearer → Authorization: Bearer on the fired request", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    await post("alpha", token, triggerBody("inbound", { auth: { bearer: "hub-jwt-xyz" } }));
+
+    const store = getVaultStore("alpha");
+    await store.createNote("ping", { tags: ["channel-message"] });
+    await settleHooks();
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.auth).toBe("Bearer hub-jwt-xyz");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Secret redaction on read (M1) — action.auth.bearer is one-way: never
+// readable back over GET, but the live fire still carries the real token.
+// ---------------------------------------------------------------------------
+
+describe("triggers webhook-auth redaction", () => {
+  test("GET list redacts action.auth.bearer; DB keeps the real value", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    await post("alpha", token, triggerBody("inbound", { auth: { bearer: "super-secret-jwt" } }));
+
+    const res = await get("alpha", token);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.triggers).toHaveLength(1);
+    // Key present (auth IS configured) but value redacted.
+    expect(body.triggers[0].action.auth.bearer).toBe("[REDACTED]");
+
+    // The stored row keeps the real bearer — redaction is response-only.
+    expect(getTrigger(getVaultStore("alpha").db, "inbound")!.action.auth!.bearer).toBe(
+      "super-secret-jwt",
+    );
+  });
+
+  test("GET :name redacts action.auth.bearer", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    await post("alpha", token, triggerBody("inbound", { auth: { bearer: "super-secret-jwt" } }));
+
+    const res = await getOne("alpha", token, "inbound");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.trigger.action.auth.bearer).toBe("[REDACTED]");
+  });
+
+  test("POST response echoes a redacted bearer (does not re-expose the input)", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    const res = await post("alpha", token, triggerBody("inbound", { auth: { bearer: "secret" } }));
+    const body = await res.json();
+    expect(body.trigger.action.auth.bearer).toBe("[REDACTED]");
+  });
+
+  test("redaction is response-only — the live webhook still fires with the REAL bearer", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    await post("alpha", token, triggerBody("inbound", { auth: { bearer: "the-real-token" } }));
+
+    // Read it back over GET (redacted) — must NOT change the fire behavior.
+    await get("alpha", token);
+    await getOne("alpha", token, "inbound");
+
+    await getVaultStore("alpha").createNote("fire", { tags: ["channel-message"] });
+    await settleHooks();
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.auth).toBe("Bearer the-real-token");
+  });
+
+  test("a trigger WITHOUT auth lists with no auth key (no spurious [REDACTED])", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    await post("alpha", token, triggerBody("inbound"));
+    const body = await (await get("alpha", token)).json();
+    expect(body.triggers[0].action.auth).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// action.auth.bearer input validation (M2)
+// ---------------------------------------------------------------------------
+
+describe("triggers auth.bearer validation", () => {
+  test("POST with auth.bearer = 42 → 400", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    const res = await post("alpha", token, triggerBody("bad", { auth: { bearer: 42 } }));
+    expect(res.status).toBe(400);
+  });
+
+  test("POST with auth.bearer = {} → 400", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    const res = await post("alpha", token, triggerBody("bad", { auth: { bearer: {} } }));
+    expect(res.status).toBe(400);
+  });
+
+  test("POST with auth.bearer = '' (empty) → 400", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    const res = await post("alpha", token, triggerBody("bad", { auth: { bearer: "" } }));
+    expect(res.status).toBe(400);
+  });
+
+  test("POST with a valid string bearer → 200", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    const res = await post("alpha", token, triggerBody("ok", { auth: { bearer: "jwt" } }));
+    expect(res.status).toBe(200);
+  });
+
+  test("POST with empty auth object ({}) → 200 (no bearer to validate)", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    const res = await post("alpha", token, triggerBody("ok2", { auth: {} }));
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence across restart
+// ---------------------------------------------------------------------------
+
+describe("triggers persistence across restart", () => {
+  test("loadVaultTriggers re-registers a persisted trigger so it fires again", async () => {
+    createVault("alpha");
+    const token = await adminToken("alpha");
+    await post("alpha", token, triggerBody("inbound"));
+
+    // Simulate a restart: drop every live hook + the store cache, then
+    // re-load from the table (the boot path).
+    clearLiveTriggers();
+    defaultHookRegistry.clear();
+    clearVaultStoreCache();
+
+    const store = getVaultStore("alpha");
+    const n = loadVaultTriggers("alpha", store);
+    expect(n).toBe(1);
+
+    await store.createNote("after restart", { tags: ["channel-message"] });
+    await settleHooks();
+
+    expect(hits).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-vault firing isolation — the load-bearing test
+// ---------------------------------------------------------------------------
+
+describe("triggers per-vault firing isolation", () => {
+  test("a trigger registered for vault A does NOT fire on a vault-B note event", async () => {
+    createVault("alpha");
+    createVault("beta");
+
+    // Register the trigger for ALPHA only.
+    const alphaTok = await adminToken("alpha");
+    await post("alpha", alphaTok, triggerBody("inbound"));
+
+    // A matching note in BETA must NOT fire the webhook.
+    const betaStore = getVaultStore("beta");
+    await betaStore.createNote("from beta", { tags: ["channel-message"] });
+    await settleHooks();
+    expect(hits).toHaveLength(0);
+
+    // The same note in ALPHA fires exactly once.
+    const alphaStore = getVaultStore("alpha");
+    await alphaStore.createNote("from alpha", { tags: ["channel-message"] });
+    await settleHooks();
+    expect(hits).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// config.yaml back-compat — global triggers still load + fire
+// ---------------------------------------------------------------------------
+
+describe("config.yaml triggers back-compat", () => {
+  test("a config.yaml (global, unscoped) trigger fires for any vault", async () => {
+    createVault("alpha");
+    createVault("beta");
+
+    // Register a global trigger the way server.ts:registerConfiguredTriggers
+    // does — no vaultName, so it fires for every vault.
+    registerTriggers(defaultHookRegistry, [
+      {
+        name: "global-hook",
+        events: ["created", "updated"],
+        when: { tags: ["channel-message"] },
+        action: { webhook: `${webhookBase}/hook` },
+      },
+    ]);
+
+    await getVaultStore("alpha").createNote("a", { tags: ["channel-message"] });
+    await getVaultStore("beta").createNote("b", { tags: ["channel-message"] });
+    await settleHooks();
+
+    // Fired for BOTH vaults — global, not vault-scoped.
+    expect(hits).toHaveLength(2);
+  });
+});

--- a/src/triggers-api.ts
+++ b/src/triggers-api.ts
@@ -1,0 +1,295 @@
+/**
+ * Runtime trigger-registration REST API (frictionless-channel-setup PR 1).
+ *
+ * Mounts under `/vault/<v>/api/triggers`, ADMIN-scoped. Registering a webhook
+ * trigger exfiltrates note data to an arbitrary URL — that's an admin
+ * capability, not `write` — so every method here gates on `vault:admin`
+ * (or the narrowed `vault:<v>:admin`). The gate is enforced in `handleTriggers`
+ * itself rather than the method-based verb gate in routing.ts, because a GET
+ * here must still require admin (read is too weak).
+ *
+ *   POST   /api/triggers        — upsert {name, events, when, action};
+ *                                 validate webhook URL; persist; (re-)register
+ *                                 live on the shared hook registry, vault-scoped.
+ *   GET    /api/triggers        — list this vault's persisted triggers.
+ *   DELETE /api/triggers/:name  — unregister the live hook + delete the row.
+ *
+ * A process-wide registry of unregister-fns keyed by (vault, name) lets
+ * POST-replace and DELETE unwind the prior live hook before re-registering.
+ */
+
+import type { SqliteStore } from "../core/src/store.ts";
+import { defaultHookRegistry } from "../core/src/hooks.ts";
+import {
+  upsertTrigger,
+  listTriggers,
+  getTrigger,
+  deleteTrigger,
+  loadAllTriggers,
+  type StoredTrigger,
+  type TriggerInput,
+} from "../core/src/triggers-store.ts";
+import { registerVaultTrigger } from "./triggers.ts";
+import { hasScopeForVault, SCOPE_ADMIN } from "./scopes.ts";
+import type { AuthResult } from "./auth.ts";
+
+// ---------------------------------------------------------------------------
+// Live registry of unregister-fns, keyed by `${vault}${name}` (SPACE
+// separator). Neither vault names (validated on create) nor trigger names
+// (NAME_RE below — [A-Za-z0-9][A-Za-z0-9_-]*) admit a space, so the composite
+// key can't collide. Survives across requests in the long-lived server
+// process; on boot it's repopulated by `loadVaultTriggers`.
+// ---------------------------------------------------------------------------
+
+const liveTriggers = new Map<string, () => void>();
+
+function liveKey(vaultName: string, triggerName: string): string {
+  return `${vaultName}${triggerName}`;
+}
+
+/** Unregister + forget any live hook for (vault, name). No-op if absent. */
+function unwindLiveTrigger(vaultName: string, triggerName: string): void {
+  const key = liveKey(vaultName, triggerName);
+  const fn = liveTriggers.get(key);
+  if (fn) {
+    try {
+      fn();
+    } catch {
+      // unregister is a pure array splice — failures shouldn't happen, but a
+      // throw here must not block delete/replace. Swallow + drop the entry.
+    }
+    liveTriggers.delete(key);
+  }
+}
+
+/**
+ * Register a stored trigger live on the shared hook registry, vault-scoped,
+ * replacing any prior same-(vault,name) hook. Exported for the boot path.
+ */
+export function registerLiveTrigger(vaultName: string, trigger: StoredTrigger): void {
+  unwindLiveTrigger(vaultName, trigger.name);
+  const unregister = registerVaultTrigger(defaultHookRegistry, trigger, vaultName);
+  liveTriggers.set(liveKey(vaultName, trigger.name), unregister);
+}
+
+/**
+ * Boot loader: register every persisted trigger for a vault, scoped to it.
+ * Idempotent — replaces any existing live registration per (vault, name).
+ * Called for each vault at server start (alongside config.yaml triggers).
+ */
+export function loadVaultTriggers(vaultName: string, store: SqliteStore): number {
+  const triggers = loadAllTriggers(store.db);
+  for (const t of triggers) {
+    registerLiveTrigger(vaultName, t);
+  }
+  return triggers.length;
+}
+
+/** Test-only: clear the live registry (unregistering each hook). */
+export function clearLiveTriggers(): void {
+  for (const [, fn] of liveTriggers) {
+    try {
+      fn();
+    } catch {
+      /* swallow */
+    }
+  }
+  liveTriggers.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+function validateInput(body: unknown):
+  | { ok: true; input: TriggerInput }
+  | { ok: false; message: string } {
+  if (typeof body !== "object" || body === null) {
+    return { ok: false, message: "request body must be a JSON object" };
+  }
+  const b = body as Record<string, unknown>;
+
+  if (typeof b.name !== "string" || !NAME_RE.test(b.name)) {
+    return {
+      ok: false,
+      message:
+        "`name` is required and must match [A-Za-z0-9][A-Za-z0-9_-]* (no whitespace, NUL, or leading punctuation)",
+    };
+  }
+
+  // events — optional; default applied at the store. When present, must be a
+  // subset of {created, updated}.
+  let events: Array<"created" | "updated"> | undefined;
+  if (b.events !== undefined) {
+    if (
+      !Array.isArray(b.events) ||
+      !b.events.every((e) => e === "created" || e === "updated")
+    ) {
+      return { ok: false, message: "`events` must be an array of 'created'/'updated'" };
+    }
+    events = b.events as Array<"created" | "updated">;
+  }
+
+  if (typeof b.when !== "object" || b.when === null || Array.isArray(b.when)) {
+    return { ok: false, message: "`when` is required and must be an object" };
+  }
+
+  if (typeof b.action !== "object" || b.action === null || Array.isArray(b.action)) {
+    return { ok: false, message: "`action` is required and must be an object" };
+  }
+  const action = b.action as Record<string, unknown>;
+  if (typeof action.webhook !== "string" || action.webhook.length === 0) {
+    return { ok: false, message: "`action.webhook` is required and must be a string URL" };
+  }
+  // Reuse the same http/https validation registerTriggers does, but fail the
+  // request here (400) rather than silently skipping at registration time.
+  try {
+    const url = new URL(action.webhook);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return {
+        ok: false,
+        message: `\`action.webhook\` must use http or https (got ${url.protocol})`,
+      };
+    }
+  } catch {
+    return { ok: false, message: `\`action.webhook\` is not a valid URL: ${action.webhook}` };
+  }
+  if (action.auth !== undefined) {
+    if (typeof action.auth !== "object" || action.auth === null || Array.isArray(action.auth)) {
+      return { ok: false, message: "`action.auth` must be an object when present" };
+    }
+    // `bearer` is the only auth field today. When present it MUST be a
+    // non-empty string — a non-string (number/object/false/null) would either
+    // silently no-op or serialize as `[object Object]` into the Authorization
+    // header at fire time. Reject at the door.
+    const auth = action.auth as Record<string, unknown>;
+    if (auth.bearer !== undefined && (typeof auth.bearer !== "string" || auth.bearer.length === 0)) {
+      return {
+        ok: false,
+        message: "`action.auth.bearer` must be a non-empty string when present",
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    input: {
+      name: b.name,
+      events,
+      when: b.when as TriggerInput["when"],
+      action: b.action as TriggerInput["action"],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response shaping
+// ---------------------------------------------------------------------------
+
+/**
+ * Redact the webhook auth secret before serializing a trigger into ANY HTTP
+ * response. A registration credential (`action.auth.bearer`, typically a hub
+ * JWT) is a one-way input: the caller supplies it, but it must never be
+ * readable back over GET (or echoed by POST). We keep the `bearer` KEY present
+ * — set to the sentinel `"[REDACTED]"` — so clients can still see that auth IS
+ * configured, just not its value.
+ *
+ * Response-only: the DB row and the live webhook-fire path keep the real
+ * bearer (verified by the per-vault firing test, which asserts the fired
+ * request still carries the real `Authorization: Bearer <token>`).
+ */
+const REDACTED = "[REDACTED]";
+
+export function redactTrigger(t: StoredTrigger): StoredTrigger {
+  const bearer = t.action.auth?.bearer;
+  if (bearer === undefined) return t;
+  return {
+    ...t,
+    action: {
+      ...t.action,
+      auth: { ...t.action.auth, bearer: REDACTED },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle `/api/triggers` and `/api/triggers/:name`. `subPath` is the portion
+ * AFTER `/triggers` (e.g. "" for the collection, "/my-trigger" for an item).
+ * Admin-scoped — the gate lives here (not the routing.ts verb gate) so GET
+ * also requires admin.
+ */
+export async function handleTriggers(
+  req: Request,
+  store: SqliteStore,
+  subPath: string,
+  vaultName: string,
+  auth: AuthResult,
+): Promise<Response> {
+  // Admin gate — every method. A webhook trigger exfiltrates note data, so
+  // even listing/reading is an admin capability here.
+  if (!hasScopeForVault(auth.scopes, vaultName, "admin")) {
+    return Response.json(
+      {
+        error: "Forbidden",
+        error_type: "insufficient_scope",
+        message: `This endpoint requires the '${SCOPE_ADMIN}' scope (or '${SCOPE_ADMIN.replace(
+          "vault:",
+          `vault:${vaultName}:`,
+        )}').`,
+        required_scope: SCOPE_ADMIN,
+        granted_scopes: auth.scopes,
+      },
+      { status: 403 },
+    );
+  }
+
+  const itemName = subPath.startsWith("/") ? decodeURIComponent(subPath.slice(1)) : "";
+
+  // Collection: /api/triggers
+  if (itemName === "") {
+    if (req.method === "GET") {
+      return Response.json({ triggers: listTriggers(store.db).map(redactTrigger) });
+    }
+    if (req.method === "POST") {
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+      }
+      const validated = validateInput(body);
+      if (!validated.ok) {
+        return Response.json({ error: validated.message }, { status: 400 });
+      }
+      // Persist (upsert by name) then (re-)register live, vault-scoped. The
+      // live registration replaces any prior same-name hook for this vault.
+      const stored = upsertTrigger(store.db, validated.input);
+      registerLiveTrigger(vaultName, stored);
+      return Response.json({ trigger: redactTrigger(stored) }, { status: 200 });
+    }
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  // Item: /api/triggers/:name
+  if (req.method === "DELETE") {
+    const existed = getTrigger(store.db, itemName) !== null;
+    unwindLiveTrigger(vaultName, itemName);
+    const removed = deleteTrigger(store.db, itemName);
+    if (!existed && !removed) {
+      return Response.json({ error: "Not found", name: itemName }, { status: 404 });
+    }
+    return Response.json({ deleted: itemName });
+  }
+  if (req.method === "GET") {
+    const t = getTrigger(store.db, itemName);
+    if (!t) return Response.json({ error: "Not found", name: itemName }, { status: 404 });
+    return Response.json({ trigger: redactTrigger(t) });
+  }
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
+}

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -31,11 +31,24 @@ import crypto from "node:crypto";
 import type { Note, Store, Attachment } from "../core/src/types.ts";
 import type { HookRegistry, HookEvent, NoteHookPayload } from "../core/src/hooks.ts";
 import type { TriggerConfig, TriggerWhen } from "./config.ts";
+import type { StoredTrigger } from "../core/src/triggers-store.ts";
 import { getVaultNameForStore } from "./vault-store.ts";
 import { assetsDir } from "./routes.ts";
 import { appendContextPart, fetchContextEntries, type ContextPayload } from "./context.ts";
 
 const DEFAULT_TIMEOUT = 60_000;
+
+/**
+ * Build the optional auth headers for a trigger's webhook POST. When
+ * `action.auth.bearer` is set we send `Authorization: Bearer <bearer>` (the
+ * JWT webhook-auth path, frictionless-channel-setup PR 1). Returns an empty
+ * object otherwise — back-compat with webhook URLs carrying a `?secret=`
+ * query param, which is unaffected by this.
+ */
+function buildAuthHeaders(action: TriggerConfig["action"]): Record<string, string> {
+  const bearer = action.auth?.bearer;
+  return bearer ? { Authorization: `Bearer ${bearer}` } : {};
+}
 
 export interface WebhookResponse {
   content?: string;
@@ -163,11 +176,12 @@ async function dispatchJson(
   existingMeta: Record<string, unknown>,
   hookEvent: HookEvent | undefined,
   context: ContextPayload | null,
+  authHeaders: Record<string, string>,
   signal: AbortSignal,
 ): Promise<DispatchResult> {
   const resp = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...authHeaders },
     body: JSON.stringify({
       trigger: trigger.name,
       event: hookEvent ?? "updated",
@@ -207,6 +221,7 @@ async function dispatchAttachment(
   attachments: Attachment[],
   store: Store,
   context: ContextPayload | null,
+  authHeaders: Record<string, string>,
   signal: AbortSignal,
 ): Promise<DispatchResult> {
   const assetsRoot = resolveAssetsDir(store);
@@ -223,7 +238,9 @@ async function dispatchAttachment(
   form.append("file", file);
   if (context) appendContextPart(form, context);
 
-  const resp = await fetch(url, { method: "POST", body: form, signal });
+  // multipart boundary is set by fetch from the FormData body; only the auth
+  // header is added here (no Content-Type — that would clobber the boundary).
+  const resp = await fetch(url, { method: "POST", body: form, headers: authHeaders, signal });
   if (!resp.ok) {
     throw new Error(`webhook returned ${resp.status}: ${await resp.text().catch(() => "")}`);
   }
@@ -244,6 +261,7 @@ async function dispatchContent(
   url: string,
   note: Note,
   store: Store,
+  authHeaders: Record<string, string>,
   signal: AbortSignal,
 ): Promise<DispatchResult> {
   if (!note.content || !note.content.trim()) {
@@ -252,7 +270,7 @@ async function dispatchContent(
 
   const resp = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...authHeaders },
     body: JSON.stringify({ input: note.content }),
     signal,
   });
@@ -280,15 +298,40 @@ async function dispatchContent(
 // Registration
 // ---------------------------------------------------------------------------
 
+export interface RegisterTriggersOptions {
+  logger?: { error: (...args: unknown[]) => void; info?: (...args: unknown[]) => void };
+  /**
+   * When set, the registered handler early-returns unless the firing event's
+   * vault (resolved via `getVaultNameForStore(store)`) equals this value.
+   * Used by the runtime per-vault trigger system: a trigger registered for
+   * vault A never acts on a vault-B note event. `config.yaml` triggers omit
+   * this and stay global (fire for every vault). See `registerVaultTrigger`.
+   */
+  vaultName?: string;
+}
+
 /**
  * Register all triggers from config onto a HookRegistry.
  * Returns a cleanup function that unregisters all hooks.
+ *
+ * `opts.logger` defaults to console. `opts.vaultName`, when set, scopes every
+ * registered handler to that vault (early-return on mismatch) — the
+ * load-bearing isolation for runtime per-vault triggers. A plain logger object
+ * is still accepted as the third arg for back-compat with existing callers.
  */
 export function registerTriggers(
   hooks: HookRegistry,
   triggers: TriggerConfig[],
-  logger: { error: (...args: unknown[]) => void; info?: (...args: unknown[]) => void } = console,
+  optsOrLogger: RegisterTriggersOptions | { error: (...args: unknown[]) => void; info?: (...args: unknown[]) => void } = {},
 ): () => void {
+  // Back-compat: callers historically passed a bare logger as the 3rd arg.
+  // Distinguish it from the new options object by the presence of `error`.
+  const opts: RegisterTriggersOptions =
+    optsOrLogger && typeof (optsOrLogger as { error?: unknown }).error === "function"
+      ? { logger: optsOrLogger as RegisterTriggersOptions["logger"] }
+      : (optsOrLogger as RegisterTriggersOptions);
+  const logger = opts.logger ?? console;
+  const scopedVault = opts.vaultName;
   const unregisters: Array<() => void> = [];
 
   for (const trigger of triggers) {
@@ -310,6 +353,7 @@ export function registerTriggers(
     const renderedKey = `${trigger.name}_rendered_at`;
     const timeout = trigger.action.timeout ?? DEFAULT_TIMEOUT;
     const sendMode = trigger.action.send ?? "json";
+    const authHeaders = buildAuthHeaders(trigger.action);
 
     const unregister = hooks.onNote({
       name: trigger.name,
@@ -322,6 +366,16 @@ export function registerTriggers(
         return predicate(payload as Note);
       },
       handler: async (payload: NoteHookPayload, store: Store, hookEvent?: HookEvent) => {
+        // Per-vault scoping (runtime triggers): the process-wide hook registry
+        // is shared across every vault, so a trigger registered for vault A
+        // would otherwise fire on vault-B note events too. Resolve the firing
+        // store's vault and early-return on mismatch. `config.yaml` triggers
+        // leave `scopedVault` undefined and stay global. This is the
+        // load-bearing isolation check — see the per-vault firing test.
+        if (scopedVault !== undefined && getVaultNameForStore(store) !== scopedVault) {
+          return;
+        }
+
         // Same shape contract as the predicate — triggers don't
         // subscribe to deleted events, so narrow back to Note.
         const note = payload as Note;
@@ -357,16 +411,16 @@ export function registerTriggers(
           let result: DispatchResult;
           switch (sendMode) {
             case "attachment":
-              result = await dispatchAttachment(trigger.action.webhook, note, attachments, store, context, controller.signal);
+              result = await dispatchAttachment(trigger.action.webhook, note, attachments, store, context, authHeaders, controller.signal);
               break;
             case "content":
               // send=content is pure TTS (audio out); vault context makes no
               // sense here and would confuse the server contract.
-              result = await dispatchContent(trigger.action.webhook, note, store, controller.signal);
+              result = await dispatchContent(trigger.action.webhook, note, store, authHeaders, controller.signal);
               break;
             case "json":
             default:
-              result = await dispatchJson(trigger.action.webhook, trigger, note, attachments, existingMeta, hookEvent, context, controller.signal);
+              result = await dispatchJson(trigger.action.webhook, trigger, note, attachments, existingMeta, hookEvent, context, authHeaders, controller.signal);
               break;
           }
           webhookResult = result.webhookResult;
@@ -437,4 +491,36 @@ export function registerTriggers(
   }
 
   return () => unregisters.forEach((fn) => fn());
+}
+
+/**
+ * Convert a persisted `StoredTrigger` (core/src/triggers-store.ts) into the
+ * `TriggerConfig` shape `registerTriggers` consumes. The two are structurally
+ * compatible — this is a thin, explicit bridge so the type boundary between
+ * core (storage) and src (config types) stays visible.
+ */
+export function storedTriggerToConfig(t: StoredTrigger): TriggerConfig {
+  return {
+    name: t.name,
+    events: t.events,
+    when: t.when as TriggerWhen,
+    action: t.action as unknown as TriggerConfig["action"],
+  };
+}
+
+/**
+ * Register a single runtime trigger scoped to `vaultName`. The handler
+ * early-returns unless the firing store resolves to `vaultName` (see the
+ * scoping check in `registerTriggers`), so a trigger registered for vault A
+ * never acts on a vault-B event. Otherwise identical to a config.yaml trigger
+ * — same two-phase claim + webhook fire. Returns an unregister function the
+ * caller keys by (vault, name) so POST-replace and DELETE can unwind it.
+ */
+export function registerVaultTrigger(
+  hooks: HookRegistry,
+  trigger: StoredTrigger,
+  vaultName: string,
+  logger: { error: (...args: unknown[]) => void; info?: (...args: unknown[]) => void } = console,
+): () => void {
+  return registerTriggers(hooks, [storedTriggerToConfig(trigger)], { logger, vaultName });
 }


### PR DESCRIPTION
## What

The keystone for frictionless channel setup (`design/2026-06-09-frictionless-channel-setup.md`, PR 1): triggers become **runtime-registerable, persisted, and per-vault** — no more hand-edited `config.yaml`. This is what lets the hub provision a channel's inbound trigger with one action instead of a human editing YAML.

- **API** `POST/GET/DELETE /vault/<v>/api/triggers` — **admin-scoped** on every method (a webhook trigger exfiltrates note data → admin capability, not `write`; the gate is in `handleTriggers`, dispatched before the verb gate so GET can't pass on `read`).
- **Persisted** in a per-vault `triggers` table (schema v21, additive migration); loaded at boot alongside `config.yaml` triggers (which stay global + unchanged).
- **Per-vault firing:** runtime triggers fire only for their own vault's note events (handler guard on `getVaultNameForStore`, fail-closed). Pinned by a two-vault isolation test.
- **JWT webhook auth:** `action.auth.bearer` → `Authorization: Bearer` on the webhook, retiring `?secret=`. The bearer is **redacted (`[REDACTED]`) on all read responses** — a one-way registration credential, never readable back (the live webhook still fires with the real token; redaction is response-only).
- Live registration: POST fires without a restart; replace/delete/reload never orphan or double-register hooks.

## Review
Design-doc-first → reviewer (committed-core, security-first) caught 2 must-fixes — bearer-echoed-on-GET and unvalidated bearer type — both fixed + tested. I also caught + cleaned a stray NUL-byte that had flipped the new file to git-binary (would've been invisible to diff/review).

Gates: `bun test ./core/src` 704/0 · `bun test ./src` 1510/0 · `bun run typecheck` clean (all re-run by hand). Additive, backward-compatible; version untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)