### PR TITLE
feat(api): per-vault auto_transcribe in PATCH /api/vault (enables scribe link-to-vault)

### DIFF
--- a/src/auto-transcribe.test.ts
+++ b/src/auto-transcribe.test.ts
@@ -118,4 +118,55 @@ describe("shouldAutoTranscribe", () => {
       enabledOverride: false,
     })).toBe(false);
   });
+
+  describe("per-vault precedence (per-vault → global → true)", () => {
+    test("per-vault true wins even when global is false", () => {
+      expect(shouldAutoTranscribe("audio/wav", {
+        readGlobalConfigImpl: readGlobalConfig(false),
+        getCachedScribeUrlImpl: scribePresent,
+        perVaultEnabled: true,
+      })).toBe(true);
+    });
+
+    test("per-vault false wins even when global is true", () => {
+      // The whole point: linking scribe to vault X (perVault true) elsewhere
+      // must not force-on a vault that set its own false.
+      expect(shouldAutoTranscribe("audio/wav", {
+        readGlobalConfigImpl: readGlobalConfig(true),
+        getCachedScribeUrlImpl: scribePresent,
+        perVaultEnabled: false,
+      })).toBe(false);
+    });
+
+    test("per-vault unset falls back to global", () => {
+      expect(shouldAutoTranscribe("audio/wav", {
+        readGlobalConfigImpl: readGlobalConfig(true),
+        getCachedScribeUrlImpl: scribePresent,
+        perVaultEnabled: undefined,
+      })).toBe(true);
+      expect(shouldAutoTranscribe("audio/wav", {
+        readGlobalConfigImpl: readGlobalConfig(false),
+        getCachedScribeUrlImpl: scribePresent,
+        perVaultEnabled: undefined,
+      })).toBe(false);
+    });
+
+    test("both per-vault and global unset falls back to true (no regression)", () => {
+      expect(shouldAutoTranscribe("audio/wav", {
+        readGlobalConfigImpl: readGlobalConfig(undefined),
+        getCachedScribeUrlImpl: scribePresent,
+        perVaultEnabled: undefined,
+      })).toBe(true);
+    });
+
+    test("enabledOverride still hard-overrides the per-vault value", () => {
+      // The explicit caller-opt-in path beats everything.
+      expect(shouldAutoTranscribe("audio/wav", {
+        readGlobalConfigImpl: readGlobalConfig(true),
+        getCachedScribeUrlImpl: scribePresent,
+        perVaultEnabled: false,
+        enabledOverride: true,
+      })).toBe(true);
+    });
+  });
 });

--- a/src/auto-transcribe.ts
+++ b/src/auto-transcribe.ts
@@ -19,11 +19,18 @@ import { getCachedScribeUrl } from "./scribe-discovery.ts";
  *
  * Returns `true` only when ALL three conditions hold:
  *   1. mime-type starts with `audio/` (case-insensitive).
- *   2. `globalConfig.auto_transcribe?.enabled` is not explicitly false.
- *      Default behavior (when unset) is ON — once an operator has scribe
- *      reachable, audio attachments transcribe automatically without a
- *      separate config step. Operators who want it OFF set
- *      `auto_transcribe.enabled: false` explicitly.
+ *   2. The resolved auto-transcribe toggle is not `false`. Resolution is
+ *      **per-vault → global → true**:
+ *        - `perVaultEnabled` (the owning vault's own `auto_transcribe.enabled`)
+ *          wins when set — this is what makes scribe's "link to vault X" affect
+ *          only X, not the whole server.
+ *        - else the server-wide `globalConfig.auto_transcribe?.enabled`.
+ *        - else `true` (default ON — once scribe is reachable, audio
+ *          transcribes without a separate config step). Operators who want it
+ *          OFF set `auto_transcribe.enabled: false` explicitly (per-vault or
+ *          globally).
+ *      `enabledOverride`, when present, hard-overrides the whole chain (used
+ *      by the explicit caller-opt-in path).
  *   3. Scribe is discoverable (services.json entry OR SCRIBE_URL env).
  *
  * The three conditions are independent guards: a single `false` is sufficient
@@ -35,7 +42,17 @@ export function shouldAutoTranscribe(
     /** Injection seam for tests — defaults to live globals. */
     readGlobalConfigImpl?: typeof readGlobalConfig;
     getCachedScribeUrlImpl?: () => string | undefined;
-    /** Allow per-call enabled override — used by the explicit-opt-in path. */
+    /**
+     * The owning vault's per-vault `auto_transcribe.enabled` (vault.yaml).
+     * Takes precedence over the global toggle when set, so enabling/disabling
+     * one vault doesn't move the rest. `undefined` (the vault left it unset)
+     * falls through to the global toggle.
+     */
+    perVaultEnabled?: boolean;
+    /**
+     * Hard override of the entire per-vault→global→true chain. Used by the
+     * explicit caller-opt-in path; not part of the normal precedence ladder.
+     */
     enabledOverride?: boolean;
   } = {},
 ): boolean {
@@ -43,6 +60,7 @@ export function shouldAutoTranscribe(
     return false;
   }
   const enabled = opts.enabledOverride
+    ?? opts.perVaultEnabled
     ?? (opts.readGlobalConfigImpl ?? readGlobalConfig)().auto_transcribe?.enabled
     ?? true;
   if (!enabled) return false;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -169,6 +169,33 @@ describe("config", () => {
     expect(loaded!.transcription).toBeUndefined();
   });
 
+  test("round-trips per-vault auto_transcribe.enabled (true + false)", () => {
+    // The PATCH /api/vault handler persists the per-vault toggle via
+    // writeVaultConfig; confirm it survives a read-back — this is the exact
+    // field shouldAutoTranscribe reads per-vault (per-vault → global → true).
+    const base: VaultConfig = {
+      name: "testvault",
+      api_keys: [],
+      created_at: "2026-01-01T00:00:00.000Z",
+    };
+
+    writeVaultConfig({ ...base, auto_transcribe: { enabled: true } });
+    expect(readVaultConfig("testvault")!.auto_transcribe?.enabled).toBe(true);
+
+    writeVaultConfig({ ...base, auto_transcribe: { enabled: false } });
+    expect(readVaultConfig("testvault")!.auto_transcribe?.enabled).toBe(false);
+  });
+
+  test("vault config without auto_transcribe loads as undefined (falls back to global)", () => {
+    const config: VaultConfig = {
+      name: "testvault",
+      api_keys: [],
+      created_at: "2026-01-01T00:00:00.000Z",
+    };
+    writeVaultConfig(config);
+    expect(readVaultConfig("testvault")!.auto_transcribe).toBeUndefined();
+  });
+
   test("round-trips discovery: enabled|disabled", () => {
     // Default: absent means enabled (endpoint serves names).
     writeGlobalConfig({ port: 1940 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -183,6 +183,23 @@ export interface VaultConfig {
   transcription?: {
     context?: TriggerIncludeContext[];
   };
+  /**
+   * Per-vault auto-transcribe override (vault#353 follow-up). When set, this
+   * vault's value takes precedence over the server-wide
+   * `GlobalConfig.auto_transcribe.enabled`. Resolution at the decision point
+   * (`shouldAutoTranscribe`) is **per-vault → global → true**: a vault that
+   * sets `enabled` here uses it; a vault that leaves it unset falls back to
+   * the global toggle, which itself defaults ON.
+   *
+   * This is what makes scribe's "link to vault X" genuinely per-vault —
+   * `PATCH /vault/X/api/vault {auto_transcribe:{enabled:true}}` flips only
+   * vault X, never the whole server. URL + bearer are still resolved per-
+   * process (services.json / SCRIBE_AUTH_TOKEN); only the on/off toggle is
+   * per-vault.
+   */
+  auto_transcribe?: {
+    enabled?: boolean;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -444,6 +461,14 @@ function serializeVaultConfig(config: VaultConfig): string {
     lines.push(`audio_retention: ${config.audio_retention}`);
   }
 
+  // Per-vault auto-transcribe override. Serialized as a nested block so future
+  // fields can grow under it (mirrors the GlobalConfig shape). Only emitted
+  // when `enabled` is explicitly set — an unset vault falls back to global.
+  if (config.auto_transcribe?.enabled !== undefined) {
+    lines.push("auto_transcribe:");
+    lines.push(`  enabled: ${config.auto_transcribe.enabled}`);
+  }
+
   if (config.transcription?.context?.length) {
     lines.push("transcription:");
     lines.push("  context:");
@@ -578,6 +603,22 @@ function parseVaultConfig(yaml: string, name: string): VaultConfig {
   const transcriptionContext = parseTranscriptionContext(yaml);
   if (transcriptionContext) {
     config.transcription = { context: transcriptionContext };
+  }
+
+  // Parse the per-vault auto_transcribe block — currently single boolean
+  // `enabled`. Nested 2-space-indent block (mirrors the GlobalConfig parser)
+  // so future fields can grow under it without breaking the regex.
+  const autoTranscribeStart = yaml.match(/^auto_transcribe:\s*$/m);
+  if (autoTranscribeStart) {
+    const after = yaml.slice((autoTranscribeStart.index ?? 0) + autoTranscribeStart[0].length);
+    for (const line of after.split("\n")) {
+      if (line.match(/^\S/) && line.trim().length > 0) break; // next top-level key
+      const m = line.match(/^\s+enabled:\s*(true|false)/);
+      if (m) {
+        config.auto_transcribe = { enabled: m[1]! === "true" };
+        break;
+      }
+    }
   }
 
   return config;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -47,7 +47,7 @@ import {
 } from "../core/src/expand.ts";
 import { join, extname, normalize } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
-import { assetsDir } from "./config.ts";
+import { assetsDir, readGlobalConfig, readVaultConfig } from "./config.ts";
 import { shouldAutoTranscribe } from "./auto-transcribe.ts";
 // usage.ts imports `assetsDir` from config.ts (neutral ground), so this import
 // of invalidateUsageCache does NOT form a cycle — routes.ts → usage.ts only.
@@ -1144,7 +1144,14 @@ async function handleNotesInner(
       // Explicit `transcribe: true` wins — if the caller asked, we honor that
       // regardless of the auto-transcribe toggle (back-compat).
       const explicitOptIn = body.transcribe === true;
-      const autoOptIn = !explicitOptIn && shouldAutoTranscribe(body.mimeType);
+      // Per-vault auto-transcribe: read THIS vault's `auto_transcribe.enabled`
+      // (vault.yaml) and pass it as the precedence-winning toggle. A vault that
+      // set its own value uses it; one that left it unset falls through to the
+      // global toggle inside `shouldAutoTranscribe` (per-vault → global → true).
+      const perVaultEnabled = vault
+        ? readVaultConfig(vault)?.auto_transcribe?.enabled
+        : undefined;
+      const autoOptIn = !explicitOptIn && shouldAutoTranscribe(body.mimeType, { perVaultEnabled });
       const attMeta = (explicitOptIn || autoOptIn)
         ? {
             transcribe_status: "pending" as const,
@@ -1960,9 +1967,26 @@ type VaultConfigLike = {
   name: string;
   description?: string;
   audio_retention?: "keep" | "until_transcribed" | "never";
+  auto_transcribe?: { enabled?: boolean };
 };
 
 const VALID_AUDIO_RETENTION = ["keep", "until_transcribed", "never"] as const;
+
+/**
+ * Resolve the effective auto-transcribe toggle for a vault's GET response, the
+ * SAME resolution `shouldAutoTranscribe` uses at the decision point:
+ * **per-vault → global → true**. A vault that set its own `auto_transcribe`
+ * shows that; one that left it unset shows the server-wide default (itself
+ * default-ON). This keeps the GET in lock-step with what the worker actually
+ * does, with no field-name drift.
+ */
+function resolveAutoTranscribeEnabled(vaultConfig: VaultConfigLike): boolean {
+  return (
+    vaultConfig.auto_transcribe?.enabled
+    ?? readGlobalConfig().auto_transcribe?.enabled
+    ?? true
+  );
+}
 
 function vaultResponse(vaultConfig: VaultConfigLike): Record<string, unknown> {
   return {
@@ -1970,6 +1994,9 @@ function vaultResponse(vaultConfig: VaultConfigLike): Record<string, unknown> {
     description: vaultConfig.description ?? null,
     config: {
       audio_retention: vaultConfig.audio_retention ?? "keep",
+      auto_transcribe: {
+        enabled: resolveAutoTranscribeEnabled(vaultConfig),
+      },
     },
   };
 }
@@ -1993,7 +2020,7 @@ export async function handleVault(
   if (req.method === "PATCH") {
     const body = await req.json() as {
       description?: string;
-      config?: { audio_retention?: string };
+      config?: { audio_retention?: string; auto_transcribe?: { enabled?: unknown } };
     };
     let dirty = false;
 
@@ -2014,6 +2041,28 @@ export async function handleVault(
         );
       }
       vaultConfig.audio_retention = v as typeof VALID_AUDIO_RETENTION[number];
+      dirty = true;
+    }
+
+    // auto_transcribe.enabled — PER-VAULT toggle persisted to THIS vault's
+    // vault.yaml (via `persist`, the same writeVaultConfig path as
+    // description/audio_retention). Flipping it for vault X affects only X;
+    // scribe's "link to vault X" PATCHes this and never touches other vaults.
+    // The worker reads the same per-vault field (per-vault → global → true).
+    // Validate the shape: when `auto_transcribe` is present it must carry a
+    // boolean `enabled`.
+    if (body.config?.auto_transcribe !== undefined) {
+      const enabled = body.config.auto_transcribe?.enabled;
+      if (typeof enabled !== "boolean") {
+        return json(
+          {
+            error: "invalid_auto_transcribe",
+            message: "auto_transcribe.enabled must be a boolean",
+          },
+          400,
+        );
+      }
+      vaultConfig.auto_transcribe = { ...vaultConfig.auto_transcribe, enabled };
       dirty = true;
     }
 

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -6115,3 +6115,147 @@ describe("handleVault: audio_retention", async () => {
   });
 });
 
+describe("handleVault: auto_transcribe (per-vault)", async () => {
+  function mkVaultReq(method: string, body?: unknown): Request {
+    const init: RequestInit = { method };
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+      init.headers = { "Content-Type": "application/json" };
+    }
+    return new Request(`${BASE}/vault`, init);
+  }
+
+  test("GET reflects the per-vault auto_transcribe.enabled when set", async () => {
+    const cfg = { name: "vaultA", auto_transcribe: { enabled: false } };
+    const res = await handleVault(mkReq("GET", "/vault"), store, cfg as any);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    // The vault's OWN value wins over global — per-vault → global → true.
+    expect(body.config.auto_transcribe.enabled).toBe(false);
+  });
+
+  test("GET reflects per-vault true override even if global is off", async () => {
+    const cfg = { name: "vaultA", auto_transcribe: { enabled: true } };
+    const res = await handleVault(mkReq("GET", "/vault"), store, cfg as any);
+    const body = await res.json() as any;
+    expect(body.config.auto_transcribe.enabled).toBe(true);
+  });
+
+  test("PATCH writes auto_transcribe to THIS vault's config object (per-vault)", async () => {
+    const cfg: { name: string; auto_transcribe?: { enabled?: boolean } } = { name: "vaultA" };
+    let persisted = 0;
+    const res = await handleVault(
+      mkVaultReq("PATCH", { config: { auto_transcribe: { enabled: true } } }),
+      store,
+      cfg as any,
+      () => { persisted++; },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.config.auto_transcribe.enabled).toBe(true);
+    // Persisted onto the per-vault config object (writeVaultConfig path),
+    // NOT a server-wide global — this is the field the worker reads per-vault.
+    expect(cfg.auto_transcribe?.enabled).toBe(true);
+    expect(persisted).toBe(1);
+
+    // GET round-trips the persisted per-vault value.
+    const getRes = await handleVault(mkReq("GET", "/vault"), store, cfg as any);
+    const getBody = await getRes.json() as any;
+    expect(getBody.config.auto_transcribe.enabled).toBe(true);
+  });
+
+  test("enabling vault X does NOT affect vault Y (genuinely per-vault)", async () => {
+    const vaultX: { name: string; auto_transcribe?: { enabled?: boolean } } = { name: "vaultX" };
+    const vaultY: { name: string; auto_transcribe?: { enabled?: boolean } } = { name: "vaultY" };
+
+    // Link scribe to X only.
+    await handleVault(
+      mkVaultReq("PATCH", { config: { auto_transcribe: { enabled: true } } }),
+      store,
+      vaultX as any,
+      () => {},
+    );
+
+    expect(vaultX.auto_transcribe?.enabled).toBe(true);
+    // Y is untouched — no global toggle was flipped, so Y still has no
+    // per-vault override (the old global-write behavior would have moved Y too).
+    expect(vaultY.auto_transcribe).toBeUndefined();
+  });
+
+  test("PATCH accepts auto_transcribe.enabled=false", async () => {
+    const cfg: { name: string; auto_transcribe?: { enabled?: boolean } } = {
+      name: "vaultA",
+      auto_transcribe: { enabled: true },
+    };
+    const res = await handleVault(
+      mkVaultReq("PATCH", { config: { auto_transcribe: { enabled: false } } }),
+      store,
+      cfg as any,
+      () => {},
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.config.auto_transcribe.enabled).toBe(false);
+    expect(cfg.auto_transcribe?.enabled).toBe(false);
+  });
+
+  test("PATCH rejects a non-boolean enabled with 400 and does not mutate or persist", async () => {
+    const cfg: { name: string; auto_transcribe?: { enabled?: boolean } } = {
+      name: "vaultA",
+      auto_transcribe: { enabled: true },
+    };
+    let persisted = 0;
+    const res = await handleVault(
+      mkVaultReq("PATCH", { config: { auto_transcribe: { enabled: "yes" } } }),
+      store,
+      cfg as any,
+      () => { persisted++; },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error).toBe("invalid_auto_transcribe");
+    // Unchanged — the bad write never landed.
+    expect(cfg.auto_transcribe?.enabled).toBe(true);
+    expect(persisted).toBe(0);
+  });
+
+  test("PATCH rejects auto_transcribe missing enabled with 400", async () => {
+    const cfg = { name: "vaultA" } as { name: string };
+    let persisted = 0;
+    const res = await handleVault(
+      mkVaultReq("PATCH", { config: { auto_transcribe: {} } }),
+      store,
+      cfg as any,
+      () => { persisted++; },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error).toBe("invalid_auto_transcribe");
+    expect(persisted).toBe(0);
+  });
+
+  test("auto_transcribe and audio_retention can be set in one PATCH (single persist)", async () => {
+    const cfg: { name: string; audio_retention?: string; auto_transcribe?: { enabled?: boolean } } = {
+      name: "vaultA",
+    };
+    let persisted = 0;
+    const res = await handleVault(
+      mkVaultReq("PATCH", {
+        config: { audio_retention: "until_transcribed", auto_transcribe: { enabled: true } },
+      }),
+      store,
+      cfg as any,
+      () => { persisted++; },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.config.audio_retention).toBe("until_transcribed");
+    expect(body.config.auto_transcribe.enabled).toBe(true);
+    expect(cfg.audio_retention).toBe("until_transcribed");
+    expect(cfg.auto_transcribe?.enabled).toBe(true);
+    // Both fields persisted in one writeVaultConfig call.
+    expect(persisted).toBe(1);
+  });
+
+});
+


### PR DESCRIPTION
Makes the auto_transcribe toggle per-vault (was global) so scribe's 'link to vault X' enables transcription for X only. Per-vault VaultConfig field; PATCH writes per-vault; decision resolves per-vault → global → true (no regression for unset vaults). Reviewer: MERGE (no regression, real isolation, worker doesn't re-read global, auth unchanged). Gates: src 1525/0 · core 704/0 · typecheck clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)