### PR TITLE
test(vault-create): make runCli hermetic — don't inherit PARACHUTE_HUB_ORIGIN (fixes CI flake)

### DIFF
--- a/src/vault-create.test.ts
+++ b/src/vault-create.test.ts
@@ -28,11 +28,18 @@ function runCli(
   args: string[],
   env: Record<string, string>,
 ): { exitCode: number; stdout: string; stderr: string } {
+  // Hermetic: don't inherit the dev/CI box's PARACHUTE_HUB_ORIGIN. A leaked
+  // origin makes `detectHubPresence`'s rule-1 (configured-origin) short-circuit
+  // to "hub present" with no probe, flipping the no-hub guidance copy to the
+  // "admin wizard" variant — a CI flake when the runner env has it set. Tests
+  // that genuinely want a hub origin pass it explicitly via `env`.
+  const baseEnv: Record<string, string | undefined> = { ...process.env };
+  delete baseEnv.PARACHUTE_HUB_ORIGIN;
   const proc = Bun.spawnSync({
     cmd: ["bun", CLI, ...args],
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, ...env },
+    env: { ...baseEnv, ...env },
   });
   return {
     exitCode: proc.exitCode ?? -1,


### PR DESCRIPTION
Fix-forward for the red vault main CI. The vault-create no-hub tests (assert guidance does NOT contain 'admin') failed in CI because runCli inherited the runner's PARACHUTE_HUB_ORIGIN, which makes detectHubPresence rule-1 (configured-origin) report hub-present without probing → the 'admin wizard' copy fires. runCli now strips PARACHUTE_HUB_ORIGIN from the inherited env (tests that want it pass it explicitly). Verified: PARACHUTE_HUB_ORIGIN=... bun test ./src/vault-create.test.ts now passes 24/0 (failed before). Test-only change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)