### PR TITLE
release: v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/vault",
-  "version": "0.5.3-rc.3",
+  "version": "0.6.0",
   "description": "Agent-native knowledge graph. Notes, tags, links over MCP.",
   "module": "src/cli.ts",
   "type": "module",


### PR DESCRIPTION
Version bump for the stable push (Aaron's ship call, 2026-06-09 — post-boundary-arc). Promotes everything since 0.5.2: the 0.5.3-rc hardening chain (tag-scope hardening, create-note fixes) PLUS the boundary arc (the /vault/admin/ multi-vault home, reserved-name validators, cmdRemove hygiene + last-vault marker, new manifest URL semantics). Minor bump: vault gains a whole surface mode. Tag v0.6.0 follows merge; CI publishes to npm @latest on the tag push. 🤖 Generated with [Claude Code](https://claude.com/claude-code)