### PR TITLE
feat(mirror): ship the shared Parachute GitHub App client_id as the build default

### DIFF
--- a/src/github-device-flow.test.ts
+++ b/src/github-device-flow.test.ts
@@ -80,8 +80,10 @@ describe("client id helpers", () => {
     }
   });
 
-  test("the shipped default is a real GitHub App id, not a placeholder", () => {
-    expect(GITHUB_CLIENT_ID_DEFAULT.startsWith("Iv23")).toBe(true);
+  test("the shipped default is the registered Parachute GitHub App id", () => {
+    // Pin the exact value — it's public by design, and a typo'd constant
+    // would otherwise still pass a shape check.
+    expect(GITHUB_CLIENT_ID_DEFAULT).toBe("Iv23livaRF4VcvPhu3uB");
     expect(isPlaceholderClientId(GITHUB_CLIENT_ID_DEFAULT)).toBe(false);
   });
 

--- a/src/github-device-flow.test.ts
+++ b/src/github-device-flow.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, test } from "bun:test";
 import {
   createRepo,
   fetchUser,
-  GITHUB_CLIENT_ID_PLACEHOLDER,
+  GITHUB_CLIENT_ID_DEFAULT,
   getGithubClientId,
   isPlaceholderClientId,
   listRepos,
@@ -70,18 +70,23 @@ describe("client id helpers", () => {
     }
   });
 
-  test("getGithubClientId falls back to placeholder when env unset", () => {
+  test("getGithubClientId falls back to the shared-app default when env unset", () => {
     const prev = process.env.PARACHUTE_GITHUB_CLIENT_ID;
     delete process.env.PARACHUTE_GITHUB_CLIENT_ID;
     try {
-      expect(getGithubClientId()).toBe(GITHUB_CLIENT_ID_PLACEHOLDER);
+      expect(getGithubClientId()).toBe(GITHUB_CLIENT_ID_DEFAULT);
     } finally {
       if (prev !== undefined) process.env.PARACHUTE_GITHUB_CLIENT_ID = prev;
     }
   });
 
-  test("isPlaceholderClientId catches the literal + the substring", () => {
-    expect(isPlaceholderClientId(GITHUB_CLIENT_ID_PLACEHOLDER)).toBe(true);
+  test("the shipped default is a real GitHub App id, not a placeholder", () => {
+    expect(GITHUB_CLIENT_ID_DEFAULT.startsWith("Iv23")).toBe(true);
+    expect(isPlaceholderClientId(GITHUB_CLIENT_ID_DEFAULT)).toBe(false);
+  });
+
+  test("isPlaceholderClientId catches placeholder-shaped env overrides", () => {
+    expect(isPlaceholderClientId("Iv1.PLACEHOLDER_REPLACE_ME_BEFORE_RELEASE")).toBe(true);
     expect(isPlaceholderClientId("PLACEHOLDER_X")).toBe(true);
     expect(isPlaceholderClientId("Iv1.realone")).toBe(false);
   });

--- a/src/github-device-flow.ts
+++ b/src/github-device-flow.ts
@@ -1,66 +1,67 @@
 /**
- * GitHub OAuth Device Flow client + supporting API calls.
+ * GitHub Device Flow client + supporting API calls.
  *
  * Why Device Flow (not Web Flow): self-hosted vault origins are
  * unpredictable (localhost:1940, random Tailscale FQDN, custom domain). Web
- * Flow needs a pre-registered callback URL per OAuth app; Device Flow needs
- * only a public `client_id` and the operator authorizes by typing a code at
+ * Flow needs a pre-registered callback URL; Device Flow needs only a public
+ * `client_id` and the operator authorizes by typing a code at
  * github.com/login/device from any device. Same UX as `gh auth login`.
  *
- * Spec: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow
+ * Spec: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#using-the-device-flow-to-generate-a-user-access-token
  *
  * All HTTP calls accept an injectable `fetch` so tests can mock the wire
  * without spawning a real GitHub round-trip. Production wiring uses the
  * platform `fetch` (Bun's native).
  *
- * **GITHUB_CLIENT_ID setup (REQUIRED before this works in production):**
+ * **The registered app (2026-06-10)**: the default client_id below belongs
+ * to the shared Parachute **GitHub App** (not a classic OAuth App) that
+ * every self-hosted install uses — the same model as `gh` CLI shipping its
+ * client_id in source. Registration decisions (rationale in vault#480):
+ * fine-grained permissions = Contents read/write ONLY (treat as frozen —
+ * permission changes prompt every installer to re-approve); device flow
+ * enabled; user-token expiration disabled (non-expiring `ghu_` tokens — an
+ * unattended mirror daemon can't babysit single-use refresh tokens);
+ * installable on any account; webhook inactive; no OAuth-on-install.
  *
- *   1. Visit https://github.com/settings/developers
- *   2. "OAuth Apps" → "New OAuth App"
- *   3. Application name: "Parachute Vault" (or operator-chosen)
- *      Homepage URL: https://parachute.computer
- *      Authorization callback URL: https://parachute.computer/oauth/github
- *      (callback URL is required by GitHub's form but unused in Device Flow)
- *   4. After creating: open the app's settings page
- *   5. Tick the "Enable Device Flow" checkbox
- *   6. Copy the Client ID (looks like `Iv1.abc123...` or `Ov23li...`)
- *   7. Set the `GITHUB_CLIENT_ID` constant below to that value
- *
- * The placeholder ships with this PR. Production builds are gated on a real
- * client_id; the PR body flags Aaron as the action owner.
+ * GitHub-App token semantics that shape the connect flow:
+ *   - The `scope` param is IGNORED. Token abilities = app permissions ∩
+ *     the user's own access ∩ the repos selected when INSTALLING the app.
+ *   - Authorization (this device flow) and installation are separate,
+ *     order-independent steps. A granted token reaches no repos until the
+ *     operator also installs the app on their account and selects repos
+ *     (github.com/apps/<app-slug>/installations/new).
  */
 
 // ---------------------------------------------------------------------------
-// Client ID — REPLACE BEFORE TAGGING A RELEASE.
+// Client ID — the shared Parachute GitHub App (public; safe to commit).
 //
-// This is the public OAuth app client_id. No secret is needed for Device
-// Flow (the operator's typed code is the proof-of-presence factor). Safe to
-// commit + ship in client builds. But: tied to ONE registered GitHub OAuth
-// App, which Aaron owns under the Parachute org / his account. Set this
-// after running the setup checklist above.
-//
-// TODO(aaron): replace with the real client_id from the registered OAuth
-// app. Until then, the device-flow endpoints return a clear-error response
-// instead of attempting GitHub's API with an invalid id (which surfaces an
-// opaque "Not Found" that's hard to debug).
+// No secret is needed for Device Flow (the operator's typed code is the
+// proof-of-presence factor), and a client_id is not a credential — GitHub
+// treats public clients as trivially spoofable by design. Operators who
+// want their own app (own rate-limit budget — the device-flow verification
+// cap is 50/hour PER APP fleet-wide — or full sovereignty) set
+// PARACHUTE_GITHUB_CLIENT_ID, which takes precedence. See vault#480.
 // ---------------------------------------------------------------------------
 
-export const GITHUB_CLIENT_ID_PLACEHOLDER =
-  "Iv1.PLACEHOLDER_REPLACE_ME_BEFORE_RELEASE" as const;
+export const GITHUB_CLIENT_ID_DEFAULT = "Iv23livaRF4VcvPhu3uB" as const;
 
 /**
- * The active client id at runtime. Resolved from the env (preferred — lets
- * operators override per-deploy) or the constant above (for tests +
- * defaults). Defaults to the placeholder; the route handlers check for the
- * placeholder and return an actionable error before hitting GitHub.
+ * The active client id at runtime. Resolved from the env (preferred — the
+ * bring-your-own-app path) or the shared-app default above.
  */
 export function getGithubClientId(): string {
-  return process.env.PARACHUTE_GITHUB_CLIENT_ID || GITHUB_CLIENT_ID_PLACEHOLDER;
+  return process.env.PARACHUTE_GITHUB_CLIENT_ID || GITHUB_CLIENT_ID_DEFAULT;
 }
 
-/** Returns true when no real client id has been configured. */
+/**
+ * Returns true when the configured client id is a placeholder rather than a
+ * real id — only reachable via a misconfigured PARACHUTE_GITHUB_CLIENT_ID
+ * override now that a real default ships. Route handlers keep the check so
+ * a junk override surfaces an actionable error instead of GitHub's opaque
+ * "Not Found".
+ */
 export function isPlaceholderClientId(clientId: string): boolean {
-  return clientId === GITHUB_CLIENT_ID_PLACEHOLDER || clientId.includes("PLACEHOLDER");
+  return clientId.includes("PLACEHOLDER");
 }
 
 // ---------------------------------------------------------------------------
@@ -139,8 +140,12 @@ function defaultFetch(): FetchLike {
 
 /**
  * Start a device-flow authorization. POSTs to GitHub's `/login/device/code`
- * with the public client_id + the `repo` scope (the minimum we need to push
- * to the operator's private repos).
+ * with the public client_id.
+ *
+ * No `scope` param: GitHub Apps ignore it entirely. Token abilities come
+ * from the app's fine-grained permissions (Contents read/write) intersected
+ * with the repos the operator selects when installing the app — push access
+ * to private repos comes from that install-time selection, not a scope.
  *
  * Throws on transport or shape error — the route handler catches + returns
  * a 502. Successful return is the four-tuple GitHub spec calls for
@@ -158,11 +163,6 @@ export async function requestDeviceCode(
     },
     body: new URLSearchParams({
       client_id: clientId,
-      // `repo` is the broad-private-repo scope. Read-only push isn't a
-      // thing on GitHub; if we want to push, we need write access to repo
-      // contents, which `repo` includes. The narrower scope `public_repo`
-      // wouldn't cover private repos — most operator vaults are private.
-      scope: "repo",
     }).toString(),
   });
   if (!res.ok) {

--- a/src/mirror-credentials.test.ts
+++ b/src/mirror-credentials.test.ts
@@ -104,6 +104,26 @@ describe("serialize + parse round-trip", () => {
     expect(out).toEqual(creds);
   });
 
+  test("github_oauth with empty scope round-trips (GitHub App tokens)", () => {
+    // Tokens from the shared Parachute GitHub App carry scope: "" (GitHub
+    // Apps use fine-grained permissions, not scopes). The empty string must
+    // survive serialize → parse and still pass the section-validity guard.
+    const creds: MirrorCredentials = {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "ghu_abc123def456ghi789",
+        scope: "",
+        authorized_at: "2026-06-10T18:00:00.000Z",
+        user_login: "aaron",
+        user_id: 12345,
+      },
+      pat: null,
+    };
+    const out = parseCredentials(serializeCredentials(creds));
+    expect(out).toEqual(creds);
+    expect(out.github_oauth?.scope).toBe("");
+  });
+
   test("pat credentials round-trip", () => {
     const creds: MirrorCredentials = {
       active_method: "pat",

--- a/src/mirror-credentials.ts
+++ b/src/mirror-credentials.ts
@@ -209,8 +209,8 @@ export function emptyCredentials(): MirrorCredentials {
  *
  *   active_method: github_oauth
  *   github_oauth:
- *     access_token: gho_...
- *     scope: repo
+ *     access_token: ghu_...
+ *     scope: ""
  *     authorized_at: 2026-05-28T03:14:15.000Z
  *     user_login: aaron
  *     user_id: 12345
@@ -218,6 +218,10 @@ export function emptyCredentials(): MirrorCredentials {
  *     token: ghp_...
  *     remote_url: https://github.com/aaron/my-vault.git
  *     label: "GitHub PAT"
+ *
+ * `scope` is always `""` for tokens from the shared Parachute GitHub App
+ * (GitHub Apps use fine-grained permissions, not scopes). Credentials from
+ * the classic-OAuth era may still carry `scope: repo` — both parse fine.
  */
 export function serializeCredentials(creds: MirrorCredentials): string {
   const lines: string[] = [];

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -617,10 +617,12 @@ describe("auth credential routes — device flow", () => {
     delete process.env.PARACHUTE_GITHUB_CLIENT_ID;
   });
 
-  test("device-code returns 503 with placeholder client_id (no env override)", async () => {
+  test("device-code returns 503 when the env override is placeholder-shaped", async () => {
     home = tmp("mirror-auth-placeholder-");
     makeManager(home);
-    delete process.env.PARACHUTE_GITHUB_CLIENT_ID;
+    // A real default ships in the build, so the placeholder guard is only
+    // reachable via a misconfigured PARACHUTE_GITHUB_CLIENT_ID override.
+    process.env.PARACHUTE_GITHUB_CLIENT_ID = "Iv1.PLACEHOLDER_REPLACE_ME_BEFORE_RELEASE";
     const res = await handleAuthGithubDeviceCode();
     expect(res.status).toBe(503);
     const body = (await res.json()) as { error_type: string };

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -363,16 +363,18 @@ export function _resetDeviceFlowSessionsForTest(): void {
 }
 
 /**
- * Errors out cleanly when the operator hasn't replaced the placeholder
- * client_id. The user-facing message explains the next step.
+ * Errors out cleanly when PARACHUTE_GITHUB_CLIENT_ID is set to a
+ * placeholder-shaped value. A real default ships in the build (the shared
+ * Parachute GitHub App — see github-device-flow.ts), so this is only
+ * reachable via a misconfigured override.
  */
 function placeholderClientIdResponse(): Response {
   return Response.json(
     {
-      error: "GitHub OAuth not configured",
+      error: "GitHub auth misconfigured",
       error_type: "placeholder_client_id",
       message:
-        "This Parachute Vault build doesn't have a registered GitHub OAuth App client_id. Set the PARACHUTE_GITHUB_CLIENT_ID environment variable (see src/github-device-flow.ts for setup steps) or use the Personal Access Token path instead.",
+        "PARACHUTE_GITHUB_CLIENT_ID is set to a placeholder value. Unset it to use the built-in shared Parachute GitHub App, set it to your own app's client_id, or use the Personal Access Token path instead.",
     },
     { status: 503 },
   );


### PR DESCRIPTION
Closes the "ship the shared client_id as the build default" half of #480.

## What

The mirror device flow shipped with a deliberate placeholder client_id + clear-error gate. The shared app is now **registered** (2026-06-10) — a **GitHub App**, not a classic OAuth App; full registration decisions + research are in #480's comments.

- `GITHUB_CLIENT_ID_PLACEHOLDER` → `GITHUB_CLIENT_ID_DEFAULT` carrying the real public client_id `Iv23livaRF4VcvPhu3uB`. Public by design — the `gh` CLI model (its client_id ships in source for every user). `PARACHUTE_GITHUB_CLIENT_ID` env override remains the bring-your-own-app path and takes precedence.
- **Dropped `scope: "repo"` from `requestDeviceCode`** — GitHub Apps ignore the scope param entirely. Token abilities = app permissions (Contents read/write) ∩ user's access ∩ install-time repo selection. The old comment block reasoned about OAuth scopes that no longer apply.
- `isPlaceholderClientId` retained, now guarding only placeholder-shaped **env overrides** (the sole path to the 503 with a real default shipping); clear-error message rewritten accordingly.
- File header: setup checklist → record of the actual registration + GitHub-App token semantics (authorize and install are **separate, order-independent** steps; a granted token reaches no repos until the app is installed).

## Evidence

- Live probe with the shipped id: `POST https://github.com/login/device/code` → clean `{device_code, user_code, verification_uri, expires_in: 899, interval: 5}` (device flow enabled on the app).
- `bun test ./src/` → **1563 pass / 0 fail**, 4267 expect() calls, 57 files.
- `tsc --noEmit` → clean.

## Out of scope (remains on #480)

The connect-flow adaptation to GitHub-App install semantics: chaining device code → install/repo-pick link → verify; the "authorized but not installed" clear-error; admin-UI config. Note `listRepos`/`createRepo` behavior under GitHub-App user tokens (installation-bound visibility; repo creation may need different handling) is being verified and will land as #480 follow-up work.

## Patterns check

No pattern boundaries crossed — module-internal constant + comments. No version bump per current rc discipline (bump+tag on ship call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)