### PR TITLE
feat(mirror): guided GitHub App install flow — install probe, org-aware repo picker, history-on-link, BYO-app surface (#480, #483)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,14 @@ All configuration in `~/.parachute/vault/.env`:
 
 ```
 PORT=1940
+
+# Bring-your-own GitHub App for the mirror "Back up to GitHub" flow
+# (optional — defaults to the shared Parachute app). Set BOTH or NEITHER:
+# the pair must name the SAME GitHub App; mixing apps breaks the
+# install probe (the client_id mints the tokens, the slug builds the
+# install link).
+PARACHUTE_GITHUB_CLIENT_ID=Iv1.yourappclientid
+PARACHUTE_GITHUB_APP_SLUG=your-app-slug
 ```
 
 ## Naming

--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ parachute-vault config                     # show current configuration
 parachute-vault config set KEY value       # set an env var (e.g. PORT=1940)
 parachute-vault config unset KEY           # remove an env var
 parachute-vault restart                    # apply config changes (bounces the daemon)
+# Env vars live in ~/.parachute/vault/.env. Notable ones:
+#   PORT                          — server port (default 1940)
+#   PARACHUTE_GITHUB_CLIENT_ID +
+#   PARACHUTE_GITHUB_APP_SLUG     — bring-your-own GitHub App for the mirror
+#                                   "Back up to GitHub" flow (defaults to the
+#                                   shared Parachute app). Set BOTH or NEITHER:
+#                                   the pair must name the same app — mixing
+#                                   apps breaks the install probe.
 
 # Server
 parachute-vault serve                      # run the server in the foreground (no daemon)

--- a/src/github-device-flow.test.ts
+++ b/src/github-device-flow.test.ts
@@ -7,7 +7,10 @@
  *   - pollForToken: granted / pending / slow_down / expired / denied
  *   - fetchUser happy path
  *   - listRepos: single-page, paginated, truncated
- *   - createRepo happy path
+ *   - listInstallations: happy (user + org), empty, bad shape, API error
+ *   - listInstallationRepos: happy, paginated/truncated, bad shape
+ *   - createRepo happy path + GitHubApiError status (403 = no Administration)
+ *   - app slug helpers + install URL
  */
 
 import { describe, expect, test } from "bun:test";
@@ -15,9 +18,15 @@ import { describe, expect, test } from "bun:test";
 import {
   createRepo,
   fetchUser,
+  GITHUB_APP_SLUG_DEFAULT,
   GITHUB_CLIENT_ID_DEFAULT,
+  getGithubAppSlug,
   getGithubClientId,
+  GitHubApiError,
+  installUrlForSlug,
   isPlaceholderClientId,
+  listInstallationRepos,
+  listInstallations,
   listRepos,
   pollForToken,
   requestDeviceCode,
@@ -91,6 +100,44 @@ describe("client id helpers", () => {
     expect(isPlaceholderClientId("Iv1.PLACEHOLDER_REPLACE_ME_BEFORE_RELEASE")).toBe(true);
     expect(isPlaceholderClientId("PLACEHOLDER_X")).toBe(true);
     expect(isPlaceholderClientId("Iv1.realone")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// App slug helpers
+// ---------------------------------------------------------------------------
+
+describe("app slug helpers", () => {
+  test("getGithubAppSlug reads from env when set (BYO-app pairing)", () => {
+    const prev = process.env.PARACHUTE_GITHUB_APP_SLUG;
+    try {
+      process.env.PARACHUTE_GITHUB_APP_SLUG = "my-own-app";
+      expect(getGithubAppSlug()).toBe("my-own-app");
+    } finally {
+      if (prev === undefined) delete process.env.PARACHUTE_GITHUB_APP_SLUG;
+      else process.env.PARACHUTE_GITHUB_APP_SLUG = prev;
+    }
+  });
+
+  test("getGithubAppSlug falls back to the shared-app default when env unset", () => {
+    const prev = process.env.PARACHUTE_GITHUB_APP_SLUG;
+    delete process.env.PARACHUTE_GITHUB_APP_SLUG;
+    try {
+      expect(getGithubAppSlug()).toBe(GITHUB_APP_SLUG_DEFAULT);
+    } finally {
+      if (prev !== undefined) process.env.PARACHUTE_GITHUB_APP_SLUG = prev;
+    }
+  });
+
+  test("the shipped default slug is the registered Parachute GitHub App's", () => {
+    // Pin the exact value — a typo'd slug would build a 404 install link.
+    expect(GITHUB_APP_SLUG_DEFAULT).toBe("parachute-computer");
+  });
+
+  test("installUrlForSlug builds the installations/new URL", () => {
+    expect(installUrlForSlug("parachute-computer")).toBe(
+      "https://github.com/apps/parachute-computer/installations/new",
+    );
   });
 });
 
@@ -359,6 +406,187 @@ describe("listRepos", () => {
 });
 
 // ---------------------------------------------------------------------------
+// listInstallations
+// ---------------------------------------------------------------------------
+
+describe("listInstallations", () => {
+  test("returns user + org installations with typed fields", async () => {
+    const fetcher = mockFetch([
+      {
+        match: (u) => u.includes("/user/installations"),
+        response: {
+          ok: true,
+          status: 200,
+          body: {
+            total_count: 2,
+            installations: [
+              {
+                id: 101,
+                app_slug: "parachute-computer",
+                account: { login: "aaron", type: "User" },
+                repository_selection: "selected",
+              },
+              {
+                id: 202,
+                app_slug: "parachute-computer",
+                account: { login: "unforced-org", type: "Organization" },
+                repository_selection: "all",
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const installations = await listInstallations("ghu_test", fetcher);
+    expect(installations).toHaveLength(2);
+    expect(installations[0]!.id).toBe(101);
+    expect(installations[0]!.account.login).toBe("aaron");
+    expect(installations[0]!.account.type).toBe("User");
+    expect(installations[0]!.repository_selection).toBe("selected");
+    expect(installations[1]!.account.type).toBe("Organization");
+    expect(installations[1]!.app_slug).toBe("parachute-computer");
+  });
+
+  test("empty installations array = authorized but not installed", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: { ok: true, status: 200, body: { total_count: 0, installations: [] } },
+      },
+    ]);
+    const installations = await listInstallations("ghu_test", fetcher);
+    expect(installations).toEqual([]);
+  });
+
+  test("throws on a response missing the installations array", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: { ok: true, status: 200, body: { total_count: 0 } },
+      },
+    ]);
+    await expect(listInstallations("ghu_test", fetcher)).rejects.toThrow(
+      /missing installations array/,
+    );
+  });
+
+  test("throws on an item missing required fields", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: {
+          ok: true,
+          status: 200,
+          body: { total_count: 1, installations: [{ id: "not-a-number", account: null }] },
+        },
+      },
+    ]);
+    await expect(listInstallations("ghu_test", fetcher)).rejects.toThrow(
+      /missing required fields/,
+    );
+  });
+
+  test("throws GitHubApiError carrying the status on non-2xx", async () => {
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: { ok: false, status: 401, body: { message: "Bad credentials" } },
+      },
+    ]);
+    try {
+      await listInstallations("ghu_revoked", fetcher);
+      throw new Error("expected listInstallations to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubApiError);
+      expect((err as GitHubApiError).status).toBe(401);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listInstallationRepos
+// ---------------------------------------------------------------------------
+
+function installationRepoItem(i: number, owner = "aaron"): Record<string, unknown> {
+  return {
+    name: `repo${i}`,
+    full_name: `${owner}/repo${i}`,
+    private: true,
+    html_url: `https://github.com/${owner}/repo${i}`,
+    description: null,
+    updated_at: "2026-06-10T00:00:00Z",
+    clone_url: `https://github.com/${owner}/repo${i}.git`,
+    owner: { login: owner },
+  };
+}
+
+describe("listInstallationRepos", () => {
+  test("single page returns GitHubRepoInfo shapes from the installation", async () => {
+    const fetcher = mockFetch([
+      {
+        match: (u) => u.includes("/user/installations/101/repositories") && u.includes("page=1"),
+        response: {
+          ok: true,
+          status: 200,
+          body: { total_count: 1, repositories: [installationRepoItem(0)] },
+        },
+      },
+    ]);
+    const result = await listInstallationRepos("ghu_test", 101, { perPage: 100, maxPages: 3 }, fetcher);
+    expect(result.repos).toHaveLength(1);
+    expect(result.truncated).toBe(false);
+    expect(result.repos[0]!.full_name).toBe("aaron/repo0");
+    expect(result.repos[0]!.owner).toBe("aaron");
+    expect(result.repos[0]!.private).toBe(true);
+  });
+
+  test("paginates until a short page; truncates at the maxPages cap", async () => {
+    const fullPage = { total_count: 4, repositories: [installationRepoItem(0), installationRepoItem(1)] };
+    const fetcher = mockFetch([
+      { match: (u) => u.includes("page=1"), response: { ok: true, status: 200, body: fullPage } },
+      { match: (u) => u.includes("page=2"), response: { ok: true, status: 200, body: fullPage } },
+    ]);
+    const result = await listInstallationRepos("ghu_test", 7, { perPage: 2, maxPages: 2 }, fetcher);
+    expect(result.repos).toHaveLength(4);
+    expect(result.truncated).toBe(true);
+
+    // Short-page end: page 2 has fewer than perPage → untruncated.
+    const fetcher2 = mockFetch([
+      { match: (u) => u.includes("page=1"), response: { ok: true, status: 200, body: fullPage } },
+      {
+        match: (u) => u.includes("page=2"),
+        response: { ok: true, status: 200, body: { total_count: 3, repositories: [installationRepoItem(2)] } },
+      },
+    ]);
+    const result2 = await listInstallationRepos("ghu_test", 7, { perPage: 2, maxPages: 3 }, fetcher2);
+    expect(result2.repos).toHaveLength(3);
+    expect(result2.truncated).toBe(false);
+  });
+
+  test("throws on a response missing the repositories array", async () => {
+    const fetcher = mockFetch([
+      { match: () => true, response: { ok: true, status: 200, body: { total_count: 0 } } },
+    ]);
+    await expect(
+      listInstallationRepos("ghu_test", 101, {}, fetcher),
+    ).rejects.toThrow(/missing repositories array/);
+  });
+
+  test("throws GitHubApiError carrying the status on non-2xx", async () => {
+    const fetcher = mockFetch([
+      { match: () => true, response: { ok: false, status: 404, body: { message: "Not Found" } } },
+    ]);
+    try {
+      await listInstallationRepos("ghu_test", 999, {}, fetcher);
+      throw new Error("expected listInstallationRepos to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubApiError);
+      expect((err as GitHubApiError).status).toBe(404);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createRepo
 // ---------------------------------------------------------------------------
 
@@ -407,5 +635,29 @@ describe("createRepo", () => {
     await expect(
       createRepo("gho_test", { name: "exists" }, fetcher),
     ).rejects.toThrow(/already exists/);
+  });
+
+  test("403 (shared Contents-only app) throws GitHubApiError with status 403", async () => {
+    // POST /user/repos needs Administration:write — the shared app's
+    // expected failure. The route maps this status to the guided-manual
+    // error, so the status must survive the throw.
+    const fetcher = mockFetch([
+      {
+        match: () => true,
+        response: {
+          ok: false,
+          status: 403,
+          body: { message: "Resource not accessible by integration" },
+        },
+      },
+    ]);
+    try {
+      await createRepo("ghu_test", { name: "my-vault" }, fetcher);
+      throw new Error("expected createRepo to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubApiError);
+      expect((err as GitHubApiError).status).toBe(403);
+      expect((err as Error).message).toContain("Resource not accessible");
+    }
   });
 });

--- a/src/github-device-flow.ts
+++ b/src/github-device-flow.ts
@@ -30,6 +30,19 @@
  *     order-independent steps. A granted token reaches no repos until the
  *     operator also installs the app on their account and selects repos
  *     (github.com/apps/<app-slug>/installations/new).
+ *   - Every GitHub App can read ALL public repos — never infer "installed"
+ *     from repo visibility. `GET /user/installations` (which requires NO
+ *     permissions) is the canonical install probe: an empty array means
+ *     "authorized but not installed yet."
+ *
+ * **Bring-your-own-app (BYO)**: operators who want their own GitHub App
+ * (own rate-limit budget, full sovereignty) must override BOTH env vars as
+ * a pair — `PARACHUTE_GITHUB_CLIENT_ID` (their app's client_id, used for
+ * the device flow) AND `PARACHUTE_GITHUB_APP_SLUG` (their app's URL slug,
+ * used to build the install link). Overriding only one mixes two apps:
+ * tokens would be minted for one app while the install link points at the
+ * other, and `GET /user/installations` (which lists installations of the
+ * TOKEN's app) would never agree with the link.
  */
 
 // ---------------------------------------------------------------------------
@@ -62,6 +75,36 @@ export function getGithubClientId(): string {
  */
 export function isPlaceholderClientId(clientId: string): boolean {
   return clientId.includes("PLACEHOLDER");
+}
+
+// ---------------------------------------------------------------------------
+// App slug — the shared Parachute GitHub App's URL slug. Drives the install
+// link (github.com/apps/<slug>/installations/new), which the connect flow
+// surfaces when the operator is authorized-but-not-installed. BYO-app
+// operators override PARACHUTE_GITHUB_APP_SLUG *together with*
+// PARACHUTE_GITHUB_CLIENT_ID (see the header comment — the pair must come
+// from the same app).
+// ---------------------------------------------------------------------------
+
+export const GITHUB_APP_SLUG_DEFAULT = "parachute-computer" as const;
+
+/**
+ * The active app slug at runtime. Resolved from the env (the BYO-app path,
+ * paired with PARACHUTE_GITHUB_CLIENT_ID) or the shared-app default above.
+ */
+export function getGithubAppSlug(): string {
+  return process.env.PARACHUTE_GITHUB_APP_SLUG || GITHUB_APP_SLUG_DEFAULT;
+}
+
+/**
+ * The "install this app / pick repos" URL for an app slug. Installation is
+ * the second, separate step of the connect flow (authorization being the
+ * first); the same URL also serves "add another account/org" and "change
+ * repo selection" — GitHub routes already-installed accounts to the
+ * configure screen.
+ */
+export function installUrlForSlug(slug: string): string {
+  return `https://github.com/apps/${encodeURIComponent(slug)}/installations/new`;
 }
 
 // ---------------------------------------------------------------------------
@@ -117,6 +160,45 @@ export interface ListReposResult {
    *  we stopped paginating. Signals the UI to recommend the manual-URL
    *  paste or a search filter. */
   truncated: boolean;
+}
+
+/**
+ * One installation of the app, as returned by `GET /user/installations`.
+ * That endpoint lists installations OF THE TOKEN'S APP that the token's
+ * user can access — user-account installs and org installs alike — and
+ * requires NO permissions, so it works with the Contents-only shared app.
+ * An empty list means "authorized but not installed yet" (the device-flow
+ * grant alone reaches no repos).
+ */
+export interface GitHubInstallation {
+  id: number;
+  /** The app's URL slug (e.g. "parachute-computer"). Always this app's —
+   *  the endpoint is app-scoped by the token — but carried for display +
+   *  defensive checks. */
+  app_slug: string;
+  account: {
+    login: string;
+    /** "User" or "Organization". */
+    type: string;
+  };
+  /** "all" or "selected" — whether the installation covers every repo on
+   *  the account or an operator-picked subset. */
+  repository_selection: string;
+}
+
+/**
+ * Error thrown by the GitHub API helpers when GitHub returns a non-2xx
+ * response. Carries the HTTP status so route handlers can branch on
+ * specific failure classes (e.g. createRepo's 403 = the app lacks
+ * Administration:write) without string-matching the message.
+ */
+export class GitHubApiError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "GitHubApiError";
+    this.status = status;
+  }
 }
 
 /** Minimal fetch-like surface — injectable for tests. */
@@ -292,6 +374,13 @@ export async function fetchUser(
  * Truncates after `maxPages * perPage` repos (default 3 * 100 = 300) — most
  * operators have far fewer, the truncation signals the UI to prompt for a
  * search filter.
+ *
+ * **No longer the repo-picker source** (vault#480): `type=owner` excludes
+ * org-owned repos by construction, and with a GitHub-App token an
+ * uninstalled app still sees all PUBLIC repos — so this list silently
+ * misleads ("looks connected, shows the wrong repos"). The picker now goes
+ * `listInstallations` → `listInstallationRepos`, which enumerates exactly
+ * what the operator granted. Kept for non-picker callers.
  */
 export async function listRepos(
   token: string,
@@ -354,11 +443,171 @@ export async function listRepos(
   return { repos, truncated };
 }
 
+// ---------------------------------------------------------------------------
+// Installation APIs — the honest sources for the connect flow (vault#480).
+// ---------------------------------------------------------------------------
+
+/**
+ * List the token-user's installations of this app — `GET /user/installations`.
+ *
+ * Requires NO permissions (works with the Contents-only shared app), and is
+ * the canonical "is the app installed?" probe: an empty array means the
+ * operator authorized via device flow but hasn't installed the app on any
+ * account yet, so the token reaches no repos. Items cover both user-account
+ * and org installs, which is how org-owned mirror repos become reachable.
+ *
+ * Single page at per_page=100 — more than 100 installations of one app for
+ * one user is beyond any plausible operator; truncating there is acceptable.
+ *
+ * Throws `GitHubApiError` on a non-2xx response, plain Error on a bad shape.
+ */
+export async function listInstallations(
+  token: string,
+  fetchImpl: FetchLike = defaultFetch(),
+): Promise<GitHubInstallation[]> {
+  const res = await fetchImpl("https://api.github.com/user/installations?per_page=100", {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `token ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new GitHubApiError(
+      `GitHub /user/installations fetch failed (${res.status}): ${body.slice(0, 200)}`,
+      res.status,
+    );
+  }
+  const parsed = (await res.json()) as { installations?: unknown };
+  if (!parsed || !Array.isArray(parsed.installations)) {
+    throw new Error(
+      `GitHub /user/installations response missing installations array: ${JSON.stringify(parsed).slice(0, 200)}`,
+    );
+  }
+  const installations: GitHubInstallation[] = [];
+  for (const item of parsed.installations as Array<Record<string, unknown>>) {
+    const account = item.account as Record<string, unknown> | null | undefined;
+    if (
+      typeof item.id !== "number" ||
+      !account ||
+      typeof account.login !== "string" ||
+      typeof account.type !== "string"
+    ) {
+      throw new Error(
+        `GitHub /user/installations item missing required fields: ${JSON.stringify(item).slice(0, 200)}`,
+      );
+    }
+    installations.push({
+      id: item.id,
+      app_slug: typeof item.app_slug === "string" ? item.app_slug : "",
+      account: { login: account.login, type: account.type },
+      repository_selection:
+        typeof item.repository_selection === "string" ? item.repository_selection : "selected",
+    });
+  }
+  return installations;
+}
+
+/**
+ * Paginated list of the repos one installation grants access to —
+ * `GET /user/installations/{id}/repositories`. Metadata-read suffices (our
+ * Contents permission implies it); private repos within the installation
+ * are included, which is exactly the set the repo picker should show.
+ * Pagination + truncation semantics match `listRepos` (per_page=100,
+ * `maxPages` cap, `truncated` flag for the UI).
+ *
+ * Throws `GitHubApiError` on a non-2xx response, plain Error on a bad shape.
+ */
+export async function listInstallationRepos(
+  token: string,
+  installationId: number,
+  opts: { maxPages?: number; perPage?: number } = {},
+  fetchImpl: FetchLike = defaultFetch(),
+): Promise<ListReposResult> {
+  const perPage = opts.perPage ?? 100;
+  const maxPages = opts.maxPages ?? 3;
+  const repos: GitHubRepoInfo[] = [];
+  let truncated = false;
+  for (let page = 1; page <= maxPages; page++) {
+    const res = await fetchImpl(
+      `https://api.github.com/user/installations/${installationId}/repositories?per_page=${perPage}&page=${page}`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `token ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      throw new GitHubApiError(
+        `GitHub /user/installations/${installationId}/repositories fetch failed (${res.status}, page ${page}): ${body.slice(0, 200)}`,
+        res.status,
+      );
+    }
+    const parsed = (await res.json()) as { repositories?: unknown };
+    if (!parsed || !Array.isArray(parsed.repositories)) {
+      throw new Error(
+        `GitHub /user/installations/${installationId}/repositories response missing repositories array: ${JSON.stringify(parsed).slice(0, 200)}`,
+      );
+    }
+    const items = parsed.repositories as Array<{
+      name: string;
+      full_name: string;
+      private: boolean;
+      html_url: string;
+      description: string | null;
+      updated_at: string;
+      clone_url: string;
+      owner: { login: string };
+    }>;
+    for (const item of items) {
+      if (
+        typeof item.name !== "string" ||
+        typeof item.full_name !== "string" ||
+        !item.owner ||
+        typeof item.owner.login !== "string"
+      ) {
+        throw new Error(
+          `GitHub /user/installations/${installationId}/repositories item missing required fields: ${JSON.stringify(item).slice(0, 200)}`,
+        );
+      }
+      repos.push({
+        owner: item.owner.login,
+        name: item.name,
+        full_name: item.full_name,
+        private: item.private,
+        html_url: item.html_url,
+        description: item.description,
+        updated_at: item.updated_at,
+        clone_url: item.clone_url,
+      });
+    }
+    // No more pages.
+    if (items.length < perPage) {
+      return { repos, truncated: false };
+    }
+    if (page === maxPages) {
+      truncated = true;
+    }
+  }
+  return { repos, truncated };
+}
+
 /**
  * Create a new repo on the authenticated user's account. Defaults to private
  * because the operator's vault is more likely sensitive than public. The
  * repo gets initialized empty (no README) so the first `git push` from the
  * mirror lands the operator's vault as commit 1.
+ *
+ * **403 with the shared app is EXPECTED** (vault#480): `POST /user/repos`
+ * requires the Administration repository permission (write); the shared
+ * Parachute app is frozen at Contents-only, so this call only succeeds for
+ * BYO-app operators whose app grants Administration:write. Throws
+ * `GitHubApiError` carrying the status so the route can map the 403 to the
+ * guided-manual-creation error rather than a generic failure.
  */
 export async function createRepo(
   token: string,
@@ -388,8 +637,9 @@ export async function createRepo(
     } catch {
       // not JSON
     }
-    throw new Error(
+    throw new GitHubApiError(
       `GitHub /user/repos create failed (${res.status}): ${parsed.message ?? body.slice(0, 200)}`,
+      res.status,
     );
   }
   const item = (await res.json()) as {

--- a/src/github-device-flow.ts
+++ b/src/github-device-flow.ts
@@ -380,7 +380,9 @@ export async function fetchUser(
  * uninstalled app still sees all PUBLIC repos — so this list silently
  * misleads ("looks connected, shows the wrong repos"). The picker now goes
  * `listInstallations` → `listInstallationRepos`, which enumerates exactly
- * what the operator granted. Kept for non-picker callers.
+ * what the operator granted. No production callers remain — kept exported
+ * for its test coverage and as a building block for potential external /
+ * non-App callers.
  */
 export async function listRepos(
   token: string,

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -27,6 +27,7 @@ import {
   handleAuthGet,
   handleAuthGithubCreateRepo,
   handleAuthGithubDeviceCode,
+  handleAuthGithubInstallations,
   handleAuthGithubPoll,
   handleAuthGithubRepos,
   handleAuthGithubSelectRepo,
@@ -728,6 +729,12 @@ describe("auth credential routes — device flow", () => {
     expect(saved?.active_method).toBe("github_oauth");
     expect(saved?.github_oauth?.access_token).toBe("gho_real1234567890");
     expect(saved?.github_oauth?.user_login).toBe("aaron");
+    // vault#483: the grant also carries the history-on-link outcome (the
+    // dedicated branches are covered in the "history-on-link" describe).
+    expect("history_enabled" in (grantBody as Record<string, unknown>)).toBe(true);
+    // The grant may have started the mirror lifecycle (history-on-link) —
+    // tear it down so no safety-net timer outlives the test.
+    await manager.stop();
   });
 });
 
@@ -986,14 +993,14 @@ describe("auth credential routes — github repos / create-repo", () => {
     expect(res.status).toBe(400);
   });
 
-  test("repos returns list when authed", async () => {
+  test("repos lists from the installation (vault#480) — installed:true + account annotation", async () => {
     home = tmp("mirror-auth-repos-ok-");
     const { manager } = makeManager(home);
     writeCredentials("default", {
       active_method: "github_oauth",
       github_oauth: {
-        access_token: "gho_test1234567890",
-        scope: "repo",
+        access_token: "ghu_test1234567890",
+        scope: "",
         authorized_at: "2026-05-28T03:14:15.000Z",
         user_login: "aaron",
         user_id: 1,
@@ -1002,26 +1009,219 @@ describe("auth credential routes — github repos / create-repo", () => {
     });
     const fetcher = buildMockFetch([
       {
-        match: (u) => u.includes("/user/repos"),
-        body: [
-          {
-            name: "a",
-            full_name: "aaron/a",
-            private: true,
-            html_url: "https://github.com/aaron/a",
-            description: null,
-            updated_at: "2026-05-28T00:00:00Z",
-            clone_url: "https://github.com/aaron/a.git",
-            owner: { login: "aaron" },
-          },
-        ],
+        match: (u) => u.includes("/user/installations?"),
+        body: {
+          total_count: 1,
+          installations: [
+            {
+              id: 101,
+              app_slug: "parachute-computer",
+              account: { login: "aaron", type: "User" },
+              repository_selection: "selected",
+            },
+          ],
+        },
+      },
+      {
+        match: (u) => u.includes("/user/installations/101/repositories"),
+        body: {
+          total_count: 1,
+          repositories: [
+            {
+              name: "a",
+              full_name: "aaron/a",
+              private: true,
+              html_url: "https://github.com/aaron/a",
+              description: null,
+              updated_at: "2026-05-28T00:00:00Z",
+              clone_url: "https://github.com/aaron/a.git",
+              owner: { login: "aaron" },
+            },
+          ],
+        },
       },
     ]);
     const res = await handleAuthGithubRepos(manager, fetcher);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { repos: Array<{ full_name: string }> };
+    const body = (await res.json()) as {
+      installed: boolean;
+      truncated: boolean;
+      repos: Array<{ full_name: string; account_login: string; installation_id: number }>;
+    };
+    expect(body.installed).toBe(true);
+    expect(body.truncated).toBe(false);
     expect(body.repos).toHaveLength(1);
     expect(body.repos[0]!.full_name).toBe("aaron/a");
+    expect(body.repos[0]!.account_login).toBe("aaron");
+    expect(body.repos[0]!.installation_id).toBe(101);
+  });
+
+  test("repos unions multiple installations (user + org) with per-repo annotation", async () => {
+    // The org-repos blind spot Aaron hit live: GET /user/repos?type=owner
+    // excluded org-owned repos by construction. The installations source
+    // enumerates both.
+    home = tmp("mirror-auth-repos-multi-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "ghu_test1234567890",
+        scope: "",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+    const repoItem = (owner: string, name: string) => ({
+      name,
+      full_name: `${owner}/${name}`,
+      private: true,
+      html_url: `https://github.com/${owner}/${name}`,
+      description: null,
+      updated_at: "2026-06-10T00:00:00Z",
+      clone_url: `https://github.com/${owner}/${name}.git`,
+      owner: { login: owner },
+    });
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/installations?"),
+        body: {
+          total_count: 2,
+          installations: [
+            {
+              id: 101,
+              app_slug: "parachute-computer",
+              account: { login: "aaron", type: "User" },
+              repository_selection: "selected",
+            },
+            {
+              id: 202,
+              app_slug: "parachute-computer",
+              account: { login: "unforced-org", type: "Organization" },
+              repository_selection: "selected",
+            },
+          ],
+        },
+      },
+      {
+        match: (u) => u.includes("/user/installations/101/repositories"),
+        body: { total_count: 1, repositories: [repoItem("aaron", "personal-vault")] },
+      },
+      {
+        match: (u) => u.includes("/user/installations/202/repositories"),
+        body: { total_count: 1, repositories: [repoItem("unforced-org", "team-vault")] },
+      },
+    ]);
+    const res = await handleAuthGithubRepos(manager, fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      installed: boolean;
+      repos: Array<{ full_name: string; account_login: string; installation_id: number }>;
+    };
+    expect(body.installed).toBe(true);
+    expect(body.repos).toHaveLength(2);
+    expect(body.repos[0]!.full_name).toBe("aaron/personal-vault");
+    expect(body.repos[0]!.account_login).toBe("aaron");
+    expect(body.repos[0]!.installation_id).toBe(101);
+    expect(body.repos[1]!.full_name).toBe("unforced-org/team-vault");
+    expect(body.repos[1]!.account_login).toBe("unforced-org");
+    expect(body.repos[1]!.installation_id).toBe(202);
+  });
+
+  test("repos returns the machine-readable not_installed state when authorized but not installed", async () => {
+    home = tmp("mirror-auth-repos-notinstalled-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "ghu_test1234567890",
+        scope: "",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/installations?"),
+        body: { total_count: 0, installations: [] },
+      },
+    ]);
+    const res = await handleAuthGithubRepos(manager, fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      installed: boolean;
+      install_url: string;
+      repos: unknown[];
+      truncated: boolean;
+    };
+    expect(body.installed).toBe(false);
+    expect(body.install_url).toBe(
+      "https://github.com/apps/parachute-computer/installations/new",
+    );
+    expect(body.repos).toEqual([]);
+    expect(body.truncated).toBe(false);
+  });
+
+  test("repos carries truncated:true when an installation hits the page cap", async () => {
+    home = tmp("mirror-auth-repos-trunc-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "ghu_test1234567890",
+        scope: "",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+    // The route calls listInstallationRepos with defaults (perPage=100,
+    // maxPages=3): serve 3 FULL pages of 100 so the cap trips.
+    const fullPage = (page: number) => ({
+      total_count: 1000,
+      repositories: Array.from({ length: 100 }, (_, i) => {
+        const n = page * 100 + i;
+        return {
+          name: `r${n}`,
+          full_name: `aaron/r${n}`,
+          private: false,
+          html_url: `https://github.com/aaron/r${n}`,
+          description: null,
+          updated_at: "2026-06-10T00:00:00Z",
+          clone_url: `https://github.com/aaron/r${n}.git`,
+          owner: { login: "aaron" },
+        };
+      }),
+    });
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/installations?"),
+        body: {
+          total_count: 1,
+          installations: [
+            {
+              id: 101,
+              app_slug: "parachute-computer",
+              account: { login: "aaron", type: "User" },
+              repository_selection: "all",
+            },
+          ],
+        },
+      },
+      { match: (u) => u.includes("/repositories") && u.includes("page=1"), body: fullPage(0) },
+      { match: (u) => u.includes("/repositories") && u.includes("page=2"), body: fullPage(1) },
+      { match: (u) => u.includes("/repositories") && u.includes("page=3"), body: fullPage(2) },
+    ]);
+    const res = await handleAuthGithubRepos(manager, fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { installed: boolean; truncated: boolean; repos: unknown[] };
+    expect(body.installed).toBe(true);
+    expect(body.truncated).toBe(true);
+    expect(body.repos).toHaveLength(300);
   });
 
   test("create-repo proxies through with mocked fetch", async () => {
@@ -1062,6 +1262,393 @@ describe("auth credential routes — github repos / create-repo", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { full_name: string };
     expect(body.full_name).toBe("aaron/new-vault");
+  });
+
+  test("create-repo maps GitHub's 403 to app_lacks_admin_permission + the guided-manual path (vault#480)", async () => {
+    // Expected with the shared Contents-only app: POST /user/repos needs
+    // Administration:write. The response must be actionable + machine-
+    // readable, not a generic 502.
+    home = tmp("mirror-auth-create-repo-403-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "ghu_test1234567890",
+        scope: "",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/repos"),
+        status: 403,
+        body: { message: "Resource not accessible by integration" },
+      },
+    ]);
+    const req = new Request("http://x/create", {
+      method: "POST",
+      body: JSON.stringify({ name: "new-vault" }),
+    });
+    const res = await handleAuthGithubCreateRepo(req, manager, fetcher);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error_type: string; message: string };
+    expect(body.error_type).toBe("app_lacks_admin_permission");
+    // Names the guided-manual path: create at github.com/new → add to the
+    // installation → refresh.
+    expect(body.message).toContain("github.com/new");
+    expect(body.message).toContain("installation");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /.parachute/mirror/auth/github/installations — install state (vault#480).
+// ---------------------------------------------------------------------------
+
+describe("auth credential routes — install state (GET /auth/github/installations)", () => {
+  let home: string;
+  afterEach(() => {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    delete process.env.PARACHUTE_GITHUB_CLIENT_ID;
+    delete process.env.PARACHUTE_GITHUB_APP_SLUG;
+  });
+
+  const oauthCreds = (): MirrorCredentials => ({
+    active_method: "github_oauth",
+    github_oauth: {
+      access_token: "ghu_test1234567890",
+      scope: "",
+      authorized_at: "2026-06-10T00:00:00.000Z",
+      user_login: "aaron",
+      user_id: 1,
+    },
+    pat: null,
+  });
+
+  test("401 github_not_connected when no github_oauth credential exists", async () => {
+    home = tmp("mirror-installstate-nocred-");
+    const { manager } = makeManager(home);
+    const res = await handleAuthGithubInstallations(manager);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error_type: string; message: string };
+    expect(body.error_type).toBe("github_not_connected");
+    expect(body.message).toContain("device flow");
+  });
+
+  test("authorized but not installed → installed:false + install_url, empty installations", async () => {
+    home = tmp("mirror-installstate-notinstalled-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", oauthCreds());
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/installations?"),
+        body: { total_count: 0, installations: [] },
+      },
+    ]);
+    const res = await handleAuthGithubInstallations(manager, fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      app: { client_id: string; slug: string; is_shared_default: boolean };
+      installed: boolean;
+      install_url: string;
+      installations: unknown[];
+    };
+    expect(body.installed).toBe(false);
+    expect(body.installations).toEqual([]);
+    expect(body.install_url).toBe(
+      "https://github.com/apps/parachute-computer/installations/new",
+    );
+    expect(body.app.slug).toBe("parachute-computer");
+    expect(body.app.client_id).toBe("Iv23livaRF4VcvPhu3uB");
+    expect(body.app.is_shared_default).toBe(true);
+  });
+
+  test("installed on a user account AND an org → both surfaced", async () => {
+    home = tmp("mirror-installstate-installed-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", oauthCreds());
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/installations?"),
+        body: {
+          total_count: 2,
+          installations: [
+            {
+              id: 101,
+              app_slug: "parachute-computer",
+              account: { login: "aaron", type: "User" },
+              repository_selection: "selected",
+            },
+            {
+              id: 202,
+              app_slug: "parachute-computer",
+              account: { login: "unforced-org", type: "Organization" },
+              repository_selection: "all",
+            },
+          ],
+        },
+      },
+    ]);
+    const res = await handleAuthGithubInstallations(manager, fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      installed: boolean;
+      installations: Array<{
+        id: number;
+        account_login: string;
+        account_type: string;
+        repository_selection: string;
+      }>;
+    };
+    expect(body.installed).toBe(true);
+    expect(body.installations).toHaveLength(2);
+    expect(body.installations[0]).toEqual({
+      id: 101,
+      account_login: "aaron",
+      account_type: "User",
+      repository_selection: "selected",
+    });
+    expect(body.installations[1]).toEqual({
+      id: 202,
+      account_login: "unforced-org",
+      account_type: "Organization",
+      repository_selection: "all",
+    });
+  });
+
+  test("BYO-app env overrides are reflected in the app block (is_shared_default false)", async () => {
+    home = tmp("mirror-installstate-byo-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", oauthCreds());
+    process.env.PARACHUTE_GITHUB_CLIENT_ID = "Iv1.byoclient";
+    process.env.PARACHUTE_GITHUB_APP_SLUG = "my-own-app";
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/installations?"),
+        body: { total_count: 0, installations: [] },
+      },
+    ]);
+    const res = await handleAuthGithubInstallations(manager, fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      app: { client_id: string; slug: string; is_shared_default: boolean };
+      install_url: string;
+    };
+    expect(body.app.client_id).toBe("Iv1.byoclient");
+    expect(body.app.slug).toBe("my-own-app");
+    expect(body.app.is_shared_default).toBe(false);
+    expect(body.install_url).toBe("https://github.com/apps/my-own-app/installations/new");
+  });
+
+  test("502 when GitHub is unreachable / errors", async () => {
+    home = tmp("mirror-installstate-apierr-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", oauthCreds());
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/installations?"),
+        status: 401,
+        body: { message: "Bad credentials" },
+      },
+    ]);
+    const res = await handleAuthGithubInstallations(manager, fetcher);
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Installation check failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// vault#483 fix 1 — history-on-link (credential save enables history for a
+// never-configured vault; explicit operator choices are respected).
+//
+// Managers here are wired to the REAL per-vault mirror-config file (the
+// makeSyncManager pattern) because the never-configured branch keys off the
+// file's existence — the in-memory makeManager deps would diverge from what
+// maybeEnableHistoryOnLink reads.
+// ---------------------------------------------------------------------------
+
+describe("history-on-link (vault#483)", () => {
+  let home: string;
+  let manager: MirrorManager;
+  afterEach(async () => {
+    if (manager) await manager.stop();
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+    _resetDeviceFlowSessionsForTest();
+  });
+
+  /** Run the device flow to `granted` against a mocked GitHub. */
+  async function grantDeviceFlow(mgr: MirrorManager): Promise<{
+    state: string;
+    history_enabled: true | false | "left_disabled";
+  }> {
+    const fetchCode = buildMockFetch([
+      {
+        match: (u) => u.includes("/login/device/code"),
+        body: {
+          device_code: "dev_xyz",
+          user_code: "ABCD-1234",
+          verification_uri: "https://github.com/login/device",
+          expires_in: 900,
+          interval: 5,
+        },
+      },
+    ]);
+    const codeRes = await handleAuthGithubDeviceCode(fetchCode);
+    expect(codeRes.status).toBe(200);
+    const { polling_id } = (await codeRes.json()) as { polling_id: string };
+    const fetchGranted = buildMockFetch([
+      {
+        match: (u) => u.includes("/login/oauth/access_token"),
+        body: { access_token: "ghu_granted1234567890", scope: "", token_type: "bearer" },
+      },
+      {
+        match: (u) => u.includes("/user"),
+        body: { login: "aaron", id: 12345, name: "Aaron G" },
+      },
+    ]);
+    const grantRes = await handleAuthGithubPoll(
+      new Request("http://x/poll", { method: "POST", body: JSON.stringify({ polling_id }) }),
+      mgr,
+      fetchGranted,
+    );
+    expect(grantRes.status).toBe(200);
+    return (await grantRes.json()) as {
+      state: string;
+      history_enabled: true | false | "left_disabled";
+    };
+  }
+
+  test("device-flow grant on a never-configured vault enables history with the standard defaults", async () => {
+    home = tmp("history-link-fresh-");
+    manager = makeSyncManager(home);
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+
+    const body = await grantDeviceFlow(manager);
+    expect(body.state).toBe("granted");
+    expect(body.history_enabled).toBe(true);
+
+    // Config file now exists with the standard internal-mirror defaults.
+    const cfg = readMirrorConfigForVault("default");
+    expect(cfg?.enabled).toBe(true);
+    expect(cfg?.location).toBe("internal");
+    expect(cfg?.sync_mode).toBe("events");
+    expect(cfg?.auto_commit).toBe(true);
+    // auto_push stays OFF at link time — no repo picked yet; select-repo's
+    // Cut 3 flips it once a remote exists.
+    expect(cfg?.auto_push).toBe(false);
+    // And the mirror actually started.
+    expect(manager.getStatus().enabled).toBe(true);
+  });
+
+  test("device-flow grant does NOT flip an explicitly-disabled mirror; flags left_disabled", async () => {
+    home = tmp("history-link-disabled-");
+    manager = makeSyncManager(home);
+    writeMirrorConfigForVault("default", {
+      ...defaultMirrorConfig(),
+      enabled: false,
+    });
+
+    const body = await grantDeviceFlow(manager);
+    expect(body.state).toBe("granted");
+    expect(body.history_enabled).toBe("left_disabled");
+
+    // The operator's explicit choice survives untouched.
+    const cfg = readMirrorConfigForVault("default");
+    expect(cfg?.enabled).toBe(false);
+    expect(manager.getStatus().enabled).toBe(false);
+  });
+
+  test("device-flow grant leaves an already-enabled mirror untouched (history_enabled true)", async () => {
+    home = tmp("history-link-enabled-");
+    manager = makeSyncManager(home);
+    // Non-default field values so "untouched" is distinguishable from
+    // "rewritten with defaults."
+    writeMirrorConfigForVault("default", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      sync_mode: "manual",
+      auto_commit: false,
+      safety_net_seconds: 120,
+    });
+
+    const body = await grantDeviceFlow(manager);
+    expect(body.state).toBe("granted");
+    expect(body.history_enabled).toBe(true);
+
+    const cfg = readMirrorConfigForVault("default");
+    expect(cfg?.enabled).toBe(true);
+    expect(cfg?.sync_mode).toBe("manual");
+    expect(cfg?.auto_commit).toBe(false);
+    expect(cfg?.safety_net_seconds).toBe(120);
+  });
+
+  test("PAT save on a never-configured vault enables history, then Cut 3 flips auto_push (remote known)", async () => {
+    home = tmp("history-link-pat-fresh-");
+    manager = makeSyncManager(home);
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+
+    // probeOverride bypasses the real `git ls-remote`; 127.0.0.1:1 keeps the
+    // post-save initial push hermetic (instant connection refusal — never a
+    // real GitHub round-trip).
+    const res = await handleAuthPat(
+      new Request("http://x/pat", {
+        method: "POST",
+        body: JSON.stringify({
+          token: "ghp_link_test_token_123",
+          remote_url: "https://127.0.0.1:1/owner/repo.git",
+        }),
+      }),
+      manager,
+      async () => ({ ok: true }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      history_enabled: true | false | "left_disabled";
+      auto_push_enabled: boolean;
+    };
+    expect(body.history_enabled).toBe(true);
+    // PAT carries the remote, so the full chain runs: history on → Cut 3
+    // flips auto_push on the now-enabled mirror.
+    expect(body.auto_push_enabled).toBe(true);
+    const cfg = readMirrorConfigForVault("default");
+    expect(cfg?.enabled).toBe(true);
+    expect(cfg?.auto_push).toBe(true);
+    // No token leak.
+    expect(JSON.stringify(body)).not.toContain("ghp_link_test_token_123");
+  }, 30_000);
+
+  test("PAT save respects an explicitly-disabled mirror (left_disabled; auto_push untouched)", async () => {
+    home = tmp("history-link-pat-disabled-");
+    manager = makeSyncManager(home);
+    writeMirrorConfigForVault("default", {
+      ...defaultMirrorConfig(),
+      enabled: false,
+    });
+
+    const res = await handleAuthPat(
+      new Request("http://x/pat", {
+        method: "POST",
+        body: JSON.stringify({
+          token: "ghp_link_test_token_456",
+          remote_url: "https://127.0.0.1:1/owner/repo.git",
+        }),
+      }),
+      manager,
+      async () => ({ ok: true }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      history_enabled: true | false | "left_disabled";
+      auto_push_enabled: boolean;
+    };
+    expect(body.history_enabled).toBe("left_disabled");
+    expect(body.auto_push_enabled).toBe(false);
+    const cfg = readMirrorConfigForVault("default");
+    expect(cfg?.enabled).toBe(false);
+    expect(cfg?.auto_push).toBe(false);
   });
 });
 

--- a/src/mirror-routes.test.ts
+++ b/src/mirror-routes.test.ts
@@ -848,6 +848,19 @@ describe("auth credential routes — credential-save side-effects (Cuts 3 + 6)",
       auto_commit: false,
       auto_push: false,
     });
+    // Mirror the in-memory deps config into the REAL per-vault file:
+    // select-repo now runs maybeEnableHistoryOnLink (PR #484 fold), whose
+    // never-configured branch keys off the file's existence — without it
+    // the helper would see "never configured" and clobber this test's
+    // config with defaults.
+    writeMirrorConfigForVault("default", {
+      ...defaultMirrorConfig(),
+      enabled: true,
+      location: "internal",
+      sync_mode: "manual",
+      auto_commit: false,
+      auto_push: false,
+    });
     await manager.start();
     expect(manager.getConfig().auto_push).toBe(false);
 
@@ -905,6 +918,14 @@ describe("auth credential routes — credential-save side-effects (Cuts 3 + 6)",
     home = tmp("mirror-selectrepo-disabled-");
     const { manager, deps } = makeManager(home);
     deps.writeMirrorConfig({
+      ...defaultMirrorConfig(),
+      enabled: false,
+      auto_push: false,
+    });
+    // Real file too — select-repo's history-on-link (PR #484 fold) must
+    // see this as an EXPLICIT enabled:false (left_disabled), not as a
+    // never-configured vault it should enable.
+    writeMirrorConfigForVault("default", {
       ...defaultMirrorConfig(),
       enabled: false,
       auto_push: false,
@@ -1129,6 +1150,67 @@ describe("auth credential routes — github repos / create-repo", () => {
     expect(body.repos[1]!.installation_id).toBe(202);
   });
 
+  test("repos are sorted most-recently-updated first within each account group", async () => {
+    // The installation-repositories endpoint has no `sort` param (the old
+    // GET /user/repos?sort=updated source did) — the handler sorts each
+    // group itself so the repo the operator probably wants is near the top.
+    home = tmp("mirror-auth-repos-sorted-");
+    const { manager } = makeManager(home);
+    writeCredentials("default", {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "ghu_test1234567890",
+        scope: "",
+        authorized_at: "2026-05-28T03:14:15.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+    const repoItem = (name: string, updated_at: string) => ({
+      name,
+      full_name: `aaron/${name}`,
+      private: true,
+      html_url: `https://github.com/aaron/${name}`,
+      description: null,
+      updated_at,
+      clone_url: `https://github.com/aaron/${name}.git`,
+      owner: { login: "aaron" },
+    });
+    const fetcher = buildMockFetch([
+      {
+        match: (u) => u.includes("/user/installations?"),
+        body: {
+          total_count: 1,
+          installations: [
+            {
+              id: 101,
+              app_slug: "parachute-computer",
+              account: { login: "aaron", type: "User" },
+              repository_selection: "all",
+            },
+          ],
+        },
+      },
+      {
+        match: (u) => u.includes("/user/installations/101/repositories"),
+        body: {
+          total_count: 3,
+          // Alphabetical wire order (GitHub's default) — NOT recency.
+          repositories: [
+            repoItem("alpha", "2026-01-01T00:00:00Z"),
+            repoItem("beta", "2026-06-09T00:00:00Z"),
+            repoItem("gamma", "2026-03-15T00:00:00Z"),
+          ],
+        },
+      },
+    ]);
+    const res = await handleAuthGithubRepos(manager, fetcher);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { repos: Array<{ name: string }> };
+    expect(body.repos.map((r) => r.name)).toEqual(["beta", "gamma", "alpha"]);
+  });
+
   test("repos returns the machine-readable not_installed state when authorized but not installed", async () => {
     home = tmp("mirror-auth-repos-notinstalled-");
     const { manager } = makeManager(home);
@@ -1327,11 +1409,14 @@ describe("auth credential routes — install state (GET /auth/github/installatio
     pat: null,
   });
 
-  test("401 github_not_connected when no github_oauth credential exists", async () => {
+  test("400 github_not_connected when no github_oauth credential exists", async () => {
+    // 400, not 401, matching the sibling repos handler — a 401 would trip
+    // the SPA's authedFetch token-refresh machinery (clearing a valid
+    // cached admin token) over a condition that isn't an auth failure.
     home = tmp("mirror-installstate-nocred-");
     const { manager } = makeManager(home);
     const res = await handleAuthGithubInstallations(manager);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { error_type: string; message: string };
     expect(body.error_type).toBe("github_not_connected");
     expect(body.message).toContain("device flow");
@@ -1644,6 +1729,91 @@ describe("history-on-link (vault#483)", () => {
       history_enabled: true | false | "left_disabled";
       auto_push_enabled: boolean;
     };
+    expect(body.history_enabled).toBe("left_disabled");
+    expect(body.auto_push_enabled).toBe(false);
+    const cfg = readMirrorConfigForVault("default");
+    expect(cfg?.enabled).toBe(false);
+    expect(cfg?.auto_push).toBe(false);
+  });
+
+  /** Seed a stored github_oauth credential — the select-repo precondition.
+   *  Models a credential saved BEFORE history-on-link existed: the operator
+   *  re-enters via "Choose repository…" without a fresh grant. */
+  function seedOauthCredential(): void {
+    writeCredentials("default", {
+      active_method: "github_oauth",
+      github_oauth: {
+        access_token: "gho_selectrepo1234567890",
+        scope: "repo",
+        authorized_at: "2026-06-10T00:00:00.000Z",
+        user_login: "aaron",
+        user_id: 1,
+      },
+      pat: null,
+    });
+  }
+
+  test("select-repo on a never-configured vault enables history + carries history_enabled (PR #484 fold)", async () => {
+    // The #483 re-entry gap: a credential saved pre-history-on-link on a
+    // never-configured vault. The grant/PAT paths never ran for this
+    // config, so select-repo is the first linked action — it must wire
+    // history (before auto_push, which no-ops on a disabled mirror).
+    home = tmp("history-link-selectrepo-fresh-");
+    manager = makeSyncManager(home);
+    fs.mkdirSync(path.join(home, "vault", "data", "default"), { recursive: true });
+    seedOauthCredential();
+    expect(readMirrorConfigForVault("default")).toBeUndefined();
+
+    const res = await handleAuthGithubSelectRepo(
+      new Request("http://x/select", {
+        method: "POST",
+        body: JSON.stringify({ owner: "aaron", name: "my-vault" }),
+      }),
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      history_enabled: true | false | "left_disabled";
+      auto_push_enabled: boolean;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.history_enabled).toBe(true);
+    // History first, so the full chain runs: enabled mirror → Cut 3 flips
+    // auto_push (the PAT handler's ordering, mirrored).
+    expect(body.auto_push_enabled).toBe(true);
+    const cfg = readMirrorConfigForVault("default");
+    expect(cfg?.enabled).toBe(true);
+    expect(cfg?.location).toBe("internal");
+    expect(cfg?.auto_push).toBe(true);
+    expect(manager.getStatus().enabled).toBe(true);
+    // No token leak.
+    expect(JSON.stringify(body)).not.toContain("gho_selectrepo1234567890");
+  }, 30_000);
+
+  test("select-repo respects an explicitly-disabled mirror (left_disabled; stays off)", async () => {
+    home = tmp("history-link-selectrepo-disabled-");
+    manager = makeSyncManager(home);
+    writeMirrorConfigForVault("default", {
+      ...defaultMirrorConfig(),
+      enabled: false,
+    });
+    seedOauthCredential();
+
+    const res = await handleAuthGithubSelectRepo(
+      new Request("http://x/select", {
+        method: "POST",
+        body: JSON.stringify({ owner: "aaron", name: "my-vault" }),
+      }),
+      manager,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      history_enabled: true | false | "left_disabled";
+      auto_push_enabled: boolean;
+    };
+    // The operator's explicit choice survives — the UI gets the one-click
+    // "Turn on history now?" offer instead of a silent flip.
     expect(body.history_enabled).toBe("left_disabled");
     expect(body.auto_push_enabled).toBe(false);
     const cfg = readMirrorConfigForVault("default");

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -868,9 +868,12 @@ export async function handleAuthDelete(manager: MirrorManager): Promise<Response
  *     install_url: string,           // github.com/apps/<slug>/installations/new
  *     installations: [{ id, account_login, account_type, repository_selection }]
  *   }
- *   401 { error, error_type: "github_not_connected", message } — no stored
+ *   400 { error, error_type: "github_not_connected", message } — no stored
  *       github_oauth credential; the device flow hasn't been run (or a PAT
- *       is active instead — install state is a GitHub-App concept).
+ *       is active instead — install state is a GitHub-App concept). 400,
+ *       not 401, matching the sibling repos handler: a 401 here would trip
+ *       the SPA's authedFetch token-refresh machinery and clear a
+ *       perfectly valid cached admin token over a non-auth condition.
  *   502 { error, message } — GitHub unreachable / API error.
  */
 export async function handleAuthGithubInstallations(
@@ -886,7 +889,7 @@ export async function handleAuthGithubInstallations(
         message:
           "No GitHub sign-in is stored for this vault. Run the device flow first (POST /.parachute/mirror/auth/github/device-code).",
       },
-      { status: 401 },
+      { status: 400 },
     );
   }
   const clientId = getGithubClientId();
@@ -994,7 +997,16 @@ export async function handleAuthGithubRepos(
   try {
     for (const installation of installations) {
       const result = await listInstallationRepos(token, installation.id, {}, fetchImpl);
-      for (const repo of result.repos) {
+      // `GET /user/installations/{id}/repositories` takes no `sort` param
+      // (unlike the old `GET /user/repos?sort=updated` picker source), so
+      // order within each account group ourselves: most-recently-updated
+      // first, so the repo the operator probably wants sits near the top.
+      // ISO-8601 timestamps compare lexicographically. Per-group (not
+      // across the union) so the SPA's account grouping stays contiguous.
+      const sorted = [...result.repos].sort((a, b) =>
+        b.updated_at.localeCompare(a.updated_at),
+      );
+      for (const repo of sorted) {
         repos.push({
           ...repo,
           account_login: installation.account.login,
@@ -1142,6 +1154,18 @@ export async function handleAuthGithubSelectRepo(
     name,
   );
 
+  // vault#483: linking implies backup intent — the choose-repo re-entry can
+  // be the FIRST credential-linked action for this vault (a credential saved
+  // before history-on-link existed, on a never-configured vault: the #483
+  // "linked but silently inert" state). Run history-on-link here too, BEFORE
+  // the Cut-3/Cut-6 steps below and mirroring handleAuthPat's ordering:
+  // history on (the reload's start() resolves mirror_path so the remote
+  // write below actually lands), then Cut 3 sees an enabled mirror and flips
+  // auto_push, then Cut 6 fires the initial push. An explicitly-disabled
+  // mirror short-circuits all of it (history stays off → maybeEnableAutoPush
+  // no-ops on disabled).
+  const history_enabled = await maybeEnableHistoryOnLink(manager);
+
   // Apply to the mirror dir if running. If the mirror isn't running (no
   // mirror_path), we still consider this a success — the credentials are
   // stored, and the URL will get applied next time the mirror starts.
@@ -1175,6 +1199,7 @@ export async function handleAuthGithubSelectRepo(
       // Echo the redacted form back so the SPA can show "pushing to <repo>".
       // No raw token in the response.
       remote: `https://github.com/${owner}/${name}.git`,
+      history_enabled,
       auto_push_was_already_enabled: autoPushChange.was_already_enabled,
       auto_push_enabled: autoPushChange.auto_push_now_enabled,
       initial_push: initialPush,

--- a/src/mirror-routes.ts
+++ b/src/mirror-routes.ts
@@ -24,8 +24,11 @@
  * hand + restarting the vault.
  */
 
+import { existsSync } from "node:fs";
+
 import {
   defaultMirrorConfig,
+  mirrorConfigPath,
   readMirrorConfigForVault,
   validateExternalPath,
   validateMirrorConfigShape,
@@ -46,11 +49,17 @@ import {
   type MirrorCredentials,
 } from "./mirror-credentials.ts";
 import {
+  GITHUB_APP_SLUG_DEFAULT,
+  GITHUB_CLIENT_ID_DEFAULT,
+  GitHubApiError,
   createRepo,
   fetchUser,
+  getGithubAppSlug,
   getGithubClientId,
+  installUrlForSlug,
   isPlaceholderClientId,
-  listRepos,
+  listInstallationRepos,
+  listInstallations,
   pollForToken,
   requestDeviceCode,
   type FetchLike,
@@ -298,9 +307,10 @@ export function buildMirrorGetResponse(
 }
 
 // ---------------------------------------------------------------------------
-// Credential routes — Cut 3 of the UI-configurable push credentials work.
+// Credential routes — Cut 3 of the UI-configurable push credentials work,
+// reshaped by the GitHub-App installation semantics (vault#480).
 //
-// Six surfaces, all `vault:<name>:admin`-gated upstream:
+// Surfaces, all `vault:<name>:admin`-gated upstream:
 //
 //   POST   /.parachute/mirror/auth/github/device-code  — start GitHub Device
 //          Flow; returns { polling_id, user_code, verification_uri, expires_in,
@@ -308,19 +318,29 @@ export function buildMirrorGetResponse(
 //          by polling_id (a short opaque token) so the device_code doesn't
 //          land on the wire twice.
 //   POST   /.parachute/mirror/auth/github/poll         — poll for token, body
-//          { polling_id }. On `granted`: fetch user, save credentials, set
-//          remote URL, return { state: "granted", user }. Other states
-//          surface verbatim.
+//          { polling_id }. On `granted`: fetch user, save credentials, enable
+//          history for a never-configured vault (vault#483), return
+//          { state: "granted", user, history_enabled }. Other states surface
+//          verbatim.
 //   POST   /.parachute/mirror/auth/pat                 — validate + store a
 //          PAT (token + remote_url + label). Validates via `git ls-remote`.
+//          Same history-on-link behavior as the poll grant (vault#483).
 //   GET    /.parachute/mirror/auth                     — current connection
-//          status (NO secrets). Returns the sanitized public shape.
+//          status (NO secrets, NO network). Returns the sanitized public shape.
 //   DELETE /.parachute/mirror/auth                     — wipe credentials,
 //          unset embedded-credential remote URL.
-//   GET    /.parachute/mirror/auth/github/repos        — list operator's
-//          GitHub repos via stored OAuth token.
+//   GET    /.parachute/mirror/auth/github/installations — install state
+//          (vault#480): which app, whether it's installed anywhere, the
+//          install link, and the per-account installations. The one
+//          explicitly-network status endpoint — `GET /auth` stays offline.
+//   GET    /.parachute/mirror/auth/github/repos        — list the repos the
+//          operator's app INSTALLATIONS grant (user + org accounts), via the
+//          stored OAuth token. Returns { installed: false, install_url,
+//          repos: [] } when the app isn't installed anywhere yet.
 //   POST   /.parachute/mirror/auth/github/create-repo  — create a new private
-//          repo on behalf of the operator.
+//          repo on behalf of the operator. 403s with the shared Contents-only
+//          app (mapped to error_type "app_lacks_admin_permission" + the
+//          guided-manual path); works for BYO apps with Administration:write.
 //
 // ---------------------------------------------------------------------------
 
@@ -517,12 +537,12 @@ export async function handleAuthGithubPoll(
     }
     // Clean up the polling session.
     deviceFlowSessions.delete(body.polling_id);
-    // Apply to git remote if mirror is currently running on an external
-    // path that's a git repo. The credentials become active on next push;
-    // the operator doesn't have to restart vault. We don't have an owner/
-    // repo yet (the operator hasn't picked a repo) — that wiring happens
-    // in the create-repo or repo-picked path. So at this point we just
-    // store credentials; the URL gets set when the operator picks a repo.
+    // vault#483: linking implies backup intent — enable history for a
+    // never-configured vault (consent-respecting; see the helper). No
+    // remote URL is set here — we don't have an owner/repo yet (the
+    // operator hasn't picked a repo); that wiring happens in select-repo,
+    // which is also where auto_push flips on (Cut 3).
+    const history_enabled = await maybeEnableHistoryOnLink(manager);
     return Response.json(
       {
         state: "granted",
@@ -532,6 +552,7 @@ export async function handleAuthGithubPoll(
           name: user.name,
           avatar_url: user.avatar_url,
         },
+        history_enabled,
       },
       { headers: { "Access-Control-Allow-Origin": "*" } },
     );
@@ -565,6 +586,14 @@ export async function handleAuthGithubPoll(
 export async function handleAuthPat(
   req: Request,
   manager: MirrorManager,
+  // Test seam for the `git ls-remote` validation probe (default
+  // `probeGitLsRemote`, which spawns real git against the supplied remote).
+  // Inject a fn returning `{ok: true}` to exercise the post-validation save
+  // path (credential persist + history-on-link, vault#483) hermetically.
+  probeOverride?: (
+    url: string,
+    timeoutMs: number,
+  ) => Promise<{ ok: boolean; error?: string }>,
 ): Promise<Response> {
   let body: { token?: unknown; remote_url?: unknown; label?: unknown };
   try {
@@ -659,7 +688,7 @@ export async function handleAuthPat(
           u.password = token;
           return u.toString();
         })();
-  const probeResult = await probeGitLsRemote(authedUrl, 10_000);
+  const probeResult = await (probeOverride ?? probeGitLsRemote)(authedUrl, 10_000);
   if (!probeResult.ok) {
     return Response.json(
       {
@@ -696,6 +725,15 @@ export async function handleAuthPat(
     );
   }
 
+  // vault#483: linking implies backup intent — enable history for a
+  // never-configured vault BEFORE the Cut-3/Cut-6 steps below, so a fresh
+  // vault gets the whole intended flow in one save: history on (the reload's
+  // start() applies the just-written PAT remote to `origin`), then Cut 3
+  // sees an enabled mirror and flips auto_push on, then Cut 6 fires the
+  // initial push. An explicitly-disabled mirror short-circuits all of it
+  // (history stays off → maybeEnableAutoPush no-ops on disabled).
+  const history_enabled = await maybeEnableHistoryOnLink(manager);
+
   // Push the new URL onto the mirror's git remote if it's currently
   // resolved + on disk. Non-fatal if the mirror isn't running.
   await applyCredentialsToMirror(manager);
@@ -715,6 +753,7 @@ export async function handleAuthPat(
   return Response.json(
     {
       ...sanitizeCredentials(next),
+      history_enabled,
       auto_push_was_already_enabled: autoPushChange.was_already_enabled,
       auto_push_enabled: autoPushChange.auto_push_now_enabled,
       initial_push: initialPush,
@@ -813,8 +852,99 @@ export async function handleAuthDelete(manager: MirrorManager): Promise<Response
 }
 
 /**
- * `GET /.parachute/mirror/auth/github/repos` — list operator's repos via
- * the stored OAuth token. Requires `active_method === "github_oauth"`.
+ * `GET /.parachute/mirror/auth/github/installations` — install state for
+ * the connect flow (vault#480). Answers three UI questions in one call:
+ * which app is in play (shared default vs BYO), is it installed ANYWHERE
+ * for this operator, and which accounts (user/orgs) carry installations.
+ *
+ * Deliberately a separate, explicitly-network endpoint: `GET /auth` stays
+ * a pure local read of the stored credential. The SPA calls this when it
+ * renders the connect flow / repo picker, not on every status poll.
+ *
+ * Response:
+ *   200 {
+ *     app: { client_id, slug, is_shared_default },
+ *     installed: boolean,            // installations.length > 0
+ *     install_url: string,           // github.com/apps/<slug>/installations/new
+ *     installations: [{ id, account_login, account_type, repository_selection }]
+ *   }
+ *   401 { error, error_type: "github_not_connected", message } — no stored
+ *       github_oauth credential; the device flow hasn't been run (or a PAT
+ *       is active instead — install state is a GitHub-App concept).
+ *   502 { error, message } — GitHub unreachable / API error.
+ */
+export async function handleAuthGithubInstallations(
+  manager: MirrorManager,
+  fetchImpl?: FetchLike,
+): Promise<Response> {
+  const creds = readCredentials(manager.getVaultName());
+  if (!creds || creds.active_method !== "github_oauth" || !creds.github_oauth) {
+    return Response.json(
+      {
+        error: "Not connected to GitHub",
+        error_type: "github_not_connected",
+        message:
+          "No GitHub sign-in is stored for this vault. Run the device flow first (POST /.parachute/mirror/auth/github/device-code).",
+      },
+      { status: 401 },
+    );
+  }
+  const clientId = getGithubClientId();
+  const slug = getGithubAppSlug();
+  let installations;
+  try {
+    installations = await listInstallations(creds.github_oauth.access_token, fetchImpl);
+  } catch (err) {
+    return Response.json(
+      {
+        error: "Installation check failed",
+        message: (err as Error).message ?? String(err),
+      },
+      { status: 502 },
+    );
+  }
+  return Response.json(
+    {
+      app: {
+        client_id: clientId,
+        slug,
+        is_shared_default:
+          clientId === GITHUB_CLIENT_ID_DEFAULT && slug === GITHUB_APP_SLUG_DEFAULT,
+      },
+      installed: installations.length > 0,
+      install_url: installUrlForSlug(slug),
+      installations: installations.map((i) => ({
+        id: i.id,
+        account_login: i.account.login,
+        account_type: i.account.type,
+        repository_selection: i.repository_selection,
+      })),
+    },
+    { headers: { "Access-Control-Allow-Origin": "*" } },
+  );
+}
+
+/**
+ * `GET /.parachute/mirror/auth/github/repos` — list the repos the
+ * operator's app installations grant, via the stored OAuth token. Requires
+ * `active_method === "github_oauth"`.
+ *
+ * Source (vault#480): `GET /user/installations` → per-installation
+ * `GET /user/installations/{id}/repositories`, unioned. This replaces the
+ * old `GET /user/repos?type=owner` source, which (a) excluded org-owned
+ * repos by construction and (b) showed all-public-repos when the app wasn't
+ * installed at all (every GitHub App reads public repos) — Aaron walked
+ * into exactly that "looks connected, shows the wrong repos" state live.
+ *
+ * Response:
+ *   200 installed:    { installed: true, repos: [{ ...GitHubRepoInfo,
+ *                       account_login, installation_id }], truncated }
+ *   200 not installed: { installed: false, install_url, repos: [],
+ *                       truncated: false } — machine-readable
+ *                       authorized-but-not-installed state; the UI shows
+ *                       the guided-install step, no string-matching needed.
+ *   400 { error, message } — no github_oauth credential stored.
+ *   502 { error, message } — GitHub unreachable / API error.
  */
 export async function handleAuthGithubRepos(
   manager: MirrorManager,
@@ -830,9 +960,49 @@ export async function handleAuthGithubRepos(
       { status: 400 },
     );
   }
-  let result;
+  const token = creds.github_oauth.access_token;
+  let installations;
   try {
-    result = await listRepos(creds.github_oauth.access_token, {}, fetchImpl);
+    installations = await listInstallations(token, fetchImpl);
+  } catch (err) {
+    return Response.json(
+      {
+        error: "Repo list failed",
+        message: (err as Error).message ?? String(err),
+      },
+      { status: 502 },
+    );
+  }
+
+  if (installations.length === 0) {
+    // Authorized but not installed — the device-flow grant alone reaches no
+    // repos. Distinct, machine-readable state (NOT an empty repo list that
+    // looks like "you have no repos").
+    return Response.json(
+      {
+        installed: false,
+        install_url: installUrlForSlug(getGithubAppSlug()),
+        repos: [],
+        truncated: false,
+      },
+      { headers: { "Access-Control-Allow-Origin": "*" } },
+    );
+  }
+
+  const repos: Array<GitHubRepoInfo & { account_login: string; installation_id: number }> = [];
+  let truncated = false;
+  try {
+    for (const installation of installations) {
+      const result = await listInstallationRepos(token, installation.id, {}, fetchImpl);
+      for (const repo of result.repos) {
+        repos.push({
+          ...repo,
+          account_login: installation.account.login,
+          installation_id: installation.id,
+        });
+      }
+      if (result.truncated) truncated = true;
+    }
   } catch (err) {
     return Response.json(
       {
@@ -843,7 +1013,7 @@ export async function handleAuthGithubRepos(
     );
   }
   return Response.json(
-    { repos: result.repos, truncated: result.truncated },
+    { installed: true, repos, truncated },
     { headers: { "Access-Control-Allow-Origin": "*" } },
   );
 }
@@ -852,6 +1022,15 @@ export async function handleAuthGithubRepos(
  * `POST /.parachute/mirror/auth/github/create-repo` — create a new repo on
  * the operator's account, return the new RepoInfo. The SPA flows straight
  * from this into the "repo selected" state.
+ *
+ * With the shared Parachute app this 403s by design (vault#480):
+ * `POST /user/repos` needs Administration:write; the shared app is frozen
+ * at Contents-only. The 403 maps to error_type "app_lacks_admin_permission"
+ * with the guided-manual path (create at github.com/new → add it to the
+ * installation → refresh the picker). The endpoint stays functional for
+ * BYO-app operators whose app grants Administration:write — and per the
+ * install docs, app-created repos auto-join the installation, so their
+ * create→push flow works end-to-end.
  */
 export async function handleAuthGithubCreateRepo(
   req: Request,
@@ -894,6 +1073,20 @@ export async function handleAuthGithubCreateRepo(
       fetchImpl,
     );
   } catch (err) {
+    if (err instanceof GitHubApiError && err.status === 403) {
+      // Expected with the shared Contents-only app: POST /user/repos needs
+      // Administration:write. Actionable, machine-readable mapping — the UI
+      // renders the guided-manual checklist off error_type, not a string.
+      return Response.json(
+        {
+          error: "Create not permitted for this GitHub App",
+          error_type: "app_lacks_admin_permission",
+          message:
+            "The Parachute GitHub App can't create repositories (it only has Contents permission — creating repos needs Administration). Create it manually instead: 1) create a private, uninitialized repo at github.com/new, 2) add it to the app installation (GitHub → Settings → Applications → Configure), 3) refresh the repo list here and pick it.",
+        },
+        { status: 403 },
+      );
+    }
     return Response.json(
       { error: "Create failed", message: (err as Error).message ?? String(err) },
       { status: 502 },
@@ -988,6 +1181,73 @@ export async function handleAuthGithubSelectRepo(
     },
     { headers: { "Access-Control-Allow-Origin": "*" } },
   );
+}
+
+/**
+ * vault#483 fix 1 — linking implies backup intent. Outcome flag for the
+ * credential-save responses:
+ *   - `true` — history (the mirror) is on: either this link just enabled it
+ *     (never-configured vault) or it was already enabled.
+ *   - `"left_disabled"` — a mirror config exists with `enabled: false`; we
+ *     refuse to silently flip an explicit operator choice. The UI should
+ *     offer the one-click "Turn on history now?" enable.
+ *   - `false` — we tried to enable history but the mirror didn't come up
+ *     (e.g. git missing). Config intent is persisted (PUT semantics); the
+ *     mirror status carries the actionable error.
+ */
+export type HistoryOnLink = true | false | "left_disabled";
+
+/**
+ * When a GitHub credential lands (device-flow grant or PAT save), turn
+ * history on for a vault that has NEVER had a mirror configured — nobody
+ * links GitHub to a vault for any reason other than backing it up. Aaron hit
+ * this live (vault#483): pre-#440 vaults have no mirror-config file, so
+ * linking stored a credential and then... nothing, with the only path out
+ * buried in advanced settings.
+ *
+ * Consent-respecting by design:
+ *   - **No config file** (never configured) → enable the internal mirror
+ *     with the standard defaults (enabled, internal, events, auto_commit on,
+ *     auto_push off — the same shape #440 gives new vaults). Writes through
+ *     `manager.reload()` — the exact path the PUT handler uses — so persist +
+ *     lifecycle-start stay one code path.
+ *   - **Config file exists with enabled:false** → explicit operator choice;
+ *     do NOT flip it. Return `"left_disabled"` so the UI can offer one-click
+ *     enable instead.
+ *   - **Config file exists with enabled:true** → nothing to do.
+ *
+ * The file-existence check (not just the parsed read) is the load-bearing
+ * distinction: an existing-but-malformed file parses to `undefined`, same as
+ * absent — but it still represents operator-touched state, so we treat it as
+ * "exists, not known-enabled" and leave it alone.
+ */
+async function maybeEnableHistoryOnLink(
+  manager: MirrorManager,
+): Promise<HistoryOnLink> {
+  const vaultName = manager.getVaultName();
+  if (!existsSync(mirrorConfigPath(vaultName))) {
+    try {
+      const status = await manager.reload({
+        ...defaultMirrorConfig(),
+        enabled: true,
+      });
+      if (!status.enabled) {
+        console.warn(
+          `[mirror-auth] history-on-link: enabled the mirror config for vault "${vaultName}" but it didn't start: ${status.last_error ?? "unknown error"}`,
+        );
+        return false;
+      }
+      return true;
+    } catch (err) {
+      console.warn(
+        `[mirror-auth] history-on-link: could not enable the mirror for vault "${vaultName}" (non-fatal): ${(err as Error).message ?? err}`,
+      );
+      return false;
+    }
+  }
+  const persisted = readMirrorConfigForVault(vaultName);
+  if (persisted?.enabled) return true;
+  return "left_disabled";
 }
 
 /**

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -87,6 +87,7 @@ import {
   handleAuthGet,
   handleAuthGithubCreateRepo,
   handleAuthGithubDeviceCode,
+  handleAuthGithubInstallations,
   handleAuthGithubPoll,
   handleAuthGithubRepos,
   handleAuthGithubSelectRepo,
@@ -733,6 +734,13 @@ export async function route(
     }
     if (subpath === "/.parachute/mirror/auth/github/poll") {
       if (req.method === "POST") return handleAuthGithubPoll(req, manager);
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+    if (subpath === "/.parachute/mirror/auth/github/installations") {
+      // Install state (vault#480) — which app, installed-anywhere?, install
+      // link, per-account installations. Explicitly-network (probes GitHub);
+      // the offline status read stays on GET /.parachute/mirror/auth.
+      if (req.method === "GET") return handleAuthGithubInstallations(manager);
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
     if (subpath === "/.parachute/mirror/auth/github/repos") {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -39,11 +39,19 @@ export interface VaultDetailResult {
   stats: VaultStats;
 }
 
-/** Status code carried alongside the message so callers can branch numerically. */
+/**
+ * Status code carried alongside the message so callers can branch
+ * numerically. `errorType` carries the server's machine-readable
+ * `error_type` discriminator when the response body includes one (e.g.
+ * `app_lacks_admin_permission` from create-repo, `github_not_connected`
+ * from the installations probe) so the UI can branch on a stable token
+ * instead of string-matching the human message.
+ */
 export class HttpError extends Error {
   constructor(
     public readonly status: number,
     message: string,
+    public readonly errorType?: string,
   ) {
     super(message);
     this.name = "HttpError";
@@ -341,6 +349,19 @@ export interface DeviceCodeResponse {
   interval: number;
 }
 
+/**
+ * vault#483 fix 1 — outcome flag carried on the credential-save responses
+ * (device-flow grant + PAT save). Linking implies backup intent, so the
+ * backend turns history on for a never-configured vault:
+ *   - `true` — history (the mirror) is on: just-enabled or already on.
+ *   - `"left_disabled"` — a config exists with `enabled: false`; the server
+ *     refuses to silently flip an explicit operator choice. The UI offers
+ *     the one-click "Turn on history now?" enable (`PUT` with enabled:true).
+ *   - `false` — enable was attempted but the mirror didn't come up; the
+ *     mirror status carries the actionable error.
+ */
+export type HistoryOnLink = true | false | "left_disabled";
+
 export type DevicePollState =
   | { state: "pending" }
   | { state: "slow_down"; interval: number }
@@ -349,6 +370,8 @@ export type DevicePollState =
   | {
       state: "granted";
       user: { login: string; id: number; name: string | null; avatar_url?: string };
+      /** vault#483 — history-on-link outcome (see `HistoryOnLink`). */
+      history_enabled: HistoryOnLink;
     };
 
 export interface GitHubRepoInfo {
@@ -361,6 +384,55 @@ export interface GitHubRepoInfo {
   updated_at: string;
   clone_url: string;
 }
+
+// ---------------------------------------------------------------------------
+// GitHub App install state — vault#480.
+//
+// GitHub-App semantics that shape the connect flow: authorization (device
+// flow) and installation are SEPARATE, order-independent steps. A granted
+// token reaches no private repos until the operator also installs the app
+// on their account (and each org) and selects repos. The installations
+// endpoint is the canonical probe; `installed: false` = authorized-but-
+// not-installed (the state Aaron walked into blind).
+// ---------------------------------------------------------------------------
+
+export interface GitHubAppInfo {
+  client_id: string;
+  /** URL slug — drives github.com/apps/<slug>/installations/new. */
+  slug: string;
+  /** True when running on the shared Parachute app; false = BYO app. */
+  is_shared_default: boolean;
+}
+
+export interface GitHubInstallationInfo {
+  id: number;
+  account_login: string;
+  account_type: "User" | "Organization";
+  /** Whether the installation grants all repos or a hand-picked subset. */
+  repository_selection: "all" | "selected";
+}
+
+export interface GithubInstallState {
+  app: GitHubAppInfo;
+  installed: boolean;
+  install_url: string;
+  installations: GitHubInstallationInfo[];
+}
+
+/** A repo annotated with which installation (account) grants it. */
+export interface GitHubRepoWithInstallation extends GitHubRepoInfo {
+  account_login: string;
+  installation_id: number;
+}
+
+/**
+ * Discriminated repo-picker payload. `installed: false` means the operator
+ * authorized the app but hasn't installed it anywhere — the UI shows the
+ * guided-install step instead of an empty "you have no repos" list.
+ */
+export type GithubReposResult =
+  | { installed: true; repos: GitHubRepoWithInstallation[]; truncated: boolean }
+  | { installed: false; install_url: string; repos: GitHubRepoWithInstallation[]; truncated: false };
 
 export async function getMirrorAuth(vaultName: string): Promise<MirrorCredentialStatus> {
   const res = await authedFetch(
@@ -420,6 +492,8 @@ export async function pollGithubDeviceFlow(
  * commit will push to <repo>" rather than a silent "saved" confirmation.
  */
 export interface MirrorCredentialSaveResult extends MirrorCredentialStatus {
+  /** vault#483 — history-on-link outcome (see `HistoryOnLink`). */
+  history_enabled: HistoryOnLink;
   auto_push_was_already_enabled: boolean;
   auto_push_enabled: boolean;
   initial_push:
@@ -444,17 +518,49 @@ export async function postMirrorAuthPat(
   return (await res.json()) as MirrorCredentialSaveResult;
 }
 
+/**
+ * Install state for the connect flow (vault#480): which GitHub App is in
+ * play (shared default vs BYO), whether it's installed ANYWHERE for this
+ * operator, the install link, and the per-account installations.
+ *
+ * Explicitly a network probe (the server calls GitHub) — call it when
+ * rendering the connect flow / repo picker, not on every status poll.
+ * Throws `HttpError` with `errorType: "github_not_connected"` (401) when
+ * no GitHub sign-in is stored.
+ */
+export async function getGithubInstallations(
+  vaultName: string,
+): Promise<GithubInstallState> {
+  const res = await authedFetch(
+    vaultName,
+    `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/installations`,
+  );
+  if (!res.ok) {
+    const { message, errorType } = await readErrorParts(res);
+    throw new HttpError(res.status, message, errorType);
+  }
+  return (await res.json()) as GithubInstallState;
+}
+
 export async function listGithubRepos(
   vaultName: string,
-): Promise<{ repos: GitHubRepoInfo[]; truncated: boolean }> {
+): Promise<GithubReposResult> {
   const res = await authedFetch(
     vaultName,
     `/vault/${encodeURIComponent(vaultName)}/.parachute/mirror/auth/github/repos`,
   );
   if (!res.ok) throw new HttpError(res.status, await readError(res));
-  return (await res.json()) as { repos: GitHubRepoInfo[]; truncated: boolean };
+  return (await res.json()) as GithubReposResult;
 }
 
+/**
+ * Create a repo on the operator's account. With the shared Parachute app
+ * this 403s by design (`POST /user/repos` needs Administration:write; the
+ * shared app is frozen at Contents-only) — the throw carries
+ * `errorType: "app_lacks_admin_permission"` so the UI renders the
+ * guided-manual checklist instead of an error toast. BYO apps that grant
+ * Administration:write succeed.
+ */
 export async function createGithubRepo(
   vaultName: string,
   args: { name: string; description?: string; private?: boolean },
@@ -468,7 +574,10 @@ export async function createGithubRepo(
       body: JSON.stringify(args),
     },
   );
-  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  if (!res.ok) {
+    const { message, errorType } = await readErrorParts(res);
+    throw new HttpError(res.status, message, errorType);
+  }
   return (await res.json()) as GitHubRepoInfo;
 }
 
@@ -575,15 +684,32 @@ export async function postMirrorImport(
 }
 
 async function readError(res: Response): Promise<string> {
+  return (await readErrorParts(res)).message;
+}
+
+/**
+ * Like `readError` but also surfaces the machine-readable `error_type`
+ * discriminator (when present) so callers can construct an `HttpError`
+ * the UI can branch on without string-matching.
+ */
+async function readErrorParts(
+  res: Response,
+): Promise<{ message: string; errorType?: string }> {
   try {
     const text = await res.text();
-    const parsed = JSON.parse(text) as { error?: string; error_description?: string; message?: string };
-    if (parsed.error_description) return parsed.error_description;
-    if (parsed.message) return parsed.message;
-    if (parsed.error) return parsed.error;
-    if (text) return text;
+    const parsed = JSON.parse(text) as {
+      error?: string;
+      error_description?: string;
+      error_type?: string;
+      message?: string;
+    };
+    const errorType = typeof parsed.error_type === "string" ? parsed.error_type : undefined;
+    if (parsed.error_description) return { message: parsed.error_description, errorType };
+    if (parsed.message) return { message: parsed.message, errorType };
+    if (parsed.error) return { message: parsed.error, errorType };
+    if (text) return { message: text, errorType };
   } catch {
     // not JSON
   }
-  return `${res.status} ${res.statusText}`;
+  return { message: `${res.status} ${res.statusText}` };
 }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -407,6 +407,9 @@ export interface GitHubAppInfo {
 export interface GitHubInstallationInfo {
   id: number;
   account_login: string;
+  /** Cast from the wire without runtime narrowing — safe by degradation:
+   *  an unknown value falls through to the 'user' branch in
+   *  `installationSettingsUrl`, it isn't validated. */
   account_type: "User" | "Organization";
   /** Whether the installation grants all repos or a hand-picked subset. */
   repository_selection: "all" | "selected";
@@ -525,8 +528,9 @@ export async function postMirrorAuthPat(
  *
  * Explicitly a network probe (the server calls GitHub) — call it when
  * rendering the connect flow / repo picker, not on every status poll.
- * Throws `HttpError` with `errorType: "github_not_connected"` (401) when
- * no GitHub sign-in is stored.
+ * Throws `HttpError` with `errorType: "github_not_connected"` (400 — not
+ * 401, which would trip `authedFetch`'s token-refresh retry and clear a
+ * perfectly valid cached admin token) when no GitHub sign-in is stored.
  */
 export async function getGithubInstallations(
   vaultName: string,
@@ -587,6 +591,13 @@ export interface SelectGithubRepoResult {
   owner: string;
   name: string;
   remote: string;
+  /**
+   * vault#483 — history-on-link outcome (see `HistoryOnLink`). Select-repo
+   * runs history-on-link too: the "Choose repository…" re-entry can be the
+   * first linked action for a credential saved before history-on-link
+   * existed, on a never-configured vault.
+   */
+  history_enabled: HistoryOnLink;
   /** Cut 3/Cut 6 — auto_push side-effects from credential save. */
   auto_push_was_already_enabled: boolean;
   auto_push_enabled: boolean;

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -45,6 +45,28 @@ vi.mock("../lib/api.ts", async () => {
     listGithubRepos: vi.fn(),
     createGithubRepo: vi.fn(),
     selectGithubRepo: vi.fn(),
+    // Install-state probe (vault#480). Default: shared app, installed on
+    // the operator's user account with all-repos selection — the happy
+    // "ready" state, so pre-#480 tests with a github_oauth credential see
+    // a quiet probe instead of a crash. Per-test overrides via
+    // `vi.mocked(api.getGithubInstallations).mockResolvedValue(...)`.
+    getGithubInstallations: vi.fn().mockResolvedValue({
+      app: {
+        client_id: "Iv23livaRF4VcvPhu3uB",
+        slug: "parachute-computer",
+        is_shared_default: true,
+      },
+      installed: true,
+      install_url: "https://github.com/apps/parachute-computer/installations/new",
+      installations: [
+        {
+          id: 11,
+          account_login: "aaron",
+          account_type: "User",
+          repository_selection: "all",
+        },
+      ],
+    }),
     // Import from git (vault#391).
     postMirrorImport: vi.fn(),
   };
@@ -966,6 +988,7 @@ describe("VaultMirror — Git remote credentials", () => {
         remote_url: "https://x-access-token:***@github.com/a/b.git",
         token_preview: "ghp_…7890",
       },
+      history_enabled: true,
       auto_push_was_already_enabled: false,
       auto_push_enabled: true,
       initial_push: {
@@ -1311,6 +1334,522 @@ describe("VaultMirror — Import from git section", () => {
     await user.click(screen.getByRole("button", { name: /Start import/i }));
     await waitFor(() =>
       expect(screen.getByText(/git clone failed/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+// ===========================================================================
+// GitHub App install flow (vault#480) + history-on-link (vault#483).
+//
+// GitHub-App semantics: authorization (device flow) and installation are
+// SEPARATE steps — a granted token reaches no private repos until the app
+// is also installed. The page probes install state whenever a github_oauth
+// credential is active and renders the guided state machine:
+//   not-linked → linked-but-not-installed → installed-no-repo → ready.
+// ===========================================================================
+
+const githubCreds = (): api.MirrorCredentialStatus => ({
+  active_method: "github_oauth",
+  github_oauth: {
+    user_login: "aaron",
+    user_id: 1,
+    scope: "",
+    authorized_at: "2026-06-10T03:14:15.000Z",
+    token_preview: "ghu_…7890",
+  },
+  pat: null,
+});
+
+const installStateFixture = (
+  over: Partial<api.GithubInstallState> = {},
+): api.GithubInstallState => ({
+  app: {
+    client_id: "Iv23livaRF4VcvPhu3uB",
+    slug: "parachute-computer",
+    is_shared_default: true,
+  },
+  installed: true,
+  install_url: "https://github.com/apps/parachute-computer/installations/new",
+  installations: [
+    { id: 11, account_login: "aaron", account_type: "User", repository_selection: "all" },
+  ],
+  ...over,
+});
+
+const repoFixture = (
+  over: Partial<api.GitHubRepoWithInstallation> = {},
+): api.GitHubRepoWithInstallation => ({
+  owner: "aaron",
+  name: "a-vault",
+  full_name: "aaron/a-vault",
+  private: true,
+  html_url: "https://github.com/aaron/a-vault",
+  description: null,
+  updated_at: "2026-06-01T00:00:00Z",
+  clone_url: "https://github.com/aaron/a-vault.git",
+  account_login: "aaron",
+  installation_id: 11,
+  ...over,
+});
+
+describe("VaultMirror — GitHub App install flow (vault#480)", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(true);
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue(githubCreds());
+    // Re-establish the persistent default per test: `vi.clearAllMocks()`
+    // clears CALLS but a sibling test's `mockResolvedValue` would
+    // otherwise leak its implementation into tests relying on the
+    // installed-on-@aaron baseline.
+    vi.mocked(api.getGithubInstallations).mockResolvedValue(installStateFixture());
+  });
+
+  it("renders the linked-but-not-installed guided state (the one Aaron hit blind)", async () => {
+    vi.mocked(api.getGithubInstallations).mockResolvedValue(
+      installStateFixture({ installed: false, installations: [] }),
+    );
+    renderRoute();
+
+    // Explainer: authorized, one step left.
+    await waitFor(() =>
+      expect(
+        screen.getByText(/one step left: install the app/i),
+      ).toBeInTheDocument(),
+    );
+    // Install link points at the API-provided install URL.
+    const installLink = screen.getByRole("link", { name: /Install on GitHub/i });
+    expect(installLink.getAttribute("href")).toBe(
+      "https://github.com/apps/parachute-computer/installations/new",
+    );
+    // Repeatable re-check action.
+    expect(
+      screen.getByRole("button", { name: /I've installed it — check again/i }),
+    ).toBeInTheDocument();
+    // Org note — installing is per-account and repeatable.
+    expect(
+      screen.getByText(/Install the app on that org too/i),
+    ).toBeInTheDocument();
+  });
+
+  it("transitions not-installed → installed via the check-again action", async () => {
+    // First probe (page load): not installed. Second (the re-check):
+    // the factory default — installed on @aaron.
+    vi.mocked(api.getGithubInstallations).mockResolvedValueOnce(
+      installStateFixture({ installed: false, installations: [] }),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /I've installed it — check again/i }),
+      ).toBeInTheDocument(),
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: /I've installed it — check again/i }),
+    );
+
+    // The installed state replaces the guided-install panel.
+    await waitFor(() =>
+      expect(screen.getByText(/App installed on/i)).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("button", { name: /Choose repository/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/one step left: install the app/i),
+    ).not.toBeInTheDocument();
+    expect(api.getGithubInstallations).toHaveBeenCalledTimes(2);
+  });
+
+  it("ready state shows the active-app identity line, selection mode, and repeatable org install", async () => {
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/App installed on/i)).toBeInTheDocument(),
+    );
+    // Active-app identity (shared default).
+    expect(
+      screen.getByText(/Using the shared Parachute GitHub App/i),
+    ).toBeInTheDocument();
+    // repository_selection surfaced.
+    expect(screen.getByText(/All repos/i)).toBeInTheDocument();
+    // "Install on another account/org" stays reachable.
+    expect(
+      screen.getByRole("link", { name: /Install on another account or org/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("repo picker groups repos by account (user + org) and labels selected-only installs", async () => {
+    vi.mocked(api.getGithubInstallations).mockResolvedValue(
+      installStateFixture({
+        installations: [
+          { id: 11, account_login: "aaron", account_type: "User", repository_selection: "all" },
+          {
+            id: 22,
+            account_login: "parachute-org",
+            account_type: "Organization",
+            repository_selection: "selected",
+          },
+        ],
+      }),
+    );
+    vi.mocked(api.listGithubRepos).mockResolvedValue({
+      installed: true,
+      repos: [
+        repoFixture(),
+        repoFixture({
+          owner: "parachute-org",
+          name: "org-vault",
+          full_name: "parachute-org/org-vault",
+          account_login: "parachute-org",
+          installation_id: 22,
+        }),
+      ],
+      truncated: false,
+    });
+    vi.mocked(api.selectGithubRepo).mockResolvedValue({
+      ok: true,
+      applied: true,
+      owner: "parachute-org",
+      name: "org-vault",
+      remote: "https://github.com/parachute-org/org-vault.git",
+      auto_push_was_already_enabled: false,
+      auto_push_enabled: true,
+      initial_push: { fired: true, pushed: true, sha: "feedface123456" },
+    });
+
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Choose repository/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Choose repository/i }));
+
+    // The picker modal probes install state, then lists repos grouped by
+    // account: both group headers + the org's "Selected repos only" label.
+    const modal = await screen.findByRole("dialog");
+    await waitFor(() =>
+      expect(within(modal).getByText("parachute-org")).toBeInTheDocument(),
+    );
+    expect(within(modal).getByText("aaron")).toBeInTheDocument();
+    expect(within(modal).getByText(/Selected repos only/i)).toBeInTheDocument();
+    // Org repo is pickable — the old GET /user/repos picker couldn't see
+    // org repos at all.
+    await user.click(within(modal).getByRole("button", { name: /org-vault/i }));
+    await waitFor(() =>
+      expect(api.selectGithubRepo).toHaveBeenCalledWith("work", {
+        owner: "parachute-org",
+        name: "org-vault",
+      }),
+    );
+  });
+
+  it("shared app: create-repo renders the guided-manual checklist, never a dead POST", async () => {
+    vi.mocked(api.listGithubRepos).mockResolvedValue({
+      installed: true,
+      repos: [repoFixture()],
+      truncated: false,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Choose repository/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Choose repository/i }));
+    const modal = await screen.findByRole("dialog");
+    await waitFor(() =>
+      expect(
+        within(modal).getByRole("button", { name: /\+ Create new private repo/i }),
+      ).toBeInTheDocument(),
+    );
+    await user.click(
+      within(modal).getByRole("button", { name: /\+ Create new private repo/i }),
+    );
+
+    // The checklist renders directly — the shared app is KNOWN
+    // Contents-only, so there's no Create button that would just 403.
+    await waitFor(() =>
+      expect(
+        within(modal).getByText(/deliberately can't create repos/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      within(modal).queryByRole("button", { name: /^Create$/i }),
+    ).not.toBeInTheDocument();
+
+    // Typing a name prefills the github.com/new link (best-effort).
+    await user.type(
+      within(modal).getByLabelText(/New repo name/i),
+      "my-vault-backup",
+    );
+    const newRepoLink = within(modal).getByRole("link", {
+      name: /Create a new repo on GitHub/i,
+    });
+    expect(newRepoLink.getAttribute("href")).toBe(
+      "https://github.com/new?name=my-vault-backup",
+    );
+    // Step 2 deep-links the installation's settings page.
+    const configureLink = within(modal).getByRole("link", {
+      name: /configure on aaron/i,
+    });
+    expect(configureLink.getAttribute("href")).toBe(
+      "https://github.com/settings/installations/11",
+    );
+    // Step 3 closes the loop back into the picker. ("Refresh list" also
+    // exists in the picker's own action row — expect both.)
+    expect(
+      within(modal).getAllByRole("button", { name: /Refresh list/i }).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(api.createGithubRepo).not.toHaveBeenCalled();
+  });
+
+  it("BYO app: create-repo 403 app_lacks_admin_permission falls back to the checklist (not an error toast)", async () => {
+    vi.mocked(api.getGithubInstallations).mockResolvedValue(
+      installStateFixture({
+        app: { client_id: "Iv1.byo", slug: "my-backup-app", is_shared_default: false },
+        install_url: "https://github.com/apps/my-backup-app/installations/new",
+      }),
+    );
+    vi.mocked(api.listGithubRepos).mockResolvedValue({
+      installed: true,
+      repos: [repoFixture()],
+      truncated: false,
+    });
+    vi.mocked(api.createGithubRepo).mockRejectedValue(
+      new api.HttpError(
+        403,
+        "The Parachute GitHub App can't create repositories…",
+        "app_lacks_admin_permission",
+      ),
+    );
+
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Choose repository/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Choose repository/i }));
+    const modal = await screen.findByRole("dialog");
+    await waitFor(() =>
+      expect(
+        within(modal).getByRole("button", { name: /\+ Create new private repo/i }),
+      ).toBeInTheDocument(),
+    );
+    await user.click(
+      within(modal).getByRole("button", { name: /\+ Create new private repo/i }),
+    );
+
+    // BYO app → the live Create button renders (the app MIGHT grant
+    // Administration:write — no way to know without trying).
+    await user.type(within(modal).getByLabelText(/New repo name/i), "new-backup");
+    await user.click(within(modal).getByRole("button", { name: /^Create$/i }));
+
+    // 403 with the machine-readable error_type → guided checklist, and
+    // the modal does NOT flip to the error phase. (The word
+    // "Administration" sits in an <em>, so match the surrounding text
+    // node — getNodeText only sees an element's own text children.)
+    await waitFor(() =>
+      expect(
+        within(modal).getByText(/permission needed to create repos/i),
+      ).toBeInTheDocument(),
+    );
+    expect(within(modal).queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("BYO disclosure: renders custom-app identity + the registration recipe", async () => {
+    vi.mocked(api.getGithubInstallations).mockResolvedValue(
+      installStateFixture({
+        app: { client_id: "Iv1.byo", slug: "my-backup-app", is_shared_default: false },
+      }),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/Using your own GitHub App/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText("my-backup-app")).toBeInTheDocument();
+
+    // The collapsible recipe: env-var pair + the no-private-key stance.
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: /Use your own GitHub App/i }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/PARACHUTE_GITHUB_CLIENT_ID/)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/PARACHUTE_GITHUB_APP_SLUG/)).toBeInTheDocument();
+    expect(screen.getByText(/Don't generate a private key/i)).toBeInTheDocument();
+    expect(screen.getByText(/Contents — Read and write/i)).toBeInTheDocument();
+  });
+});
+
+// ===========================================================================
+// History-on-link (vault#483) — linking implies backup intent. The backend
+// reports what it did via `history_enabled`; the section renders the
+// outcome: on ✓ / one-click enable offer / pointer at the status error.
+// ===========================================================================
+
+describe("VaultMirror — history-on-link (vault#483)", () => {
+  beforeEach(() => {
+    vi.mocked(scope.hasAdminScope).mockReturnValue(true);
+    vi.mocked(api.getMirrorAuth).mockResolvedValue({
+      active_method: null,
+      github_oauth: null,
+      pat: null,
+    });
+    // See the sibling describe — guard against implementation leakage.
+    vi.mocked(api.getGithubInstallations).mockResolvedValue(installStateFixture());
+  });
+
+  /** Drives the PAT modal to a save — the shortest path to a credential-
+   *  save response carrying `history_enabled`. */
+  async function savePat(user: ReturnType<typeof userEvent.setup>) {
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Use Personal Access Token/i }),
+      ).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: /Use Personal Access Token/i }));
+    const modal = await screen.findByRole("dialog");
+    await user.type(within(modal).getByLabelText(/Token/i), "ghp_x");
+    await user.type(
+      within(modal).getByLabelText(/Remote URL/i),
+      "https://github.com/a/b.git",
+    );
+    await user.click(screen.getByRole("button", { name: /Validate & save/i }));
+  }
+
+  const patSaveResult = (
+    history: api.HistoryOnLink,
+  ): api.MirrorCredentialSaveResult => ({
+    active_method: "pat",
+    github_oauth: null,
+    pat: {
+      label: "GitHub PAT",
+      remote_url: "https://x-access-token:***@github.com/a/b.git",
+      token_preview: "ghp_…7890",
+    },
+    history_enabled: history,
+    auto_push_was_already_enabled: false,
+    auto_push_enabled: true,
+    initial_push: { fired: false, reason: "nothing_to_push" },
+  });
+
+  it("history_enabled: true → 'History is on ✓' confirmation", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+    vi.mocked(api.postMirrorAuthPat).mockResolvedValue(patSaveResult(true));
+    renderRoute();
+    const user = userEvent.setup();
+    await savePat(user);
+    await waitFor(() =>
+      expect(screen.getByText(/History is on/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("history_enabled: 'left_disabled' → one-click enable that PUTs enabled:true", async () => {
+    // The vault carries an explicit enabled:false the backend refused to
+    // flip — the UI offers consent-respecting one-click enable instead.
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: false, location: "internal" }),
+    );
+    vi.mocked(api.postMirrorAuthPat).mockResolvedValue(
+      patSaveResult("left_disabled"),
+    );
+    vi.mocked(api.putMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+    renderRoute();
+    const user = userEvent.setup();
+    await savePat(user);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Version history is still off for this vault/i),
+      ).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: /Turn on history now/i }));
+    await waitFor(() =>
+      expect(api.putMirror).toHaveBeenCalledWith("work", { enabled: true }),
+    );
+    // The banner flips to the confirmation.
+    await waitFor(() =>
+      expect(screen.getByText(/History is on/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("history_enabled: false → points at the mirror status error", async () => {
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: false, location: "internal" }),
+    );
+    vi.mocked(api.postMirrorAuthPat).mockResolvedValue(patSaveResult(false));
+    renderRoute();
+    const user = userEvent.setup();
+    await savePat(user);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/tried to turn on version history .* didn't\s*start/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("device-flow grant carries history through the full connect chain (grant → probe → guided install → picker)", async () => {
+    // The end-to-end Aaron path: authorize via device flow, history-on-link
+    // fires at the grant, the probe says "not installed", the guided
+    // install renders IN the modal, the re-check lands in the picker.
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: true, location: "internal" }),
+    );
+    vi.mocked(api.startGithubDeviceFlow).mockResolvedValue({
+      polling_id: "pid",
+      user_code: "WXYZ-9876",
+      verification_uri: "https://github.com/login/device",
+      expires_in: 900,
+      interval: 1, // floor — keeps the poll tick ~1s in this test
+    });
+    vi.mocked(api.pollGithubDeviceFlow).mockResolvedValue({
+      state: "granted",
+      user: { login: "aaron", id: 1, name: "Aaron" },
+      history_enabled: true,
+    });
+    vi.mocked(api.getGithubInstallations)
+      .mockResolvedValueOnce(installStateFixture({ installed: false, installations: [] }))
+      .mockResolvedValueOnce(installStateFixture());
+    vi.mocked(api.listGithubRepos).mockResolvedValue({
+      installed: true,
+      repos: [repoFixture()],
+      truncated: false,
+    });
+
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Connect GitHub/i })).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Connect GitHub/i }));
+    // Device code renders, then the ~1s poll tick lands the grant and the
+    // modal probes installations → guided install.
+    await waitFor(() => expect(screen.getByText("WXYZ-9876")).toBeInTheDocument());
+    const modal = screen.getByRole("dialog");
+    await waitFor(
+      () =>
+        expect(
+          within(modal).getByText(/one step left: install the app/i),
+        ).toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+    // History banner surfaced at grant time (NOT deferred to repo pick —
+    // the operator may close the modal mid-flow).
+    expect(screen.getByText(/History is on/i)).toBeInTheDocument();
+
+    // Re-check → installed → picker with the repo list.
+    await user.click(
+      within(modal).getByRole("button", { name: /I've installed it — check again/i }),
+    );
+    await waitFor(() =>
+      expect(within(modal).getByRole("button", { name: /a-vault/i })).toBeInTheDocument(),
     );
   });
 });

--- a/web/ui/src/routes/VaultMirror.test.tsx
+++ b/web/ui/src/routes/VaultMirror.test.tsx
@@ -5,7 +5,7 @@
  * `lib/api.ts` is mocked for the wire surface; `lib/scope.ts` is mocked
  * so admin-vs-read gating is controllable per test without crafting JWTs.
  */
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1515,6 +1515,7 @@ describe("VaultMirror — GitHub App install flow (vault#480)", () => {
       owner: "parachute-org",
       name: "org-vault",
       remote: "https://github.com/parachute-org/org-vault.git",
+      history_enabled: true,
       auto_push_was_already_enabled: false,
       auto_push_enabled: true,
       initial_push: { fired: true, pushed: true, sha: "feedface123456" },
@@ -1545,6 +1546,43 @@ describe("VaultMirror — GitHub App install flow (vault#480)", () => {
       }),
     );
   });
+
+  it("open picker fetches the repo list exactly once — no per-second refetch loop (PR #484 fold)", async () => {
+    // Regression: the modal's countdown ticker re-rendered every phase each
+    // second, and RepoPicker's inline `onError`/`onNotInstalled` props sat
+    // in its fetch-effect deps — so an open picker refetched the repo list
+    // (1+N GitHub API calls server-side) every ~1s. With the fix, the
+    // ticker is gated to the polling phase and the callbacks are stable:
+    // sitting in the open picker across several ticker periods must not
+    // re-arm the fetch. Real time (not vi.useFakeTimers) — RTL's waitFor
+    // can't detect vitest fake timers and deadlocks; the sibling
+    // device-flow test waits on real ~1s ticks the same way.
+    vi.mocked(api.listGithubRepos).mockResolvedValue({
+      installed: true,
+      repos: [repoFixture()],
+      truncated: false,
+    });
+    renderRoute();
+    const user = userEvent.setup();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Choose repository/i }),
+      ).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: /Choose repository/i }));
+    const modal = await screen.findByRole("dialog");
+    await waitFor(() =>
+      expect(
+        within(modal).getByRole("button", { name: /a-vault/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(api.listGithubRepos).toHaveBeenCalledTimes(1);
+
+    // Sit in the open picker across ~3 ticker periods. The unfixed code
+    // refires the fetch on every 1s tick (4+ calls by now).
+    await act(() => new Promise((resolve) => setTimeout(resolve, 3200)));
+    expect(api.listGithubRepos).toHaveBeenCalledTimes(1);
+  }, 15_000);
 
   it("shared app: create-repo renders the guided-manual checklist, never a dead POST", async () => {
     vi.mocked(api.listGithubRepos).mockResolvedValue({
@@ -1850,6 +1888,52 @@ describe("VaultMirror — history-on-link (vault#483)", () => {
     );
     await waitFor(() =>
       expect(within(modal).getByRole("button", { name: /a-vault/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("repo-pick re-entry (choose-repo) surfaces the history outcome like the grant path (PR #484 fold)", async () => {
+    // A credential saved BEFORE history-on-link existed, on a vault whose
+    // mirror is explicitly off: the operator re-enters via "Choose
+    // repository…" (no fresh grant, so the grant-time onHistory never
+    // fires). The select-repo response now carries history_enabled — the
+    // banner must fire off THAT, here the one-click enable offer.
+    vi.mocked(api.getMirror).mockResolvedValue(
+      snapshotFixture({ enabled: false, location: "internal" }),
+    );
+    vi.mocked(api.getMirrorAuth).mockResolvedValue(githubCreds());
+    vi.mocked(api.listGithubRepos).mockResolvedValue({
+      installed: true,
+      repos: [repoFixture()],
+      truncated: false,
+    });
+    vi.mocked(api.selectGithubRepo).mockResolvedValue({
+      ok: true,
+      applied: false,
+      owner: "aaron",
+      name: "a-vault",
+      remote: "https://github.com/aaron/a-vault.git",
+      history_enabled: "left_disabled",
+      auto_push_was_already_enabled: false,
+      auto_push_enabled: false,
+      initial_push: { fired: false, reason: "auto_push_disabled" },
+    });
+
+    renderRoute();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Choose repository/i }),
+      ).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Choose repository/i }));
+    const modal = await screen.findByRole("dialog");
+    await user.click(
+      await within(modal).findByRole("button", { name: /a-vault/i }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Version history is still off for this vault/i),
+      ).toBeInTheDocument(),
     );
   });
 });

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -41,7 +41,11 @@ import { SignInBanner } from "../lib/SignInBanner.tsx";
 import {
   HttpError,
   type DeviceCodeResponse,
+  type GitHubInstallationInfo,
   type GitHubRepoInfo,
+  type GitHubRepoWithInstallation,
+  type GithubInstallState,
+  type HistoryOnLink,
   type MirrorConfig,
   type MirrorCredentialSaveResult,
   type MirrorCredentialStatus,
@@ -52,6 +56,7 @@ import {
   type SelectGithubRepoResult,
   createGithubRepo,
   deleteMirrorAuth,
+  getGithubInstallations,
   getMirror,
   getMirrorAuth,
   listGithubRepos,
@@ -305,6 +310,7 @@ function MirrorScreen({
             // the SPA's view of state. Same trigger as putMirror.
             onRefresh();
           }}
+          onConfigChanged={onRefresh}
           locationIsExternal={snapshot.config.location === "external"}
         />
       ) : null}
@@ -978,10 +984,13 @@ function ConfigForm({
  * The OAuth modal works like this: operator clicks "Connect GitHub",
  * vault calls GitHub's device-code endpoint, the modal displays the
  * user_code + verification_uri, operator types the code at
- * github.com/login/device, the modal polls until granted, then surfaces a
- * repo picker (or a "Create new private repo" form). Picking a repo
- * writes the embedded-credential URL onto the mirror's `origin`, closes
- * the flow.
+ * github.com/login/device, the modal polls until granted — then (vault#480)
+ * probes `GET /user/installations`: GitHub-App authorization and
+ * installation are SEPARATE steps, so a freshly-granted token reaches no
+ * repos until the app is also installed. Not installed → the guided-install
+ * state (install link + re-check). Installed → a repo picker grouped by
+ * account (user + orgs). Picking a repo writes the embedded-credential URL
+ * onto the mirror's `origin`, closes the flow.
  *
  * The PAT modal is the fallback: two fields (token + remote URL) + a
  * "Validate & save" button. The server runs `git ls-remote` against the
@@ -993,6 +1002,7 @@ function GitRemoteSection({
   credsError,
   onCredsChanged,
   onCredsSaved,
+  onConfigChanged,
   locationIsExternal,
 }: {
   vaultName: string;
@@ -1006,9 +1016,15 @@ function GitRemoteSection({
    * auto_push + last_push_at land in the SPA's view of state.
    */
   onCredsSaved: (result: MirrorCredentialSaveResult | SelectGithubRepoResult) => void;
+  /**
+   * vault#483 — fires after the one-click "Turn on history now" enable so
+   * the parent refreshes the snapshot (the status banner flips to "on").
+   */
+  onConfigChanged: () => void;
   locationIsExternal: boolean;
 }) {
   const [oauthOpen, setOauthOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [patOpen, setPatOpen] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -1021,6 +1037,54 @@ function GitRemoteSection({
   const [saveResult, setSaveResult] = useState<
     MirrorCredentialSaveResult | SelectGithubRepoResult | null
   >(null);
+  /**
+   * vault#483 — history-on-link outcome from the most recent credential
+   * save (device-flow grant or PAT). Drives the post-link history banner:
+   * "History is on ✓" / one-click enable offer / pointer at the status.
+   */
+  const [historyNote, setHistoryNote] = useState<HistoryOnLink | null>(null);
+  const [enablingHistory, setEnablingHistory] = useState(false);
+
+  /**
+   * vault#480 — GitHub App install state. Probed when a github_oauth
+   * credential is active (authorization and installation are SEPARATE
+   * GitHub-App steps — a granted token reaches no private repos until the
+   * app is also installed). This is the page-level probe that surfaces
+   * the "authorized but not installed" state Aaron hit blind: previously
+   * the section said "Connected ✓" and nothing else.
+   *
+   * Deliberately fetched only while a GitHub credential exists (the
+   * endpoint 401s otherwise) — `GET /auth` stays the offline status read.
+   */
+  const [install, setInstall] = useState<GithubInstallState | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [installTick, setInstallTick] = useState(0);
+
+  const githubConnected = creds?.active_method === "github_oauth" && !!creds.github_oauth;
+
+  useEffect(() => {
+    if (!githubConnected) {
+      setInstall(null);
+      setInstallError(null);
+      return;
+    }
+    let cancelled = false;
+    getGithubInstallations(vaultName)
+      .then((state) => {
+        if (cancelled) return;
+        setInstall(state);
+        setInstallError(null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setInstallError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vaultName, githubConnected, installTick]);
+
+  const recheckInstall = () => setInstallTick((n) => n + 1);
 
   const connected = creds?.active_method !== null && creds?.active_method !== undefined;
 
@@ -1033,11 +1097,48 @@ function GitRemoteSection({
     try {
       const c = await deleteMirrorAuth(vaultName);
       onCredsChanged(c);
+      setHistoryNote(null);
     } catch (err) {
       setActionError(err instanceof Error ? err.message : String(err));
     } finally {
       setDisconnecting(false);
     }
+  };
+
+  /**
+   * One-click enable for the `"left_disabled"` history outcome — the vault
+   * has an explicit `enabled: false` config the backend (rightly) refused
+   * to flip on link. Clicking is the operator's consent; PUT with
+   * enabled:true is the documented one-click path (vault#483).
+   */
+  const onEnableHistory = async () => {
+    setEnablingHistory(true);
+    setActionError(null);
+    try {
+      await putMirror(vaultName, { enabled: true });
+      setHistoryNote(true);
+      onConfigChanged();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEnablingHistory(false);
+    }
+  };
+
+  /**
+   * The device-flow modal can close at ANY phase — including right after
+   * the grant, before a repo pick (exactly how Aaron ended up authorized-
+   * but-stuck). Re-read the (offline) credential status on close so a
+   * mid-flow grant immediately reflects on the page, where the install
+   * probe then takes over and renders the guided-install state.
+   */
+  const onOauthModalClosed = () => {
+    setOauthOpen(false);
+    getMirrorAuth(vaultName)
+      .then((c) => onCredsChanged(c))
+      .catch(() => {
+        /* page-level credsError covers persistent failures */
+      });
   };
 
   return (
@@ -1131,9 +1232,107 @@ function GitRemoteSection({
         </p>
       )}
 
+      {/*
+        vault#480 — GitHub App install state. Authorization (the device
+        flow) and installation are SEPARATE steps; this block renders the
+        page-level truth for a github_oauth credential:
+          - not installed → the guided-install state (the one Aaron hit
+            blind: "Connected ✓" used to be the whole story).
+          - installed → which accounts carry installations + the repo
+            picker re-entry + the repeatable "install on another org".
+      */}
+      {githubConnected && installError ? (
+        <div className="warn-banner" role="alert" style={{ marginBottom: "0.75rem" }}>
+          Couldn't check the GitHub App install state:{" "}
+          <code>{installError}</code>{" "}
+          <button type="button" className="secondary" onClick={recheckInstall}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+      {githubConnected && !install && !installError ? (
+        <p className="dim">Checking GitHub App installation…</p>
+      ) : null}
+      {githubConnected && install && !install.installed ? (
+        <InstallNeededPanel install={install} onRecheck={recheckInstall} />
+      ) : null}
+      {githubConnected && install && install.installed ? (
+        <div style={{ marginBottom: "0.75rem" }}>
+          <div className="kv" style={{ marginBottom: "0.75rem" }}>
+            <div>App installed on</div>
+            <div>
+              {install.installations.map((i) => (
+                <div key={i.id}>
+                  <code>{i.account_login}</code>{" "}
+                  <span className="dim">
+                    ({i.account_type === "Organization" ? "organization" : "user"} ·{" "}
+                    {i.repository_selection === "selected"
+                      ? "Selected repos only"
+                      : "All repos"}
+                    )
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="actions">
+            <button type="button" onClick={() => setPickerOpen(true)}>
+              Choose repository…
+            </button>
+            <a
+              href={install.install_url}
+              target="_blank"
+              rel="noreferrer"
+              className="dim"
+              style={{ alignSelf: "center" }}
+            >
+              Install on another account or org →
+            </a>
+          </div>
+        </div>
+      ) : null}
+
       {actionError ? (
         <div className="error-banner" role="alert">
           <code>{actionError}</code>
+        </div>
+      ) : null}
+
+      {/*
+        vault#483 — history-on-link outcome banner. Linking implies backup
+        intent, so the backend turns history on for a never-configured
+        vault and reports what happened; the one state it refuses to flip
+        silently (an explicit enabled:false) gets the one-click offer here
+        instead of a confusing trip into Advanced settings.
+      */}
+      {historyNote === true ? (
+        <div className="mint-banner" role="status" style={{ marginBottom: "0.75rem" }}>
+          <strong>History is on ✓</strong> — this vault keeps a local git
+          history of every change, ready to push once a repository is wired.{" "}
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => setHistoryNote(null)}
+            aria-label="Dismiss history note"
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+      {historyNote === "left_disabled" ? (
+        <div className="info-banner" role="status" style={{ marginBottom: "0.75rem" }}>
+          <strong>Version history is still off for this vault</strong> (it was
+          switched off earlier, so we didn't flip it behind your back). Backups
+          push the vault's history — turn it on to start recording changes.{" "}
+          <button type="button" onClick={onEnableHistory} disabled={enablingHistory}>
+            {enablingHistory ? "Turning on…" : "Turn on history now"}
+          </button>
+        </div>
+      ) : null}
+      {historyNote === false ? (
+        <div className="warn-banner" role="alert" style={{ marginBottom: "0.75rem" }}>
+          We tried to turn on version history for this vault but it didn't
+          start — see <strong>Advanced settings → Status</strong> for the error.
         </div>
       ) : null}
 
@@ -1249,10 +1448,15 @@ function GitRemoteSection({
         )}
       </div>
 
+      {/* BYO-app disclosure — first-class sovereignty surface (vault#480). */}
+      <ByoAppSection install={install} />
+
       {oauthOpen ? (
         <GithubOAuthModal
           vaultName={vaultName}
-          onClose={() => setOauthOpen(false)}
+          mode="connect"
+          onClose={onOauthModalClosed}
+          onHistory={setHistoryNote}
           onConnected={(c, selectResult) => {
             onCredsChanged(c);
             if (selectResult) {
@@ -1264,6 +1468,30 @@ function GitRemoteSection({
         />
       ) : null}
 
+      {/*
+        Repo-picker re-entry for an already-linked GitHub credential —
+        same modal, skipping the device flow (the grant already exists).
+        Covers both "installed but never picked a repo" and "switch to a
+        different repo".
+      */}
+      {pickerOpen && githubConnected ? (
+        <GithubOAuthModal
+          vaultName={vaultName}
+          mode="choose-repo"
+          initialLogin={creds?.github_oauth?.user_login ?? ""}
+          onClose={() => setPickerOpen(false)}
+          onHistory={setHistoryNote}
+          onConnected={(c, selectResult) => {
+            onCredsChanged(c);
+            if (selectResult) {
+              setSaveResult(selectResult);
+              onCredsSaved(selectResult);
+            }
+            setPickerOpen(false);
+          }}
+        />
+      ) : null}
+
       {patOpen ? (
         <PATModal
           vaultName={vaultName}
@@ -1271,6 +1499,7 @@ function GitRemoteSection({
           onSaved={(result) => {
             onCredsChanged(result);
             setSaveResult(result);
+            setHistoryNote(result.history_enabled);
             onCredsSaved(result);
             setPatOpen(false);
           }}
@@ -1280,22 +1509,188 @@ function GitRemoteSection({
   );
 }
 
+/**
+ * The "authorized but not installed" state (vault#480) — the first thing
+ * most operators hit, because GitHub's authorize screen says nothing about
+ * repos. Authorization (the device-flow grant) and installation are
+ * separate, order-independent GitHub-App steps; until the app is installed
+ * the token reaches no repos at all (every GitHub App can read public
+ * repos, which is how the old picker quietly showed the WRONG list).
+ */
+function InstallNeededPanel({
+  install,
+  onRecheck,
+}: {
+  install: GithubInstallState;
+  onRecheck: () => void;
+}) {
+  return (
+    <div className="info-banner" role="status" style={{ marginBottom: "0.75rem" }}>
+      <p style={{ marginTop: 0 }}>
+        <strong>Authorized ✓ — one step left: install the app so it can reach
+        your repos.</strong>{" "}
+        Authorizing told GitHub who you are; installing picks which
+        repositories the app may touch. Until then it can't see any of your
+        private repos.
+      </p>
+      <div className="actions" style={{ marginBottom: "0.5rem" }}>
+        <a
+          href={install.install_url}
+          target="_blank"
+          rel="noreferrer"
+          style={{ fontWeight: 600 }}
+        >
+          Install on GitHub →
+        </a>
+        <button type="button" className="secondary" onClick={onRecheck}>
+          I've installed it — check again
+        </button>
+      </div>
+      <p className="dim" style={{ marginBottom: 0, fontSize: "0.9em" }}>
+        Keeping vaults in an organization? Install the app on that org too —
+        the same install link works for every account, as many times as you
+        need.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * BYO-app surface (vault#480) — which GitHub App this vault talks to, plus
+ * the full bring-your-own-app recipe behind a disclosure. Aaron's framing:
+ * "make it easy for people to take responsibility for their own data" —
+ * the shared app is the convenient default, not a dependency you're stuck
+ * with. First-class on the page, not buried in docs.
+ *
+ * The app identity comes from the install-state probe (the server knows
+ * which client_id/slug it's configured with); before any GitHub credential
+ * exists we describe the default instead of claiming a specific app.
+ */
+function ByoAppSection({ install }: { install: GithubInstallState | null }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ marginTop: "1rem" }}>
+      <p className="dim" style={{ marginBottom: "0.5rem", fontSize: "0.9em" }}>
+        {install ? (
+          install.app.is_shared_default ? (
+            <>
+              Using the shared Parachute GitHub App (
+              <code>{install.app.slug}</code>).
+            </>
+          ) : (
+            <>
+              Using your own GitHub App (<code>{install.app.slug}</code>).
+            </>
+          )
+        ) : (
+          <>
+            "Connect GitHub" uses the shared Parachute GitHub App by default.
+          </>
+        )}{" "}
+        <button
+          type="button"
+          className="secondary"
+          onClick={() => setOpen((s) => !s)}
+          aria-expanded={open}
+        >
+          {open ? "Hide" : "Use your own GitHub App"}
+        </button>
+      </p>
+      {open ? (
+        <div className="info-banner" role="note">
+          <p style={{ marginTop: 0 }}>
+            You don't have to trust the shared app: register your own GitHub
+            App and point this vault at it. Your tokens are then minted by an
+            app only you control — your own rate-limit budget, your own blast
+            radius. Taking responsibility for your own data is the point of
+            self-hosting; this makes it one form away.
+          </p>
+          <p style={{ marginBottom: "0.35rem" }}>
+            <strong>Register the app</strong> (GitHub → Settings → Developer
+            settings → GitHub Apps → New GitHub App):
+          </p>
+          <ul style={{ marginTop: 0 }}>
+            <li>
+              Repository permissions: <strong>Contents — Read and write</strong>.
+              Nothing else.
+            </li>
+            <li>
+              <strong>Enable Device Flow</strong> (checkbox under "Identifying
+              and authorizing users").
+            </li>
+            <li>
+              <strong>Uncheck "Expire user authorization tokens"</strong> — an
+              unattended backup daemon can't babysit 8-hour tokens.
+            </li>
+            <li>Webhook: inactive. Callback URL: anything (device flow ignores it).</li>
+            <li>
+              <strong>Don't generate a private key</strong> — Parachute never
+              uses one, and an app with no key can't mint installation tokens
+              behind your back. We recommend against creating one at all.
+            </li>
+          </ul>
+          <p style={{ marginBottom: "0.35rem" }}>
+            <strong>Point this vault at it</strong> — set both env vars as a
+            pair in the vault's <code>.env</code>, then restart the vault:
+          </p>
+          <pre style={{ margin: "0 0 0.5rem" }}>
+            <code>
+              {"PARACHUTE_GITHUB_CLIENT_ID=<your app's client ID>\nPARACHUTE_GITHUB_APP_SLUG=<your app's URL slug>"}
+            </code>
+          </pre>
+          <p className="dim" style={{ marginBottom: 0, fontSize: "0.9em" }}>
+            Both together — the client ID mints the tokens, the slug builds the
+            install link; mixing apps breaks the connect flow. Then disconnect
+            and reconnect GitHub here to mint tokens from your app.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // GitHub OAuth modal — device flow start + poll loop + repo picker.
 // ---------------------------------------------------------------------------
 
+/**
+ * The connect flow's phases (vault#480 reshaped post-grant):
+ *
+ *   starting → polling → [granted] → probing → install-needed ⇄ probing
+ *                                            ↘ picker → (select-repo, done)
+ *
+ * `probing` runs the `GET /user/installations` check after a grant —
+ * authorization alone reaches no repos; the app must ALSO be installed.
+ * `install-needed` is the guided-install state with the install link and
+ * a re-check action. In `mode: "choose-repo"` (re-entry for an already-
+ * linked credential) the device-flow phases are skipped entirely and the
+ * modal opens at `probing`.
+ */
 type OAuthPhase =
   | { kind: "starting" }
   | { kind: "polling"; code: DeviceCodeResponse; pollIntervalMs: number; startedAt: number }
-  | { kind: "granted"; user: { login: string } }
+  | { kind: "probing"; user: { login: string } }
+  | { kind: "install-needed"; user: { login: string }; install: GithubInstallState }
+  | { kind: "picker"; user: { login: string }; install: GithubInstallState }
   | { kind: "error"; message: string };
 
 function GithubOAuthModal({
   vaultName,
+  mode,
+  initialLogin,
   onClose,
   onConnected,
+  onHistory,
 }: {
   vaultName: string;
+  /**
+   * "connect" — full device flow from the top. "choose-repo" — a GitHub
+   * credential already exists; skip straight to the install probe + repo
+   * picker (the re-entry path for "linked but never picked a repo").
+   */
+  mode: "connect" | "choose-repo";
+  /** The stored credential's login — seeds the picker in choose-repo mode. */
+  initialLogin?: string;
   onClose: () => void;
   /**
    * Cut 3/6: second arg carries the select-repo result so the parent
@@ -1307,8 +1702,18 @@ function GithubOAuthModal({
     creds: MirrorCredentialStatus,
     selectResult?: SelectGithubRepoResult,
   ) => void;
+  /**
+   * vault#483 — fires the moment the grant lands (NOT at repo-pick time:
+   * the operator may close the modal mid-flow and the history outcome
+   * already happened server-side). Parent renders the history banner.
+   */
+  onHistory: (history: HistoryOnLink) => void;
 }) {
-  const [phase, setPhase] = useState<OAuthPhase>({ kind: "starting" });
+  const [phase, setPhase] = useState<OAuthPhase>(
+    mode === "choose-repo"
+      ? { kind: "probing", user: { login: initialLogin ?? "" } }
+      : { kind: "starting" },
+  );
   const [now, setNow] = useState(Date.now());
   const pollAbortRef = useRef<boolean>(false);
 
@@ -1318,10 +1723,21 @@ function GithubOAuthModal({
     return () => clearInterval(id);
   }, []);
 
-  // Start the device flow on mount.
+  // Abort flag for the poll loop — unmount-only. (Setting it in the
+  // start effect's cleanup would fire on the starting→polling transition
+  // itself and strangle the first poll tick.)
   useEffect(() => {
+    return () => {
+      pollAbortRef.current = true;
+    };
+  }, []);
+
+  // Start the device flow when entering the "starting" phase (mount in
+  // connect mode, or "Try again" after an error). choose-repo mode never
+  // enters this phase.
+  useEffect(() => {
+    if (phase.kind !== "starting") return;
     let cancelled = false;
-    pollAbortRef.current = false;
     startGithubDeviceFlow(vaultName)
       .then((code) => {
         if (cancelled) return;
@@ -1341,13 +1757,13 @@ function GithubOAuthModal({
       });
     return () => {
       cancelled = true;
-      pollAbortRef.current = true;
     };
-  }, [vaultName]);
+  }, [phase.kind, vaultName]);
 
   // Poll loop — re-armed on every phase transition while phase=polling.
   useEffect(() => {
     if (phase.kind !== "polling") return;
+    pollAbortRef.current = false;
     const code = phase.code;
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1358,7 +1774,11 @@ function GithubOAuthModal({
         const result = await pollGithubDeviceFlow(vaultName, code.polling_id);
         if (cancelled) return;
         if (result.state === "granted") {
-          setPhase({ kind: "granted", user: { login: result.user.login } });
+          // Surface the history-on-link outcome NOW — it already happened
+          // server-side, and the operator may close the modal before
+          // finishing the repo pick.
+          onHistory(result.history_enabled);
+          setPhase({ kind: "probing", user: { login: result.user.login } });
           return;
         }
         if (result.state === "denied") {
@@ -1386,6 +1806,33 @@ function GithubOAuthModal({
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
+  }, [phase, vaultName, onHistory]);
+
+  // Install probe — runs whenever the modal enters the "probing" phase
+  // (post-grant, choose-repo mount, or an "I've installed it" re-check).
+  useEffect(() => {
+    if (phase.kind !== "probing") return;
+    const user = phase.user;
+    let cancelled = false;
+    getGithubInstallations(vaultName)
+      .then((install) => {
+        if (cancelled) return;
+        setPhase(
+          install.installed
+            ? { kind: "picker", user, install }
+            : { kind: "install-needed", user, install },
+        );
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setPhase({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [phase, vaultName]);
 
   const copyCode = async (code: string) => {
@@ -1400,7 +1847,9 @@ function GithubOAuthModal({
     <div className="modal-backdrop" role="dialog" aria-modal="true">
       <div className="modal">
         <div className="list-header">
-          <h3 style={{ margin: 0 }}>Connect GitHub</h3>
+          <h3 style={{ margin: 0 }}>
+            {mode === "choose-repo" ? "Choose a repository" : "Connect GitHub"}
+          </h3>
           <button type="button" className="secondary" onClick={onClose}>
             Close
           </button>
@@ -1439,16 +1888,29 @@ function GithubOAuthModal({
           </>
         ) : null}
 
-        {phase.kind === "granted" ? (
+        {phase.kind === "probing" ? (
+          <p className="muted">Checking where the app is installed…</p>
+        ) : null}
+
+        {phase.kind === "install-needed" ? (
+          <InstallNeededPanel
+            install={phase.install}
+            onRecheck={() => setPhase({ kind: "probing", user: phase.user })}
+          />
+        ) : null}
+
+        {phase.kind === "picker" ? (
           <RepoPicker
             vaultName={vaultName}
             user={phase.user}
+            install={phase.install}
             onPicked={async (owner, name) => {
               const selectResult = await selectGithubRepo(vaultName, { owner, name });
               const c = await getMirrorAuth(vaultName);
               onConnected(c, selectResult);
             }}
             onError={(message) => setPhase({ kind: "error", message })}
+            onNotInstalled={() => setPhase({ kind: "probing", user: phase.user })}
           />
         ) : null}
 
@@ -1458,7 +1920,16 @@ function GithubOAuthModal({
               <code>{phase.message}</code>
             </div>
             <div className="actions">
-              <button type="button" onClick={() => setPhase({ kind: "starting" })}>
+              <button
+                type="button"
+                onClick={() =>
+                  setPhase(
+                    mode === "choose-repo"
+                      ? { kind: "probing", user: { login: initialLogin ?? "" } }
+                      : { kind: "starting" },
+                  )
+                }
+              >
                 Try again
               </button>
               <button type="button" className="secondary" onClick={onClose}>
@@ -1484,32 +1955,65 @@ function formatCountdown(expiresIn: number, startedAt: number, now: number): str
 // Repo picker — surfaces after a granted device-flow token.
 // ---------------------------------------------------------------------------
 
+/**
+ * Builds the GitHub "configure this installation" URL — where the operator
+ * adds a repo to the app's repo selection. Per-account: user installations
+ * live under personal settings, org installations under the org's.
+ */
+function installationSettingsUrl(installation: GitHubInstallationInfo): string {
+  return installation.account_type === "Organization"
+    ? `https://github.com/organizations/${encodeURIComponent(installation.account_login)}/settings/installations/${installation.id}`
+    : `https://github.com/settings/installations/${installation.id}`;
+}
+
 function RepoPicker({
   vaultName,
   user,
+  install,
   onPicked,
   onError,
+  onNotInstalled,
 }: {
   vaultName: string;
   user: { login: string };
+  /** Install state from the probe — drives grouping + create guidance. */
+  install: GithubInstallState;
   onPicked: (owner: string, name: string) => Promise<void>;
   onError: (message: string) => void;
+  /**
+   * The repos call can come back `installed: false` even after a positive
+   * probe (the operator uninstalled in another tab). Bounce the flow back
+   * to the install-needed state instead of rendering an empty picker.
+   */
+  onNotInstalled: () => void;
 }) {
-  const [repos, setRepos] = useState<GitHubRepoInfo[] | null>(null);
+  const [repos, setRepos] = useState<GitHubRepoWithInstallation[] | null>(null);
   const [truncated, setTruncated] = useState(false);
   const [filter, setFilter] = useState("");
   const [picking, setPicking] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
   const [showCreate, setShowCreate] = useState(false);
+  /**
+   * Set when create-repo came back 403 `app_lacks_admin_permission` (BYO
+   * app without Administration:write). The shared app skips the POST
+   * entirely (we KNOW it's Contents-only) and renders the guide directly.
+   */
+  const [createForbidden, setCreateForbidden] = useState(false);
+  const [refreshTick, setRefreshTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
+    setRepos(null);
     listGithubRepos(vaultName)
-      .then(({ repos, truncated }) => {
+      .then((result) => {
         if (cancelled) return;
-        setRepos(repos);
-        setTruncated(Boolean(truncated));
+        if (!result.installed) {
+          onNotInstalled();
+          return;
+        }
+        setRepos(result.repos);
+        setTruncated(Boolean(result.truncated));
       })
       .catch((err) => {
         if (!cancelled) onError(err instanceof Error ? err.message : String(err));
@@ -1517,13 +2021,33 @@ function RepoPicker({
     return () => {
       cancelled = true;
     };
-  }, [vaultName, onError]);
+  }, [vaultName, onError, onNotInstalled, refreshTick]);
 
   const filtered = (repos ?? []).filter((r) =>
     filter.length === 0
       ? true
       : r.full_name.toLowerCase().includes(filter.toLowerCase()),
   );
+
+  /**
+   * Group by the installation account (user + each org) so org repos are
+   * visibly per-account rather than one undifferentiated soup — the old
+   * picker couldn't see org repos at all (vault#480). First-seen order;
+   * the backend unions per-installation so groups arrive contiguous.
+   */
+  const groups: Array<{ login: string; repos: GitHubRepoWithInstallation[] }> = [];
+  for (const repo of filtered) {
+    const last = groups[groups.length - 1];
+    if (last && last.login === repo.account_login) {
+      last.repos.push(repo);
+    } else {
+      const existing = groups.find((g) => g.login === repo.account_login);
+      if (existing) existing.repos.push(repo);
+      else groups.push({ login: repo.account_login, repos: [repo] });
+    }
+  }
+  const installationFor = (login: string): GitHubInstallationInfo | undefined =>
+    install.installations.find((i) => i.account_login === login);
 
   const pickRepo = async (owner: string, name: string) => {
     setPicking(`${owner}/${name}`);
@@ -1547,11 +2071,25 @@ function RepoPicker({
       });
       await onPicked(repo.owner, repo.name);
     } catch (err) {
-      onError(err instanceof Error ? err.message : String(err));
+      // The shared Contents-only app can't create repos (needs
+      // Administration:write) — and a BYO app might not grant it either.
+      // Map the machine-readable 403 to the guided-manual checklist
+      // instead of an error toast; everything else stays a hard error.
+      if (err instanceof HttpError && err.errorType === "app_lacks_admin_permission") {
+        setCreateForbidden(true);
+      } else {
+        onError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
       setCreating(false);
     }
   };
+
+  // The shared app is KNOWN Contents-only — don't render a button that's
+  // guaranteed to 403 ("no dead buttons"); go straight to the guide. BYO
+  // apps get the live create button (they may grant Administration:write),
+  // falling back to the same guide on the 403.
+  const createIsManual = install.app.is_shared_default || createForbidden;
 
   return (
     <>
@@ -1570,9 +2108,9 @@ function RepoPicker({
 
       {truncated ? (
         <p className="muted" style={{ fontSize: "0.85em" }}>
-          Showing the first 300 repos. Use the filter above to narrow down — or
-          paste the clone URL directly via Personal Access Token below if your
-          repo isn't here.
+          Showing the first 300 repos per account. Use the filter above to
+          narrow down — or paste the clone URL directly via Personal Access
+          Token if your repo isn't here.
         </p>
       ) : null}
 
@@ -1584,25 +2122,70 @@ function RepoPicker({
             <p className="dim">No repos match "{filter}".</p>
           ) : null}
           {filtered.length === 0 && filter.length === 0 && repos.length === 0 ? (
-            <p className="dim">You don't own any repos on this account yet.</p>
+            <p className="dim">
+              The app installation doesn't include any repos yet — pick some
+              via "Change repo access on GitHub" below, then refresh.
+            </p>
           ) : null}
-          {filtered.map((r) => (
-            <button
-              type="button"
-              key={r.full_name}
-              className="repo-row"
-              onClick={() => pickRepo(r.owner, r.name)}
-              disabled={picking !== null}
-            >
-              <span>
-                <strong>{r.name}</strong>
-                {r.private ? <span className="dim"> · private</span> : null}
-              </span>
-              <span className="dim">{r.updated_at.slice(0, 10)}</span>
-            </button>
-          ))}
+          {groups.map((group) => {
+            const installation = installationFor(group.login);
+            return (
+              <div key={group.login}>
+                <p className="dim" style={{ margin: "0.5rem 0 0.25rem" }}>
+                  <strong>{group.login}</strong>
+                  {installation ? (
+                    <>
+                      {" "}
+                      ·{" "}
+                      {installation.account_type === "Organization"
+                        ? "organization"
+                        : "user"}{" "}
+                      ·{" "}
+                      {installation.repository_selection === "selected"
+                        ? "Selected repos only"
+                        : "All repos"}
+                    </>
+                  ) : null}
+                </p>
+                {group.repos.map((r) => (
+                  <button
+                    type="button"
+                    key={r.full_name}
+                    className="repo-row"
+                    onClick={() => pickRepo(r.owner, r.name)}
+                    disabled={picking !== null}
+                  >
+                    <span>
+                      <strong>{r.name}</strong>
+                      {r.private ? <span className="dim"> · private</span> : null}
+                    </span>
+                    <span className="dim">{r.updated_at.slice(0, 10)}</span>
+                  </button>
+                ))}
+              </div>
+            );
+          })}
         </div>
       ) : null}
+
+      <div className="actions" style={{ marginTop: "0.75rem" }}>
+        <button
+          type="button"
+          className="secondary"
+          onClick={() => setRefreshTick((n) => n + 1)}
+        >
+          Refresh list
+        </button>
+        <a
+          href={install.install_url}
+          target="_blank"
+          rel="noreferrer"
+          className="dim"
+          style={{ alignSelf: "center" }}
+        >
+          Install on another account or org →
+        </a>
+      </div>
 
       {!showCreate ? (
         <div className="actions" style={{ marginTop: "0.75rem" }}>
@@ -1624,26 +2207,115 @@ function RepoPicker({
             placeholder="my-vault-backup"
             onChange={(e) => setNewName(e.target.value)}
           />
-          <div className="actions">
-            <button
-              type="button"
-              onClick={createAndPick}
-              disabled={creating || newName.trim().length === 0}
-            >
-              {creating ? "Creating…" : "Create"}
-            </button>
-            <button
-              type="button"
-              className="secondary"
-              onClick={() => setShowCreate(false)}
-              disabled={creating}
-            >
-              Cancel
-            </button>
-          </div>
+          {createIsManual ? (
+            <CreateRepoGuide
+              install={install}
+              suggestedName={newName.trim()}
+              onRefresh={() => setRefreshTick((n) => n + 1)}
+            />
+          ) : (
+            <div className="actions">
+              <button
+                type="button"
+                onClick={createAndPick}
+                disabled={creating || newName.trim().length === 0}
+              >
+                {creating ? "Creating…" : "Create"}
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => setShowCreate(false)}
+                disabled={creating}
+              >
+                Cancel
+              </button>
+            </div>
+          )}
         </div>
       )}
     </>
+  );
+}
+
+/**
+ * Guided-manual repo creation (vault#480). The shared Parachute app is
+ * frozen at Contents-only — `POST /user/repos` needs Administration:write,
+ * so in-app creation 403s by design (least-privilege won: a backup mirror
+ * shouldn't hold repo-deletion powers). The guide walks the three manual
+ * steps with deep links instead of leaving the operator at a dead button.
+ */
+function CreateRepoGuide({
+  install,
+  suggestedName,
+  onRefresh,
+}: {
+  install: GithubInstallState;
+  suggestedName: string;
+  onRefresh: () => void;
+}) {
+  const newRepoUrl =
+    suggestedName.length > 0
+      ? `https://github.com/new?name=${encodeURIComponent(suggestedName)}`
+      : "https://github.com/new";
+  return (
+    <div className="info-banner" role="note" style={{ marginTop: "0.5rem" }}>
+      <p style={{ marginTop: 0 }}>
+        {install.app.is_shared_default ? (
+          <>
+            The Parachute app deliberately can't create repos for you (it only
+            holds the <em>Contents</em> permission — creating repos would need
+            admin powers a backup doesn't deserve). Three quick steps instead:
+          </>
+        ) : (
+          <>
+            Your GitHub App doesn't have the <em>Administration</em> permission
+            needed to create repos. Three quick steps instead:
+          </>
+        )}
+      </p>
+      <ol style={{ marginTop: 0, marginBottom: "0.5rem" }}>
+        <li>
+          <a href={newRepoUrl} target="_blank" rel="noreferrer">
+            Create a new repo on GitHub →
+          </a>{" "}
+          <span className="dim">
+            (private; leave it empty — no README or .gitignore)
+          </span>
+        </li>
+        <li>
+          Add it to the app's repo access:{" "}
+          {install.installations.length > 0 ? (
+            install.installations.map((i, idx) => (
+              <span key={i.id}>
+                {idx > 0 ? " · " : null}
+                <a
+                  href={installationSettingsUrl(i)}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  configure on {i.account_login} →
+                </a>
+              </span>
+            ))
+          ) : (
+            <a href={install.install_url} target="_blank" rel="noreferrer">
+              install the app →
+            </a>
+          )}{" "}
+          <span className="dim">
+            (skip if the installation already grants "All repos")
+          </span>
+        </li>
+        <li>
+          Come back and{" "}
+          <button type="button" className="secondary" onClick={onRefresh}>
+            Refresh list
+          </button>{" "}
+          — then pick it.
+        </li>
+      </ol>
+    </div>
   );
 }
 
@@ -2220,16 +2892,25 @@ function ImportRepoPickerModal({
 }) {
   const [repos, setRepos] = useState<GitHubRepoInfo[] | null>(null);
   const [truncated, setTruncated] = useState(false);
+  /** vault#480 — authorized-but-not-installed; carries the install link. */
+  const [notInstalledUrl, setNotInstalledUrl] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     listGithubRepos(vaultName)
-      .then(({ repos, truncated }) => {
+      .then((result) => {
         if (cancelled) return;
-        setRepos(repos);
-        setTruncated(Boolean(truncated));
+        if (!result.installed) {
+          // Authorized but the app isn't installed anywhere — repos can't
+          // be listed. Surface the install link instead of an empty list.
+          setNotInstalledUrl(result.install_url);
+          setRepos([]);
+          return;
+        }
+        setRepos(result.repos);
+        setTruncated(Boolean(result.truncated));
       })
       .catch((err) => {
         if (cancelled) return;
@@ -2260,6 +2941,16 @@ function ImportRepoPickerModal({
             <code>{error}</code>
           </div>
         ) : null}
+        {notInstalledUrl ? (
+          <div className="info-banner" role="status">
+            The Parachute GitHub App isn't installed on any of your accounts
+            yet, so there are no repos to list.{" "}
+            <a href={notInstalledUrl} target="_blank" rel="noreferrer">
+              Install it on GitHub →
+            </a>{" "}
+            then reopen this picker.
+          </div>
+        ) : null}
         <div className="form-row">
           <input
             type="search"
@@ -2270,7 +2961,8 @@ function ImportRepoPickerModal({
         </div>
         {truncated ? (
           <p className="muted" style={{ fontSize: "0.85em" }}>
-            Showing the first 300 repos. Use the filter above to narrow down.
+            Showing the first 300 repos per account. Use the filter above to
+            narrow down.
           </p>
         ) : null}
         {repos === null && !error ? <p className="muted">Loading repos…</p> : null}
@@ -2279,8 +2971,8 @@ function ImportRepoPickerModal({
             {filtered.length === 0 && filter.length > 0 ? (
               <p className="dim">No repos match "{filter}".</p>
             ) : null}
-            {filtered.length === 0 && filter.length === 0 && repos.length === 0 ? (
-              <p className="dim">You don't own any repos on this account.</p>
+            {filtered.length === 0 && filter.length === 0 && repos.length === 0 && !notInstalledUrl ? (
+              <p className="dim">The app installation doesn't include any repos.</p>
             ) : null}
             {filtered.map((r) => (
               <button

--- a/web/ui/src/routes/VaultMirror.tsx
+++ b/web/ui/src/routes/VaultMirror.tsx
@@ -1054,7 +1054,8 @@ function GitRemoteSection({
    * the section said "Connected ✓" and nothing else.
    *
    * Deliberately fetched only while a GitHub credential exists (the
-   * endpoint 401s otherwise) — `GET /auth` stays the offline status read.
+   * endpoint 400s github_not_connected otherwise) — `GET /auth` stays the
+   * offline status read.
    */
   const [install, setInstall] = useState<GithubInstallState | null>(null);
   const [installError, setInstallError] = useState<string | null>(null);
@@ -1717,11 +1718,18 @@ function GithubOAuthModal({
   const [now, setNow] = useState(Date.now());
   const pollAbortRef = useRef<boolean>(false);
 
-  // Tick clock so the countdown ticks down visibly.
+  // Tick clock so the polling-phase countdown ticks down visibly. Gated to
+  // the polling phase — `now` is only consumed by the countdown render. An
+  // unconditional ticker re-rendered the modal every second in EVERY phase,
+  // which (with the inline callback props RepoPicker's fetch effect depended
+  // on) made the open picker refetch the repo list each tick, burning the
+  // operator's GitHub rate limit (PR #484 review fold).
+  const isPolling = phase.kind === "polling";
   useEffect(() => {
+    if (!isPolling) return;
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
-  }, []);
+  }, [isPolling]);
 
   // Abort flag for the poll loop — unmount-only. (Setting it in the
   // start effect's cleanup would fire on the starting→polling transition
@@ -1835,6 +1843,22 @@ function GithubOAuthModal({
     };
   }, [phase, vaultName]);
 
+  // Stable identities for RepoPicker's callback props — both sit in its
+  // fetch-effect dependency array, so inline arrows (recreated every render)
+  // would re-arm the effect and refetch the repo list on any modal
+  // re-render (PR #484 review fold). Functional setPhase keeps them
+  // dependency-free: onNotInstalled reads the CURRENT picker phase's user
+  // instead of closing over a stale one.
+  const handlePickerError = useCallback(
+    (message: string) => setPhase({ kind: "error", message }),
+    [],
+  );
+  const handlePickerNotInstalled = useCallback(() => {
+    setPhase((p) =>
+      p.kind === "picker" ? { kind: "probing", user: p.user } : p,
+    );
+  }, []);
+
   const copyCode = async (code: string) => {
     try {
       await navigator.clipboard.writeText(code);
@@ -1906,11 +1930,17 @@ function GithubOAuthModal({
             install={phase.install}
             onPicked={async (owner, name) => {
               const selectResult = await selectGithubRepo(vaultName, { owner, name });
+              // vault#483 — select-repo also runs history-on-link server-side
+              // (the "Choose repository…" re-entry can be the first linked
+              // action for a credential saved before history-on-link
+              // existed). Surface the outcome the same way the grant path
+              // does, before the modal closes.
+              onHistory(selectResult.history_enabled);
               const c = await getMirrorAuth(vaultName);
               onConnected(c, selectResult);
             }}
-            onError={(message) => setPhase({ kind: "error", message })}
-            onNotInstalled={() => setPhase({ kind: "probing", user: phase.user })}
+            onError={handlePickerError}
+            onNotInstalled={handlePickerNotInstalled}
           />
         ) : null}
 


### PR DESCRIPTION
Two commits: the backend connect-flow rework (`377d97d`) + the mirror-page SPA state machine (`001f739`). Born from Aaron's live walk (#480): he authorized the app via device flow, reasonably believed he was done, and got a picker full of only his public repos — with org repos invisible entirely — and history silently off (#483).

## The state machine (mirror page + connect modal)

GitHub-App semantics: **authorization and installation are separate, order-independent steps**, and every GitHub App can read all public repos — so "installed" must come from `GET /user/installations` (the canonical probe; needs no permissions; empty = authorized-but-not-installed), never be inferred from repo visibility.

1. **not-linked** — unchanged: PAT primary, "Connect GitHub" device-flow shortcut.
2. **linked-but-not-installed** — the page probes install state whenever a `github_oauth` credential is active and renders the guided state Aaron hit blind: "Authorized ✓ — one step left: install the app so it can reach your repos", an **Install on GitHub →** link (API-provided `install_url`, slug-correct for BYO apps), an "I've installed it — check again" re-probe, and the org note ("vaults in an org? Install the app on that org too — repeatable"). The connect modal renders the same panel post-grant: `device code → poll → grant → probe → install-needed ⇄ probing → picker`.
3. **installed-no-repo** — picker fed by the installations-based endpoint, repos **grouped by account** (user + orgs — the old `GET /user/repos?type=owner` picker excluded org repos by construction), each group labeled with account type + `repository_selection` ("All repos" / "Selected repos only"). "Install on another account or org →" and "Refresh list" stay reachable. A **"Choose repository…"** re-entry opens the picker for an already-linked credential — previously, closing the modal mid-flow left no way back in short of disconnecting.
4. **ready** — existing linked+repo state plus the active-app identity line.

**Create-repo guidance**: the shared app is frozen at Contents-only, so `POST /user/repos` 403s by design (Administration:write is a bigger grant than a backup mirror deserves). The shared app gets the guided-manual checklist *proactively* — no dead button: ① create at github.com/new (best-effort `?name=` prefill) → ② add it to the installation (per-installation settings deep-links, user vs organization URL shapes) → ③ Refresh list and pick it. BYO apps keep the live Create button (they may grant Administration:write) and fall back to the same checklist on the machine-readable 403.

## REST contract consumed (shipped in `377d97d`)

- **NEW** `GET /vault/<name>/.parachute/mirror/auth/github/installations` (admin-gated; the one explicitly-network status endpoint — `GET /auth` stays offline): `200 { app: { client_id, slug, is_shared_default }, installed, install_url, installations: [{ id, account_login, account_type, repository_selection }] }`; `401 error_type: "github_not_connected"`; `502` upstream failure.
- **CHANGED** `GET …/auth/github/repos`: installed → `200 { installed: true, repos: [{ …RepoInfo, account_login, installation_id }], truncated }` (union over user + org installations); authorized-but-not-installed → `200 { installed: false, install_url, repos: [], truncated: false }`. The SPA branches on the `installed` discriminator, never strings. Old `{ repos, truncated }` decoding remains a strict subset of the installed case.
- **CHANGED** `POST …/auth/github/create-repo`: shared-app failure → `403 { error_type: "app_lacks_admin_permission" }` (SPA `HttpError` now carries `errorType`); BYO apps with Administration:write still `200`.
- **CHANGED** `POST …/auth/github/poll` (granted) + `POST …/auth/pat`: response carries `history_enabled: true | false | "left_disabled"`.

## History-on-link (#483) — the consent-respecting rule

Linking implies backup intent: on credential save, a **never-configured** vault (no mirror-config file) gets the internal mirror enabled with the standard #440 defaults. An **explicit `enabled: false` is never flipped silently** — the server reports `"left_disabled"` and the SPA offers the one-click "Turn on history now" (`PUT { enabled: true }`); clicking *is* the consent. `false` (enable attempted, mirror didn't start) points at Advanced settings → Status for the actionable error. The SPA surfaces the outcome **at grant time**, not repo-pick time — a mid-flow modal close can't eat it — and modal close re-reads credential status so a mid-flow grant reflects on the page immediately.

## BYO-app surface (sovereignty, first-class)

The page shows which app is in use — "Using the shared Parachute GitHub App (`parachute-computer`)" or "Using your own GitHub App (`<slug>`)" — with a collapsible **"Use your own GitHub App"** recipe: register a GitHub App with **Contents read & write only**, **enable Device Flow**, **disable user-token expiration**, webhook inactive, and **don't generate a private key** (recommended against entirely — Parachute never uses one, and a key-less app can't have installation tokens minted behind the operator's back); then set `PARACHUTE_GITHUB_CLIENT_ID` + `PARACHUTE_GITHUB_APP_SLUG` **as a pair** and restart the vault. Framing per Aaron: make it easy for people to take responsibility for their own data.

## Also fixed in passing

- The device-flow modal's "Try again" never actually restarted the flow (start effect only ran on mount); fixing that exposed a poll-abort-ref bug (the cleanup strangled the first poll tick) — abort is now unmount-only, the poll loop resets it on arm.
- `ImportRepoPickerModal` handles the new `installed: false` repos response with an install link instead of a misleading empty list.

## Test evidence

All fixtures + injected mocks — zero live GitHub anywhere.

- Backend (`377d97d`): client tests for `listInstallations` / `listInstallationRepos` / 403-carrying `createRepo`; route tests for install-state (no-cred 401 / not-installed / user+org / BYO env / 502), picker union + truncation, create-repo 403 mapping, history-on-link (fresh-enables / explicit-disabled-untouched / already-enabled-untouched via both grant and PAT).
- SPA (`001f739`, +11 vitest): the four page states; not-installed → installed re-check transition; picker grouping by account + org repo pick (`selectGithubRepo` with the org owner); shared-app proactive checklist with `createGithubRepo` never called; BYO 403 → checklist (not an error toast); BYO identity + recipe render; all three `history_enabled` outcomes incl. the one-click `PUT { enabled: true }`; an end-to-end device-flow chain (grant → probe → guided install → re-check → picker) on a 1s poll tick.

**Gates** (runner-literal):
- `bun test ./src/` → **1592 pass, 0 fail, 4384 expect() calls, 57 files**
- `bun run typecheck` (root) → clean
- `cd web/ui && bunx vitest run` → **Test Files 12 passed (12), Tests 198 passed (198)**
- `cd web/ui && bun run typecheck` → clean

No version bump (bump + tag ride the ship call, not the PR).

Progresses #483 (fix 1 — history-on-link; fix 2, the pre-#440 backfill nudge, stays tracked on the issue)
Progresses #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
