### PR TITLE
feat(api): content range/pagination on query-notes + REST — bounded reads for large notes (Benjamin's spec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@ to `@latest`.
 
 ## [Unreleased]
 
+### Added
+
+- **Content range / pagination — bounded reads for large notes (Benjamin's
+  spec).** `query-notes` (MCP) and the REST `GET /notes` family (point read,
+  `?id=`, structured list, search) accept `content_offset` (default 0) +
+  `content_length` (byte budget, min 4). When either is set, the returned
+  `content` is a byte slice and the response gains `content_offset`
+  (effective start), `content_total_length`, and `content_next_offset`
+  (`null` when complete) — so MCP clients can read notes too large to
+  return in one response by looping `content_next_offset` back in as
+  `content_offset`. Unit is UTF-8 bytes; slices always end on a codepoint
+  boundary *within* the budget (never over; up to 3 bytes under when a
+  multi-byte character straddles the cut), and an offset landing
+  mid-codepoint aligns down to the codepoint's leading byte, so
+  concatenating the slices reconstructs the content byte-for-byte (pinned
+  by a property test). On list queries the same window applies to each
+  note's content independently; with `expand_links=true` the range applies
+  to the expanded content. Range params on a content-less shape
+  (`include_content=false`, or a list left on its lean default) error
+  loudly (`INVALID_QUERY` / 400) rather than silently no-op. Responses
+  without range params are byte-identical to before. (No rc bump in this
+  entry — the version bump lands at tag time.)
+
 ### Performance (query path — the 2026-06-10 measurements)
 
 - **Tag/list queries no longer materialize every candidate row.**

--- a/README.md
+++ b/README.md
@@ -530,6 +530,23 @@ curl -H "Authorization: Bearer $VAULT_TOKEN" \
 
 Caller-tunable preview length is a future enhancement — file an issue if 120 chars isn't enough.
 
+### Read a large note in chunks (content range)
+
+A 100KB+ transcript won't fit in one MCP response. Pass `content_offset` / `content_length` (UTF-8 bytes) for a bounded read — the response carries the slice plus `content_total_length` and `content_next_offset` (`null` when complete). Loop, feeding `content_next_offset` back in as `content_offset`; concatenating the slices reconstructs the content byte-for-byte. Slices end on a codepoint boundary within the budget (never over `content_length`, at most 3 bytes under).
+
+```bash
+curl -H "Authorization: Bearer $VAULT_TOKEN" \
+  "http://localhost:1940/vault/default/api/notes/Meetings%2F2026-06-09?content_offset=0&content_length=65536"
+# → { ..., "content": "<first ≤64KB>", "content_total_length": 118034, "content_next_offset": 65530 }
+```
+
+```jsonc
+// MCP — same params on query-notes; works per-note on lists with include_content: true
+{ "name": "query-notes", "arguments": { "id": "Meetings/2026-06-09", "content_offset": 0, "content_length": 65536 } }
+```
+
+Range params require content in the response — with `include_content=false` (or a list query left on its lean default) they error rather than silently no-op. Full semantics in [docs/HTTP_API.md](./docs/HTTP_API.md) ("Content range — bounded reads for large notes").
+
 ### Incremental rebuilds: "what changed since X"
 
 The SSG / sync pattern. Two equivalent forms — bracket-style is canonical going forward; the flat form is the same shape that ships through the REST/MCP date filter today.

--- a/core/src/content-range.test.ts
+++ b/core/src/content-range.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Content range / pagination tests — bounded reads for large notes.
+ *
+ * Three layers:
+ *   1. Unit tests of the parse + slice helpers (boundary cases: offset
+ *      past end, sub-minimum budget, multi-byte codepoints at the cut).
+ *   2. Property test of the reassembly invariant: walking a string from
+ *      offset 0 via `content_next_offset` and concatenating the slices is
+ *      byte-identical to the full content, for arbitrary unicode content
+ *      and budgets — and no slice ever exceeds the byte budget.
+ *   3. MCP face (`query-notes` execute): single + list shapes, the
+ *      include_content interaction, and the no-params regression
+ *      (response shape byte-identical to pre-pagination behavior).
+ *
+ * The REST face is exercised in src/content-range-routes.test.ts.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { SqliteStore } from "./store.js";
+import { generateMcpTools } from "./mcp.js";
+import {
+  parseContentRange,
+  sliceContentRange,
+  applyContentRange,
+  MIN_CONTENT_LENGTH,
+} from "./content-range.js";
+
+// ---------------------------------------------------------------------------
+// 1. parseContentRange
+// ---------------------------------------------------------------------------
+
+describe("parseContentRange", () => {
+  it("returns null when neither param is present (range mode off)", () => {
+    expect(parseContentRange(undefined, undefined)).toBeNull();
+    expect(parseContentRange(null, null)).toBeNull();
+  });
+
+  it("treats empty strings as absent (REST `?content_offset=`)", () => {
+    expect(parseContentRange("", "")).toBeNull();
+  });
+
+  it("offset only → length omitted (read to end)", () => {
+    expect(parseContentRange(10, undefined)).toEqual({ offset: 10 });
+  });
+
+  it("length only → offset defaults to 0", () => {
+    expect(parseContentRange(undefined, 64)).toEqual({ offset: 0, length: 64 });
+  });
+
+  it("accepts decimal strings (REST query params)", () => {
+    expect(parseContentRange("5", "1024")).toEqual({ offset: 5, length: 1024 });
+  });
+
+  it("rejects negative offset", () => {
+    expect(() => parseContentRange(-1, undefined)).toThrow(/content_offset/);
+  });
+
+  it("rejects non-integer values", () => {
+    expect(() => parseContentRange(1.5, undefined)).toThrow(/content_offset/);
+    expect(() => parseContentRange(undefined, 7.2)).toThrow(/content_length/);
+    expect(() => parseContentRange("abc", undefined)).toThrow(/content_offset/);
+    expect(() => parseContentRange(undefined, "-4")).toThrow(/content_length/);
+  });
+
+  it(`rejects zero / negative / sub-minimum budget (< ${MIN_CONTENT_LENGTH})`, () => {
+    expect(() => parseContentRange(undefined, 0)).toThrow(/content_length/);
+    expect(() => parseContentRange(undefined, -8)).toThrow(/content_length/);
+    expect(() => parseContentRange(undefined, MIN_CONTENT_LENGTH - 1)).toThrow(/content_length/);
+    // The minimum itself is fine.
+    expect(parseContentRange(undefined, MIN_CONTENT_LENGTH)).toEqual({
+      offset: 0,
+      length: MIN_CONTENT_LENGTH,
+    });
+  });
+
+  it("throws QueryError with INVALID_QUERY code", () => {
+    try {
+      parseContentRange(undefined, 2);
+      throw new Error("should have thrown");
+    } catch (e: any) {
+      expect(e.name).toBe("QueryError");
+      expect(e.code).toBe("INVALID_QUERY");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. sliceContentRange — boundary cases
+// ---------------------------------------------------------------------------
+
+describe("sliceContentRange", () => {
+  it("plain ASCII window", () => {
+    const r = sliceContentRange("hello world", { offset: 0, length: 5 });
+    expect(r.content).toBe("hello");
+    expect(r.content_offset).toBe(0);
+    expect(r.content_total_length).toBe(11);
+    expect(r.content_next_offset).toBe(5);
+  });
+
+  it("continuation window reaches the end → next_offset null", () => {
+    const r = sliceContentRange("hello world", { offset: 5, length: 100 });
+    expect(r.content).toBe(" world");
+    expect(r.content_next_offset).toBeNull();
+  });
+
+  it("offset with no length reads to the end", () => {
+    const r = sliceContentRange("hello world", { offset: 6 });
+    expect(r.content).toBe("world");
+    expect(r.content_total_length).toBe(11);
+    expect(r.content_next_offset).toBeNull();
+  });
+
+  it("offset exactly at end → empty slice, complete", () => {
+    const r = sliceContentRange("abc", { offset: 3 });
+    expect(r.content).toBe("");
+    expect(r.content_offset).toBe(3);
+    expect(r.content_total_length).toBe(3);
+    expect(r.content_next_offset).toBeNull();
+  });
+
+  it("offset past end → empty slice, complete (graceful loop termination)", () => {
+    const r = sliceContentRange("abc", { offset: 999, length: 16 });
+    expect(r.content).toBe("");
+    expect(r.content_offset).toBe(3); // clamped to total
+    expect(r.content_total_length).toBe(3);
+    expect(r.content_next_offset).toBeNull();
+  });
+
+  it("empty content → empty slice, total 0", () => {
+    const r = sliceContentRange("", { offset: 0, length: 16 });
+    expect(r.content).toBe("");
+    expect(r.content_total_length).toBe(0);
+    expect(r.content_next_offset).toBeNull();
+  });
+
+  it("budget cutting mid-codepoint backs off to the boundary (never over budget)", () => {
+    // "ab😀cd" — bytes: a=0, b=1, 😀=2..5 (4 bytes), c=6, d=7; total 8.
+    const s = "ab\u{1F600}cd";
+    expect(Buffer.byteLength(s, "utf8")).toBe(8);
+
+    // Budget 5 would cut mid-emoji → slice backs off to byte 2.
+    const r1 = sliceContentRange(s, { offset: 0, length: 5 });
+    expect(r1.content).toBe("ab");
+    expect(Buffer.byteLength(r1.content, "utf8")).toBeLessThanOrEqual(5);
+    expect(r1.content_next_offset).toBe(2);
+
+    // Next window picks up the whole emoji.
+    const r2 = sliceContentRange(s, { offset: 2, length: 4 });
+    expect(r2.content).toBe("\u{1F600}");
+    expect(r2.content_next_offset).toBe(6);
+
+    // Final window.
+    const r3 = sliceContentRange(s, { offset: 6, length: 4 });
+    expect(r3.content).toBe("cd");
+    expect(r3.content_next_offset).toBeNull();
+  });
+
+  it("offset landing mid-codepoint aligns DOWN (no bytes skipped) and echoes the effective offset", () => {
+    const s = "ab\u{1F600}cd"; // emoji occupies bytes 2..5
+    const r = sliceContentRange(s, { offset: 4, length: 8 });
+    expect(r.content_offset).toBe(2); // aligned down to the emoji's lead byte
+    expect(r.content).toBe("\u{1F600}cd");
+    expect(r.content_next_offset).toBeNull();
+  });
+
+  it("minimum budget always makes progress, even on a 4-byte codepoint", () => {
+    const s = "\u{1F600}\u{1F601}"; // two 4-byte emoji
+    const r = sliceContentRange(s, { offset: 0, length: MIN_CONTENT_LENGTH });
+    expect(r.content).toBe("\u{1F600}");
+    expect(r.content_next_offset).toBe(4);
+  });
+
+  it("applyContentRange mutates the shaped result in place", () => {
+    const result: any = { id: "n1", content: "hello world", tags: ["x"] };
+    applyContentRange(result, { offset: 0, length: 5 });
+    expect(result.content).toBe("hello");
+    expect(result.content_offset).toBe(0);
+    expect(result.content_total_length).toBe(11);
+    expect(result.content_next_offset).toBe(5);
+    expect(result.tags).toEqual(["x"]); // untouched
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2b. Property test — reassembly invariant
+// ---------------------------------------------------------------------------
+
+/** Deterministic PRNG (mulberry32) so failures reproduce. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe("content range — reassembly property", () => {
+  // Mixed-width pool: 1-byte ASCII, 2-byte (é, ψ), 3-byte (你, ‱), 4-byte
+  // (😀, 𝄞) — plus whitespace, so windows land on every codepoint width.
+  const POOL = ["a", "Z", "9", " ", "\n", "é", "ψ", "你", "‱", "\u{1F600}", "\u{1D11E}"];
+
+  it("concatenating all slices is byte-identical to the full content; no slice exceeds the budget", () => {
+    const rand = mulberry32(0xc0ffee);
+    for (let iter = 0; iter < 60; iter++) {
+      const charCount = Math.floor(rand() * 120); // includes 0 (empty content)
+      let content = "";
+      for (let i = 0; i < charCount; i++) {
+        content += POOL[Math.floor(rand() * POOL.length)]!;
+      }
+      const budget = MIN_CONTENT_LENGTH + Math.floor(rand() * 13); // 4..16 bytes
+      const totalBytes = Buffer.byteLength(content, "utf8");
+
+      let offset = 0;
+      let assembled = "";
+      let lastTotal: number | null = null;
+      // Hard ceiling on iterations: every window must advance by >= 1 byte.
+      for (let step = 0; step <= totalBytes + 2; step++) {
+        const slice = sliceContentRange(content, { offset, length: budget });
+        expect(Buffer.byteLength(slice.content, "utf8")).toBeLessThanOrEqual(budget);
+        expect(slice.content_total_length).toBe(totalBytes);
+        lastTotal = slice.content_total_length;
+        assembled += slice.content;
+        if (slice.content_next_offset === null) break;
+        // Progress guarantee — next offset strictly advances.
+        expect(slice.content_next_offset).toBeGreaterThan(offset);
+        offset = slice.content_next_offset;
+      }
+
+      expect(assembled).toBe(content);
+      expect(Buffer.from(assembled, "utf8").equals(Buffer.from(content, "utf8"))).toBe(true);
+      expect(lastTotal).toBe(totalBytes);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. MCP face — query-notes
+// ---------------------------------------------------------------------------
+
+describe("MCP query-notes — content range", () => {
+  let db: Database;
+  let store: SqliteStore;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    store = new SqliteStore(db);
+  });
+
+  function queryTool() {
+    const tools = generateMcpTools(store);
+    return tools.find((t) => t.name === "query-notes")!;
+  }
+
+  it("single note: paged read loop reassembles the full content", async () => {
+    // Mixed-width content so windows hit multi-byte boundaries.
+    const content = ("section \u{1F600} 你好 " .repeat(40)).trim();
+    const note = await store.createNote(content);
+    const query = queryTool();
+
+    let offset = 0;
+    let assembled = "";
+    for (;;) {
+      const r: any = await query.execute({ id: note.id, content_offset: offset, content_length: 64 });
+      expect(r.content_total_length).toBe(Buffer.byteLength(content, "utf8"));
+      assembled += r.content;
+      if (r.content_next_offset === null) break;
+      offset = r.content_next_offset;
+    }
+    expect(assembled).toBe(content);
+  });
+
+  it("single note: response carries the range fields and the slice", async () => {
+    const note = await store.createNote("0123456789");
+    const r: any = await queryTool().execute({ id: note.id, content_length: 4 });
+    expect(r.content).toBe("0123");
+    expect(r.content_offset).toBe(0);
+    expect(r.content_total_length).toBe(10);
+    expect(r.content_next_offset).toBe(4);
+    expect(r.id).toBe(note.id); // rest of the note shape intact
+  });
+
+  it("single note, no range params → byte-identical to today (regression)", async () => {
+    const note = await store.createNote("full body here");
+    const r: any = await queryTool().execute({ id: note.id });
+    expect(r.content).toBe("full body here");
+    expect("content_total_length" in r).toBe(false);
+    expect("content_next_offset" in r).toBe(false);
+    expect("content_offset" in r).toBe(false);
+  });
+
+  it("single note: content_offset past end → empty slice, complete", async () => {
+    const note = await store.createNote("abc");
+    const r: any = await queryTool().execute({ id: note.id, content_offset: 999 });
+    expect(r.content).toBe("");
+    expect(r.content_total_length).toBe(3);
+    expect(r.content_next_offset).toBeNull();
+  });
+
+  it("single note: include_content=false + range params → loud error", async () => {
+    const note = await store.createNote("abc");
+    expect(
+      queryTool().execute({ id: note.id, include_content: false, content_length: 8 }),
+    ).rejects.toThrow(/include_content/);
+  });
+
+  it("rejects sub-minimum / invalid budgets before any query work", async () => {
+    const note = await store.createNote("abc");
+    expect(queryTool().execute({ id: note.id, content_length: 0 })).rejects.toThrow(/content_length/);
+    expect(queryTool().execute({ id: note.id, content_length: -5 })).rejects.toThrow(/content_length/);
+    expect(queryTool().execute({ id: note.id, content_length: 2 })).rejects.toThrow(/content_length/);
+    expect(queryTool().execute({ id: note.id, content_offset: -1 })).rejects.toThrow(/content_offset/);
+  });
+
+  it("list query: include_content=true applies the window per note", async () => {
+    await store.createNote("alpha alpha alpha", { tags: ["big"] });
+    await store.createNote("beta beta beta beta", { tags: ["big"] });
+    const out: any[] = (await queryTool().execute({
+      tag: "big",
+      include_content: true,
+      content_length: 5,
+    })) as any[];
+    expect(out.length).toBe(2);
+    for (const n of out) {
+      expect(Buffer.byteLength(n.content, "utf8")).toBeLessThanOrEqual(5);
+      expect(typeof n.content_total_length).toBe("number");
+      expect(n.content_next_offset).toBe(5);
+    }
+  });
+
+  it("list query: lean default (no include_content) + range params → loud error", async () => {
+    await store.createNote("alpha", { tags: ["big"] });
+    expect(queryTool().execute({ tag: "big", content_length: 8 })).rejects.toThrow(
+      /include_content/,
+    );
+  });
+
+  it("list query, no range params → no range fields injected (regression)", async () => {
+    await store.createNote("alpha", { tags: ["big"] });
+    const out: any[] = (await queryTool().execute({ tag: "big", include_content: true })) as any[];
+    expect(out.length).toBe(1);
+    expect("content_total_length" in out[0]).toBe(false);
+    expect("content_next_offset" in out[0]).toBe(false);
+  });
+
+  it("expand_links: the range applies to the EXPANDED content", async () => {
+    await store.createNote("inlined body of B", { path: "B" });
+    const a = await store.createNote("A says: [[B]]", { path: "A" });
+    const query = queryTool();
+
+    const unpaged: any = await query.execute({ id: a.id, expand_links: true });
+    const paged: any = await query.execute({
+      id: a.id,
+      expand_links: true,
+      content_offset: 0,
+      content_length: 100000,
+    });
+    expect(paged.content).toBe(unpaged.content);
+    expect(paged.content_total_length).toBe(Buffer.byteLength(unpaged.content, "utf8"));
+    expect(paged.content_next_offset).toBeNull();
+  });
+
+  it("query-notes schema advertises the params (MCP discovery)", () => {
+    const query = queryTool();
+    const props = (query.inputSchema as any).properties;
+    expect(props.content_offset).toBeDefined();
+    expect(props.content_length).toBeDefined();
+    expect(query.description).toContain("content_offset");
+    expect(query.description).toContain("content_next_offset");
+  });
+});

--- a/core/src/content-range.ts
+++ b/core/src/content-range.ts
@@ -1,0 +1,185 @@
+/**
+ * Content range / pagination — bounded reads for large notes.
+ *
+ * MCP responses are size-limited: a 100KB+ transcript can't come back in
+ * one `query-notes` call, and a remote MCP client has no `curl | head -c`
+ * escape hatch. These helpers let a caller read note content in byte
+ * windows:
+ *
+ *   request:  `content_offset` (default 0) + `content_length` (byte budget)
+ *   response: `content` (the slice) + `content_offset` (effective start)
+ *             + `content_total_length` + `content_next_offset`
+ *             (`null` when the slice reaches the end)
+ *
+ * Unit is **UTF-8 bytes** — the same unit as `byteSize` on the lean
+ * NoteIndex shape, and the natural unit for budgeting response size. But
+ * naive byte-slicing can split a multi-byte codepoint, which would corrupt
+ * the JSON string. So slices always end on a codepoint boundary *within*
+ * the budget: a slice never exceeds `content_length` bytes but may come up
+ * to 3 bytes short when a multi-byte character straddles the cut. A
+ * `content_offset` that lands mid-codepoint (only possible when the caller
+ * computes offsets by hand — chained `content_next_offset` values are
+ * always boundary-aligned) is aligned DOWN to the codepoint's leading byte
+ * so no bytes are ever skipped; the effective start is echoed back as
+ * `content_offset` on the response.
+ *
+ * Reassembly invariant (pinned by content-range.test.ts): starting at
+ * offset 0 and following `content_next_offset` until `null`, the
+ * concatenation of slices is byte-identical to the full content.
+ */
+
+import { QueryError } from "./query-operators.js";
+
+/**
+ * Minimum accepted `content_length`. A UTF-8 codepoint is at most 4 bytes,
+ * so any budget >= 4 is guaranteed to make progress (the codepoint at the
+ * window start always fits). Budgets 1–3 could stall forever on a 4-byte
+ * emoji (empty slice, next_offset == offset); rejecting them up front is
+ * deterministic and simpler than a runtime "no progress" error.
+ */
+export const MIN_CONTENT_LENGTH = 4;
+
+export interface ContentRange {
+  /** Byte offset (UTF-8) to start reading from. */
+  offset: number;
+  /** Max bytes to return. Absent = read to the end. */
+  length?: number;
+}
+
+export interface ContentRangeFields {
+  content: string;
+  /** Effective start (requested offset aligned down to a codepoint boundary). */
+  content_offset: number;
+  /** Full content size in UTF-8 bytes. */
+  content_total_length: number;
+  /** Byte offset to resume from, or null when the slice reaches the end. */
+  content_next_offset: number | null;
+}
+
+function toNonNegativeInt(raw: unknown, name: string): number | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  let n: number;
+  if (typeof raw === "number") {
+    n = raw;
+  } else if (typeof raw === "string") {
+    if (raw.trim() === "") return undefined; // `?content_offset=` — treat empty as absent
+    if (!/^\d+$/.test(raw.trim())) {
+      throw new QueryError(
+        `invalid \`${name}\` value ${JSON.stringify(raw)} — must be a non-negative integer (UTF-8 byte count).`,
+        "INVALID_QUERY",
+      );
+    }
+    n = Number(raw.trim());
+  } else {
+    throw new QueryError(
+      `invalid \`${name}\` value — must be a non-negative integer (UTF-8 byte count).`,
+      "INVALID_QUERY",
+    );
+  }
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new QueryError(
+      `invalid \`${name}\` value ${JSON.stringify(raw)} — must be a non-negative integer (UTF-8 byte count).`,
+      "INVALID_QUERY",
+    );
+  }
+  return n;
+}
+
+/**
+ * Parse the `content_offset` / `content_length` pair. Returns `null` when
+ * neither is present (range mode off — response shape byte-identical to
+ * the no-pagination behavior). Throws `QueryError` (INVALID_QUERY) on
+ * negative / non-integer values or a `content_length` below
+ * {@link MIN_CONTENT_LENGTH}.
+ *
+ * Accepts numbers (MCP params) and decimal strings (REST query params);
+ * empty strings count as absent.
+ */
+export function parseContentRange(offsetRaw: unknown, lengthRaw: unknown): ContentRange | null {
+  const offset = toNonNegativeInt(offsetRaw, "content_offset");
+  const length = toNonNegativeInt(lengthRaw, "content_length");
+  if (offset === undefined && length === undefined) return null;
+  if (length !== undefined && length < MIN_CONTENT_LENGTH) {
+    throw new QueryError(
+      `invalid \`content_length\` value ${JSON.stringify(lengthRaw)} — must be at least ${MIN_CONTENT_LENGTH} bytes (the size of the largest UTF-8 codepoint, so every window makes progress).`,
+      "INVALID_QUERY",
+    );
+  }
+  return { offset: offset ?? 0, ...(length !== undefined ? { length } : {}) };
+}
+
+/**
+ * The error both faces raise when range params are combined with a
+ * response shape that excludes content (`include_content=false`, or a
+ * list query left on its lean default). Centralized so MCP and REST emit
+ * the same message.
+ */
+export function contentRangeRequiresContent(): QueryError {
+  return new QueryError(
+    `content_offset/content_length apply to note content, but content is not included in this response shape. Pass include_content=true (lists default to false) or drop the range params.`,
+    "INVALID_QUERY",
+  );
+}
+
+/** True for UTF-8 continuation bytes (0b10xxxxxx). */
+function isContinuationByte(b: number): boolean {
+  return (b & 0xc0) === 0x80;
+}
+
+/**
+ * Slice `content` to the requested byte window, never splitting a UTF-8
+ * codepoint and never exceeding `range.length` bytes. See module doc for
+ * the alignment rules.
+ */
+export function sliceContentRange(content: string, range: ContentRange): ContentRangeFields {
+  const bytes = Buffer.from(content, "utf8");
+  const total = bytes.byteLength;
+
+  // At/past the end: empty slice, complete. Graceful (not an error) so a
+  // pagination loop that overshoots — e.g. the note shrank between calls —
+  // terminates cleanly on `content_next_offset: null`.
+  if (range.offset >= total) {
+    return {
+      content: "",
+      content_offset: total,
+      content_total_length: total,
+      content_next_offset: null,
+    };
+  }
+
+  // Align the start DOWN to the leading byte of the codepoint containing
+  // `offset` — never skip bytes (a forward-align would drop them from
+  // every window and break reassembly).
+  let start = range.offset;
+  while (start > 0 && isContinuationByte(bytes[start]!)) start--;
+
+  // Window end: budget capped at total. Align DOWN so the slice doesn't
+  // end mid-codepoint — under the budget, never over.
+  let end = range.length === undefined ? total : Math.min(start + range.length, total);
+  while (end > start && end < total && isContinuationByte(bytes[end]!)) end--;
+
+  return {
+    content: bytes.subarray(start, end).toString("utf8"),
+    content_offset: start,
+    content_total_length: total,
+    content_next_offset: end >= total ? null : end,
+  };
+}
+
+/**
+ * Apply a content range to a shaped response object in place: replaces
+ * `content` with the slice and adds `content_offset`,
+ * `content_total_length`, `content_next_offset`. No-op fields are never
+ * added when range mode is off — callers only invoke this with a parsed
+ * (non-null) range.
+ */
+export function applyContentRange(
+  result: { content?: unknown; [key: string]: unknown },
+  range: ContentRange,
+): void {
+  const fields = sliceContentRange(typeof result.content === "string" ? result.content : "", range);
+  result.content = fields.content;
+  result.content_offset = fields.content_offset;
+  result.content_total_length = fields.content_total_length;
+  result.content_next_offset = fields.content_next_offset;
+}

--- a/core/src/mcp.ts
+++ b/core/src/mcp.ts
@@ -15,6 +15,12 @@ import {
   type ExpandContext,
   type ExpandMode,
 } from "./expand.js";
+import {
+  parseContentRange,
+  applyContentRange,
+  contentRangeRequiresContent,
+  MIN_CONTENT_LENGTH,
+} from "./content-range.js";
 
 export interface McpToolDef {
   name: string;
@@ -153,6 +159,8 @@ export function generateMcpTools(store: Store, opts?: GenerateMcpToolsOpts): Mcp
 
 Defaults: include_content=true for single note, false for lists. include_links=false. tag_match="any".
 
+Large notes: pass \`content_offset\` / \`content_length\` (UTF-8 bytes) for a bounded read of note content — the response carries the slice plus \`content_total_length\` and \`content_next_offset\` (null when complete). Loop, feeding \`content_next_offset\` back as \`content_offset\`, to read a note too large for one response.
+
 Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returned content. Tune with \`expand_depth\` (1–3, default 1) and \`expand_mode\` ("full" inlines full content, "summary" inlines only metadata.summary). Expansions are deduplicated across the query and cycle-guarded.`,
       inputSchema: {
         type: "object",
@@ -243,6 +251,16 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               "Opaque cursor for 'since last checked' agent loops (vault#313). First call: omit. The response will include `next_cursor` — pass it on the subsequent call to receive only notes created or updated since the prior page. The cursor binds to the query's filters (tag, path, metadata, etc.); changing them between calls returns a structured `cursor_query_mismatch` error. Pagination via cursor orders results by `updated_at ASC` and is mutually exclusive with `order_by` and `sort: \"desc\"`. The response shape switches to `{notes, next_cursor}` when this parameter is present.",
           },
           include_content: { type: "boolean", description: "Include note content (default: true for single, false for list)" },
+          content_offset: {
+            type: "number",
+            description:
+              "Byte offset (UTF-8) into note content to start reading from (default 0). For reading a note too large for one response: pass the previous response's `content_next_offset` here to continue. An offset landing mid-codepoint is aligned DOWN to the codepoint's leading byte (chained `content_next_offset` values are always aligned); the effective start is echoed back as `content_offset` on the response. Requires content in the response — errors when combined with include_content=false (or a list query without include_content=true).",
+          },
+          content_length: {
+            type: "number",
+            description:
+              `Maximum bytes (UTF-8) of note content to return (minimum ${MIN_CONTENT_LENGTH}). When this or content_offset is set, the returned \`content\` is the byte slice and the response gains \`content_offset\` (effective start), \`content_total_length\` (full content size in bytes), and \`content_next_offset\` (pass back as content_offset to continue; null when the slice reaches the end). Slices end on a UTF-8 codepoint boundary, so a slice may be up to 3 bytes under the budget — never over. Concatenating the slices from offset 0 through content_next_offset=null reconstructs the content byte-for-byte. On list queries the same window applies to each note's content independently. When expand_links=true the range applies to the returned (expanded) content.`,
+          },
           include_metadata: {
             oneOf: [
               { type: "boolean" },
@@ -292,17 +310,31 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
             }
           : null;
 
+        // --- Content range (bounded reads for large notes) ---
+        // Validates loudly: bad values throw QueryError here, before any
+        // query work. Null when neither param is present — response shape
+        // stays byte-identical to the no-pagination behavior.
+        const contentRange = parseContentRange(params.content_offset, params.content_length);
+
         // --- Single note by ID/path ---
         if (params.id) {
           const note = resolveNote(db, params.id as string);
           if (!note) return { error: "Note not found", id: params.id };
           const includeContent = params.include_content !== false; // default true for single
+          // Range params are meaningless on a content-less shape — error
+          // rather than silently ignore (same loud-validation policy as
+          // `expand`).
+          if (contentRange && !includeContent) throw contentRangeRequiresContent();
           let result: any = includeContent ? { ...note } : noteOps.toNoteIndex(note);
           if (expandCtx && includeContent && typeof result.content === "string") {
             // Mark the top-level note as already expanded so it can't recursively inline itself.
             expandCtx.expanded.add(note.id);
             result.content = expandContent(result.content, expandCtx, expandDepth);
           }
+          // Range applies to the FINAL returned content — after wikilink
+          // expansion — so the window the client pages through is the same
+          // document it would have received unpaged.
+          if (contentRange && includeContent) applyContentRange(result, contentRange);
           result = filterMetadata(result, params.include_metadata as boolean | string[] | undefined);
           if (params.include_links) {
             result.links = linkOps.getLinksHydrated(db, note.id);
@@ -457,6 +489,10 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
 
         // --- Format output ---
         const includeContent = params.include_content === true; // default false for list
+        // Range params require content in the response — on lists that
+        // means an explicit include_content=true (the lean default carries
+        // no content to slice). Error rather than silently ignore.
+        if (contentRange && !includeContent) throw contentRangeRequiresContent();
         const includeMetadata = params.include_metadata as boolean | string[] | undefined;
         let output: any[] = includeContent ? results.map((n) => ({ ...n })) : results.map(noteOps.toNoteIndex);
 
@@ -469,6 +505,15 @@ Link expansion: pass \`expand_links: true\` to inline [[wikilinks]] from returne
               n.content = expandContent(n.content, expandCtx, expandDepth);
             }
           }
+        }
+
+        // --- Content range (per-note, post-expansion) ---
+        // The same byte window applies to EACH note's content independently
+        // — the primary use is a single large note, but list mode keeps the
+        // simple per-note semantic (every note reports its own
+        // content_total_length / content_next_offset).
+        if (contentRange && includeContent) {
+          for (const n of output) applyContentRange(n, contentRange);
         }
 
         // --- Apply metadata filtering ---

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -306,6 +306,57 @@ single string and keep calling without special-casing the empty case.
 cursors and date filters coexist (cursor = "since last checked", dateFilter
 = "between X and Y").
 
+## Content range — bounded reads for large notes
+
+MCP responses are size-limited: a 100KB transcript can't come back from one
+`query-notes` call, and a remote MCP client has no `curl | head -c` escape
+hatch. `content_offset` / `content_length` page through note *content* in
+byte windows (orthogonal to `cursor`, which pages through note *lists*):
+
+```
+GET /vault/{name}/api/notes/{id}?content_offset=0&content_length=65536
+→ { ..., "content": "<first ≤64KB>",
+       "content_offset": 0,            // effective start (see alignment below)
+       "content_total_length": 118034, // full size, UTF-8 bytes
+       "content_next_offset": 65530 }  // pass back as content_offset; null when done
+```
+
+Loop until `content_next_offset` is `null`; concatenating the slices
+reconstructs the content byte-for-byte (the reassembly invariant is pinned
+by a property test).
+
+**Unit + alignment.** The unit is **UTF-8 bytes** (same as `byteSize` on the
+lean `NoteIndex`). Slices always end on a codepoint boundary *within* the
+budget — never over `content_length`, but up to 3 bytes under when a
+multi-byte character straddles the cut (which is why the example above
+resumes at 65530, not 65536). An offset landing mid-codepoint (only possible
+when you compute offsets by hand — chained `content_next_offset` values are
+always aligned) is aligned **down** to the codepoint's leading byte so no
+bytes are skipped; the effective start is echoed back as `content_offset`.
+
+**Rules.**
+
+- `content_offset` ≥ 0 (default 0); `content_length` ≥ 4 (the largest UTF-8
+  codepoint, so every window makes progress). Invalid values → `400
+  INVALID_QUERY`.
+- Range params require content in the response. With
+  `include_content=false` — or a list query left on its lean default — they
+  error (`400 INVALID_QUERY`) rather than silently no-op.
+- An offset at/past the end returns `content: ""` with
+  `content_next_offset: null` (graceful loop termination, e.g. when the
+  note shrank between calls).
+- On **list** queries (with `include_content=true`) the same window applies
+  to each note's content independently — every note reports its own
+  `content_total_length` / `content_next_offset`. The primary use is a
+  single large note.
+- With `expand=true` (wikilink inlining) the range applies to the returned
+  (expanded) content.
+- Without range params, responses are byte-identical to the pre-pagination
+  shape — no new fields appear.
+
+The MCP face is identical: `query-notes` takes `content_offset` /
+`content_length` as tool params and returns the same response fields.
+
 ## Endpoints
 
 The rest of this section documents every endpoint reachable on the REST
@@ -398,6 +449,11 @@ Query params:
 - **Output shape**
   - `include_content=true|false` — return `Note[]` (full body) instead of
     the default lean `NoteIndex[]`.
+  - `content_offset=N&content_length=M` — byte window over each returned
+    note's content (requires `include_content=true` here; the lean default
+    has no content to slice). See "Content range — bounded reads for large
+    notes" above for units, alignment, and the response fields
+    (`content_total_length`, `content_next_offset`).
   - `include_links=true` — fold each note's outbound links into the result
     rows.
   - `include_attachments=true` — fold each note's attachments into the
@@ -552,6 +608,10 @@ Folding options:
 - `include_attachments=true` — append attachments as an `attachments` field.
 - `include_metadata=...` — same allowlist as the list endpoint.
 - `expand=true&depth=N` — inline `[[wikilink]]` targets.
+- `content_offset=N&content_length=M` — bounded read of a large note's
+  content in byte windows; the response gains `content_offset` /
+  `content_total_length` / `content_next_offset`. See "Content range —
+  bounded reads for large notes" above.
 
 #### `PATCH /vault/{name}/api/notes/{idOrPath}` — `vault:write`
 Update content, path, metadata, extension, tags, or links. The body

--- a/src/content-range-routes.test.ts
+++ b/src/content-range-routes.test.ts
@@ -1,0 +1,178 @@
+/**
+ * REST face of content range / pagination (bounded reads for large notes).
+ *
+ * Exercises all four GET shapes that accept `content_offset` /
+ * `content_length`:
+ *   - GET /notes?id=…           (single, folded into the collection route)
+ *   - GET /notes/:idOrPath      (single point read)
+ *   - GET /notes?…              (structured list)
+ *   - GET /notes?search=…       (full-text list)
+ *
+ * Slice mechanics (codepoint boundaries, reassembly invariant) are pinned
+ * in core/src/content-range.test.ts; this suite covers the HTTP wiring:
+ * param parsing, 400s, per-shape application, and the no-params
+ * regression. Fully sandboxed — in-memory SQLite, no daemon.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { BunStore } from "./vault-store.ts";
+import { handleNotes } from "./routes.ts";
+
+let db: Database;
+let store: BunStore;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  store = new BunStore(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+const BASE = "http://localhost/api";
+
+function get(path: string): Promise<Response> {
+  return handleNotes(new Request(`${BASE}/notes${path}`, { method: "GET" }), store, pathSub(path));
+}
+
+/** Extract the handleNotes subpath ("/<id>" for point reads, "" otherwise). */
+function pathSub(path: string): string {
+  const m = path.match(/^\/([^?/]+)/);
+  return m ? `/${m[1]}` : "";
+}
+
+describe("REST content range — single note", () => {
+  it("GET /notes?id=… honors content_length and adds the range fields", async () => {
+    const note = await store.createNote("0123456789");
+    const res = await get(`?id=${note.id}&content_length=4`);
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.content).toBe("0123");
+    expect(body.content_offset).toBe(0);
+    expect(body.content_total_length).toBe(10);
+    expect(body.content_next_offset).toBe(4);
+  });
+
+  it("GET /notes/:id honors content_offset (tail read to the end)", async () => {
+    const note = await store.createNote("hello world", { path: "tail-note" });
+    const res = await get(`/${note.id}?content_offset=6`);
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.content).toBe("world");
+    expect(body.content_total_length).toBe(11);
+    expect(body.content_next_offset).toBeNull();
+  });
+
+  it("paged loop over REST reassembles multi-byte content byte-identically", async () => {
+    const content = "ab\u{1F600}cd 你好 ".repeat(20).trim();
+    const note = await store.createNote(content);
+    let offset = 0;
+    let assembled = "";
+    for (;;) {
+      const res = await get(`/${note.id}?content_offset=${offset}&content_length=16`);
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      expect(Buffer.byteLength(body.content, "utf8")).toBeLessThanOrEqual(16);
+      assembled += body.content;
+      if (body.content_next_offset === null) break;
+      offset = body.content_next_offset;
+    }
+    expect(assembled).toBe(content);
+  });
+
+  it("offset past end → 200 with empty slice and null next_offset", async () => {
+    const note = await store.createNote("abc");
+    const res = await get(`?id=${note.id}&content_offset=500`);
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.content).toBe("");
+    expect(body.content_next_offset).toBeNull();
+    expect(body.content_total_length).toBe(3);
+  });
+
+  it("include_content=false + range params → 400 INVALID_QUERY", async () => {
+    const note = await store.createNote("abc");
+    const res = await get(`?id=${note.id}&include_content=false&content_length=8`);
+    expect(res.status).toBe(400);
+    const body: any = await res.json();
+    expect(body.code).toBe("INVALID_QUERY");
+    expect(body.error).toContain("include_content");
+  });
+
+  it("zero / sub-minimum / malformed budgets → 400 INVALID_QUERY", async () => {
+    const note = await store.createNote("abc");
+    for (const qs of ["content_length=0", "content_length=2", "content_length=abc", "content_offset=-1"]) {
+      const res = await get(`?id=${note.id}&${qs}`);
+      expect(res.status).toBe(400);
+      const body: any = await res.json();
+      expect(body.code).toBe("INVALID_QUERY");
+    }
+  });
+
+  it("no range params → response shape unchanged (regression)", async () => {
+    const note = await store.createNote("plain body", { path: "plain" });
+    const res = await get(`/${note.id}`);
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.content).toBe("plain body");
+    expect("content_total_length" in body).toBe(false);
+    expect("content_next_offset" in body).toBe(false);
+    expect("content_offset" in body).toBe(false);
+  });
+});
+
+describe("REST content range — list shapes", () => {
+  it("structured list with include_content=true applies the window per note", async () => {
+    await store.createNote("first body first body", { tags: ["paged"] });
+    await store.createNote("second body second body", { tags: ["paged"] });
+    const res = await get(`?tag=paged&include_content=true&content_length=6`);
+    expect(res.status).toBe(200);
+    const body: any[] = await res.json();
+    expect(body.length).toBe(2);
+    for (const n of body) {
+      expect(Buffer.byteLength(n.content, "utf8")).toBeLessThanOrEqual(6);
+      expect(typeof n.content_total_length).toBe("number");
+      expect(n.content_next_offset).toBe(6);
+    }
+  });
+
+  it("structured list on the lean default + range params → 400", async () => {
+    await store.createNote("body", { tags: ["paged"] });
+    const res = await get(`?tag=paged&content_length=8`);
+    expect(res.status).toBe(400);
+    const body: any = await res.json();
+    expect(body.code).toBe("INVALID_QUERY");
+    expect(body.error).toContain("include_content");
+  });
+
+  it("search list with include_content=true applies the window per note", async () => {
+    await store.createNote("the quick brown fox jumps over the lazy dog");
+    const res = await get(`?search=fox&include_content=true&content_length=9`);
+    expect(res.status).toBe(200);
+    const body: any[] = await res.json();
+    expect(body.length).toBe(1);
+    expect(Buffer.byteLength(body[0].content, "utf8")).toBeLessThanOrEqual(9);
+    expect(body[0].content_total_length).toBe(
+      Buffer.byteLength("the quick brown fox jumps over the lazy dog", "utf8"),
+    );
+  });
+
+  it("search list on the lean default + range params → 400", async () => {
+    await store.createNote("the quick brown fox");
+    const res = await get(`?search=fox&content_length=8`);
+    expect(res.status).toBe(400);
+    const body: any = await res.json();
+    expect(body.code).toBe("INVALID_QUERY");
+  });
+
+  it("list without range params → no range fields injected (regression)", async () => {
+    await store.createNote("body here", { tags: ["paged"] });
+    const res = await get(`?tag=paged&include_content=true`);
+    expect(res.status).toBe(200);
+    const body: any[] = await res.json();
+    expect("content_total_length" in body[0]).toBe(false);
+    expect("content_next_offset" in body[0]).toBe(false);
+  });
+});

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -15,6 +15,12 @@ import type { Store, Note, QueryOpts } from "../core/src/types.ts";
 import { TAG_EXPAND_MODES, type TagExpandMode } from "../core/src/tag-hierarchy.ts";
 import { listUnresolvedWikilinks } from "../core/src/wikilinks.ts";
 import { getNote, getNotes, getNoteTags, toNoteIndex, filterMetadata, MAX_BATCH_SIZE, validateExtension, ExtensionValidationError } from "../core/src/notes.ts";
+import {
+  parseContentRange,
+  applyContentRange,
+  contentRangeRequiresContent,
+  type ContentRange,
+} from "../core/src/content-range.ts";
 import { attachValidationStatus } from "../core/src/mcp.ts";
 import * as linkOps from "../core/src/links.ts";
 import * as tagSchemaOps from "../core/src/tag-schemas.ts";
@@ -101,6 +107,37 @@ function parseLinkCountDirection(url: URL): "both" | "outbound" | "inbound" {
 function parseQueryList(url: URL, key: string): string[] | undefined {
   const val = url.searchParams.get(key);
   return val ? val.split(",") : undefined;
+}
+
+/**
+ * Parse `?content_offset=` / `?content_length=` (content range — bounded
+ * reads for large notes; unit is UTF-8 bytes, see core/src/content-range.ts
+ * for the codepoint-boundary slicing rules). Returns `{ range: null }` when
+ * neither param is present (response byte-identical to the no-pagination
+ * shape), or `{ error }` (400 INVALID_QUERY) on invalid values or when the
+ * response shape excludes content — range params on a content-less shape
+ * error loudly rather than silently no-op, same policy as `?expand=`.
+ */
+function parseContentRangeQuery(
+  url: URL,
+  includeContent: boolean,
+): { range: ContentRange | null; error?: Response } {
+  try {
+    const range = parseContentRange(
+      parseQuery(url, "content_offset") ?? undefined,
+      parseQuery(url, "content_length") ?? undefined,
+    );
+    if (range && !includeContent) throw contentRangeRequiresContent();
+    return { range };
+  } catch (e: any) {
+    // Duck-type on `name` — core is a separate module, so `instanceof`
+    // is fragile across bundling boundaries (same note as the QueryError
+    // handling in the structured-query path below).
+    if (e && e.name === "QueryError") {
+      return { range: null, error: json({ error: e.message, code: e.code ?? "INVALID_QUERY" }, 400) };
+    }
+    throw e;
+  }
 }
 
 /**
@@ -706,12 +743,18 @@ async function handleNotesInner(
           return json({ error: "Note not found", id }, 404);
         }
         const includeContent = parseBool(parseQuery(url, "include_content"), true);
+        const contentRange = parseContentRangeQuery(url, includeContent);
+        if (contentRange.error) return contentRange.error;
         let result: any = includeContent ? { ...note } : toNoteIndex(note);
         const expand = parseExpandParams(url, db, tagScope);
         if (expand && includeContent && typeof result.content === "string") {
           expand.ctx.expanded.add(note.id);
           result.content = expandContent(result.content, expand.ctx, expand.depth);
         }
+        // Content range applies to the FINAL returned content (post-
+        // expansion) — the window the client pages through is the same
+        // document it would have received unpaged.
+        if (contentRange.range && includeContent) applyContentRange(result, contentRange.range);
         result = filterMetadata(result, parseIncludeMetadata(url));
         if (parseBool(parseQuery(url, "include_links"), false)) {
           // Tag-scope: drop links whose neighbor is out of scope so the
@@ -769,6 +812,8 @@ async function handleNotesInner(
         // returns 200 [] (consistent with "no matches"), not 403.
         const results = filterNotesByTagScope(rawResults, tagScope.allowed, tagScope.raw);
         const includeContent = parseBool(parseQuery(url, "include_content"), false);
+        const contentRange = parseContentRangeQuery(url, includeContent);
+        if (contentRange.error) return contentRange.error;
         const inclMeta = parseIncludeMetadata(url);
         let output: any[] = includeContent ? results.map((n) => ({ ...n })) : results.map(toNoteIndex);
         const expand = parseExpandParams(url, db, tagScope);
@@ -779,6 +824,10 @@ async function handleNotesInner(
               n.content = expandContent(n.content, expand.ctx, expand.depth);
             }
           }
+        }
+        // Content range — per-note, post-expansion (see core/src/content-range.ts).
+        if (contentRange.range && includeContent) {
+          for (const n of output) applyContentRange(n, contentRange.range);
         }
         if (inclMeta !== undefined && inclMeta !== true) {
           output = output.map((n: any) => filterMetadata(n, inclMeta));
@@ -910,6 +959,8 @@ async function handleNotesInner(
       results = filterNotesByTagScope(results, tagScope.allowed, tagScope.raw);
 
       const includeContent = parseBool(parseQuery(url, "include_content"), false);
+      const contentRange = parseContentRangeQuery(url, includeContent);
+      if (contentRange.error) return contentRange.error;
       const includeLinks = parseBool(parseQuery(url, "include_links"), false);
       const includeAttachments = parseBool(parseQuery(url, "include_attachments"), false);
       const includeLinkCount = parseBool(parseQuery(url, "include_link_count"), false);
@@ -923,6 +974,10 @@ async function handleNotesInner(
             n.content = expandContent(n.content, expand.ctx, expand.depth);
           }
         }
+      }
+      // Content range — per-note, post-expansion (see core/src/content-range.ts).
+      if (contentRange.range && includeContent) {
+        for (const n of output) applyContentRange(n, contentRange.range);
       }
       if (inclMeta !== undefined && inclMeta !== true) {
         output = output.map((n: any) => filterMetadata(n, inclMeta));
@@ -1259,12 +1314,16 @@ async function handleNotesInner(
       return json({ error: "Not found" }, 404);
     }
     const includeContent = parseBool(parseQuery(url, "include_content"), true);
+    const contentRange = parseContentRangeQuery(url, includeContent);
+    if (contentRange.error) return contentRange.error;
     let result: any = includeContent ? { ...note } : toNoteIndex(note);
     const expand = parseExpandParams(url, db, tagScope);
     if (expand && includeContent && typeof result.content === "string") {
       expand.ctx.expanded.add(note.id);
       result.content = expandContent(result.content, expand.ctx, expand.depth);
     }
+    // Content range applies to the FINAL returned content (post-expansion).
+    if (contentRange.range && includeContent) applyContentRange(result, contentRange.range);
     result = filterMetadata(result, parseIncludeMetadata(url));
     if (parseBool(parseQuery(url, "include_links"), false)) {
       // Tag-scope: drop out-of-scope-neighbor links (no-op unscoped).


### PR DESCRIPTION
## What

Benjamin's spec (weave-approved team-vault work item `Work/vault-content-pagination`): MCP responses are size-limited, so his 103KB/116KB transcripts couldn't come back from one `query-notes` call — the only escape was local `curl | head -c`, which remote MCP clients don't have. Adam Elfers' traversal-log workflow generates the same class of large note.

`query-notes` (MCP) and the REST `GET /notes` family (point read `GET /notes/:id`, `?id=`, structured list, search list) now accept:

- `content_offset` — UTF-8 byte offset to start from (default 0)
- `content_length` — byte budget (min 4)

When either is set, the returned `content` is the byte slice and the response gains:

- `content_offset` — effective start (boundary-aligned, echoed back)
- `content_total_length` — full content size in UTF-8 bytes
- `content_next_offset` — pass back as `content_offset` to continue; `null` when complete

## Semantics decided

| Decision | Choice |
|---|---|
| **Unit** | UTF-8 **bytes** (what Benjamin named; same unit as `byteSize` on the lean NoteIndex) |
| **Codepoint safety** | Slices end on a codepoint boundary *within* the budget — never over `content_length`, up to 3 bytes under when a multi-byte char straddles the cut |
| **Unaligned offset** | Aligned **down** to the codepoint's leading byte (never skips bytes); effective start echoed as `content_offset`. Chained `content_next_offset` values are always aligned |
| **Minimum budget** | `content_length >= 4` (largest UTF-8 codepoint) — guarantees every window makes progress; sub-minimum/zero/negative → `INVALID_QUERY` / 400 |
| **`include_content` interaction** | Range params on a content-less shape (`include_content=false`, or a list left on its lean default) **error loudly** rather than silently no-op — same loud-validation policy as `expand` |
| **List shape** | Same window applies to **each** note's content independently; every note reports its own `content_total_length` / `content_next_offset`. Primary case stays single-note |
| **`expand_links`** | Range applies to the returned (**expanded**) content — the window pages the same document the client would have received unpaged |
| **Offset past end** | `content: ""` + `content_next_offset: null` (graceful loop termination, e.g. note shrank between calls) — not an error |
| **No params** | Responses byte-identical to today; no new fields (regression-pinned on both faces) |

## Discovery

The `query-notes` inputSchema + tool description (the text MCP clients read) advertise both params, the response fields, and the loop pattern — pinned by a test.

## Implementation

- `core/src/content-range.ts` — new module: `parseContentRange` (validation), `sliceContentRange` (boundary-aligned byte slicing), `applyContentRange`, shared `contentRangeRequiresContent` error. Single source of truth for both faces.
- `core/src/mcp.ts` — query-notes: schema + description + single/list execute paths.
- `src/routes.ts` — `parseContentRangeQuery` helper + the four GET shapes.

## Tests (43 new)

- `core/src/content-range.test.ts` (32) — parse validation; boundary cases (offset past end, zero/negative/sub-min budget, multi-byte codepoint at the cut, mid-codepoint offset alignment, min-budget progress on 4-byte emoji); **seeded property test** of the reassembly invariant (concatenating all slices byte-identical to full content, no slice over budget, strict progress — 60 randomized mixed-width corpora); MCP face (paged loop reassembly, range fields, errors, list shape, expand_links interplay, no-params regression, schema discovery).
- `src/content-range-routes.test.ts` (11) — REST face across all four GET shapes: 200s with fields, paged loop over HTTP reassembles multi-byte content, 400 `INVALID_QUERY` cases, no-params regression. Fully sandboxed (in-memory SQLite, no daemon).

## Gates (literal)

- `bun test`: **2351 pass / 3 skip / 0 fail** (2354 tests across 75 files)
- `bun run typecheck` (`tsc --noEmit`): **clean**
- No version bump (per rc-at-tag-time discipline)

## Docs

- `docs/HTTP_API.md` — new "Content range — bounded reads for large notes" section (unit, alignment, rules) + param bullets on the list endpoint + point-read folding options
- `README.md` — "Read a large note in chunks" recipe (curl + MCP)
- `CHANGELOG.md` — Unreleased → Added

**External touchpoint (not in this repo):** `parachute.computer/scripting.njk` mentions `include_content` but has no large-note recipe — a follow-up there could add the chunked-read pattern. The MCP server instructions blurb (vault-projection "Scripting & automation" section) doesn't enumerate per-tool params, so no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)